### PR TITLE
chore(firebase serve): use `FIREBASE_TOKEN` and `--project` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ cache:
   bundler: true
   directories:
   # - $HOME/[path]
-rvm:
-- 2.2.3
+rvm: [2.3.0]
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
 # before_install:
 
@@ -16,19 +19,19 @@ install:
 script:
   - ./deploy/cibuild
 
+after_script:
+  # Just FYI test. Won't fail the build if it has errors.
+  - ./deploy/check_sitemap.rb
+  - ./deploy/html_proof.rb
+  # # Checks for bad HTML, broken links, and forces build to fail if it fails.
+  # # (By default, Travis doesn't fail builds after deployment.)
+  # - "./deploy/html_proof.rb || travis_terminate 1"
+
 # branch whitelist
 # branches:
 #   only:
 #   - master        # test the master branch
 #   - /stage-(.*)/  # test every branch which starts with "stage-"
-
-env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-
-
-# after_success:
-# We could add the deployment to firebase here if there are no additional customizations etc...
 
 deploy:
   - provider: script
@@ -36,11 +39,3 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-
-after_deploy:
-  # Just FYI test. Won't fail the build if it has errors.
-  - ./deploy/check_sitemap.rb
-  - ./deploy/html_proof.rb
-  # # Checks for bad HTML, broken links, and forces build to fail if it fails.
-  # # (By default, Travis doesn't fail builds after deployment.)
-  # - "./deploy/html_proof.rb || travis_terminate 1"

--- a/deploy/check_sitemap.rb
+++ b/deploy/check_sitemap.rb
@@ -2,10 +2,15 @@
 
 require_relative 'urls/get_all'
 
+if !$FIREBASE_TOKEN
+  puts "#{$PROGRAM_NAME}: FIREBASE_TOKEN environment variable isn't defined. Skipping checks."
+  exit(0)
+end
+
 puts "===== Checking inbound links and redirects through HTMLProofer ====="
 
 puts "Spawning firebase server on localhost"
-pid = spawn("firebase serve --port #{$PORT}", :out => "/dev/null")
+pid = spawn("firebase serve --port #{$PORT} --token '#{$FIREBASE_TOKEN}' --project #{$FIREBASE_PROJECT}", :out => "/dev/null")
 puts "..."
 sleep 5
 

--- a/deploy/deploy-firebase.sh
+++ b/deploy/deploy-firebase.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-echo "================ Deploy to Firebase ========================"
-firebase deploy --token "${FIREBASE_TOKEN}" --non-interactive --project default
+: ${FIREBASE_PROJECT:=default}
 
+echo "================ Deploy to Firebase ($FIREBASE_PROJECT) ========================"
+firebase deploy --token "$FIREBASE_TOKEN" --project $FIREBASE_PROJECT

--- a/deploy/html_proof.rb
+++ b/deploy/html_proof.rb
@@ -6,13 +6,18 @@ require 'tempfile'
 
 require_relative 'urls/get_all'
 
+if !$FIREBASE_TOKEN
+  puts "#{$PROGRAM_NAME}: FIREBASE_TOKEN environment variable isn't defined. Skipping checks."
+  exit(0)
+end
+
 puts "===== Checking HTML and outbound links through HTMLProofer ====="
 
 # TODO(filiph) remove when not needed
 $LOCALHOST_NEW_URLS.delete("#{$LOCALHOST}events/2016/summit/index.html")
 
 puts "Spawning firebase server on localhost"
-pid = spawn("firebase serve --port #{$PORT}", :out => "/dev/null")
+pid = spawn("firebase serve --port #{$PORT} --token '#{$FIREBASE_TOKEN}' --project #{$FIREBASE_PROJECT}", :out => "/dev/null")
 puts "..."
 sleep 5
 

--- a/deploy/urls/get_all.rb
+++ b/deploy/urls/get_all.rb
@@ -5,6 +5,8 @@ require_relative 'old_site_urls'
 $PORT = 5000
 $DOMAIN = 'https://www.dartlang.org/'
 $LOCALHOST = "http://localhost:#{$PORT}/"
+$FIREBASE_TOKEN = ENV['FIREBASE_TOKEN']
+$FIREBASE_PROJECT = ENV['FIREBASE_PROJECT'] || 'default'
 
 puts "Parsing current sitemap.xml for all current URLs"
 sitemap = File.open("publish/sitemap.xml") { |f| Nokogiri::XML(f) }


### PR DESCRIPTION
As firebase/firebase-tools#302 explains, starting with firebase-tools 3.6, firebase serve will require authentication credentials.

To be able to serve locally, one needs a token, _and_ a project must be specified, without these the local serve fails, as is shown in [this Travis log](https://travis-ci.org/chalin/site-www/builds/235775690):
> Error: No project active, but project aliases are available.

The corresponding `site-webdev` change was done via https://github.com/dart-lang/site-webdev/pull/654.