### PR TITLE
Document "// ignore_for_file" in analysis_options.md

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -257,6 +257,21 @@ analyzer:
 This analysis options file instructs the analysis tools to ignore
 the TODO rule.
 
+Alternatively, to ignore a specific rule for a specific file, you can
+use a comment:
+
+{% prettify dart %}
+// ignore_for_file: unused_import
+{% endprettify %}
+
+This acts for the whole file, before or after the comment, and is
+particularly useful for generated code. A comma-separated list may be
+used to suppress more than one rule:
+
+{% prettify dart %}
+// ignore_for_file: unused_import, invalid_assignment
+{% endprettify %}
+
 ## Changing the severity of analysis rules
 
 Using the same mechanism, you can also globally change the severity

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -257,8 +257,8 @@ analyzer:
 This analysis options file instructs the analysis tools to ignore
 the TODO rule.
 
-Alternatively, to ignore a specific rule for a specific file, you can
-use a comment:
+Alternatively, as of Dart 1.24 you can ignore a specific rule for a 
+specific file using an `ignore_for_file` comment:
 
 {% prettify dart %}
 // ignore_for_file: unused_import


### PR DESCRIPTION
I wasn't quite sure the best way to document this -- there are now a lot of ways of suppressing rules! Suggestions welcome.

This is a new addition -- do we need to call out which SDK version it's available from?

Thanks.