### PR TITLE
Changing "Dart VM" to "Command line" in several key places.

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -52,7 +52,7 @@
       children:
       - title: "API Reference"
         permalink: http://docs.flutter.io/flutter/
-    - title: "Dart VM"
+    - title: "Command line"
       permalink: /dart-vm
       children:
       - title: "Install Dart"

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -18,9 +18,9 @@
         <div class="content">
           <h4>Technologies</h4>
           <ul>
-            <li><a href="{{site.webdev}}">Dart webdev</a></li>
+            <li><a href="{{site.webdev}}">Web</a></li>
             <li><a href="{{site.webdev}}/angular">AngularDart</a></li>
-            <li><a href="{{site.dart_vm}}">Dart VM</a></li>
+            <li><a href="{{site.dart_vm}}">Command line</a></li>
             <li><a href="https://dart-lang.github.io/observatory/">Observatory</a></li>
             <li><a href="{{site.flutter}}">Flutter</a></li>
           </ul>

--- a/src/dart-vm/index.md
+++ b/src/dart-vm/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Dart VM"
+title: "Command line"
 description: "The landing page for all things relating to the Dart virtual machine (Dart VM)"
 toc: false
 permalink: /dart-vm

--- a/src/index.html
+++ b/src/index.html
@@ -109,7 +109,7 @@ Stream<span class="frontpage-highlight" data-text="Generics are optional but ext
               <p>Find packages.</p>
             </a>
             <a href="{{site.webdev}}" class="chip no-automatic-external">
-              <h3>Dart webdev</h3>
+              <h3>Web</h3>
               <p>Build browser apps.</p>
             </a>
             <a href="https://flutter.io/" class="chip no-automatic-external">
@@ -117,7 +117,7 @@ Stream<span class="frontpage-highlight" data-text="Generics are optional but ext
               <p>Build mobile apps.</p>
             </a>
             <a href="/dart-vm" class="chip no-automatic-external">
-              <h3>Dart VM</h3>
+              <h3>Command line</h3>
               <p>Build scripts, servers.</p>
             </a>
           </div>


### PR DESCRIPTION
Fixes issue: https://github.com/dart-lang/site-www/issues/245

Should we go further than changing "Dart VM" on just the grey box on the front page? In this PR, I've changed "Dart VM" in the footer, side nav, and on the Dart VM home page, as well as the grey box. I changed "Web" in the footer, as well as the grey box.

Take a look and we'll discuss.

Staged: 
https://sz-www-1.firebaseapp.com/  (grey boxes)
https://sz-www-1.firebaseapp.com/dart-vm  (footer, side-nav, and title)

Btw: "command line" isn't generally hyphenated unless used as an adjective, for example, "the command-line interface", but "type the following at the command line."  

English...such a silly language.

@anders-sandholm  @kwalrath  @filiph 