### PR TITLE
Improve print styles

### DIFF
--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -346,7 +346,13 @@ body.homepage .get-started-section {
 
 /* Don't display navigation aids when printing */
 @media print {
-	#page-header, #sidenav, #subnav, #page-footer, .banner {
+	#page-header, #sidenav, #subnav, #page-footer, .banner, #toc {
 		display:none !important;
 	}
+  #page-content {
+    > article {
+      width: auto;
+      margin: 0;
+    }
+  }
 }


### PR DESCRIPTION
Pages with TOCs now print at a reasonable size and in their entirety.

This PR improves print size/legibility on all the pages I tested. Many long pages that were previously cut off now print in their entirety. The only page that's much worse than before is /samples, which no longer prints in its entirety. A couple of pages (/guides/get-started, /guides/language/effective-dart) print unnecessary blank pages at the end now.

Contributes to #149.