### PR TITLE
authorizing additional publishers of a package

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -128,8 +128,10 @@ Be sure to delete any files you don't want to include (or add them to
 before uploading your package,
 so examine the list carefully before completing your upload.
 
-## Multiple Authors
+## Multiple authors vs multiple publishers
 
+The authors of a package as listed in the `pubspec.yaml` file
+is different from the list of people authorized to publish that package.
 Whoever first uploads or publishes a package 
 becomes the only person who can publish new versions of that package.
 Use [`pub uploader`](cmd/pub-uploader) to manage the list

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -128,14 +128,14 @@ Be sure to delete any files you don't want to include (or add them to
 before uploading your package,
 so examine the list carefully before completing your upload.
 
-## Multiple authors vs multiple publishers
+## Authors versus uploaders
 
-The authors of a package as listed in the `pubspec.yaml` file
-is different from the list of people authorized to publish that package.
-Whoever first uploads or publishes a package 
-becomes the only person who can publish new versions of that package.
-Use [`pub uploader`](cmd/pub-uploader) to manage the list
-of authorized publishers.
+The package authors as listed in the `pubspec.yaml` file
+are different from the list of people authorized to publish that package.
+Whoever publishes the first version of some package automatically becomes
+the first and only person authorized to upload additional versions of the package.
+To allow or disallow other people to upload versions,
+use the [`pub uploader`](cmd/pub-uploader) command.
 
 ## Publishing is forever
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -128,6 +128,13 @@ Be sure to delete any files you don't want to include (or add them to
 before uploading your package,
 so examine the list carefully before completing your upload.
 
+## Multiple Authors
+
+Whoever first uploads or publishes a package 
+becomes the only person who can publish new versions of that package.
+Use [`pub uploader`](cmd/pub-uploader) to manage the list
+of authorized publishers.
+
 ## Publishing is forever
 
 Keep in mind that publishing is forever. As soon as you publish your package,

--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -24,6 +24,18 @@ You can reset pub's authentication process by removing the credentials file:
 rm ~/.pub-cache/credentials.json
 {% endprettify %}
 
+## Getting an "UnauthorizedAccess" error when publishing a package {#pub-publish-unauthorized}
+
+You receive the following error when running `pub publish`:
+
+{% prettify none %}
+UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versions to package '<foo>'..
+{% endprettify %}
+
+You will see this message if you are not on the list of people
+authorized to publish new versions of a package.
+See [Multiple authors vs multiple publishers](publishing#multiple-authors-vs-multiple-publishers).
+
 ## Pub build fails with HttpException error {#pub-get-fails}
 
 You receive an HttpException error similar to the following when

--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -34,7 +34,7 @@ UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versi
 
 You will see this message if you are not on the list of people
 authorized to publish new versions of a package.
-See [Multiple authors vs multiple publishers](publishing#multiple-authors-vs-multiple-publishers).
+See [Authors versus uploaders](publishing#authors-versus-uploaders).
 
 ## Pub build fails with HttpException error {#pub-get-fails}
 


### PR DESCRIPTION
These changes highlight the difference between package authors (those listed in the pubspec.yaml) and authorized publishers.
@munificent 
