### PR TITLE
Fix broken link to /tos.htm

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1111,6 +1111,11 @@
         "type": 301
       },
       {
+        "source": "/tos.htm",
+        "destination": "/terms",
+        "type": 301
+      },
+      {
         "source": "/tos.html",
         "destination": "/terms",
         "type": 301


### PR DESCRIPTION
This link was included in the old sitemap. We’re currently only redirecting /tos.html (with L)