### PR TITLE
Fix typo in language tour

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1603,7 +1603,7 @@ The previous example is equivalent to:
 var button = querySelector('#button');
 button.text = 'Confirm';
 button.classes.add('important');
-button.onClick.listen((3) => window.alert('Confirmed!'));
+button.onClick.listen((e) => window.alert('Confirmed!'));
 {% endprettify %}
 
 You can also nest your cascades. For example:


### PR DESCRIPTION
Typo `(3) => ...`, and it should be `(e) => ...`.