### PR TITLE
Don't display navigation when printing

### DIFF
--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -343,3 +343,10 @@ body.homepage .get-started-section {
 		padding-right: 5%;
 	}
 }
+
+/* Don't display navigation aids when printing */
+@media print {
+	#page-header, #sidenav, #subnav, #page-footer, .banner {
+		display:none !important;
+	}
+}


### PR DESCRIPTION
To see the changes, go to the staging site and view a page. Here's one I've used for testing, but any other page should work as well (especially if it's long):

https://kw-www-dartlang-1.firebaseapp.com/guides/language/effective-dart/style

Then view the print version of the page. The easiest way is to just bring up the Chrome print dialog, which has a preview.

Compare it to the existing version of the page, which has bad print styles (#149).

@Sfshaza could you please take a look? 