### PR TITLE
Fix code example for "Using generic methods"

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3373,7 +3373,8 @@ A newer syntax, called _generic methods_, allows type arguments on methods and f
 {% prettify dart %}
 [[highlight]]T[[/highlight]] first[[highlight]]<T>[[/highlight]](List<[[highlight]]T[[/highlight]]> ts) {
   // ...Do some initial work or error checking, then...
-  [[highlight]]T[[/highlight]] tmp ?= ts[0];
+  [[highlight]]T[[/highlight]] tmp;
+  tmp ??= ts[0];
   // ...Do some additional checking or processing...
   return tmp;
 }

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3373,8 +3373,7 @@ A newer syntax, called _generic methods_, allows type arguments on methods and f
 {% prettify dart %}
 [[highlight]]T[[/highlight]] first[[highlight]]<T>[[/highlight]](List<[[highlight]]T[[/highlight]]> ts) {
   // ...Do some initial work or error checking, then...
-  [[highlight]]T[[/highlight]] tmp;
-  tmp ??= ts[0];
+  [[highlight]]T[[/highlight]] tmp = ts[0];
   // ...Do some additional checking or processing...
   return tmp;
 }


### PR DESCRIPTION
This fixes the following:
1. The proper syntax for the assign-if-null operator is `??=` instead of `?=`.
2. `??=` cannot be used in combination with declaring a variable (i.e. within the same statement). The reason for this might be because the variable is always `null` at the point of declaration anyway.