### PR TITLE
Sound Dart Guide -> Sound Dart

### DIFF
--- a/src/_guides/language/index.md
+++ b/src/_guides/language/index.md
@@ -23,7 +23,7 @@ These two resources are popular with both beginning Dartisans and experts.
 
 ## Other resources
 
-[Sound Dart Guide](/guides/language/sound-dart)
+[Sound Dart](/guides/language/sound-dart)
 : How and why to write sound Dart code, and how to use strong mode to
   enable soundness.
 

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: "Sound Dart Guide"
+title: "Sound Dart"
 description: "."
 ---
 


### PR DESCRIPTION
We don't usually say "Guide" in titles. There's no reason to do so here, is there?