### PR TITLE
reorg/simplify sidenav, better matching webdev

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,8 +1,3 @@
-- title:
-  children:
-  - title: Get Started
-    permalink: /guides/get-started
-
 - title: Language
   children:
     - title: "Overview"

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -15,6 +15,8 @@
           permalink: /guides/language/effective-dart/usage
         - title: Design
           permalink: /guides/language/effective-dart/design
+    - title: Sample Code
+      permalink: /samples
 
 - title: Libraries
   children:
@@ -55,8 +57,6 @@
     permalink: /tutorials
   - title: "Articles"
     permalink: /articles
-  - title: Sample Code
-    permalink: /samples
   - title: "Dart Tools"
     permalink: /tools
   - title: "Community and Support"

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,11 +1,7 @@
-- title: Quick Start
+- title:
   children:
-    - title: Get Started
-      permalink: /guides/get-started
-    - title: Sample Code
-      permalink: /samples
-    - title: Codelabs
-      permalink: /codelabs
+  - title: Get Started
+    permalink: /guides/get-started
 
 - title: Language
   children:
@@ -32,28 +28,12 @@
     - title: Tour
       permalink: /guides/libraries/library-tour
 
-- title: "Tools"
-  children:
-  - title: "Dart Tools"
-    permalink: /tools
-
-- title: "Testing"
-  children:
-  - title: "Dart Testing"
-    permalink: /guides/testing
-
-- title: "Community"
-  children:
-  - title: "Community and Support"
-    permalink: /community
-
 - title: "Platforms"
   children:
     - title: "Overview"
       permalink: /guides/platforms
     - title: "Web"
       permalink: https://webdev.dartlang.org/
-#     permalink: http://localhost:4001/
     - title: "Mobile (Flutter)"
       permalink: https://flutter.io/
       children:
@@ -66,3 +46,23 @@
         permalink: /install
       - title: "API Reference"
         permalink: https://api.dartlang.org
+
+- title: "Testing"
+  children:
+  - title: "Dart Testing"
+    permalink: /guides/testing
+
+- title: "Resources"
+  children:
+  - title: "Codelabs"
+    permalink: /codelabs
+  - title: "Tutorials"
+    permalink: /tutorials
+  - title: "Articles"
+    permalink: /articles
+  - title: Sample Code
+    permalink: /samples
+  - title: "Dart Tools"
+    permalink: /tools
+  - title: "Community and Support"
+    permalink: /community

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -10,6 +10,11 @@
       </p>
     </div>
 
+    <ul>
+      <li>
+        <a class="btn btn-default{% if page.url == '/guides/get-started' %} active{% endif %}" href="/guides/get-started">Get Started</a>
+      </li>
+    </ul>
     {% assign linklist = site.data.side-nav %}
     {% include linklist.html %}
   </div>


### PR DESCRIPTION
This fixes all aspects mentioned in #327, _except_ for Kathy's suggested rename of "Dart VM" to "Server" because that will require quite a bit of work both to the sidenav and permalinks. I've created a separate issue to track that (#328).

Staged at https://dartlang-org-dev.firebaseapp.com

Fixes #327