### PR TITLE
Remove unnecessary "there might be bugs" warning

### DIFF
--- a/src/_articles/language/beyond-async.md
+++ b/src/_articles/language/beyond-async.md
@@ -16,16 +16,6 @@ we discussed asynchronous methods and await expressions.
 These features are part of a complete initiative to support asynchronous
 programming and generators in Dart.
 
-<aside class="alert alert-info" markdown="1">
-**Note:**
-In 1.9, we shipped initial implementations of the entire async-await feature
-set, including synchronous and asynchronous generators.
-There might still be [bugs](https://github.com/dart-lang/sdk/issues),
-but all the specified features are implemented.
-Bear in mind that the precise details of some of these features might
-change slightly.
-</aside>
-
 ## Generators
 
 Dart 1.9 introduced <em>generator functions</em>. These are functions that


### PR DESCRIPTION
Either we have this feature or we don't - if there aren't any major bugs yet we shouldn't have this warning. It's been a while since 1.9...

/cc @filiph 