### PR TITLE
revise "obsolete" wording

### DIFF
--- a/src/_articles/design-decisions/why-dart-types.md
+++ b/src/_articles/design-decisions/why-dart-types.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: "Why Dart Types Are Optional and Unsound"
-description: "A review of why Dart has optional static type annotations."
+description: "(Obsolete) A review of why Dart has optional static type annotations."
 written: 2011-12-01
 category: design-decisions
 obsolete: true
@@ -11,12 +11,10 @@ _Written by Eli Brandt<br>
 December 2011_
 
 <aside class="alert alert-warning" markdown="1">
-**Note:**
-This article describes classic Dart and
-doesn't reflect new work on a sound type system for Dart.
-For more recent information,
-see [Sound Dart](/guides/language/sound-dart)
-and [Sound Dart: FAQ](/guides/language/sound-faq).
+**This page is obsolete**
+because it doesn't reflect work on a
+[sound type system for Dart](/guides/language/sound-dart)
+([FAQ](/guides/language/sound-faq)).
 </aside>
 
 Dart uses types in a way that might seem strange.  Most popular languages


### PR DESCRIPTION
* Added “(Obsolete)” to the description to make it show up in the
article index and summary text.
* We could use “**This page is obsolete** because” in all obsolete
pages.

Should we also mark [Optional Types in Dart](https://www.dartlang.org/articles/language/optional-types) as obsolete?

Staged:
https://kw-www-dartlang-1.firebaseapp.com/articles/design-decisions/why-dart-types
https://kw-www-dartlang-1.firebaseapp.com/articles/design-decisions
https://kw-www-dartlang-1.firebaseapp.com/articles#design-decisions