### PR TITLE
mention Dart Editor and the Eclipse plugin in the tools page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1096,7 +1096,7 @@
         "type": 301
       },
       {
-        "source": "/tools/eclipse-plugin/",
+        "source": "/tools/eclipse-plugin",
         "destination": "/tools",
         "type": 301
       },

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -63,6 +63,11 @@ and available as open source:
 </li>
 </ul>
 
+<aside class="alert alert-info" markdown="1">
+**Note:** Two previous options, Dart Editor and the Eclipse Plugin for Dart,
+are no longer maintained.
+</aside>
+
 ## SDKs
 
 Which SDK you need depends on what type of app you're developing.


### PR DESCRIPTION
Also, all variants of /tools/eclipse-plugin (with optional / or .html) redirect to /tools. (Probably doesn't matter, but I was there anyway.)

Staged:
https://kw-www-dartlang-1.firebaseapp.com/tools
https://kw-www-dartlang-1.firebaseapp.com/tools/eclipse-plugin
https://kw-www-dartlang-1.firebaseapp.com/tools/eclipse-plugin/
https://kw-www-dartlang-1.firebaseapp.com/tools/eclipse-plugin.html

Fixes #124