### PR TITLE
Fixed references to dartdevc

### DIFF
--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -120,7 +120,8 @@ This adapter handles HttpRequest objects from dart:io.
 
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
-For the best performance when developing with [dartdevc](/tools/dartdevc),
+For the best performance when developing with
+[dartdevc,]({{site.webdev}}/tools/dartdevc)
 put [implementation
 files](/tools/pub/package-layout#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.

--- a/src/dart-2.0.md
+++ b/src/dart-2.0.md
@@ -128,6 +128,6 @@ and [Strong Mode Dart.](/guides/language/sound-dart)
 To use strong mode in Dart 1.x, [you must enable
 it.](/guides/language/sound-dart#how-to-enable-strong-mode)
 Note that runtime checks are not yet available unless you are developing
-for the web and using [dartdevc]({{site.webdev}}/tools/dartdevc).
+for the web and using [dartdevc.]({{site.webdev}}/tools/dartdevc)
 
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -206,7 +206,8 @@ resolve. Instead, your entrypoints should go in the appropriate
 
 <aside class="alert alert-info" markdown="1">
 **Tip for web apps:**
-For the best performance when developing with [dartdevc](/tools/dartdevc),
+For the best performance when developing with
+[dartdevc,]({{site.webdev}}/tools/dartdevc)
 put [implementation files](#implementation-files) under `/lib/src`,
 instead of elsewhere under `/lib`.
 Also, avoid imports of <code>package:<em>package_name</em>/src/...</code>.

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -32,32 +32,26 @@ and a `bin` directory that has these command-line tools:
 : The standalone VM
 
 [dart2js]({{site.webdev}}/tools/dart2js)
-: The Dart-to-JavaScript compiler<br>(used only for web development)
+: The Dart-to-JavaScript compiler
+(used only for web development)
 
 [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli#dartanalyzer)
 : The static analyzer
+
+[dartdevc]({{site.webdev}}/tools/dartdevc)
+: The Dart development compiler
+(used only for web development)
 
 </div> <div class="col-md-6" markdown="1">
 
 [dartdoc](https://github.com/dart-lang/dartdoc#dartdoc)
 : The API documentation generator
 
-[pub](/tools/pub)
-: The Dart package manager
-
 [dartfmt](https://github.com/dart-lang/dart_style#readme)
 : The Dart code formatter
 
-
-{% comment %}
-We aren't yet ready to add info on dartdevc...
-
-</div> <div class="col-md-6" markdown="1">
-
-[dartdevc]()
-: xxx
-
-{% endcomment %}
+[pub](/tools/pub)
+: The Dart package manager
 
 </div> </div>
 


### PR DESCRIPTION
Fixed a couple of bad links, and added dartdevc to the list of SDK tools.

Staged at:
https://kw-www-dartlang-1.firebaseapp.com/tools/sdk
https://kw-www-dartlang-1.firebaseapp.com/guides/libraries/create-library-packages
https://kw-www-dartlang-1.firebaseapp.com/dart-2.0
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/package-layout

/tbr @Sfshaza 