### PR TITLE
Update pub docs

### DIFF
--- a/src/_includes/pub-in-prereleases.html
+++ b/src/_includes/pub-in-prereleases.html
@@ -1,0 +1,10 @@
+<aside class="alert alert-warning" markdown="1">
+  **SDK constraints and Dart 2.0 pre-releases:**
+  The pub version solver in 2.0 pre-releases can choose package versions that
+  haven’t been verified to work with 2.0.
+
+  If you find a package that has Dart 2.0 issues,
+  please report those issues immediately to the package maintainer,
+  and let the Dart community know about any workarounds you find.
+  For more information, see [Dart 2.0 Updates.](/dart-2.0)
+</aside>

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -12,7 +12,7 @@ Flutter has its own commands for managing and updating packages.
 For more information, see
 [Using Packages]({{site.flutter}}/using-packages/) and
 [Upgrading Flutter]({{site.flutter}}/upgrading/)
-on the [Flutter website]({{site.flutter}}).
+on the [Flutter website.]({{site.flutter}})
 
 Quick links to the `pub` commands:
 
@@ -35,21 +35,23 @@ See [Troubleshooting Pub](/tools/pub/troubleshoot).
 
 Pub's commands fall into the following categories:
 
-* [Managing apps](#managing-apps)
+* [Managing package dependencies](#managing-apps)
 * [Running and serving apps](#running-and-serving-apps)
 * [Building
   and deploying apps and packages](#building-and-deploying-apps-and-packages)
 
-## Managing apps
+## Managing package dependencies {#managing-apps}
 
 Pub provides a number of commands that support
-the creation and maintenance of a Dart application.
+the creation and maintenance of a Dart package.
+(Remember, every app that uses library packages must
+itself be a package.)
 
 In this group, the most commonly used commands are `pub get` and
-`pub upgrade`, which retrieve or upgrade dependencies used by a project.
+`pub upgrade`, which retrieve or upgrade dependencies used by a package.
 Every time you modify a pubspec file, run `pub get`
 to make sure the dependencies are up to date. Some IDEs
-perform this step automatically on the creation of a package,
+perform this step automatically on the creation of a project,
 or any modification of the pubspec.
 
 [`pub cache`](/tools/pub/cmd/pub-cache)
@@ -58,23 +60,23 @@ or any modification of the pubspec.
   your cache.
 
 [`pub deps`](/tools/pub/cmd/pub-deps)
-: Lists all dependencies used by a package.
+: Lists all dependencies used by the current package.
 
 [`pub downgrade`](/tools/pub/cmd/pub-downgrade)
 : Retrieves the lowest versions of all the packages that are
-  listed as dependencies used by the application. Used for testing
+  listed as dependencies used by the current package. Used for testing
   the lower range of your package's dependencies.
 
 [`pub get`](/tools/pub/cmd/pub-get)
 : Retrieves the packages that are listed as the dependencies for
-  the application.
+  the current package.
   If a `pubspec.lock` file already exists, fetches the version
   of each dependency (if possible) as listed in the lock file.
   Creates or updates the lock file, as needed.
 
 [`pub upgrade`](/tools/pub/cmd/pub-upgrade)
 : Retrieves the latest version of each package listed
-  as dependencies used by the application. If a `pubspec.lock`
+  as dependencies used by the current package. If a `pubspec.lock`
   file exists, ignores the versions listed in the lock file and fetches
   the newest versions that honor the constraints in the pubspec.
   Creates or updates the lock file, as needed.

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -42,10 +42,8 @@ Pub's commands fall into the following categories:
 
 ## Managing package dependencies {#managing-apps}
 
-Pub provides a number of commands that support
-the creation and maintenance of a Dart package.
-(Remember, every app that uses library packages must
-itself be a package.)
+Pub provides a number of commands for managing the
+[packages your code depends on](/tools/pub/dependencies).
 
 In this group, the most commonly used commands are `pub get` and
 `pub upgrade`, which retrieve or upgrade dependencies used by a package.
@@ -80,6 +78,7 @@ or any modification of the pubspec.
   file exists, ignores the versions listed in the lock file and fetches
   the newest versions that honor the constraints in the pubspec.
   Creates or updates the lock file, as needed.
+
 
 ## Running and serving apps
 

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -40,7 +40,8 @@ Pub's commands fall into the following categories:
 * [Building
   and deploying apps and packages](#building-and-deploying-apps-and-packages)
 
-## Managing package dependencies {#managing-apps}
+<a id="managing-apps"></a>
+## Managing package dependencies
 
 Pub provides a number of commands for managing the
 [packages your code depends on](/tools/pub/dependencies).

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -34,7 +34,11 @@ dependencies:
 
 Here's an example of the `pub deps` output for markdown_converter:
 
-{% prettify none %}
+{% comment %}
+The <pre style...> is a workaround for prettify treating the
+quotes like they start strings.
+{% endcomment %}
+<pre style="color:#222">
 $ pub deps
 markdown_converter 0.0.0
 |-- barback 0.15.2+6
@@ -47,7 +51,8 @@ markdown_converter 0.0.0
 |   '-- stack_trace 1.4.2
 |       '-- path...
 '-- markdown 0.7.2
-{% endprettify %}
+</pre>
+
 
 ## Options
 

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -15,7 +15,7 @@ $ pub downgrade [args] [dependencies]
 Without any additional arguments, `pub downgrade` gets the lowest versions of
 all the dependencies listed in the [`pubspec.yaml`](/tools/pub/pubspec) file
 in the current working directory, as well as their [transitive
-dependencies](/tools/pub/glossary#transitive-dependency), to the `.packages` file.
+dependencies](/tools/pub/glossary#transitive-dependency).
 For example:
 
 {% prettify sh %}
@@ -34,10 +34,9 @@ The `pub downgrade` command creates a lockfile. If one already exists,
 pub ignores that file and generates a new one from scratch, using the lowest
 versions of all dependencies.
 
-The `pub downgrade` command supports the same command-line arguments
-as the [`pub get` command](/tools/pub/cmd/pub-get).
+See the [`pub get` documentation](/tools/pub/cmd/pub-get) for more information
+on package resolution and the system package cache.
 
-{% include packages-dir.html %}
 
 ## Downgrading specific dependencies
 
@@ -69,12 +68,14 @@ highest versions of any transitive dependencies that fit the new dependency
 constraints. Any transitive dependencies are usually also downgraded
 as a result.
 
+
 ## Getting a new dependency
 
 If a dependency is added to the pubspec before `pub downgrade` is run,
-it gets the new dependency and any of its transitive dependencies and
-places them in the `.packages` file. This
+it gets the new dependency and any of its transitive dependencies,
+placing them in the `.packages` file. This
 is the same behavior as `pub get`.
+
 
 ## Removing a dependency
 
@@ -85,21 +86,26 @@ importing. Any transitive dependencies of the removed dependency are
 also removed, as long as no remaining immediate dependencies also
 depend on them. This is the same behavior as `pub get`.
 
+
 ## Downgrading while offline
 
-If you don't have network access, you can still run `pub downgrade`. Since pub
-downloads packages to a central cache shared by all packages on your system, it
-can often find previously-downloaded packages there without needing to hit the
-network.
+If you don't have network access, you can still run `pub downgrade`.
+Because pub downloads packages to a central cache shared by all packages
+on your system, it can often find previously downloaded packages
+without needing to use the network.
 
-However, by default, pub always tries to go online when you downgrade if you
-have any hosted dependencies so that it can see if newer versions of them are
-available. If you don't want it to do that, pass the `--offline` flag when
-running pub. In this mode, it only looks in your local package cache and
-tries to find a set of versions that work with your package from what's already
+However, by default, `pub downgrade` tries to go online if you
+have any hosted dependencies.
+If you don't want pub to do that, pass it the `--offline` flag.
+In offline mode, pub looks only in your local package cache,
+trying to find a set of versions that work with your package from what's already
 available.
 
+
 ## Options {#options}
+
+The `pub downgrade` command supports the
+[`pub get` options](/tools/pub/cmd/pub-get#options).
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -9,7 +9,7 @@ _Get_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
 {% prettify sh %}
-$ pub get [--offline] [--no-packages-dir | --packages-dir]
+$ pub get [--offline] [--packages-dir]
 {% endprettify %}
 
 This command gets all the dependencies listed in the
@@ -37,21 +37,6 @@ PENDING: here just to make it easy to find discussions of `packages`...
 {% include packages-dir.html %}
 {% endcomment %}
 
-<aside class="alert alert-warning" markdown="1">
-  **As of Dart 1.20, the `.packages` file has replaced `packages` directories.**
-
-  If both are present, tools use the `.packages` file.
-  For more information, see
-  [Resolving package: URIs](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#resolving-package-uris).
-
-  For backward compatibility, the `pub serve` command still
-  produces a virtual `packages` directory,
-  and the `pub build` command produces an actual `packages` directory
-  in its output directory.
-  To make other `pub` commands create `packages` directories,
-  specify `--packages-dir`.
-</aside>
-
 Once the dependencies are acquired, they may be referenced in Dart code.
 For example, if a package depends on `test`:
 
@@ -76,8 +61,23 @@ This is the primary difference between `pub get` and
 [`pub upgrade`](/tools/pub/cmd/pub-upgrade), which always tries to
 get the latest versions of all dependencies.
 
+{% include pub-in-prereleases.html %}
+
+## Package resolution: .packages and packages
+
+By default, pub creates a `.packages` file
+that maps from package names to location URIs.
+Before the `.packages` file, pub used to create `packages` directories.
+
+The `pub serve` command still
+produces a virtual `packages` directory,
+and the `pub build` command produces an actual `packages` directory
+in its output directory.
+To make other `pub` commands create `packages` directories,
+specify `--packages-dir`.
+
 <aside class="alert alert-info" markdown="1">
-**Note:** Do not check the generated `.package` file,
+**Note:** Don't check the generated `.package` file,
 `packages` directories, or `.pub` directory (when present)
 into your repo;
 add them to your repo's `.gitignore` file.
@@ -85,24 +85,29 @@ add them to your repo's `.gitignore` file.
 of files that should not be checked into the repo.
 </aside>
 
+For more information, see the
+[package specification file proposal.](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#proposal)
+
+
 ## Getting a new dependency
 
 If a dependency is added to the pubspec and then `pub get` is run,
 it gets the new dependency and any of its transitive dependencies and
-updates the mapping in the `.packages` file and
-the links in the `packages` directory.
+updates the mapping in the `.packages` file.
 However, pub won't change the versions of any already-acquired
 dependencies unless that's necessary to get the new dependency.
+
 
 ## Removing a dependency
 
 If a dependency is removed from the pubspec and then `pub get` is run,
-it removes the dependency from the `.packages` file and
-`packages` directory, thus making it unavailable for importing.
+it removes the dependency from the `.packages` file,
+making the dependency unavailable for importing.
 Any transitive dependencies of the removed dependency are also removed,
 as long as no remaining immediate dependencies also depend on them.
 Removing a dependency never changes the versions of any
 already-acquired dependencies.
+
 
 ## The system package cache
 
@@ -117,32 +122,39 @@ worrying about re-downloading packages.
 
 By default, the system package cache is located in the `.pub-cache`
 subdirectory of your home directory (on Mac and Linux),
-or in `%APPDATA%\Pub\Cache` (on Windows). (The precise location of the
-cache may vary depending on the Windows version.)
-You can configure the location of the cache by setting
+or in `%APPDATA%\Pub\Cache` (on Windows;
+the location might vary depending on the Windows version).
+You can configure the location of the cache by setting the
 [`PUB_CACHE`](/tools/pub/installing)
 environment variable before running pub.
+
 
 ## Getting while offline
 
 If you don't have network access, you can still run `pub get`.
-Since pub downloads packages to a central cache shared by all packages
-on your system, it can often find previous-downloaded packages there
-without needing to hit the network.
+Because pub downloads packages to a central cache shared by all packages
+on your system, it can often find previously downloaded packages
+without needing to use the network.
 
-However, by default, pub always tries to go online when you get if you
-have any hosted dependencies so that it can see if newer versions of them are
-available. If you don't want it to do that, pass the `--offline` flag when
-running pub. In this mode, it only looks in your local package cache and
-tries to find a set of versions that work with your package from what's already
+However, by default, `pub get` tries to go online if you
+have any hosted dependencies,
+so that pub can detect newer versions of dependencies.
+If you don't want pub to do that, pass it the `--offline` flag.
+In offline mode, pub looks only in your local package cache,
+trying to find a set of versions that work with your package from what's already
 available.
 
-Keep in mind that pub generates a lockfile after it does this. If the
-only version of some dependency in your cache happens to be old, this locks
-your app to that version. The next time you are online, you will likely want to
+Keep in mind that pub generates a lockfile. If the
+only version of some dependency in your cache happens to be old,
+offline `pub get` locks your app to that old version.
+The next time you are online, you will likely want to
 run [`pub upgrade`](/tools/pub/cmd/pub-upgrade) to upgrade to a later version.
 
+
 ## Options
+
+The `pub get` command supports the `--offline` and `--packages-dir`
+command-line arguments, as discussed above.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -12,12 +12,17 @@ _Upgrade_ is one of the commands of the _pub_ tool.
 $ pub upgrade [args] [dependencies]
 {% endprettify %}
 
+Like [`pub get`](/tools/pub/cmd/pub-get),
+`pub upgrade` gets dependencies.
+The difference is that `pub upgrade` ignores any existing
+[lockfile](/tools/pub/glossary#lockfile),
+so that pub can get the latest versions of all dependencies.
+
 Without any additional arguments, `pub upgrade` gets the latest
 versions of all the dependencies listed in the
 [`pubspec.yaml`](/tools/pub/pubspec.html) file in the current working
 directory, as well as their [transitive
-dependencies](/tools/pub/glossary#transitive-dependency), to the
-`.packages` file.
+dependencies](/tools/pub/glossary#transitive-dependency).
 For example:
 
 {% prettify sh %}
@@ -25,32 +30,30 @@ $ pub upgrade
 Dependencies upgraded!
 {% endprettify %}
 
-When `pub upgrade` upgrades dependency versions, it writes a
-[lockfile](/tools/pub/glossary#lockfile) to ensure that future
-[`pub get`s](/tools/pub/cmd/pub-get) will use the same versions of those
-dependencies. Application packages should check in the lockfile to
-source control; this ensures the application will use the exact same
+When `pub upgrade` upgrades dependency versions, it writes a lockfile to ensure that
+[`pub get`](/tools/pub/cmd/pub-get) will use the same versions of those
+dependencies. For application packages, check in the lockfile to
+source control; this ensures the application has the exact same
 versions of all dependencies for all developers and when deployed to
-production. Library packages should not check in the lockfile, though,
-since they're expected to work with a range of dependency versions.
+production. For library packages, don't check in the lockfile,
+because libraries are expected to work with a range of dependency versions.
 
 If a lockfile already exists, `pub upgrade` ignores it and generates a new
-one from scratch using the latest versions of all dependencies. This is the
-primary difference between `pub upgrade` and `pub get`, which always tries to
-get the dependency versions specified in the existing lockfile.
+one from scratch, using the latest versions of all dependencies.
 
-The `pub upgrade` command supports the same command-line arguments
-as the [`pub get` command](/tools/pub/cmd/pub-get).
+{% include pub-in-prereleases.html %}
 
-{% include packages-dir.html %}
+See the [`pub get` documentation](/tools/pub/cmd/pub-get) for more information
+on package resolution and the system package cache.
 
 <aside class="alert alert-info" markdown="1">
 **Note:** In earlier releases of Dart, _pub upgrade_ was called _pub update_.
 </aside>
 
+
 ## Upgrading specific dependencies
 
-It's possible to tell `pub upgrade` to upgrade specific dependencies to the
+You can tell `pub upgrade` to upgrade specific dependencies to the
 latest version while leaving the rest of the dependencies alone as much as
 possible. For example:
 
@@ -63,12 +66,14 @@ versions that are locked in the lockfile. However, if the requested upgrades
 cause incompatibilities with these locked versions, they are selectively
 unlocked until a compatible set of versions is found.
 
+
 ## Getting a new dependency
 
 If a dependency is added to the pubspec before `pub upgrade` is run,
 it gets the new dependency and any of its transitive dependencies,
 placing them in the `.packages` file. This
 is the same behavior as `pub get`.
+
 
 ## Removing a dependency
 
@@ -79,26 +84,33 @@ importing. Any transitive dependencies of the removed dependency are
 also removed, as long as no remaining immediate dependencies also
 depend on them. This is the same behavior as `pub get`.
 
+
 ## Upgrading while offline
 
 If you don't have network access, you can still run `pub upgrade`.
-Since pub downloads packages to a central cache shared by all packages
-on your system, it can often find previously downloaded packages there
-without needing to hit the network.
+Because pub downloads packages to a central cache shared by all packages
+on your system, it can often find previously downloaded packages
+without needing to use the network.
 
-However, by default, pub always tries to go online when you upgrade if you
-have any hosted dependencies so that it can see if newer versions of them are
-available. If you don't want it to do that, pass the `--offline` flag when
-running pub. In this mode, it only looks in your local package cache and
-tries to find a set of versions that work with your package from what's already
+However, by default, `pub upgrade` tries to go online if you
+have any hosted dependencies,
+so that pub can detect newer versions of dependencies.
+If you don't want pub to do that, pass it the `--offline` flag.
+In offline mode, pub looks only in your local package cache,
+trying to find a set of versions that work with your package from what's already
 available.
 
-Keep in mind that pub *will* generate a lockfile after it does this. If the
-only version of some dependency in your cache happens to be old, this locks
-your app to that version. The next time you are online, you will likely want to
+Keep in mind that pub generates a lockfile. If the
+only version of some dependency in your cache happens to be old,
+offline `pub upgrade` locks your app to that old version.
+The next time you are online, you will likely want to
 run `pub upgrade` again to upgrade to a later version.
 
+
 ## Options
+
+The `pub upgrade` command supports the
+[`pub get` options](/tools/pub/cmd/pub-get#options).
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -107,16 +107,16 @@ If it's `flutter`, the dependency is satisfiable as long as:
 
 If it's an unknown identifier, the dependency is always considered unsatisfied.
 
-In order to publish a package with an `sdk` dependency,
-it must have a Dart SDK constraint whose minimum version is at least
-1.19.0 which ensures that older versions of pub won't accidentally
-install packages that need SDK dependencies.
+A package with an `sdk` dependency
+must have a Dart SDK constraint with a minimum version of at least 1.19.0.
+This constraint ensures that older versions of pub won't
+install packages that have `sdk` dependencies.
 
 ### Hosted packages
 
 A *hosted* package is one that can be downloaded from pub.dartlang.org
-(or another HTTP server that speaks the same API). Most of your dependencies
-will be of this form, as shown in the following example:
+or another HTTP server that speaks the same API. Most dependencies
+are hosted and are declared like this:
 
 {% prettify yaml %}
 dependencies:
@@ -265,14 +265,16 @@ A version constraint is a series of:
   (because it's the first version to introduce some breaking change).
 
 You can specify version parts as you want, and their ranges are intersected
-together. For example, `>=1.2.3 <2.0.0` allows any version from `1.2.3` to
+together. For example, `'>=1.2.3 <2.0.0'` allows any version from `1.2.3` to
 `2.0.0` excluding `2.0.0` itself. An easier way to express this range is
 by using [caret syntax](#caret-syntax), or `^1.2.3`.
 
-<aside class="alert alert-info">
-Note that `>` is also valid YAML syntax so you will want to quote
-the version string (like `'<=1.2.3 >2.0.0'`) if the version
-constraint starts with that.
+<aside class="alert alert-warning" markdown="1">
+If the **`>`** character is in the version constraint,
+be sure to **quote the constraint string**,
+so the character isn't interpreted as YAML syntax.
+For example, never use `>=1.2.3 <2.0.0`;
+instead, use `'>=1.2.3 <2.0.0'` or `^1.2.3`.
 </aside>
 
 ### Caret syntax

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -115,8 +115,8 @@ install packages that have `sdk` dependencies.
 ### Hosted packages
 
 A *hosted* package is one that can be downloaded from pub.dartlang.org
-or another HTTP server that speaks the same API. Most dependencies
-are hosted and are declared like this:
+(or another HTTP server that speaks the same API). Here's an example
+of declaring a dependency on a hosted package:
 
 {% prettify yaml %}
 dependencies:

--- a/src/tools/pub/get-started.md
+++ b/src/tools/pub/get-started.md
@@ -90,7 +90,10 @@ Pub creates a
 that maps each package name
 that your app depends on to the corresponding package in the system cache.
 
-{% include packages-dir.html %}
+{% comment %}
+PENDING: Here only to make it easy to find the packages discussion:
+packages-dir.html
+{% endcomment %}
 
 ## Importing libraries from packages
 To import libraries found in packages, use the

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -127,7 +127,7 @@ exact configuration of packages used by an application.
 
 The lockfile is generated automatically for you by pub when you run
 [`pub get`](/tools/pub/cmd/pub-get.html), [`pub upgrade`](/tools/pub/cmd/pub-upgrade.html),
-or [`pub downgrade`](/tools/pub/cmd/pub-downgrade.html)..
+or [`pub downgrade`](/tools/pub/cmd/pub-downgrade.html).
 If your package is an application package, you will typically check this into
 source control. For library packages, you usually won't.
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -70,11 +70,6 @@ enchilada/
 
 {% include packages-dir.html %}
 
-{% comment %}
-Not ready for this...
-These symlinks are not generated if you specify `--no-package-symlinks` in
-Dart 1.2 or later.
-{% endcomment %}
 
 ## The basics
 


### PR DESCRIPTION
Fixes #386 

Added a 2.0.0 pre-release note to `pub get` & `pub upgrade`.

The rest of the changes are mostly little issues I happened to notice while I was in there. Fixed some inconsistencies, tightened up or clarified some wording.

Main changes are staged here: (@kevmoo, please look at these)
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-get
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-upgrade

Other changes here: (@nex3 or someone else with good pub knowledge, please look at these)
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-deps
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/cmd/pub-downgrade
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/dependencies
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/get-started
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/glossary
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/package-layout