### PR TITLE
More prep for Dart 2.0

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -41,11 +41,6 @@
         "type": 301
       },
       {
-        "source": "/articles",
-        "destination": "/articles",
-        "type": 301
-      },
-      {
         "source": "/articles/api-naming-guide/**",
         "destination": "/guides/language/effective-dart/design",
         "type": 301
@@ -878,11 +873,6 @@
       {
         "source": "/resources/dart-tips-ep-2/**",
         "destination": "/resources/dart-tips/dart-tips-ep-2",
-        "type": 301
-      },
-      {
-        "source": "/resources/dart-tips",
-        "destination": "/resources/dart-tips",
         "type": 301
       },
       {

--- a/firebase.json
+++ b/firebase.json
@@ -1066,11 +1066,6 @@
         "type": 301
       },
       {
-        "source": "/tools/jetbrains-plugin",
-        "destination": "/tools/jetbrains-plugin",
-        "type": 301
-      },
-      {
         "source": "/tools/observatory/**",
         "destination": "https://dart-lang.github.io/observatory",
         "type": 301

--- a/firebase.json
+++ b/firebase.json
@@ -331,11 +331,6 @@
         "type": 301
       },
       {
-        "source": "/community/who-uses-dart.html",
-        "destination": "/community/who-uses-dart",
-        "type": 301
-      },
-      {
         "source": "/dart-by-example",
         "destination": "/dart-vm/dart-by-example",
         "type": 301
@@ -1051,11 +1046,6 @@
         "type": 301
       },
       {
-        "source": "/tools/faq.html",
-        "destination": "/tools/faq",
-        "type": 301
-      },
-      {
         "source": "/tools/observatory/**",
         "destination": "https://dart-lang.github.io/observatory",
         "type": 301
@@ -1066,63 +1056,13 @@
         "type": 301
       },
       {
-        "source": "/tools/pub/assets-and-transformers.html",
-        "destination": "/tools/pub/assets-and-transformers",
-        "type": 301
-      },
-      {
         "source": "/tools/pub/cmd/pub-build.html",
         "destination": "https://webdev.dartlang.org/tools/pub/pub-build",
         "type": 301
       },
       {
-        "source": "/tools/pub/cmd/pub-cache.html",
-        "destination": "/tools/pub/cmd/pub-cache",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-deps.html",
-        "destination": "/tools/pub/cmd/pub-deps",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-downgrade.html",
-        "destination": "/tools/pub/cmd/pub-downgrade",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-get.html",
-        "destination": "/tools/pub/cmd/pub-get",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-global.html",
-        "destination": "/tools/pub/cmd/pub-global",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-lish.html",
-        "destination": "/tools/pub/cmd/pub-lish",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-run.html",
-        "destination": "/tools/pub/cmd/pub-run",
-        "type": 301
-      },
-      {
         "source": "/tools/pub/cmd/pub-serve.html",
         "destination": "https://webdev.dartlang.org/tools/pub/pub-serve",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-upgrade.html",
-        "destination": "/tools/pub/cmd/pub-upgrade",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/cmd/pub-uploader.html",
-        "destination": "/tools/pub/cmd/pub-uploader",
         "type": 301
       },
       {
@@ -1136,63 +1076,8 @@
         "type": 301
       },
       {
-        "source": "/tools/pub/dependencies.html",
-        "destination": "/tools/pub/dependencies",
-        "type": 301
-      },
-      {
         "source": "/tools/pub/faq.html",
         "destination": "/tools/faq#pub",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/get-started.html",
-        "destination": "/tools/pub/get-started",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/glossary.html",
-        "destination": "/tools/pub/glossary",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/installing.html",
-        "destination": "/tools/pub/installing",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/package-layout.html",
-        "destination": "/tools/pub/package-layout",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/publishing.html",
-        "destination": "/tools/pub/publishing",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/pubspec.html",
-        "destination": "/tools/pub/pubspec",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/transformers/aggregate.html",
-        "destination": "/tools/pub/transformers/aggregate",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/transformers/lazy-transformer.html",
-        "destination": "/tools/pub/transformers/lazy-transformer",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/troubleshoot.html",
-        "destination": "/tools/pub/troubleshoot",
-        "type": 301
-      },
-      {
-        "source": "/tools/pub/versioning.html",
-        "destination": "/tools/pub/versioning",
         "type": 301
       },
       {

--- a/src/_articles/dart-vm/reflection-with-mirrors.md
+++ b/src/_articles/dart-vm/reflection-with-mirrors.md
@@ -43,8 +43,6 @@ At this time, only part of the planned API has been realized.
 The part that exists deals with _introspection_,
 the ability of a program to discover and use its own structure.
 The introspection API has been largely implemented on the Dart VM.
-In dart2js, a similar implementation is under development, but is
-still incomplete.
 
 The introspection API is declared in the library named `dart:mirrors`.
 If you wish to use introspection, import it:

--- a/src/_articles/libraries/converters-and-codecs.md
+++ b/src/_articles/libraries/converters-and-codecs.md
@@ -130,9 +130,9 @@ File.openRead().transform(UTF8.decoder).
 ## Chunked conversion
 
 The concept of chunked conversions can be confusing, but at its core, it is
-relatively simple. When a chunked conversion (including a stream transformation)
-is started, the converter’s
-[startChunkedConversion]({{site.dart_api}}/dart-convert/ChunkedConverter/startChunkedConversion.html)
+relatively simple. When a chunked conversion (including a stream
+transformation) is started, the converter’s
+[startChunkedConversion]({{site.dart_api}}/dart-convert/Converter/startChunkedConversion.html)
 method is invoked with an output-
 sink as argument. The method then returns an input sink into which the caller
 puts data.

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -144,21 +144,21 @@ mind:
     from executing at all; a run-time error results in an
     [exception](#exceptions) being raised while the code executes.
 
-<ul>
-  <li id="runtime-modes" class="no_toc" markdown="1">
-  Dart has two <em id="runtime-modes">runtime modes</em>:
-  production and checked. We recommend that
-  you develop and debug in checked mode, and deploy to production mode.
+-   Dart has two <em>runtime modes</em>:
+    production and checked. We recommend that
+    you develop and debug in checked mode, and deploy to production mode.
+    *Production mode* is the default runtime mode of a Dart program,
+    optimized for speed. Production mode ignores [assert
+    statements](#assert) and static types.
+    *Checked mode* is a developer-friendly mode that helps you catch some
+    type errors during runtime. For example, if you assign a non-number to a
+    variable declared as a `num`, then checked mode throws an exception.
 
-  *Production mode* is the default runtime mode of a Dart program,
-  optimized for speed. Production mode ignores [assert
-  statements](#assert) and static types.
+{% include checked-mode-2.0.html %}
 
-  *Checked mode* is a developer-friendly mode that helps you catch some
-  type errors during runtime. For example, if you assign a non-number to a
-  variable declared as a `num`, then checked mode throws an exception.
-  </li>
-</ul>
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 ## Keywords
 
@@ -233,6 +233,11 @@ throws an exception unless *condition* is true. For details,
 see the [Assert](#assert) section.
 </div>
 
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 ### Optional types
 
@@ -573,6 +578,12 @@ mode*, the preceding code doesn’t print at all because `name` is converted to
 `false` (because `name != true`).
 In Dart running in *checked mode*, the preceding code
 throws an exception because the `name` variable is not a bool.
+
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 {% comment %}
 xxx: This code also produces an error:
@@ -2047,6 +2058,12 @@ assert(urlString.startsWith('https'));
 Assert statements work only in checked mode. They have no effect in
 production mode.
 </div>
+
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 To attach a message to an assert,
 add a string as the second argument.

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -111,7 +111,7 @@ mind:
 -   In [strong mode](/guides/language/sound-dart), static and runtime
     checks ensure that your code is type safe, helping you catch bugs
     in development, rather than at runtime. Strong mode is optional in
-    Dart 1.x, but not optional in [Dart 2.0[(/dart-2.0).
+    Dart 1.x, but not optional in [Dart 2.0](/dart-2.0).
 
 -   Dart parses all your code before running it. You can provide tips to
     Dart—for example, by using types or compile-time constants—to catch
@@ -144,7 +144,7 @@ mind:
     from executing at all; a run-time error results in an
     [exception](#exceptions) being raised while the code executes.
 
--   Dart has two <em>runtime modes</em>:
+-   Dart 1.x has two <em>runtime modes</em>:
     production and checked. We recommend that
     you develop and debug in checked mode, and deploy to production mode.
     *Production mode* is the default runtime mode of a Dart program,
@@ -244,7 +244,7 @@ update-for-dart-2
 {% include optional-types-2.0.html %}
 
 {% comment %}
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 You have the option of adding static types to your variable
@@ -1169,7 +1169,7 @@ and optionally typed, between parentheses.
 {% include optional-types-2.0.html %}
 
 {% comment %}
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 The code block that follows contains the function's body:
@@ -3267,7 +3267,7 @@ annotate your code, making your intent clearer.
 {% include optional-types-2.0.html %}
 
 {% comment %}
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 For example, if you intend for a list to contain only strings, you can

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -5,7 +5,7 @@ description: "Why and how to write sound Dart code."
 ---
 
 {% comment %}
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 This guide tells you why and how to write sound (type safe) Dart code.

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -728,6 +728,12 @@ void main() {
 This code raises no issues when run in checked mode, but generates
 numerous errors when analyzed under strong mode.
 
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ## Other resources
 
 The following resources have further information on sound Dart and

--- a/src/_guides/language/sound-faq.md
+++ b/src/_guides/language/sound-faq.md
@@ -104,14 +104,20 @@ an expression evaluates to a specific type at runtime.
 Strong mode performs stronger type checking. For more information, see
 [Strong mode vs. checked mode](/guides/language/sound-dart#strong-mode-vs-checked-mode).
 
-Checked mode will be obsolete in Dart 2.0 and will be removed. For more
-information, see [Dart 2.0 Updates.](/dart-2.0)
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 <a name="why-another-mode"></a>
 ### Why do we need another mode for Dart?
 
-Checked mode will be obsolete in Dart 2.0 and will be removed. For more
-information, see [Dart 2.0 Updates.](/dart-2.0)
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 <a name="where-is-the-spec"></a>
 ### Is strong mode specified? If so, where is the spec?

--- a/src/_guides/language/sound-faq.md
+++ b/src/_guides/language/sound-faq.md
@@ -6,7 +6,7 @@ toc: false
 ---
 
 {% comment %}
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 This page collects some questions and answers about why and how to
@@ -21,7 +21,6 @@ write sound Dart code. Be sure to also check out the
 <li><a href="#how-does-it-benefit-me">How does strong mode benefit me, the developer?</a></li>
 <li><a href="#how-does-it-benefit-users">How does strong mode benefit my users?</a></li>
 <li><a href="#how-is-it-different-than-checked-mode">What is the difference between strong mode and checked mode?</a></li>
-<li><a href="#why-another-mode">Why do we need another mode for Dart?</a></li>
 <li><a href="#where-is-the-spec">Is strong mode specified? If so, where is the spec?</a></li>
 <li><a href="#is-strong-mode-done">Is strong mode "done" or are there still changes to come?</a></li>
 <li><a href="#how-did-dart-change">How did strong mode change the Dart language?</a></li>
@@ -103,15 +102,6 @@ Checked mode performs limited type checking but doesn’t guarantee that
 an expression evaluates to a specific type at runtime.
 Strong mode performs stronger type checking. For more information, see
 [Strong mode vs. checked mode](/guides/language/sound-dart#strong-mode-vs-checked-mode).
-
-{% include checked-mode-2.0.html %}
-
-{% comment %}
-update-for-dart-2
-{% endcomment %}
-
-<a name="why-another-mode"></a>
-### Why do we need another mode for Dart?
 
 {% include checked-mode-2.0.html %}
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -7,7 +7,7 @@ toc: false
 
 {% comment %}
 The first few questions/answers are for strong mode under Dart 1.x.
-update-for-dart-2.0
+update-for-dart-2
 {% endcomment %}
 
 If you're having problems converting your code to strong mode,

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -363,6 +363,12 @@ assert(fruit is String);
 fruits.add(5);  // BAD: Throws exception in checked mode.
 {% endprettify %}
 
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 Refer to the [List API
 docs]({{site.dart_api}}/dart-core/List-class.html) for a full list of
 methods.
@@ -1441,8 +1447,8 @@ dart:html, not command-line apps.
 <div class="alert alert-info" markdown="1">
 **Note:**
 For higher level approaches to web app UIs, see
-[Polymer Dart](https://github.com/dart-lang/polymer-dart/wiki) and
-[Angular 2 for Dart]({{site.webdev}}/angular).
+[AngularDart]({{site.webdev}}/angular) and
+[Polymer Dart](https://github.com/dart-lang/polymer-dart/wiki).
 </div>
 
 To use the HTML library in your web app, import dart:html:
@@ -2031,8 +2037,8 @@ audio,]({{site.dart_api}}/dart-web_audio/dart-web_audio-library.html)
 
 The [dart:io library]({{site.dart_api}}/dart-io/dart-io-library.html) provides APIs to
 deal with files, directories, processes, sockets, WebSockets, and HTTP
-clients and servers. Only command-line apps can use dart:io—not web
-apps.
+clients and servers. Only command-line scripts and servers can use
+dart:io—not web apps.
 
 In general, the dart:io library implements and promotes an asynchronous
 API. Synchronous methods can easily block an application, making it
@@ -2045,7 +2051,7 @@ with a Sync suffix on the method name. We don’t cover them here.
 
 <div class="alert alert-info" markdown="1">
 **Note:**
-Only command-line apps can import and use `dart:io`.
+Only command-line scripts and servers can import and use `dart:io`.
 </div>
 
 

--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -80,7 +80,7 @@ elsewhere.
 
 ### Web libraries
 
-If you write web apps, check out Angular 2, a web application framework.
+If you write web apps, check out AngularDart, a web application framework.
 Other available resources are the js package for interoperability with
 JavaScript APIs, and the dart:html library for low-level HTML programming.
 

--- a/src/_includes/checked-mode-2.0.html
+++ b/src/_includes/checked-mode-2.0.html
@@ -1,0 +1,5 @@
+<aside class="alert alert-info" markdown="1">
+  **Dart 2.0 note**:
+  Checked mode will be obsolete in Dart 2.0 and will be removed. For more
+  information, see [Dart 2.0 Updates.](/dart-2.0)
+</aside>

--- a/src/_includes/checked-mode-2.0.html
+++ b/src/_includes/checked-mode-2.0.html
@@ -1,5 +1,5 @@
 <aside class="alert alert-info" markdown="1">
   **Dart 2.0 note**:
-  Checked mode will be obsolete in Dart 2.0 and will be removed. For more
-  information, see [Dart 2.0 Updates.](/dart-2.0)
+  Checked mode won't be in Dart 2.0. For more information,
+  see [Dart 2.0 Updates.](/dart-2.0)
 </aside>

--- a/src/_includes/dartium-2.0.html
+++ b/src/_includes/dartium-2.0.html
@@ -1,0 +1,7 @@
+<aside class="alert alert-info" markdown="1">
+  **Dartium is going away in Dart 2.0:**
+  In Dart 2.0, you'll use Chrome or other standard browsers for testing
+  instead of Dartium, thanks to a new development compiler called
+  [_dartdevc_]({{site.webdev}}/tools/dartdevc).
+  For information on Dartium's removal, see [Dart 2.0 Updates.](/dart-2.0)
+</aside>

--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -22,7 +22,7 @@ Thanks!
 [Wrike](https://www.wrike.com/)
 : Outcollaborate. Wrike combines real-time collaboration with easy-to-use
   project management so your team can accomplish more.
-  Built with Dart, <nobr>Angular 2</nobr>.
+  Built with AngularDart.
 
 [Workiva](https://www.workiva.com/)
 : Next generation client applications for our Wdesk productivity suite are
@@ -54,7 +54,7 @@ Thanks!
 : RTAC HMI browser-based SCADA system.
 
 Google internal sales tool
-: Built with Angular 2 for Dart.
+: Built with AngularDart.
 
 [drone.io](http://drone.io)
 : Continuous integration with support for testing Dart apps.
@@ -109,8 +109,8 @@ Google internal sales tool
 [WorkTrail](https://worktrail.net)
 : Time tracking app.
 
-[Angular](https://github.com/angular/angular.dart)
-: Angular 2 for Dart is a port of the popular framework to Dart.
+[AngularDart](https://github.com/angular/angular.dart)
+: AngularDart is a port of the popular framework to Dart.
 
 [Google Elections](http://news.dartlang.org/2013/09/googles-german-election-map-powered-by.html)
 : Elections results maps built with Dart.
@@ -148,10 +148,10 @@ AdWords for video
 : The application that advertisers use to promote video ads on YouTube
   and other sites. Advertisers create accounts, setup campaigns, create ads,
   target them to users, and see how users are finding their ads useful, etc.
-  Built with Angular 2 for Dart.
+  Built with AngularDart.
 
 Google internal tool for marketing
-: Built with Angular 2 for Dart.
+: Built with AngularDart.
 
 [Prime APPcatalog](http://www.primeapp.it/en)
 : An interactive product catalog for tablets and smartphones. Built with Dart,
@@ -210,7 +210,7 @@ players' teams. Build with polymer.dart and StageXL.
 
 [QuemEuTirei](http://www.quemeutirei.com.br)
 : A Secret Santa application. You can create Events, setup your Profile and
-Gifts and invite friends. Build with Angular 2 Dart (client) and Shelf (server).
+Gifts and invite friends. Build with AngularDart (client) and Shelf (server).
 
 [ListShine](https://www.listshine.com)
 : Email Marketing Software powered by Dart (client).

--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -167,9 +167,12 @@ Google internal tool for marketing
 : A high-performance, HTML5 web app authoring and distribution platform built
   on and made for the modern web.
 
+{% comment %}
+Broken link and can't find lumo on the sonardesign.com site.
 [Lumo](http://lumo.sonardesign.com)
 : An online presentation service that allows you to create, present,
   and share presentations on any device.
+{% endcomment %}
 
 [Children of Ur](http://www.childrenofur.com/)
 : A community reboot of the closed massively multiplayer game called

--- a/src/dart-vm/tools/dart-vm.md
+++ b/src/dart-vm/tools/dart-vm.md
@@ -31,6 +31,12 @@ Common command-line options for dart include:
 `-c` or `--checked`
 : Enables _both_ assertions and type checks (checked mode).
 
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 `--packages=<path>`
 : Specifies the path to the package resolution configuration file.
   For more information, see
@@ -107,6 +113,12 @@ You can also generate snapshots:
   [Snapshots](https://github.com/dart-lang/sdk/wiki/Snapshots) on GitHub.
 
 ## Enabling checked mode
+
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 Dart programs run in one of two modes: checked or production. By default, the
 Dart VM runs in production mode. We recommend that you enable checked mode for

--- a/src/install/archive/index.md
+++ b/src/install/archive/index.md
@@ -21,6 +21,12 @@ and the [Dart API documentation]({{site.dart_api}}).
 Want to install Dart with your OS's package manager?
 Go to the [main Dart installation page](/install).
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ## Stable channel
 
 Stable channel builds are tested and approved for production use.

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -21,6 +21,12 @@ If you are doing web development, you will also need **Dartium**.
 Instructions for installing Dartium are also provided in the following pages,
 or see the [zip file archive](/install/archive).
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ## Automated installation and updates
 
 A package manager can help you easily install and update the Dart SDK.

--- a/src/install/linux.md
+++ b/src/install/linux.md
@@ -26,6 +26,12 @@ If you are doing web development, you will also need to
     class="download-link"
     href="{{ site.custom.downloads.dartarchive-stable-url-prefix }}/latest/dartium/dartium-linux-x64-release.zip">install Dartium for Linux</a>.
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ## Using apt-get
 
 To install the Dart SDK with apt-get, you first need to do some setup.

--- a/src/install/mac.md
+++ b/src/install/mac.md
@@ -31,6 +31,12 @@ $ brew tap dart-lang/dart
 $ brew install dart --with-content-shell --with-dartium
 {% endprettify %}
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ### Installing dev channel releases
 
 To choose the dev channel version of whatever Dart software you install,

--- a/src/install/windows.md
+++ b/src/install/windows.md
@@ -18,7 +18,7 @@ Another option is
 
 ## Using a third-party installer {#installer}
 
-A 
+A
 [Dart SDK installer for Windows](http://www.gekorm.com/dart-windows/)
 is available and supported by the community.
 You can use the wizard to install stable or dev versions of
@@ -41,6 +41,12 @@ If you are doing web development, you should also add one more tool:
   A special build of Chromium that includes a Dart VM.
   Use it to interactively test and debug Dart web apps
   without first compiling them to JavaScript.
+
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 If you're working on server-side Dart, all you need is the `dart-sdk`:
 

--- a/src/tools/analyzer.md
+++ b/src/tools/analyzer.md
@@ -7,7 +7,7 @@ description: "The tool that analyzes and validates your Dart code."
 
 The static analyzer evaluates your Dart code,
 checking for errors and warnings that are specified in the
-[Dart Language Specification](https://www.dartlang.org/docs/spec/).
+[Dart Language Specification](/guides/language/spec).
 
 Many tools in the Dart ecosystem (including IDEs, DartPad, and dartanalyzer)
 perform static analysis on code. Most of these tools (with the exception
@@ -41,10 +41,10 @@ Specification](https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/b
 for protocol details.) The following tools use the analysis server:
 
 * Dart and Flutter plugins for IDEs (such as
-  [WebStorm](https://webdev.dartlang.org/tools/webstorm),
-  [IntelliJ](https://www.dartlang.org/tools/jetbrains-plugin), and
+  [WebStorm]({{site.webdev}}/tools/webstorm),
+  [IntelliJ](/tools/jetbrains-plugin), and
   [Atom](https://atom.io/packages/dartlang))
-* [DartPad](https://www.dartlang.org/tools/dartpad)
+* [DartPad](/tools/dartpad)
 
 If your tool requires access to the abstract syntax tree (AST), use the
 [package:analyzer](https://pub.dartlang.org/packages/analyzer) library.
@@ -55,7 +55,7 @@ The following tools use package:analyzer:
 * [`dartdevc`]({{site.webdev}}/tools/dartdevc)
 * [`dartdoc`](https://github.com/dart-lang/dartdoc)
 * [`dartfmt`](https://github.com/dart-lang/dart_style)
-* [`flutter analyze`](https://flutter.io/debugging/#the-dart-analyzer)
+* [`flutter analyze`]({{site.flutter}}/debugging/#the-dart-analyzer)
 
 You might also be interested in the [Dart analyzer discussion
 group.](https://groups.google.com/a/dartlang.org/forum/#!forum/analyzer-discuss)

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -82,6 +82,11 @@ Which SDK you need depends on what type of app you're developing.
 | Mobile app | Flutter | [Flutter Setup]({{site.flutter}}/setup) | [flutter.io]({{site.flutter}}) |
 {:.table .table-striped}
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 
 ## Command-line tools

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -144,7 +144,7 @@ by removing a directory.
 See the JetBrains website for more information.
 
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/)
-  * [Dart support](https://www.jetbrains.com/help/idea/dart-support.html)
+  * [Dart PhpStorm Help](https://www.jetbrains.com/help/phpstorm/dart.html)
   * [Features](https://www.jetbrains.com/idea/features/)
   * [Quick start](https://www.jetbrains.com/help/idea/meet-intellij-idea.html)
 * [Dart Plugin by JetBrains](https://plugins.jetbrains.com/plugin/6351)

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -29,6 +29,11 @@ Once your IDE has the Dart plugin,
 you need to tell it where to find the Dart SDK and
 (optionally) Dartium.
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
 
 ### Downloading the IDE
 
@@ -106,7 +111,7 @@ Here's one way to configure Dart support:
   <b>Note:</b>
   The <b>Dart SDK</b> path specifies the directory that
   contains the SDK's `bin` and `lib` directories;
-  the `bin` directory contains tools such as `dart` and `dart2js`.
+  the `bin` directory contains tools such as `dart` and `dartfmt`.
   The <b>Dartium</b> path specifies the full path to the
   `Chromium` executable that contains the Dart VM.
   The IDE ensures that the paths are valid.

--- a/src/tools/pub/assets-and-transformers.md
+++ b/src/tools/pub/assets-and-transformers.md
@@ -81,6 +81,12 @@ files because browsers in the wild don't support Dart natively. The `pub
 serve` command, on the other hand, does generate `.dart` assets, because
 you can use Dartium while you're developing your app.
 
+{% include dartium-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 ## Specifying transformers
 
 To tell pub to apply a transformer to your package's assets, specify the

--- a/src/tools/pub/cmd/pub-run.md
+++ b/src/tools/pub/cmd/pub-run.md
@@ -94,6 +94,12 @@ For options that apply to all pub commands, see
 
 </dl>
 
+{% include checked-mode-2.0.html %}
+
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+
 <aside class="alert alert-info" markdown="1">
 *Problems?*
 See [Troubleshooting Pub](/tools/pub/troubleshoot).

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -32,8 +32,7 @@ and a `bin` directory that has these command-line tools:
 : The standalone VM
 
 [dart2js]({{site.webdev}}/tools/dart2js)
-: The Dart-to-JavaScript compiler
-(used only for web development)
+: The Dart-to-JavaScript compiler (used only for web development)
 
 [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli#dartanalyzer)
 : The static analyzer


### PR DESCRIPTION
Addressed more issues as listed in the "Dart 2.0 cleanup" spreadsheet.

Staged:
https://sz-www-1.firebaseapp.com/tools/jetbrains-plugin   (was a broken link)
https://sz-www-1.firebaseapp.com    (lots of affected pages)