### PR TITLE
Adding notes about structure of web apps for dartdevc.

### DIFF
--- a/src/_articles/language/mixins.md
+++ b/src/_articles/language/mixins.md
@@ -15,13 +15,13 @@ some of the restrictions of early implementations; this document
 describes the current state of play.
 
 Dart 1.13 and greater supports mixins that can extend from classes
-other than `Object`, and can call `super.method()`. This support is only 
-available by default in the Dart VM and in Analyzer behind a flag. 
-More specifically, it is behind the `--supermixin` flag in the 
-command-line analyzer. It is also available in the analysis server, 
-behind a client-configurable option. For example, in Atom use the 
-analysis.updateOptions request to set the enableSuperMixins option 
-to true. Dart2js and DDC do not support this yet.
+other than `Object`, and can call `super.method()`. This support is only
+available by default in the Dart VM and in Analyzer behind a flag.
+More specifically, it is behind the `--supermixin` flag in the
+command-line analyzer. It is also available in the analysis server,
+behind a client-configurable option. For example, in Atom use the
+analysis.updateOptions request to set the enableSuperMixins option to true.
+Dart2js and dartdevc (also known as _DDC_) do not support this yet.
 
 Dart 1.12 or lower supports mixins that must extend Object,
 and must not call super().

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -120,8 +120,9 @@ This adapter handles HttpRequest objects from dart:io.
 
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
-For the best performance when developing with [dartdev](/tools/dartdevc),
-put [implementaton files](#implementation-files) under `/lib/src`,
+For the best performance when developing with [dartdevc](/tools/dartdevc),
+put [implementaton
+files](/tools/pub/package-layout#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.
 Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.
 </aside>

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -118,6 +118,14 @@ export 'src/server_handler.dart';
 The shelf package also contains a mini library: shelf_io.
 This adapter handles HttpRequest objects from dart:io.
 
+<aside class="alert alert-info" markdown="1">
+**Tip for web apps:**
+For the best performance when developing with [dartdev](/tools/dartdevc),
+put [implementaton files](#implementation-files) under `/lib/src`,
+instead of elsewhere under `/lib`.
+Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.
+</aside>
+
 ## Importing library files
 
 When importing a library file, you can use the

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -121,7 +121,7 @@ This adapter handles HttpRequest objects from dart:io.
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
 For the best performance when developing with [dartdevc](/tools/dartdevc),
-put [implementaton
+put [implementation
 files](/tools/pub/package-layout#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.
 Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -161,17 +161,18 @@ enchilada/
     tortilla.dart
 {% endprettify %}
 
-Many packages are [*library packages*](/tools/pub/glossary#library-package): they
-define Dart libraries that other packages can import and use. These public Dart
-library files go inside a directory called `lib`.
+Many packages are [*library
+packages*](/tools/pub/glossary#library-package): they
+define Dart libraries that other packages can import and use.
+These public Dart library files go inside a directory called `lib`.
 
 Most packages define a single library that users can import. In that case,
 its name should usually be the same as the name of the package, like
-`enchilada.dart` in the example here. But you can also define other libraries
-with whatever names make sense for your package.
+`enchilada.dart` in the example here. But you can also define other
+libraries with whatever names make sense for your package.
 
-When you do, users can import these libraries using the name of the package and
-the library file, like so:
+When you do, users can import these libraries using the name of the
+package and the library file, like so:
 
 {% prettify dart %}
 import 'package:enchilada/enchilada.dart';
@@ -179,8 +180,8 @@ import 'package:enchilada/tortilla.dart';
 {% endprettify %}
 
 If you want to organize your public libraries, you can also create
-subdirectories inside `lib`. If you do that, users will specify that path when
-they import it. Say you have the following file hierarchy:
+subdirectories inside `lib`. If you do that, users will specify that path
+when they import it. Say you have the following file hierarchy:
 
 {% prettify none %}
 enchilada/
@@ -196,15 +197,16 @@ Users import `olives.dart` as follows:
 import 'package:enchilada/some/path/olives.dart';
 {% endprettify %}
 
-Note that only *libraries* should be in `lib`. *Entrypoints*&mdash;Dart scripts
-with a `main()` function&mdash;cannot go in `lib`. If you place a Dart script
-inside `lib`, you will discover that any `package:` imports it contains don't
+Note that only *libraries* should be in `lib`.
+*Entrypoints*&mdash;Dart scripts with a `main()` function&mdash;cannot
+go in `lib`. If you place a Dart script inside `lib`,
+you will discover that any `package:` imports it contains don't
 resolve. Instead, your entrypoints should go in the appropriate
 [entrypoint directory](/tools/pub/glossary#entrypoint-directory).
 
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
-For the best performance when developing with [dartdev](/tools/dartdevc),
+For the best performance when developing with [dartdevc](/tools/dartdevc),
 put [implementaton files](#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.
 Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.
@@ -217,8 +219,9 @@ For more information on library packages, see
 
 Dart scripts placed inside of the `bin` directory are public. Any package
 that depends on your package can run scripts from your package's `bin`
-directory using [`pub run`](/tools/pub/cmd/pub-run). <em>Any</em> package can run scripts
-from your package's bin directory using [`pub global`](/tools/pub/cmd/pub-global).
+directory using [`pub run`](/tools/pub/cmd/pub-run). <em>Any</em> package
+can run scripts from your package's bin directory using
+[`pub global`](/tools/pub/cmd/pub-global).
 
 If you intend for your package to be depended on,
 and you want your scripts to be private to your package, place them
@@ -237,8 +240,8 @@ enchilada/
 
 While most library packages exist to let you reuse Dart code, you can also
 reuse other kinds of content. For example, a package for
-[Bootstrap](http://getbootstrap.com/) might include a number of CSS files for
-consumers of the package to use.
+[Bootstrap](http://getbootstrap.com/) might include a number of CSS files
+for consumers of the package to use.
 
 These go in the top-level `lib` directory. You can put any kind of file
 in there and organize it with subdirectories however you like.
@@ -299,18 +302,17 @@ enchilada/
     style.css
 {% endprettify %}
 
-For web packages, place HTML, CSS, JavaScript, and Dart code under
-the `web` directory. Any Dart web entrypoints (in other words,
-Dart scripts that are referred to in a `<script>` tag) go under `web` and
-not `lib`. This ensures that `package:` imports can be resolved correctly.
+For web packages, place entrypoint code&mdash;Dart scripts that include
+`main()` and files that support them, such as CSS or HTML&mdash;under
+`web`.  This ensures that `package:` imports can be resolved correctly.
 You can organize the `web` directory into subdirectories if you like.
 
-You can place assets (such as images) in any directory in the root package,
-but if you want to make an asset available to other packages,
-it should go into `lib`. For more information,
-see [Public assets](#public-assets).
-
-Note that web-based examples should be placed in `example`.
+[Library code](#public-libraries) should be placed under `lib`.
+If the library won't be imported directly by code under `web`, or by
+another package, it should be placed under `lib/src`.
+[Web-based examples](#examples) should be placed in `example`. See
+[Public assets](#public-assets) for tips on where to place assets,
+such as images.
 
 ## Command-line apps
 
@@ -320,14 +322,15 @@ enchilada/
     enchilada
 {% endprettify %}
 
-Some packages define programs that can be run directly from the command line.
-These can be shell scripts or any other scripting language, including Dart.
-The `pub` application itself is one example: it's a simple shell script that
-invokes `pub.dart`.
+Some packages define programs that can be run directly from the command
+line.  These can be shell scripts or any other scripting language,
+including Dart.  The `pub` application itself is one example: it's
+a simple shell script that invokes `pub.dart`.
 
 If your package defines code like this, put it in a directory named `bin`.
 You can run that script from anywhere on the command line, if you set it up
-using [pub global](/tools/pub/cmd/pub-global#running-a-script-from-your-path).
+using
+[pub global](/tools/pub/cmd/pub-global#running-a-script-from-your-path).
 
 ## Tests and benchmarks
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -207,7 +207,7 @@ resolve. Instead, your entrypoints should go in the appropriate
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
 For the best performance when developing with [dartdevc](/tools/dartdevc),
-put [implementaton files](#implementation-files) under `/lib/src`,
+put [implementation files](#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.
 Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.
 </aside>
@@ -303,15 +303,14 @@ enchilada/
 {% endprettify %}
 
 For web packages, place entrypoint code&mdash;Dart scripts that include
-`main()` and supporting files, such as CSS or HTML&mdash;under
-`web`.  This ensures that `package:` imports can be resolved correctly.
+`main()` and supporting files, such as CSS or HTML&mdash;under `web`.
 You can organize the `web` directory into subdirectories if you like.
 
-[Library code](#public-libraries) should be placed under `lib`.
-If the library won't be imported directly by code under `web`, or by
-another package, it should be placed under `lib/src`.
-[Web-based examples](#examples) should be placed in `example`. See
-[Public assets](#public-assets) for tips on where to place assets,
+Put [library code](#public-libraries) under `lib`.
+If the library isn't imported directly by code under `web`, or by
+another package, put it under `lib/src`.
+Put [web-based examples](#examples) under `example`. See
+[Public assets](#public-assets) for tips on where to put assets,
 such as images.
 
 ## Command-line apps

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -103,9 +103,9 @@ enchilada/
 Running pub also generates a `.packages` file.
 Don't check this into source control.
 
-The open source community has a few other files that commonly appear at the top
-level of a project: `LICENSE`, `AUTHORS`, etc. If you use any of those, they can
-go in the top level of the package too.
+The open source community has a few other files that commonly appear at
+the top level of a project: `LICENSE`, `AUTHORS`, etc. If you use any
+of those, they can go in the top level of the package too.
 
 For more information, see [Pubspec Format](/tools/pub/pubspec).
 
@@ -303,7 +303,7 @@ enchilada/
 {% endprettify %}
 
 For web packages, place entrypoint code&mdash;Dart scripts that include
-`main()` and files that support them, such as CSS or HTML&mdash;under
+`main()` and supporting files, such as CSS or HTML&mdash;under
 `web`.  This ensures that `package:` imports can be resolved correctly.
 You can organize the `web` directory into subdirectories if you like.
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -202,6 +202,14 @@ inside `lib`, you will discover that any `package:` imports it contains don't
 resolve. Instead, your entrypoints should go in the appropriate
 [entrypoint directory](/tools/pub/glossary#entrypoint-directory).
 
+<aside class="alert alert-info" markdown="1">
+**Tip for web apps:**
+For the best performance when developing with [dartdev](/tools/dartdevc),
+put [implementaton files](#implementation-files) under `/lib/src`,
+instead of elsewhere under `/lib`.
+Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.
+</aside>
+
 For more information on library packages, see
 [Create Library Packages](/guides/libraries/create-library-packages).
 
@@ -234,12 +242,6 @@ consumers of the package to use.
 
 These go in the top-level `lib` directory. You can put any kind of file
 in there and organize it with subdirectories however you like.
-
-<aside class="alert alert-info" markdown="1">
-**Compatibility note:**
-In earlier releases, assets were also placed in the top-level
-`asset` directory. Pub no longer recognizes the `asset` directory.
-</aside>
 
 You can reference another package's assets using the
 [resource package](https://github.com/dart-lang/resource).
@@ -278,8 +280,7 @@ Those files are not part of the package's public API, and they might change in
 ways that could break your code.
 
 When you use libraries from within your own package, even code in `src`, you
-can (and should) still use `package:` to import them. This is perfectly
-legit:
+can (and should) still use `package:` to import them. For example:
 
 {% prettify dart %}
 import 'package:enchilada/src/beans.dart';
@@ -298,18 +299,18 @@ enchilada/
     style.css
 {% endprettify %}
 
-Dart is a web language, so many pub packages will be doing web stuff. That
-means HTML, CSS, images, and, heck, probably even some JavaScript. All of that
-goes into your package's `web` directory. You're free to organize the contents
-of that to your heart's content. Go crazy with subdirectories if that makes you
-happy.
+For web packages, place HTML, CSS, JavaScript, and Dart code under
+the `web` directory. Any Dart web entrypoints (in other words,
+Dart scripts that are referred to in a `<script>` tag) go under `web` and
+not `lib`. This ensures that `package:` imports can be resolved correctly.
+You can organize the `web` directory into subdirectories if you like.
 
-Also, and this is important, any Dart web entrypoints (in other words, Dart
-scripts that are referred to in a `<script>` tag) go under `web` and not `lib`.
-That ensures that `package:` imports can be resolved correctly.
+You can place assets (such as images) in any directory in the root package,
+but if you want to make an asset available to other packages,
+it should go into `lib`. For more information,
+see [Public assets](#public-assets).
 
-(You may be asking whether you should put your web-based example programs
-in `example` or `web`? Put those in `example`.)
+Note that web-based examples should be placed in `example`.
 
 ## Command-line apps
 


### PR DESCRIPTION
Also cleans up the description for the /web directory in package-layout.

Fixes: https://github.com/dart-lang/site-www/issues/62

Staged: 
https://sz-www-1.firebaseapp.com/tools/pub/package-layout
https://sz-www-1.firebaseapp.com/guides/libraries/create-library-packages