### PR TITLE
Codelab URLs need a trailing /

### DIFF
--- a/src/_codelabs/index.md
+++ b/src/_codelabs/index.md
@@ -9,11 +9,11 @@ toc: false
 See the latest Dart codelabs on the Google Developers site:
 
 **General**
-* [Intro to Dart for Java Developers](https://codelabs.developers.google.com/codelabs/from-java-to-dart)
+* [Intro to Dart for Java Developers](https://codelabs.developers.google.com/codelabs/from-java-to-dart/)
 
 **Flutter**
-* [Building Beautiful UIs with Flutter](https://codelabs.developers.google.com/codelabs/flutter)
-* [Firebase for Flutter](https://codelabs.developers.google.com/codelabs/flutter-firebase)
+* [Building Beautiful UIs with Flutter](https://codelabs.developers.google.com/codelabs/flutter/)
+* [Firebase for Flutter](https://codelabs.developers.google.com/codelabs/flutter-firebase/)
 
 {% comment %}
 Seth hasn't yet added links to these codelabs on flutter.io. If and
@@ -21,8 +21,8 @@ when he does, link to that.
 {% endcomment %}
 
 **AngularDart**
-* [Write a Material Design AngularDart Web App](https://codelabs.developers.google.com/codelabs/your-first-angulardart-web-app)
-* [Build an AngularDart & Firebase Web App](https://codelabs.developers.google.com/codelabs/angulardart-firebase-web-app)
+* [Write a Material Design AngularDart Web App](https://codelabs.developers.google.com/codelabs/your-first-angulardart-web-app/)
+* [Build an AngularDart & Firebase Web App](https://codelabs.developers.google.com/codelabs/angulardart-firebase-web-app/)
 
 For a full list of Dart web codelabs, see
 [webdev.dartlang.org/codelabs](https://webdev.dartlang.org/codelabs).


### PR DESCRIPTION
See https://github.com/dart-lang/angular2/issues/414.