### PR TITLE
Adding a testing page to dartlang.

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -35,6 +35,11 @@
   - title: "Dart Tools"
     permalink: /tools
 
+- title: "Testing"
+  children:
+  - title: "Dart Testing"
+    permalink: /guides/testing
+
 - title: "Community"
   children:
   - title: "Community and Support"

--- a/src/_guides/libraries/testing.md
+++ b/src/_guides/libraries/testing.md
@@ -1,0 +1,130 @@
+---
+layout: default
+title: "Dart Testing"
+description: "How to test Dart, Flutter, and 'Dart for the Web' applications?"
+---
+
+Software testing, an important part of app development, helps verify that
+your app is working correctly before unleashing it on your users.
+This Dart testing guide outlines several types of testing, and points
+you to where you can learn more about testing on the Flutter, Dart VM,
+and 'Dart for the Web' platforms.
+
+## Testing types
+
+The Dart testing docs focus on three types of testing, out of the
+[many testing types](http://www.aptest.com/testtypes.html) that
+you may be familiar with: unit, widget (or component, depending on the
+platform), and integration (or end-to-end). Testing terminology varies,
+but these are the terms and concepts that you are likely to
+encounter when using Dart technologies:
+
+* _Unit_ tests focus on verifying the smallest piece of testable
+  software, such as a function, method, or class. Your testing suite
+  should have more unit tests that widget or integration tests.
+
+* _Widget_ (or _component_) tests verify that a widget (which
+  usually consists of multiple classes) behaves as expected.
+  A widget test requires a mock framework that can mimic user actions,
+  events, perform layout, and instantiate child widgets.
+  Note that Flutter refers to widgets, and AngularDart refers to
+  components.
+
+* _Integration_ or (_end-to-end_) tests verify the behavior of
+  an entire app, or a large chunk of an app. An integration test
+  generally runs on a real device or an OS simulator, and consists
+  of two pieces: the app itself, and the test app that puts it through
+  its paces. An integration test often measures performance, so the
+  test app generally runs on a different device or OS.
+
+## Generally useful libraries
+
+How you write your tests partly depends on whether you are using Flutter,
+Dart VM, AngularDart, or other web solutions, but the following packages
+are useful across Dart platforms:
+
+* [package:test](https://pub.dartlang.org/packages/test)<br>
+  Provides a standard way of writing tests in Dart. You can use the test
+  package to:
+    * Write single tests, or groups of tests.
+    * Use the `@TestOn` annotation to restrict tests to run on
+      specific environments.
+    * Write asynchronous tests just as you would for non-asynchronous
+      tests.
+    * Tag tests using the `@Tag` annotation. For example, define a tag to
+      create a custom configuration for some tests, or to identify some tests
+      as needing more time to complete.
+    * Create a `dart_test.yaml` file to configure tagged tests across
+      multiple files or an entire package.
+
+
+* [package:mockito](https://pub.dartlang.org/packages/mockito)<br>
+  Provides a way to mock interfaces so that a piece of code is replaced
+  by a dummy implementation that emulates real code, but behaves in
+  a predictable way. This package is particularly useful for unit
+  testing. For an example that uses both package:test and package:mockito,
+  see the [International Space Station API library and its unit
+  tests](https://github.com/dart-lang/mockito/tree/master/test/example/iss)
+  in the [mockito package](https://github.com/dart-lang/mockito).
+
+## Flutter testing
+
+Use the following resources to learn more about testing Flutter apps:
+
+* [Testing Flutter Apps](https://flutter.io/testing/)<br>
+  How to perform unit, widget, or integration tests on a Flutter app.
+* [flutter_test](https://docs.flutter.io/flutter/flutter_test/flutter_test-library.html)<br>
+  A testing library for Flutter built on top of package:test.
+* [flutter_driver](https://docs.flutter.io/flutter/flutter_driver/flutter_driver-library.html)<br>
+  A testing library for testing Flutter applications on real devices and
+  emulators (in a separate process).
+* [flutter/examples/flutter_gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery)<br>
+  Tests for the Flutter gallery example.
+* [flutter/dev/manual_tests](https://github.com/flutter/flutter/tree/master/dev/manual_tests)<br>
+  Many examples of tests in the Flutter SDK.
+
+## Web testing
+
+Use the following resources to learn more about testing Dart web
+applications:
+
+* [Testing](https://webdev.dartlang.org/angular/guide/testing)<br>
+  How to use the [angular_test](https://pub.dartlang.org/packages/angular_test)
+  package to test AngularDart components and Angular subsystems.
+* [package:webdriver](https://pub.dartlang.org/packages/webdriver)<br>
+  Provides bindings that use the WebDriver JSON interface and require
+  the WebDriver remote server. [PENDING: a better way to describe this?]
+
+## Other tools and resources
+
+You may also find the following resources useful for developing and
+debugging Dart applications.
+
+### Observatory
+
+Observatory is a browser-based tool for profiling and debugging your
+Dart applications. You can learn more using the following resources:
+
+* [Observatory: A Profiler for Dart Apps](https://dart-lang.github.io/observatory/)
+* [Dart Observatory](https://flutter.io/debugging/#dart-observatory-statement-level-single-stepping-debugger-and-profiler),
+  a section in [Debugging Flutter Apps](https://flutter.io/debugging/)
+* [Dart VM Observatory](https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss)
+  discussion group
+
+### Travis
+
+If [GitHub](https://github.com/) is part of your app development workflow,
+you might consider adding continuous integration using Travis
+Continuous Integration (CI). Once configured for your repo, Travis
+detects every commit, builds the project, and runs your tests.
+
+Learn more about Travis at the following links:
+
+* [Travis CL website](https://travis-ci.org/)
+* [Building a Dart Project](https://docs.travis-ci.com/user/languages/dart)
+  covers how to configure Travis for Dart projects
+* The [shelf](https://github.com/dart-lang/shelf/blob/master/.travis.yml)
+  example uses the `dart_task` tag (in `.travis.yml`) to configure
+  the build.
+
+

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -105,8 +105,8 @@ applications:
   package to test AngularDart components and Angular subsystems.
   <!-- More pages are coming! -->
 * [package:webdriver](https://pub.dartlang.org/packages/webdriver)<br>
-  Provides bindings that use the WebDriver JSON interface and require
-  the WebDriver remote server. [PENDING: a better way to describe this?]
+  A Dart package for interfacing with
+  [WebDriver](https://www.w3.org/TR/webdriver/) servers.
 
 ## Other tools and resources
 

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Testing"
+title: "Dart Testing"
 description: "How to test Flutter, Web, and VM Applications."
 ---
 

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -5,7 +5,7 @@ description: "How to test Flutter, Web, and VM Applications."
 ---
 
 Software testing, an important part of app development, helps verify that
-your app is working correctly before releasing it to your users.
+your app is working correctly before you release it.
 This Dart testing guide outlines several types of testing, and points
 you to where you can learn how to test your
 [mobile](https://flutter.io/), [web](https://webdev.dartlang.org/),
@@ -45,13 +45,14 @@ encounter when using Dart technologies:
   or on a browser (for the web), and consists of two pieces:
   the app itself, and the test app that puts
   it through its paces. An integration test often measures performance,
-  so the test app generally runs on a different device or OS.
+  so the test app generally runs on a different device or OS
+  than the app being tested..
 
 ## Generally useful libraries
 
-How you write your tests partly depends on whether you are using Flutter,
-Dart VM, AngularDart, or other web solutions, but the following packages
-are useful across Dart platforms:
+Although your tests partly depend on the platform your code is intended
+for&mdash;Flutter, the Dart VM, or Angular Dart, for example&mdash;the
+following packages are useful across Dart platforms:
 
 * [package:test](https://pub.dartlang.org/packages/test)<br>
   Provides a standard way of writing tests in Dart. You can use the test
@@ -59,7 +60,7 @@ are useful across Dart platforms:
     * Write single tests, or groups of tests.
     * Use the `@TestOn` annotation to restrict tests to run on
       specific environments.
-    * Write asynchronous tests just as you would for non-asynchronous
+    * Write asynchronous tests just as you would write synchronous
       tests.
     * Tag tests using the `@Tag` annotation. For example, define a tag to
       create a custom configuration for some tests, or to identify some tests
@@ -100,9 +101,10 @@ Use the following resources to learn more about testing Flutter apps:
 Use the following resources to learn more about testing Dart web
 applications:
 
-* [Testing](https://webdev.dartlang.org/angular/guide/testing)<br>
+* [Testing](https://webdev.dartlang.org/angular/guide/testing)(a page
+  in the AngularDart guide)<br>
   How to use the [angular_test](https://pub.dartlang.org/packages/angular_test)
-  package to test AngularDart components and Angular subsystems.
+  package to test AngularDart components and subsystems.
   <!-- More pages are coming! -->
 * [package:webdriver](https://pub.dartlang.org/packages/webdriver)<br>
   A Dart package for interfacing with
@@ -140,11 +142,9 @@ Dart applications. You can learn more using the following resources:
 
 ### Continuous integration
 
-If your development workflow uses [GitHub](https://github.com/),
-you might consider adding a continuous integration (CI) service.
-Once configured, a CI service builds your project
-and runs its tests after every commit. Two such services are
-[Travis CI](https://travis-ci.org/) (for OS X and Unix), and
+Consider using continuous integration (CI) to build your project
+and run its tests after every commit. Two CI services for GitHub are
+[Travis CI](https://travis-ci.org/) (for OS X and Unix) and
 [AppVeyor](https://www.appveyor.com/) (for Windows).
 
 Travis has built-in support for Dart projects.

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -1,41 +1,51 @@
 ---
 layout: default
-title: "Dart Testing"
-description: "How to test Dart, Flutter, and 'Dart for the Web' applications?"
+title: "Testing"
+description: "How to test Flutter, Web, and VM Applications."
 ---
 
 Software testing, an important part of app development, helps verify that
-your app is working correctly before unleashing it on your users.
+your app is working correctly before releasing it to your users.
 This Dart testing guide outlines several types of testing, and points
-you to where you can learn more about testing on the Flutter, Dart VM,
-and 'Dart for the Web' platforms.
+you to where you can learn how to test your
+[mobile](https://flutter.io/), [web](https://webdev.dartlang.org/),
+and [server-side apps and scripts](/dart-vm).
+
+<aside class="alert alert-info" markdown="1">
+**Terminology: widget vs. component**<br>
+Flutter, an SDK for building apps for iOS and Android, defines its
+GUI elements as _widgets_. AngularDart, a web app framework,
+defines its GUI elements as _components_.
+This doc uses **component** (except when explicitly discussing Flutter),
+but both terms refer to the same concept.
+</aside>
 
 ## Testing types
 
-The Dart testing docs focus on three types of testing, out of the
-[many testing types](http://www.aptest.com/testtypes.html) that
-you may be familiar with: unit, widget (or component, depending on the
-platform), and integration (or end-to-end). Testing terminology varies,
+The Dart testing docs focus on three kinds of testing, out of the
+[many kinds of testing](https://en.wikipedia.org/wiki/Software_testing)
+that you may be familiar with: unit, component, and end-to-end
+(a form of integration testing). Testing terminology varies,
 but these are the terms and concepts that you are likely to
 encounter when using Dart technologies:
 
 * _Unit_ tests focus on verifying the smallest piece of testable
-  software, such as a function, method, or class. Your testing suite
-  should have more unit tests that widget or integration tests.
+  software, such as a function, method, or class. Your test suites
+  should have more unit tests than other kinds of tests.
 
-* _Widget_ (or _component_) tests verify that a widget (which
+* _Component_ tests verify that a component (which
   usually consists of multiple classes) behaves as expected.
-  A widget test requires a mock framework that can mimic user actions,
-  events, perform layout, and instantiate child widgets.
-  Note that Flutter refers to widgets, and AngularDart refers to
-  components.
+  A component test often requires the use of mock objects
+  that can mimic user actions, events, perform layout,
+  and instantiate child components.
 
-* _Integration_ or (_end-to-end_) tests verify the behavior of
+* _Integration_ and _end-to-end_ tests verify the behavior of
   an entire app, or a large chunk of an app. An integration test
-  generally runs on a real device or an OS simulator, and consists
-  of two pieces: the app itself, and the test app that puts it through
-  its paces. An integration test often measures performance, so the
-  test app generally runs on a different device or OS.
+  generally runs on a real device or OS simulator (for mobile),
+  or on a browser (for the web), and consists of two pieces:
+  the app itself, and the test app that puts
+  it through its paces. An integration test often measures performance,
+  so the test app generally runs on a different device or OS.
 
 ## Generally useful libraries
 
@@ -59,10 +69,12 @@ are useful across Dart platforms:
 
 
 * [package:mockito](https://pub.dartlang.org/packages/mockito)<br>
-  Provides a way to mock interfaces so that a piece of code is replaced
-  by a dummy implementation that emulates real code, but behaves in
-  a predictable way. This package is particularly useful for unit
-  testing. For an example that uses both package:test and package:mockito,
+  Provides a way to create
+  [mock objects,](https://en.wikipedia.org/wiki/Mock_object)
+  easily configured for use in fixed scenarios, and to verify
+  that the system under test interacts with the mock object in
+  expected ways.
+  For an example that uses both package:test and package:mockito,
   see the [International Space Station API library and its unit
   tests](https://github.com/dart-lang/mockito/tree/master/test/example/iss)
   in the [mockito package](https://github.com/dart-lang/mockito).
@@ -91,6 +103,7 @@ applications:
 * [Testing](https://webdev.dartlang.org/angular/guide/testing)<br>
   How to use the [angular_test](https://pub.dartlang.org/packages/angular_test)
   package to test AngularDart components and Angular subsystems.
+  <!-- More pages are coming! -->
 * [package:webdriver](https://pub.dartlang.org/packages/webdriver)<br>
   Provides bindings that use the WebDriver JSON interface and require
   the WebDriver remote server. [PENDING: a better way to describe this?]
@@ -100,31 +113,45 @@ applications:
 You may also find the following resources useful for developing and
 debugging Dart applications.
 
+### IDE
+
+When it comes to debugging, your first line of defense is your IDE.
+Dart plugins exist for many commonly used IDEs.
+
+If you don't have a preferred IDE, try
+[WebStorm](https://webdev.dartlang.org/tools/webstorm) for web apps, or
+[IntelliJ](https://www.dartlang.org/tools/jetbrains-plugin) for Flutter.
+The JetBrains products have a full-featured Dart debugger, and WebStorm and
+IntelliJ Ultimate include additional built-in support for running test suites.
+
 ### Observatory
 
 Observatory is a browser-based tool for profiling and debugging your
 Dart applications. You can learn more using the following resources:
 
-* [Observatory: A Profiler for Dart Apps](https://dart-lang.github.io/observatory/)
-* [Dart Observatory](https://flutter.io/debugging/#dart-observatory-statement-level-single-stepping-debugger-and-profiler),
+* [Observatory: A Profiler for Dart
+  Apps](https://dart-lang.github.io/observatory/)
+* [Dart
+  Observatory](https://flutter.io/debugging/#dart-observatory-statement-level-single-stepping-debugger-and-profiler),
   a section in [Debugging Flutter Apps](https://flutter.io/debugging/)
-* [Dart VM Observatory](https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss)
+* [Dart VM
+  Observatory](https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss)
   discussion group
 
-### Travis
+### Continuous integration
 
-If [GitHub](https://github.com/) is part of your app development workflow,
-you might consider adding continuous integration using Travis
-Continuous Integration (CI). Once configured for your repo, Travis
-detects every commit, builds the project, and runs your tests.
+If your development workflow uses [GitHub](https://github.com/),
+you might consider adding a continuous integration (CI) service.
+Once configured, a CI service builds your project
+and runs its tests after every commit. Two such services are
+[Travis CI](https://travis-ci.org/) (for OS X and Unix), and
+[AppVeyor](https://www.appveyor.com/) (for Windows).
 
-Learn more about Travis at the following links:
+Travis has built-in support for Dart projects.
+Learn more at the following links:
 
-* [Travis CL website](https://travis-ci.org/)
 * [Building a Dart Project](https://docs.travis-ci.com/user/languages/dart)
   covers how to configure Travis for Dart projects
 * The [shelf](https://github.com/dart-lang/shelf/blob/master/.travis.yml)
   example uses the `dart_task` tag (in `.travis.yml`) to configure
   the build.
-
-

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -20,7 +20,7 @@ This doc uses **component** (except when explicitly discussing Flutter),
 but both terms refer to the same concept.
 </aside>
 
-## Testing types
+## Kinds of testing
 
 The Dart testing docs focus on three kinds of testing, out of the
 [many kinds of testing](https://en.wikipedia.org/wiki/Software_testing)


### PR DESCRIPTION
I haven't yet hooked this page up to the index. I've placed it under guides/libraries, because testing (at least in the Dartiverse) is largely about using libraries, but I could be talked into placing it under guides/testing.

This page is mostly about pointing people to relevant resources and providing a landing page on www.dartlang that discusses testing.

Staged: https://sz-www-1.firebaseapp.com/guides/testing

Please review, @kwalrath  @chalin @yjbanov 