### PR TITLE
Obsolete the optional type system article

### DIFF
--- a/src/_articles/design-decisions/why-dart-types.md
+++ b/src/_articles/design-decisions/why-dart-types.md
@@ -4,10 +4,20 @@ title: "Why Dart Types Are Optional and Unsound"
 description: "A review of why Dart has optional static type annotations."
 written: 2011-12-01
 category: design-decisions
+obsolete: true
 ---
 
 _Written by Eli Brandt<br>
 December 2011_
+
+<aside class="alert alert-warning" markdown="1">
+**Note:**
+This article describes classic Dart and
+doesn't reflect new work on a sound type system for Dart.
+For more recent information,
+see [Sound Dart](/guides/language/sound-dart)
+and [Sound Dart: FAQ](/guides/language/sound-faq).
+</aside>
 
 Dart uses types in a way that might seem strange.  Most popular languages
 that offer a type system use it very differently.  If you're familiar with

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -661,20 +661,24 @@ numerous errors when analyzed under strong mode.
 The following resources have further information on sound Dart and
 strong mode:
 
-* [Sound Dart FAQ](/guides/language/sound-faq) - Questions and answers about
-* [Sound Dart: Fixing Common Problems](/guides/language/sound-problems) - Errors you may encounter when writing sound Dart code, and how to fix them.
+* [Sound Dart: FAQ](/guides/language/sound-faq) - Questions and answers about
   writing sound Dart code.
+* [Sound Dart: Fixing Common Problems](/guides/language/sound-problems) - Errors you may encounter when writing sound Dart code, and how to fix them.
 * [Sound Dart](https://www.youtube.com/watch?v=DKG5CMyol9U) - Leaf
-  Peterson's talk from 2016 Dart Summit
-* [Customize Static Analysis](/guides/language/analysis-options) - how
+  Peterson's talk from 2016 Dart Summit.
+* [Customize Static Analysis](/guides/language/analysis-options) - How
   to set up and customize the analyzer and linter using an analysis
-  options file
+  options file.
 
-The next four documents are part of the Dart Dev Compiler (DDC) documentation,
+The next few documents are part of the Dart Dev Compiler (DDC) documentation,
 but most of the information applies to anyone using strong mode Dart:
 
-* [Strong Mode](https://github.com/dart-lang/dev_compiler/blob/master/STRONG_MODE.md) - motivation for strong mode Dart
-* [Strong Mode Static Checking](https://github.com/dart-lang/dev_compiler/blob/master/doc/STATIC_SAFETY.md) - type inference in strong mode Dart
-* [Strong Mode in the Dart Dev Compiler](https://chromium.googlesource.com/external/github.com/dart-lang/dev_compiler/+/refs/heads/master/doc/RUNTIME_SAFETY.md) - runtime checks in DDC
-* [Prototype Syntax for Generic Methods](https://github.com/dart-lang/dev_compiler/blob/master/doc/GENERIC_METHODS.md) - generic methods were recently introduced to Dart and make it easier to write sound code
+* [Strong Mode](https://github.com/dart-lang/dev_compiler/blob/master/STRONG_MODE.md) -
+  Motivation for strong mode Dart.
+* [Strong Mode Static Checking](https://github.com/dart-lang/dev_compiler/blob/master/doc/STATIC_SAFETY.md) -
+  Type inference in strong mode Dart.
+* [Strong Mode in the Dart Dev Compiler](https://chromium.googlesource.com/external/github.com/dart-lang/dev_compiler/+/refs/heads/master/doc/RUNTIME_SAFETY.md) -
+  Runtime checks in DDC.
+* [Prototype Syntax for Generic Methods](https://github.com/dart-lang/dev_compiler/blob/master/doc/GENERIC_METHODS.md) -
+  Proposed syntax for generic methods, which make it easier to write sound code.
 


### PR DESCRIPTION
…and fix up a few things I happened to notice in the Sound Dart page.

Staged here:
https://kw-www-dartlang-1.firebaseapp.com/articles/design-decisions/why-dart-types
https://kw-www-dartlang-1.firebaseapp.com/guides/language/sound-dart#other-resources

cc @leafpetersen @kevmoo @matanlurey 