### PR TITLE
Update .packages/packages discussions for 1.19

### DIFF
--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -203,6 +203,11 @@ packages, don't commit `.packages`, the `pubspec.lock` file,
 or any `packages` directories. For more information, see
 [What Not to Commit](private-files).
 
+{% comment %}
+PENDING: here just to make it easy to find discussions of `packages`...
+{% include coming-release.html %}
+{% endcomment %}
+
 You can share your open source libraries with other developers on
 [pub.dartlang.org](https://pub.dartlang.org/) using
 [pub publish](/tools/pub/cmd/pub-lish).

--- a/src/_includes/coming-release.html
+++ b/src/_includes/coming-release.html
@@ -1,15 +1,5 @@
 <aside class="alert alert-info" markdown="1">
   **Note:**
-  The `packages` directories are being phased out, to be
-  replaced by a single `.packages` file.
-  The version of <code>pub get</code> that creates the
-  `.packages` file was added in Dart 1.12.
+  The `.packages` file is replacing `packages` directories.
   For more information, see [pub get](/tools/pub/cmd/pub-get).
-
-{% comment %}
-Not quite ready for this...
-  <p>
-  `pub get` also creates one or more `packages` directories,
-  unless you specify `--no-packages-symlinks`.</p>
-{% endcomment %}
 </aside>

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -182,18 +182,18 @@ $
 
 The `pub get` command installs the
 packages in your app's dependencies list.
+Each package can contain libraries and other assets.
 Pub works recursively;
 if an included package has dependencies, those packages are installed as well.
 
-Pub puts the package files under directories called `packages`.
-Each package can contain libraries and other assets.
+Pub caches the files for each package your app depends on,
+pointing to them from a file named `.packages` and
+directories named `packages`.
 
-If you open your app's top-level `packages` directory,
-you'll find the `vector_math` link,
-which points to the Dart libraries from the vector_math package.
+{% include coming-release.html %}
 
-Pub creates a file called `pubspec.lock`,
-which identifies the specific versions of the packages that were installed.
+Pub creates a file called `pubspec.lock`
+that identifies the specific versions of the packages that were installed.
 This helps to provide a stable development environment.
 Later you can modify the version constraints and use `pub upgrade`
 to update to new versions as needed.

--- a/src/tools/faq.md
+++ b/src/tools/faq.md
@@ -45,56 +45,16 @@ hoping to address the root cause but it will take a while to get there.
 
 #### Q. What are all the "packages" directories for?
 
-After you run pub, you'll notice that your package has little `packages`
-directories sprinkled all over it. These are needed to make `package:` imports
-work.
+After you run pub, you might notice that your package has little `packages`
+directories sprinkled all over it. Before 1.19, these directories were
+needed to make `package:` imports work.
 
 {% include coming-release.html %}
 
 When your code has an import with the `package` scheme, a Dart
-implementation like the VM or dart2js translates that to a path or URL using a
-simple rewriting rule:
-
- 1. Take the URI of your application's [entrypoint](/tools/pub/glossary#entrypoint).
- 2. Strip off the trailing file name.
- 3. Append `/packages/` followed by the rest of the import URL.
-
-For example, if you app's entrypoint is `/dev/myapp/web/main.dart` then:
-
-{% prettify dart %}
-import 'package:test/test.dart';
-{% endprettify %}
-
-Magically turns into:
-
-{% prettify dart %}
-import '/dev/myapp/web/packages/test/test.dart';
-{% endprettify %}
-
-Then Dart loads that as normal. This behavior is a [specified][spec] part of
-the Dart language. The example only works if you have a directory named
-`packages` inside your `web` directory and that directory in turn contains the
-packages that your app uses.
-
-[spec]: http://www.dartlang.org/docs/spec/
-
-Pub creates these directories for you. The main one it creates is in the root
-of your package. Inside that, it creates symlinks pointing to the `lib`
-directories of each package your app [depends][] on. (The dependencies
-themselves will usually live in your [system cache][].)
-
-[depends]: /tools/pub/glossary#dependency
-[system cache]: /tools/pub/glossary#system-cache
-
-After creating the main `packages` directory in your package's root, pub then
-creates secondary ones in every [directory in your package where a Dart
-entrypoint may appear](/tools/pub/glossary#entrypoint-directory).
-Currently that's `benchmark`, `bin`, `example`, `test`, `tool`, and `web`.
-
-Pub also creates `packages` symlinks in *subdirectories* of any of those that
-point back to the main one. Since you may have entrypoints under, for example,
-`web/admin/controllers/`, pub makes sure a `packages` directory
-is always nearby. Otherwise the imports won't work.
+implementation like the VM or dart2js translates that to a path or URL.
+This path used to be relative to the `packages` directory, but now is derived
+from information in the `.packages` file.
 
 #### Q. How can I make my client-server app work with **pub serve**?
 

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -10,14 +10,15 @@ _Downgrade_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub downgrade [dependencies...]
+$ pub downgrade [args] [dependencies]
 {% endprettify %}
 
 Without any additional arguments, `pub downgrade` gets the lowest versions of
-all the dependencies listed in the [`pubspec.yaml`](/tools/pub/pubspec)
-file in the current working directory, as well as their [transitive
-dependencies](/tools/pub/glossary#transitive-dependency), to the `packages`
-directory located next to the pubspec. For example:
+all the dependencies listed in the [`pubspec.yaml`](/tools/pub/pubspec) file
+in the current working directory, as well as their [transitive
+dependencies](/tools/pub/glossary#transitive-dependency), to the `.packages`
+file and the `packages` directory located next to the pubspec.
+For example:
 
 {% prettify sh %}
 $ pub downgrade
@@ -32,8 +33,13 @@ Changed 6 dependencies!
 {% endprettify %}
 
 The `pub downgrade` command creates a lockfile. If one already exists,
-it ignores it and generates a new one from scratch using the lowest
+pub ignores that file and generates a new one from scratch, using the lowest
 versions of all dependencies.
+
+The `pub downgrade` command supports the same command-line arguments
+as the [`pub get` command](/tools/pub/cmd/pub-get).
+
+{% include coming-release.html %}
 
 ## Downgrading specific dependencies
 
@@ -67,17 +73,19 @@ as a result.
 
 ## Getting a new dependency
 
-If a dependency is added to the pubspec before `pub downgrade` is run, it gets
-the new dependency and any of its transitive dependencies and places them in
-the `packages` directory. This is the same behavior as `pub get`.
+If a dependency is added to the pubspec before `pub downgrade` is run,
+it gets the new dependency and any of its transitive dependencies and
+places them in the `.packages` file and `packages` directory. This
+is the same behavior as `pub get`.
 
 ## Removing a dependency
 
-If a dependency is removed from the pubspec before `pub downgrade` is run, it
-removes the dependency from the `packages` directory, thus making it
-unavailable for importing. Any transitive dependencies of the removed dependency
-are also removed, as long as no remaining immediate dependencies also depend
-on them. This is the same behavior as `pub get`.
+If a dependency is removed from the pubspec before `pub downgrade` is
+run, it removes the dependency from the `.packages` file and
+`packages` directory, thus making the dependency unavailable for
+importing. Any transitive dependencies of the removed dependency are
+also removed, as long as no remaining immediate dependencies also
+depend on them. This is the same behavior as `pub get`.
 
 ## Downgrading while offline
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -10,7 +10,7 @@ _Get_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub get [--offline] [--no-packages-dirs | --packages-dirs]
+$ pub get [--offline] [--no-packages-dir | --packages-dir]
 {% endprettify %}
 
 This command gets all the dependencies listed in the
@@ -50,10 +50,10 @@ PENDING: here just to make it easy to find discussions of `packages`...
   [Resolving package: URIs](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#resolving-package-uris).
 
   As of Dart 1.19, you can suppress creation of the `packages` directories
-  by specifying `--no-packages-dirs`.
+  by specifying `--no-packages-dir`.
   To request generation of `packages` directories
   (in addition to the `.packages` file),
-  use the `--packages-dirs` flag.
+  use the `--packages-dir` flag.
 </aside>
 
 Once the dependencies are acquired, they may be referenced in Dart code.

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -10,13 +10,8 @@ _Get_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub get [--offline]
+$ pub get [--offline] [--no-package-dirs | --package-dirs]
 {% endprettify %}
-
-{% comment %}
-Not ready to advertise --no-package-symlinks
-$ pub get [--offline] [--no-package-symlinks]
-{% endcomment %}
 
 This command gets all the dependencies listed in the
 [`pubspec.yaml`](/tools/pub/pubspec) file in the current working
@@ -34,15 +29,18 @@ doesn't already contain the dependencies, `pub get`
 updates the cache,
 downloading dependencies if necessary.
 To map packages back to the system cache,
-this command creates one or more `packages` directories and,
-as of Dart 1.12, a `.packages` file.
+this command creates a `.packages` file and—unless you specify
+the `--no-packages-dir` flag—one or more
+`packages` directories.
 
 {% comment %}
+PENDING: here just to make it easy to find discussions of `packages`...
 {% include coming-release.html %}
 {% endcomment %}
 
-<aside class="alert alert-info" markdown="1">
-  **Compatibility note:**
+<aside class="alert alert-warning" markdown="1">
+  **The `.packages` file is replacing `packages` directories.**
+
   As of Dart 1.12,
   `packages` directories are being phased out and
   replaced by the `.packages` file.
@@ -50,14 +48,13 @@ as of Dart 1.12, a `.packages` file.
   tools that support it.
   For more information, see
   [Resolving package: URIs](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#resolving-package-uris).
-</aside>
 
-{% comment %}
-Not ready for this...
-As of Dart 1.12, the `.packages` file supercedes the `packages`
-directories. You can suppress creation of the packages directories
-by specifying `--no-packages-symlinks`.
-{% endcomment %}
+  As of Dart 1.19, you can suppress creation of the `packages` directories
+  by specifying `--no-package-dirs`.
+  To request generation of `packages` directories
+  (in addition to the `.packages` file),
+  use the `--package-dirs` flag.
+</aside>
 
 Once the dependencies are acquired, they may be referenced in Dart code.
 For example, if a package depends on `test`:
@@ -84,8 +81,9 @@ This is the primary difference between `pub get` and
 get the latest versions of all dependencies.
 
 <aside class="alert alert-info" markdown="1">
-**Note:** Do not check the generated `packages` directories,
-`.package` file, or `.pub` directory (when present) into your repo;
+**Note:** Do not check the generated `.package` file,
+`packages` directories, or `.pub` directory (when present)
+into your repo;
 add them to your repo's `.gitignore` file.
 [What Not to Commit](/guides/libraries/private-files) has a complete list
 of files that should not be checked into the repo.
@@ -95,16 +93,16 @@ of files that should not be checked into the repo.
 
 If a dependency is added to the pubspec and then `pub get` is run,
 it gets the new dependency and any of its transitive dependencies and
-updates the links in the `packages` directory, and the
-mapping in the `.packages` file.
-However, it won't change the versions of any already-acquired
+updates the mapping in the `.packages` file and
+the links in the `packages` directory.
+However, pub won't change the versions of any already-acquired
 dependencies unless that's necessary to get the new dependency.
 
 ## Removing a dependency
 
 If a dependency is removed from the pubspec and then `pub get` is run,
-it removes the dependency from the `packages` directory, and the
-`.packages` file, thus making it unavailable for importing.
+it removes the dependency from the `.packages` file and
+`packages` directory, thus making it unavailable for importing.
 Any transitive dependencies of the removed dependency are also removed,
 as long as no remaining immediate dependencies also depend on them.
 Removing a dependency never changes the versions of any
@@ -118,7 +116,7 @@ Dependencies downloaded over the internet, such as those from Git and
 This means that if multiple packages use the same version of the
 same dependency, it only needs to be
 downloaded and stored locally once. It also means that it's safe to delete
-the `packages` directories, or the `.packages` file, without
+the `.packages` file and `packages` directories, without
 worrying about re-downloading packages.
 
 By default, the system package cache is located in the `.pub-cache`

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -10,7 +10,7 @@ _Get_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub get [--offline] [--no-package-dirs | --package-dirs]
+$ pub get [--offline] [--no-packages-dirs | --packages-dirs]
 {% endprettify %}
 
 This command gets all the dependencies listed in the
@@ -50,10 +50,10 @@ PENDING: here just to make it easy to find discussions of `packages`...
   [Resolving package: URIs](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#resolving-package-uris).
 
   As of Dart 1.19, you can suppress creation of the `packages` directories
-  by specifying `--no-package-dirs`.
+  by specifying `--no-packages-dirs`.
   To request generation of `packages` directories
   (in addition to the `.packages` file),
-  use the `--package-dirs` flag.
+  use the `--packages-dirs` flag.
 </aside>
 
 Once the dependencies are acquired, they may be referenced in Dart code.

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -10,14 +10,16 @@ _Upgrade_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub upgrade [dependencies...]
+$ pub upgrade [args] [dependencies]
 {% endprettify %}
 
-Without any additional arguments, `pub upgrade` gets the latest versions of
-all the dependencies listed in the [`pubspec.yaml`](/tools/pub/pubspec.html) file in the
-current working directory, as well as their [transitive
-dependencies](/tools/pub/glossary#transitive-dependency),
-to the `packages` directory located next to the pubspec. For example:
+Without any additional arguments, `pub upgrade` gets the latest
+versions of all the dependencies listed in the
+[`pubspec.yaml`](/tools/pub/pubspec.html) file in the current working
+directory, as well as their [transitive
+dependencies](/tools/pub/glossary#transitive-dependency), to the
+`.packages` file and the `packages` directory located next to the pubspec.
+For example:
 
 {% prettify sh %}
 $ pub upgrade
@@ -25,19 +27,23 @@ Dependencies upgraded!
 {% endprettify %}
 
 When `pub upgrade` upgrades dependency versions, it writes a
-[lockfile](/tools/pub/glossary#lockfile)
-to ensure that future [`pub get`s](/tools/pub/cmd/pub-get)
-will use the same versions of those dependencies.
-Application packages should check in the lockfile to source control; this
-ensures the application will use the exact same versions of all dependencies for
-all developers and when deployed to production. Library packages should not
-check in the lockfile, though, since they're expected to work with a range of
-dependency versions.
+[lockfile](/tools/pub/glossary#lockfile) to ensure that future
+[`pub get`s](/tools/pub/cmd/pub-get) will use the same versions of those
+dependencies. Application packages should check in the lockfile to
+source control; this ensures the application will use the exact same
+versions of all dependencies for all developers and when deployed to
+production. Library packages should not check in the lockfile, though,
+since they're expected to work with a range of dependency versions.
 
 If a lockfile already exists, `pub upgrade` ignores it and generates a new
 one from scratch using the latest versions of all dependencies. This is the
 primary difference between `pub upgrade` and `pub get`, which always tries to
 get the dependency versions specified in the existing lockfile.
+
+The `pub upgrade` command supports the same command-line arguments
+as the [`pub get` command](/tools/pub/cmd/pub-get).
+
+{% include coming-release.html %}
 
 <aside class="alert alert-info" markdown="1">
 **Note:** In earlier releases of Dart, _pub upgrade_ was called _pub update_.
@@ -60,24 +66,26 @@ unlocked until a compatible set of versions is found.
 
 ## Getting a new dependency
 
-If a dependency is added to the pubspec before `pub upgrade` is run, it gets
-the new dependency and any of its transitive dependencies and places them in
-the `packages` directory. This is the same behavior as `pub get`.
+If a dependency is added to the pubspec before `pub upgrade` is run,
+it gets the new dependency and any of its transitive dependencies,
+placing them in the `.packages` file and the `packages` directory. This
+is the same behavior as `pub get`.
 
 ## Removing a dependency
 
-If a dependency is removed from the pubspec before `pub upgrade` is run, it
-removes the dependency from the `packages` directory, thus making it
-unavailable for importing. Any transitive dependencies of the removed dependency
-are also removed, as long as no remaining immediate dependencies also depend
-on them. This is the same behavior as `pub get`.
+If a dependency is removed from the pubspec before `pub upgrade` is
+run, it removes the dependency from the `.packages` file and
+`packages` directory, thus making the dependency unavailable for
+importing. Any transitive dependencies of the removed dependency are
+also removed, as long as no remaining immediate dependencies also
+depend on them. This is the same behavior as `pub get`.
 
 ## Upgrading while offline
 
-If you don't have network access, you can still run `pub upgrade`. Since pub
-downloads packages to a central cache shared by all packages on your system, it
-can often find previously-downloaded packages there without needing to hit the
-network.
+If you don't have network access, you can still run `pub upgrade`.
+Since pub downloads packages to a central cache shared by all packages
+on your system, it can often find previously downloaded packages there
+without needing to hit the network.
 
 However, by default, pub always tries to go online when you upgrade if you
 have any hosted dependencies so that it can see if newer versions of them are

--- a/src/tools/pub/get-started.md
+++ b/src/tools/pub/get-started.md
@@ -89,7 +89,7 @@ Next, pub creates one or more `packages` directories containing
 symlinks to the packages in the system cache.
 
 Finally, pub creates a
-<code class="literal">.packages</code> file (under your app’s top directory)
+`.packages` file (under your app’s top directory)
 that maps each package name
 that your app depends on to the corresponding package in the system cache.
 
@@ -104,13 +104,13 @@ import 'package:js/js.dart' as js;
 import 'package:intl/intl.dart';
 {% endprettify %}
 
-The Dart runtime takes everything after <code class="literal">package:</code>
-and looks it up within the <code class="literal">packages</code> directory for
+The Dart runtime takes everything after `package:`
+and looks it up within the `.packages` file or `packages` directory for
 your app.
 
 You can also use this style to import libraries from within your own package.
 
-Consider the following pubspec file which declares a dependency on
+Consider the following pubspec file, which declares a dependency on
 the (fictional) `transmogrify` package:
 
 {% prettify yaml %}

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -62,15 +62,17 @@ enchilada/
     style.css
 {% endprettify %}
 
-\* As of 1.12, the `.packages` file exists after you've run `pub get`.
+\* The `.packages` file exists after you've run `pub get`.
    Don't check it into source control.
 
 \** The `pubspec.lock` file exists after you've run `pub get`.
     Leave it out of source control unless your package is an
     [application package](/tools/pub/glossary#application-package).
 
-\*** The `packages` directories exist locally after you've run `pub get`.
-     Don't check these into source control.
+\*** The `packages` directories are
+     created when you run `pub get`,
+     unless you specify the flag `--no-packages-dir`.
+     Don't check `packages` directories into source control.
 
 \**** The `doc/api` directory exists locally after you've run
       [dartdoc](https://github.com/dart-lang/dartdoc#dartdoc).
@@ -100,18 +102,19 @@ Once you've run [`pub get`](/tools/pub/cmd/pub-get),
 [`pub upgrade`](/tools/pub/cmd/pub-upgrade), or
 [`pub downgrade`](/tools/pub/cmd/pub-downgrade) on the package, you will also have a
 **lockfile**, named `pubspec.lock`. If your package is an [application
-package](/tools/pub/glossary#application-package), this will be checked into source
-control. Otherwise, it won't be.
+package](/tools/pub/glossary#application-package), check the lockfile into source
+control. Otherwise, don't.
 
 {% prettify none %}
 enchilada/
+  .packages
   packages/
     ...
 {% endprettify %}
 
-Running pub also generates a `packages` directory. You will *not* check
-this into source control, and you won't need to worry too much about its
-contents. Consider it pub magic, but not scary magic.
+Running pub also generates a `.packages` file and—unless you specify
+the `--no-packages-dir` flag—at least one directory named `packages`.
+Don't check these into source control.
 
 The open source community has a few other files that commonly appear at the top
 level of a project: `LICENSE`, `AUTHORS`, etc. If you use any of those, they can
@@ -147,9 +150,9 @@ enchilada/
 To show users the latest changes to your package, you can include a changelog
 file where you can write a short note about the changes in your latest
 release. When you upload your package to
-[pub.dartlang.org](https://pub.dartlang.org)
-it detects that your package contains a changelog file and shows
-it in the changelog tab.
+[pub.dartlang.org](https://pub.dartlang.org),
+your package's changelog file (if any)
+appears in the changelog tab.
 
 If your CHANGELOG ends in `.md`, `.markdown`, or `.mdown`, it is parsed as
 [Markdown][].
@@ -228,38 +231,6 @@ in the top-level `tool` directory.
 If you do not intend for your package to be depended on, you can leave your
 scripts in `bin`.
 
-## Referencing packages
-
-You can, of course, reference a package from within your app.
-For example, say your source tree looks like this:
-
-{% prettify none %}
-myapp/
-  example/
-    one/
-      sub/
-        index.html
-{% endprettify %}
-
-The resulting build directory has the following structure:
-
-{% prettify none %}
-build/
-  example/
-    one/
-      packages/
-        myapp/
-          style.css
-      sub/
-        index.html
-{% endprettify %}
-
-In this scenario, index.html references the stylesheet using
-the relative path `../packages/myapp/style.css`. (Note the leading `..`.)
-
-You can also use a path relative to the root URL, such as
-`/packages/myapp/style.css`, but you must be careful on how you
-deploy your app.
 
 ## Public assets
 
@@ -277,29 +248,25 @@ consumers of the package to use.
 These go in the top-level `lib` directory. You can put any kind of file
 in there and organize it with subdirectories however you like.
 
-Users can reference another package's assets using URLs that contain
-`/packages/<package>/<path>` where `<package>` is the name of the package
-containing the asset and `<path>` is the relative path to the asset within that
-package's `lib` directory.
-
 <aside class="alert alert-info" markdown="1">
+**Compatibility note:**
 In earlier releases, assets were also placed in the top-level
 `asset` directory. Pub no longer recognizes the `asset` directory.
 </aside>
 
-For example, let's say your package wanted to use enchilada's `guacamole.css`
-styles. In an HTML file in your package, you can add:
+You can reference another package's assets using the
+[resource package](https://github.com/dart-lang/resource).
 
-{% prettify html %}
-<link href="packages/enchilada/guacamole.css" rel="stylesheet">
-{% endprettify %}
-
-When you run your application using [`pub serve`]({{site.webdev}}/tools/pub/pub-serve), or build
-it to something deployable using [`pub build`]({{site.webdev}}/tools/pub/pub-build), pub
-copies over any referenced assets that your package depends on.
+<aside class="alert alert-warning" markdown="1">
+**Warning:**
+Old code might refer to assets using `/packages/<package>/<path>` URLs;
+that code will break when `packages` directories go away.
+A temporary workaround is to use the `--packages-dir` flag.
+</aside>
 
 For more information about using assets, see
 [Pub Assets and Transformers](/tools/pub/assets-and-transformers).
+
 
 ## Implementation files
 
@@ -352,8 +319,7 @@ happy.
 
 Also, and this is important, any Dart web entrypoints (in other words, Dart
 scripts that are referred to in a `<script>` tag) go under `web` and not `lib`.
-That ensures that a `packages` directory is created nearby so that `package:`
-imports can be resolved correctly.
+That ensures that `package:` imports can be resolved correctly.
 
 (You may be asking whether you should put your web-based example programs
 in `example` or `web`? Put those in `example`.)

--- a/src/tools/pub/versioning.md
+++ b/src/tools/pub/versioning.md
@@ -263,7 +263,7 @@ on the context. In `my_app`, `widgets` will use `collection 1.9.9`. But
 in `other_app`, `widgets` will get saddled with `collection 1.4.9` because of
 the _other_ constraint that `otherapp` places on it.
 
-This is why each app gets its own `packages` directory: The concrete version
+This is why each app gets its own `.packages` file: The concrete version
 selected for each package depends on the entire dependency graph of the
 containing app.
 
@@ -339,8 +339,8 @@ directly or indirectly and the best version of that package that will work with
 your app's constraints.
 
 Pub takes that and writes it out to a **lockfile** in your app's directory
-called `pubspec.lock`. When pub builds the `packages` directory your app, it
-uses the lockfile to know what versions of each package to pull in. (And if
+called `pubspec.lock`. When pub builds the `.packages` file for your app, it
+uses the lockfile to know what versions of each package to refer to. (And if
 you're curious to see what versions it selected, you can read the lockfile to
 find out.)
 


### PR DESCRIPTION
Here are staged versions of the affected files:

https://kw-www-dartlang-1.firebaseapp.com/guides/libraries/private-files
https://kw-www-dartlang-1.firebaseapp.com/tutorials/libraries/shared-pkgs
https://kw-www-dartlang-1.firebaseapp.com/tools/faq
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-downgrade
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-get
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-upgrade
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/get-started
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/glossary
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/package-layout
https://kw-www-dartlang-1.firebaseapp.com/tools/pub
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/versioning