### PR TITLE
Fix the good example of default optional parameters

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -939,9 +939,15 @@ pass later one. You're better off using named arguments for that.
 
 <div class="good">
 {% prettify dart %}
-new String.fromCharCodes(Iterable source, [int start = 0, int end])
-new DateTime(year, month, day, [hours, minutes, seconds, milliseconds])
-new Duration({days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0})
+String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end])
+DateTime(int year,
+         [int month = 1,
+          int day = 1,
+          int hour = 0,
+          int minute = 0,
+          int second = 0,
+          int millisecond = 0,
+          int microsecond = 0])
 {% endprettify %}
 </div>
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -940,14 +940,23 @@ pass later one. You're better off using named arguments for that.
 <div class="good">
 {% prettify dart %}
 String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end])
+
 DateTime(int year,
-         [int month = 1,
-          int day = 1,
-          int hour = 0,
-          int minute = 0,
-          int second = 0,
-          int millisecond = 0,
-          int microsecond = 0])
+    [int month = 1,
+    int day = 1,
+    int hour = 0,
+    int minute = 0,
+    int second = 0,
+    int millisecond = 0,
+    int microsecond = 0])
+
+Duration(
+    {int days: 0,
+    int hours: 0,
+    int minutes: 0,
+    int seconds: 0,
+    int milliseconds: 0,
+    int microseconds: 0})
 {% endprettify %}
 </div>
 


### PR DESCRIPTION
- Removed the "new" since that this was not valid Dart code and I assume the examples were supposed to illustrate declarations, not calls.
- Updated the functions to be aligned with the current API.
- Removed the Duration example, since:
  - it does not add much extra value,
  - it's confusing regarding the syntax (the suggested syntax is "=", not ":"),
  - there's already a lot of code since the DateTime went multiline.