### PR TITLE
Define soundness more correctly

### DIFF
--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -83,11 +83,15 @@ DartPad url: https://dartpad.dartlang.org/3c7c95683f0c06be8326a2fd3975cd19
 
 ## What is soundness?
 
-Soundness is about the relationship between the code that you write and
-the values that show up in the code at runtime. In a sound language,
-if the static type of an expression is `int`, once you evaluate the
-experssion to a value, you are guaranteed to get an `int` and nothing
-else.
+Soundness is the ability for a compiler to catch every error that may
+happen at runtime. In a sound language, the possible types of all
+values are known statically and guaranteed to be the same types at
+runtime.
+
+In Dart, if the static type of an expression is `int`, once you evaluate
+the expression to a value, you are guaranteed to either get an `int` or
+`null`. Dart will ensure that your code works with both an `int` or
+`null`.
 
 Dart was created as an optionally typed language and is not sound.
 For example, it is valid to create a list in Dart that contains

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -87,7 +87,7 @@ Soundness is about the relationship between the code that you write and
 the values that show up in the code at runtime. In a sound language,
 if the static type of an expression is `int`, once you evaluate the
 experssion to a value, you are guaranteed to get an `int` and nothing
-else (except possibly null).
+else.
 
 Dart was created as an optionally typed language and is not sound.
 For example, it is valid to create a list in Dart that contains

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -83,15 +83,19 @@ DartPad url: https://dartpad.dartlang.org/3c7c95683f0c06be8326a2fd3975cd19
 
 ## What is soundness?
 
-Soundness is the ability for a compiler to catch every error that may
-happen at runtime. In a sound language, the possible types of all
-values are known statically and guaranteed to be the same types at
-runtime.
+*Soundness* is about ensuring your program can't get into certain
+invalid states. A sound *type system* means you can never get into
+a state where an expression evaluates to a value that doesn't match
+the expression's static type. For example, if an expression's static
+type is `String`, at runtime you are guaranteed to only get a string
+when you evaluate it.
 
-In Dart, if the static type of an expression is `int`, once you evaluate
-the expression to a value, you are guaranteed to either get an `int` or
-`null`. Dart will ensure that your code works with both an `int` or
-`null`.
+Strong mode, like the type systems in Java and C# is sound. It
+enforces that soundness using a combination of static checking
+(compile errors) and runtime checks. For example, assigning a `String`
+to `int` is a compile error. Casting an `Object` to a string using
+`as String` will fail with a runtime error if the object isn't a
+string.
 
 Dart was created as an optionally typed language and is not sound.
 For example, it is valid to create a list in Dart that contains


### PR DESCRIPTION
Hi!

So quick nit-picky suggestion. I don't want to come off as pedantic or anything like that. I just want to make this suggestion to make sure that people are learning the correct definition of soundness.

Implicit nullability is not really a "sound" behavior of a language. Unless of course the language accounts for that nullability everywhere. I don't know where Dart falls on this, but I do think this small blurb leaves people with the wrong impression.

I think it might also be useful to give a more complete definition of soundness, maybe even contrasting it with completeness.

I'm working on a new documentation for [Flow](https://flowtype.org/) right now and here's what I wrote about this topic:

> In type systems, ***soundness*** is the ability for a type checker to catch every single error that *might* happen at runtime. This comes at the cost of sometimes catching errors that will not actually happen at runtime.
> 
> On the flip-side, ***completeness*** is the ability for a type checker to only ever catch errors that *would* happen at runtime. This comes at the cost of sometimes missing errors that will happen at runtime.
> 
> In an ideal world, every type checker would be both sound *and* complete so that it catches *every* error that *will *happen at runtime.

If this is useful to you, feel free to use any or all of that.

Thanks 😸 