### PR TITLE
Add info on using Dart 2.0 pre-releases

### DIFF
--- a/src/dart-2.0.md
+++ b/src/dart-2.0.md
@@ -6,10 +6,23 @@ description: How Dart 2.0 is different from Dart 1.x, and how you can prepare.
 ---
 
 This page has information about changes that are coming in Dart 2.0,
-and how you can migrate your code from Dart 1.x:
+and how you can migrate your code from Dart 1.x.
 
-* [Migration tips: web](#migration-tips-web)
-* [Migration tips: servers and command-line scripts](#migration-tips-servers-and-command-line-scripts)
+<aside class="alert alert-warning" markdown="1">
+**Don't rely on 2.0 until it's stable.**
+Dart 2.0 pre-releases will have a series of incompatible changes.
+Although we appreciate your willingness to prepare for and test Dart 2.0,
+please don't bet your livelihood on a pre-release.
+</aside>
+
+* Migration tips
+  * [Web](#migration-tips-web)
+  * [Servers and command-line scripts](#migration-tips-servers-and-command-line-scripts)
+  * [Packages](#migration-tips-packages)
+* [Testing with Dart 2.0 pre-releases](#testing)
+* Dart 2.0 differences
+  * [Obsolete features](#obsolete-features)
+  * [Strong mode and static typing](#strong-mode-and-static-typing)
 
 <aside class="alert alert-info" markdown="1">
 **Flutter note:** You don't need to do anything to prepare Flutter code
@@ -17,10 +30,6 @@ for Dart 2.0. If changes become necessary,
 we'll add Flutter details to this page.
 </aside>
 
-Here's what's different in Dart 2.0:
-
-* [Obsolete features](#obsolete-features)
-* [Strong mode and static typing](#strong-mode-and-static-typing)
 
 ## Migration tips: web
 
@@ -32,11 +41,13 @@ Convert your code to be strong mode compliant.
 
 Optimize the structure of your libraries.
 : Place library code that won't be _directly_ imported by your `web` code,
-  or by other packages, under `lib/src`. For more information,
-  see the documentation for [creating library
-  packages.](/guides/libraries/create-library-packages)
-  You can find examples of this directory structure in the [Stagehand
-  templates.](https://github.com/google/stagehand/tree/master/templates)
+  or by other packages, under `lib/src`. For more information, see the
+  documentation for [creating library packages.][creating library packages]
+  You can find examples of this directory structure in the
+  [Stagehand templates.][Stagehand templates]
+
+[creating library packages]: /guides/libraries/create-library-packages
+[Stagehand templates]: https://github.com/google/stagehand/tree/master/templates
 
 {% comment %}
 Save this section for when dartdevc is ready to use...
@@ -58,6 +69,92 @@ you can start migrating to Dart 2.0 now:
 Convert your code to be strong mode compliant.
 : For more information, see [Strong mode and static
   typing](#strong-mode-and-static-typing), below.
+
+## Migration tips: packages
+
+As a package owner, you need to do the following:
+
+* Follow the migration tips for the platforms that your package supports
+  (see above).
+* Make sure your package's users know how to report issues.
+* Respond quickly to issue reports.
+* If code changes aren't backward compatible,
+  update the lower SDK constraint.
+
+
+### Changes and backward compatibility
+
+If you have to change your package's code,
+**try to make it work in 1.x**, as well as 2.0.
+For example, you might be able to add type annotations
+or (if an API has been removed) to use an alternative 1.x API.
+
+If a backward-compatible change isn't possible,
+**update the lower [SDK constraint.][SDK constraints]**
+
+<aside class="alert alert-warning" markdown="1">
+  **Specify SDK constraints carefully!**
+  Incorrect lower constraints can cause problems for users of the stable SDK.
+</aside>
+
+[Test your changes][] to make sure that your package works as expected.
+
+[Test your changes]: /guides/testing
+
+
+### Upper constraints on the SDK version
+
+Don't update an already-published package
+solely to indicate that it can be used with Dart 2.0 pre-releases.
+As long as a package has either no [SDK constraints][]
+or an upper constraint of `<2.0.0`,
+`pub get` and similar pub commands in any Dart 2.0 pre-release
+can download the package.
+(The package won't be usable with Dart 2.0 stable releases,
+but you can fix that later.)
+
+When you update an existing package or publish a new one,
+specify an upper constraint of `<2.0.0` for the SDK version. Examples:
+
+```
+sdk: '>=1.20.1 <2.0.0'
+sdk: '>=2.0.0-dev.1.2 <2.0.0'
+```
+
+Eventually, you'll need to publish new versions of your packages to
+declare Dart 2.0 compatibility, most likely using a `<3.0.0` SDK constraint.
+Because incompatible changes might occur in any Dart 2.0 pre-release,
+don't declare Dart 2.0 compatibility until we announce that it's safe to do so.
+
+### Summary
+
+If you publish packages, get ready for Dart 2.0:
+
+* Make it easy for users to report issues.
+* Respond quickly to issues.
+* Avoid unnecessary incompatibility.
+* Specify the correct SDK constraints.
+* Test your packages.
+
+
+[pub.dartlang.org]: https://pub.dartlang.org
+[SDK constraints]: /tools/pub/pubspec#sdk-constraints
+[pubspec format]: /tools/pub/pubspec
+
+
+## Testing with Dart 2.0 pre-releases {#testing}
+
+To test your code with Dart 2.0, you can use a
+[pre-release](/install#about-sdk-release-channels-and-version-strings)
+of the Dart 2.0 SDK.
+
+When running `pub get`, `pub upgrade`, or other pub commands
+from a 2.0 pre-release, you might get packages that
+haven’t been verified to work with 2.0.
+If you find a package that has 2.0 issues,
+please report those issues immediately to the package maintainer,
+and let the Dart community know about any workarounds you find.
+
 
 ## Obsolete features
 
@@ -137,5 +234,3 @@ To use strong mode in Dart 1.x, [you must enable
 it.](/guides/language/sound-dart#how-to-enable-strong-mode)
 Note that runtime checks are not yet available unless you are developing
 for the web and using [dartdevc.]({{site.webdev}}/tools/dartdevc)
-
-

--- a/src/dart-2.0.md
+++ b/src/dart-2.0.md
@@ -97,9 +97,7 @@ If a backward-compatible change isn't possible,
   Incorrect lower constraints can cause problems for users of the stable SDK.
 </aside>
 
-[Test your changes][] to make sure that your package works as expected.
-
-[Test your changes]: /guides/testing
+[Test your changes](/guides/testing) to make sure that your package works as expected.
 
 
 ### Upper constraints on the SDK version

--- a/src/install/archive/index.md
+++ b/src/install/archive/index.md
@@ -13,10 +13,11 @@ js:
 
 {% include breadcrumbs.html %}
 
-Use this index to install specific versions of the
+Use this index to install
+[specific versions](/install#about-sdk-release-channels-and-version-strings) of the
 [Dart SDK](/tools/sdk),
-[Dartium]({{site.webdev}}/tools/dartium),
-and the [Dart API documentation]({{site.dart_api}}).
+[Dartium,]({{site.webdev}}/tools/dartium)
+and the [Dart API documentation.]({{site.dart_api}})
 
 Want to install Dart with your OS's package manager?
 Go to the [main Dart installation page](/install).

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -3,21 +3,24 @@ layout: default
 title: "Install Dart"
 description: "The bundles that support the Dart language."
 permalink: /install
-toc: false
 
 js:
 - url: /install/archive/assets/install.js
   defer: true
 ---
 
-<p>Current stable version of Dart:
-<span class="editor-build-rev-stable">[calculating]</span></p>
+<p><em>Current stable version of Dart:
+<span class="editor-build-rev-stable">[calculating]</span></em></p>
 
-Install the Dart SDK to get everything you need to write and run Dart code:
+If you’re a Flutter developer, you get Dart when you
+[install Flutter](https://flutter.io/setup/)
+or [upgrade Flutter.](https://flutter.io/upgrading/)
+
+Otherwise, install the **Dart SDK** to get everything you need to write and run Dart code:
 VM, libraries, analyzer, package manager, doc generator,
 formatter, debugger, and more.
 
-If you are doing web development, you will also need **Dartium**.
+If you're doing web development, you might also want **Dartium**.
 Instructions for installing Dartium are also provided in the following pages,
 or see the [zip file archive](/install/archive).
 
@@ -26,6 +29,7 @@ or see the [zip file archive](/install/archive).
 {% comment %}
 update-for-dart-2
 {% endcomment %}
+
 
 ## Automated installation and updates
 
@@ -36,6 +40,7 @@ A package manager can help you easily install and update the Dart SDK.
 * [Installing Dart on Mac](/install/mac) with homebrew
 * [Installing Dart on Linux](/install/linux) with our Debian package
 
+
 ## Manual install
 
 Not using a package manager for your OS? No problem!
@@ -43,7 +48,45 @@ Not using a package manager for your OS? No problem!
 [Download](/install/archive)
 zip files of the Dart SDK, Dartium, and docs.
 
+
 ## Looking for an older version?
 
 Check out our [zip file archive](/install/archive) for
 previous versions of the Dart SDK.
+
+
+## About SDK release channels and version strings
+
+The Dart SDK has two release channels:
+
+* **stable** channel: **stable releases**
+  (updated no more frequently than every 6 weeks)
+* **dev** channel: **pre-releases**
+  (usually updated 1/week)
+
+Most **alpha** releases of Flutter contain a **dev** channel release of Dart.
+
+**Stable** channel releases of the Dart SDK have version strings like `1.24.2` and `2.0.0`.
+They consistent of dot-separated integers, with no hyphens or letters.
+
+**Dev** channel releases of the Dart SDK (pre-releases)
+have additional characters, starting with a hyphen (`-`).
+After the stable release of Dart 1.24.0 on June 12,
+dev channel SDKs had version strings beginning with
+`1.25.0-dev`—for example, `1.25.0-dev.16.4`.
+
+Although we don't plan to release a 1.25 Dart SDK on the stable channel,
+the `1.25.0-dev` releases made it possible to use the latest SDK without
+worrying about [SDK constraints][] and [semantic versioning.][semantic versioning]
+Now that breaking changes are expected,
+we’ve switched to version strings beginning with `2.0.0-dev`.
+
+For more information, see
+[Dart 2.0 Updates](/dart-2.0)
+and the [installation instructions](#) for your platform.
+{% comment %}
+[PENDING: add link to the news post?]
+{% endcomment %}
+
+[SDK constraints]: /tools/pub/pubspec#sdk-constraints
+[semantic versioning]: http://semver.org/

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -210,7 +210,7 @@ For more information, see
 ## SDK constraints
 
 A package can indicate which versions of its dependencies it supports, but there
-is also another implicit dependency all packages have: the Dart SDK itself.
+is another implicit dependency all packages have: the Dart SDK itself.
 Since the Dart platform evolves over time, a package may only work with certain
 versions of it.
 
@@ -235,6 +235,7 @@ with the version of the Dart SDK that you have installed.
 and **do include an upper bound** (`<2.0.0`, usually).
 Packages that break these rules might stop working in the future
 and, for that reason, might not be allowed on pub.dartlang.org.
+For more information, see [Dart 2.0 Updates.](/dart-2.0)
 </aside>
 
 


### PR DESCRIPTION
Changed pages are staged here:

https://kw-www-dartlang-1.firebaseapp.com/dart-2.0
https://kw-www-dartlang-1.firebaseapp.com/install
https://kw-www-dartlang-1.firebaseapp.com/install/archive
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/pubspec

Fixes #381
