### PR TITLE
Changing "code lab" to "codelab", as per the dev docs word list.

### DIFF
--- a/src/_codelabs/index.md
+++ b/src/_codelabs/index.md
@@ -6,7 +6,7 @@ permalink: /codelabs
 toc: false
 ---
 
-You may find the following code labs useful:
+You may find the following codelabs useful:
 
 * [Avast, Ye Pirates: Build an Angular App]({{site.webdev}}/codelabs/ng2)
   <p>Learn how to use the Angular framework with Dart while you build a pirate

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -1072,7 +1072,7 @@ for further details about the classes and libraries discussed in this tutorial.
 
 ## What next? {#what-next}
 
-* If you haven't yet tried the server-side code lab,
+* If you haven't yet tried the server-side codelab,
   try [writing a server app](https://dart-lang.github.io/server/codelab/).
 
 * [Servers with Dart](https://dart-lang.github.io/server/)


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/264

My sz-www-1 and sz-www-2 firebase instances are both in use, so I'm not bothering to stage this. (Also, it's quite minor.)

Please review, @kwalrath 