### PR TITLE
Add "brew cleanup dart" to Mac upgrade commands

### DIFF
--- a/src/install/mac.md
+++ b/src/install/mac.md
@@ -59,6 +59,7 @@ To update Dart once you've installed it using Homebrew, run:
 {% prettify shell %}
 $ brew update
 $ brew upgrade dart
+$ brew cleanup dart
 {% endprettify %}
 
 {% comment %}


### PR DESCRIPTION
Mac Spotlight will continue to see old versions of Dartium, so brew cleanup is useful to remove these