### PR TITLE
Disambiguate one of the cited exceptions.

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -204,7 +204,7 @@ people.forEach((person) {
 </div>
 
 The exception is if all you want to do is invoke some already existing function
-on each element. In that case, `forEach()` is handy.
+with each element as the argument. In that case, `forEach()` is handy.
 
 <div class="good">
 {% prettify dart %}


### PR DESCRIPTION
"AVOID using Iterable.forEach() with a function literal." lists the following exception: "The exception is if all you want to do is invoke some already existing function on each element. In that case, forEach() is handy."

As discussed internally, the intended meaning of this statement is that the function in question is called with each element as the argument. It is not supposed to refer to a function that is a member of each iterated item.

For example, it is recommended that the following:

foos.forEach((foo) => foo.bar());

is changed to:

for (final foo in foos) {
  foo.bar();
}

Since I believe the exception could be construed as suggesting forEach() be used here, I'm proposing a change to disambiguate the exception.