### PR TITLE
Make sure /dart-2.0 shows up as Content Type: html

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,15 @@
             "value": "*"
           }
         ]
+      },
+      {
+        "source": "/dart-2.0",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "text/html; charset=utf-8"
+          }
+        ]
       }
     ],
     "redirects": [


### PR DESCRIPTION
Without this fix, Firebase serves dartlang.org/dart-2.0 as “Content-Type: false”. The fix forces text/html on that particular page.