### PR TITLE
Add TOCs to effective dart pages.

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -13,6 +13,9 @@ prevpage:
 
 Here are some guidelines for writing consistent, usable APIs for libraries.
 
+* TOC
+{:toc}
+
 ## Names
 
 Naming is an important part of writing readable, maintainable code.

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -22,6 +22,9 @@ But the reality is that most of us don't write as many comments as we should.
 It's like exercise: you technically *can* do too much, but it's a lot more
 likely that you're doing too little. Try to step it up.
 
+* TOC
+{:toc}
+
 ## Comments
 
 The following tips apply to comments that you don't want included in the

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -18,6 +18,9 @@ ocular systems.  If we use a consistent style across the entire Dart ecosystem,
 it makes it easier for all of us to learn from and contribute to each others'
 code.
 
+* TOC
+{:toc}
+
 ## Identifiers
 
 Identifiers come in three flavors in Dart.

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -16,6 +16,9 @@ guidelines here every day in the bodies of your Dart code. *Users* of your
 library may not be able to tell that you've internalized the ideas here, but
 *maintainers* of it sure will.
 
+* TOC
+{:toc}
+
 ## Strings
 
 Here are some best practices to keep in mind when composing strings in Dart.


### PR DESCRIPTION
Staged at https://hc-www-dartlang-1.firebaseapp.com/guides/language/effective-dart/style

The TOC can be configured through the kramdown option toc_levels, but seems to default to exactly what we would want.

May help alleviate the issues in https://github.com/dart-lang/site-www/issues/13 although I hope to have a full fix for that later today.