### PR TITLE
Fixed broken anchor links, linkcheck is passing

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -187,7 +187,7 @@ that's being added after Dart's 1.0 release.
 You can't use `async`, `await`, or `yield` as
 an identifier in any function body marked with `async`, `async*`, or `sync*`.
 For more information, see
-[Asynchrony support](#asynchrony).
+[Asynchrony support](#asynchrony-support).
 
 All other words in the keyword table are <em>reserved words</em>.
 You can't use reserved words as identifiers.
@@ -1050,7 +1050,7 @@ void main() {
 
 <div class="alert alert-info" markdown="1">
 **Note:**
-The `..` syntax in the preceding code is called a [cascade](#cascade).
+The `..` syntax in the preceding code is called a [cascade](#cascade-notation-).
 With cascades,
 you can perform multiple operations on the members of a single object.
 </div>
@@ -1879,7 +1879,7 @@ Switch statements in Dart compare integer, string, or compile-time
 constants using `==`. The compared objects must all be instances of the
 same class (and not of any of its subtypes), and the class must not
 override `==`.
-[Enumerated types](#enums) work well in `switch` statements.
+[Enumerated types](#enumerated-types) work well in `switch` statements.
 
 <div class="alert alert-info" markdown="1">
 **Note:**
@@ -3440,7 +3440,7 @@ greet() async {
 In the preceding code,
 the `await` keyword pauses execution until the library is loaded.
 For more information about `async` and `await`,
-see [asynchrony support](#asynchrony).
+see [asynchrony support](#asynchrony-support).
 
 You can invoke `loadLibrary()` multiple times on a library without problems.
 The library is loaded only once.

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -959,7 +959,7 @@ Future, Stream, and more are in the
 You don't always need to use the Future or Stream APIs directly.
 The Dart language supports asynchronous coding
 using keywords such as `async` and `await`.
-See [Asynchrony support](/guides/language/language-tour#asynchrony)
+See [Asynchrony support](/guides/language/language-tour#asynchrony-support)
 in the language tour for details.
 </div>
 
@@ -1036,7 +1036,7 @@ For example, you might call an async function from your function.
 </div>
 
 For more information on using `await` and related Dart language features,
-see [Asynchrony support](/guides/language/language-tour#asynchrony).
+see [Asynchrony support](/guides/language/language-tour#asynchrony-support).
 
 
 #### Basic usage
@@ -1201,7 +1201,7 @@ then the second kind of event is never handled.
 
 For more information on using `await` and related
 Dart language features, see
-[Asynchrony support](/guides/language/language-tour#asynchrony).
+[Asynchrony support](/guides/language/language-tour#asynchrony-support).
 
 
 #### Listening for stream data
@@ -2129,7 +2129,7 @@ main() async {
 
 Use a Stream to read a file, a little at a time.
 You can use either the [Stream API](#stream) or `await for`,
-part of Dart's [asynchrony support](/guides/language/language-tour#asynchrony).
+part of Dart's [asynchrony support](/guides/language/language-tour#asynchrony-support).
 
 <!-- library-tour/read-file/bin/read_file.dart -->
 {% prettify dart %}

--- a/src/_tutorials/language/futures.md
+++ b/src/_tutorials/language/futures.md
@@ -88,7 +88,7 @@ To get the value that the Future represents, you have two options:
 ## Async and await {#async-await}
 
 The `async` and `await` keywords are part of the Dart language's
-[asynchrony support](/guides/language/language-tour#asynchrony).
+[asynchrony support](/guides/language/language-tour#asynchrony-support).
 They allow you to write asynchronous code that looks like synchronous
 code and doesn't use the Future API.
 
@@ -423,7 +423,7 @@ and asynchronous programming in Dart:
   an article that starts where this tutorial ends
 * [The Event Loop and Dart]({{site.webdev}}/articles/performance/event-loop),
   an article that describes how to schedule tasks using Futures
-* [Asynchrony support](/guides/language/language-tour#asynchrony),
+* [Asynchrony support](/guides/language/language-tour#asynchrony-support),
   a section in the [language tour](/guides/language/language-tour)
 * [Future API reference]({{site.dart_api}}/dart-async/Future-class.html)
 

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -453,7 +453,7 @@ and asynchronous programming in Dart.
   an article about creating your own streams
 * [Futures and Error Handling](/articles/libraries/futures-and-error-handling),
   an article that explains how to handle errors using the Future API
-* [Asynchrony support](/guides/language/language-tour#asynchrony),
+* [Asynchrony support](/guides/language/language-tour#asynchrony-support),
   a section in the [language tour](/guides/language/language-tour)
 * [Stream API reference]({{site.dart_api}}/dart-async/Stream-class.html)
 


### PR DESCRIPTION
Was reading on async feature of Dart lang, found that few links are broken. 
Fixed broken anchor links and linkcheck shows there are no more broken links. 