### PR TITLE
Add link to install page to side nav

### DIFF
--- a/src/_guides/get-started.md
+++ b/src/_guides/get-started.md
@@ -20,7 +20,7 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?horizontalRatio=70&verticalRatio=
 Note that DartPad supports only a few core libraries.
 If you want to use other libraries,
 such as dart:io or libraries from packages,
-you'll need to install an SDK.
+you'll need to [install](/install) an SDK.
 
 
 <div class="get-started-table__text">


### PR DESCRIPTION
While the site landing page has an "Install Dart" button, no other page
has a link to the "Install Dart" page. This minor PR make it easier to gain access to
the Install Dart page from anywhere on the site.

cc @Sfshaza 