### PR TITLE
Add breadcrumbs to Install and Tools pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ src/site/events/2015/summit/node_modules
 
 # Cache files
 .sass-cache
-src/.asset-cache
+.asset-cache
 .jekyll-metadata
 
 # Deployment Files

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm: 2.4.2
 
 env:
   global:
+    - JEKYLL_ENV=production
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
 before_install:

--- a/_config.yml
+++ b/_config.yml
@@ -35,41 +35,44 @@ collections:
 
 defaults:
 - scope:
-    path: ""
-    type: pages
+    path: ''
+    # type: pages
   values:
     layout: default
     toc: true
 - scope:
-    path: ""
+    path: ''
     type: articles
   values:
     layout: article
-    toc: true
 - scope:
-    path: ""
+    path: ''
     type: tutorials
   values:
     layout: tutorial
-    toc: true
 - scope:
-    path: ""
+    path: ''
     type: samples
   values:
     layout: sample
-    toc: true
 - scope:
-    path: ""
+    path: ''
     type: guides
   values:
     layout: guide
-    toc: true
 - scope:
-    path: ""
+    path: ''
     type: codelabs
   values:
     layout: codelab
-    toc: true
+- scope:
+    path: install
+  values:
+    show_breadcrumbs: true
+- scope:
+    path: tools
+  values:
+    show_breadcrumbs: true
 
 custom:
   dartpad:
@@ -98,15 +101,10 @@ custom:
 
 
 # Build settings
-safe: false
 source: src
 destination: publish
-incremental: true
 bundler_args: --without production
-markdown: kramdown
-excerpt_separator: "~~~"
 
-include: ["_pages"]
 exclude: ["diagrams", "appengine", "tests", "site"]
 
 plugins:
@@ -114,12 +112,11 @@ plugins:
 - jekyll-toc
 - jekyll-sitemap
 
-
 assets:
-  compress:
-    css: true # default - development: false, production: true
-    js: true # default - development: false, production: true
-  cache: .asset-cache # default: .asset-cache
+  # compress:
+  #  css: true # default - development: false, production: true
+  #  js: true # default - development: false, production: true
+  # cache: .asset-cache # default: .asset-cache
   # cdn: https://cdn.example.com
   # skip_baseurl_with_cdn: false
   # skip_prefix_with_cdn: false

--- a/serve_local.sh
+++ b/serve_local.sh
@@ -12,8 +12,7 @@ if [[ "$1" == "frontpage" ]]; then
   CONFIG="--config _config.yml,scripts/frontpage_only_config.yml"
 fi
 
-jekyll build $CONFIG --incremental --watch &
-
+bundle exec jekyll build $CONFIG --incremental --watch &
 j_pid=$!
 firebase serve --port 4000 &
 f_pid=$!

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -961,7 +961,7 @@ main .content {
   padding: 0;
   font-size: small;
   > .active {
-    color: $gray;
+    color: inherit;
   }
   > li {
     + li {

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -958,16 +958,17 @@ main .content {
 
 .breadcrumb {
   background-color: transparent;
+  padding: 0;
+  font-size: small;
   > .active {
     color: $gray;
   }
   > li {
     + li {
-
       &:before {
-        content: "/ ";
-        padding: 0 5px;
-        color: $gray;
+        font-family: 'Material Icons';
+        content: 'chevron_right';
+        vertical-align: bottom;
       }
     }
   }

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -49,15 +49,17 @@
   - title: "Dart Testing"
     permalink: /guides/testing
 
-- title: "Resources"
+- title: Resources
   children:
-  - title: "Codelabs"
+  - title: Install
+    permalink: /install
+  - title: Codelabs
     permalink: /codelabs
-  - title: "Tutorials"
+  - title: Tutorials
     permalink: /tutorials
-  - title: "Articles"
+  - title: Articles
     permalink: /articles
-  - title: "Dart Tools"
+  - title: Tools
     permalink: /tools
   - title: "Community and Support"
     permalink: /community

--- a/src/_includes/breadcrumbs.html
+++ b/src/_includes/breadcrumbs.html
@@ -1,24 +1,24 @@
-{% if page.show_breadcrumbs == true %}
+{% if page.show_breadcrumbs == true -%}
 
-{% capture url %}{% if page.language%}{{ page.url | remove: "/" | remove: page.language }}{% else %}{{ page.url | remove: "/" }}{% endif %}{% endcapture %}
-{% if url.size > 0 %}
+{%- capture url %}{% if page.language%}{{ page.url | remove: "/" | remove: page.language }}{% else %}{{ page.url | remove: "/" }}{% endif %}{% endcapture -%}
+{%- if url.size > 0 -%}
   <ol class="breadcrumb list-unstyled" vocab="http://schema.org/" typeof="BreadcrumbList">
-  {% assign position = 0 %}
-  {% for crumb in breadcrumbs %}
-    {% if crumb.url == "/" %}
-      {% continue %}
-    {% endif %}
+  {% assign position = 0 -%}
+  {%- for crumb in breadcrumbs -%}
+    {%- if crumb.url == "/" -%}
+      {%- continue -%}
+    {%- endif -%}
 
-    {% assign caption = crumb.title %}
-    {% assign position = position  | plus: 1 %}
+    {%- assign caption = crumb.title -%}
+    {%- assign position = position  | plus: 1 %}
     <li class="breadcrumb-item{% if crumb.url == page.url %} active{% endif %}" property="itemListElement" typeof="ListItem">
-      {% if crumb.url != page.url %}<a property="item" typeof="WebPage" href="{{ crumb.url | prepend: site.baseurl | prepend: site.url }}">{% endif %}
+      {% if crumb.url != page.url %}<a property="item" typeof="WebPage" href="{{ crumb.url }}">{% endif %}
       <span property="name">{{ caption }}</span>
       {% if crumb.url != page.url %}</a>{% endif %}
       <meta property="position" content="{{ position }}" />
     </li>
   {% endfor %}
   </ol>
-{% endif %}
+{%- endif -%}
 
-{% endif %}
+{%- endif -%}

--- a/src/_plugins/drops/breadcrumb_item.rb
+++ b/src/_plugins/drops/breadcrumb_item.rb
@@ -11,7 +11,7 @@ module Drops
     end
 
     def title
-      @page.data["breadcrumb"] != nil ? @page.data["breadcrumb"] : @page.data["title"]
+      @page.data["breadcrumb"] || @page.data["short-title"] || @page.data["title"]
     end
 
     def subset

--- a/src/install/archive/index.md
+++ b/src/install/archive/index.md
@@ -1,18 +1,13 @@
 ---
-layout: default
 title: "Index of Downloads"
 description: "Download specific stable and dev channel versions of the Dart SDK, Dartium, and the Dart API documentation."
 permalink: /install/archive
-
 js:
 - url: /install/archive/out/web/download_archive.dart.js
   defer: true
 - url: /install/archive/assets/install.js
   defer: true
 ---
-
-{% include breadcrumbs.html %}
-
 Use this index to install
 [specific versions](/install#about-sdk-release-channels-and-version-strings) of the
 [Dart SDK](/tools/sdk),
@@ -48,7 +43,7 @@ You can find the zip files at predictable URLs using the
 following pattern:
 
 {% prettify none %}
-https://storage.googleapis.com/dart-archive/channels/<[[highlight]]stable/dev[[/highlight]]>/release/<[[highlight]]release[[/highlight]]>/sdk/dartsdk-<[[highlight]]platform[[/highlight]]>-<[[highlight]]architecture[[/highlight]]>-release.zip
+https://storage.googleapis.com/dart-archive/channels/<[[highlight]]stable|dev[[/highlight]]>/release/<[[highlight]]release[[/highlight]]>/sdk/dartsdk-<[[highlight]]platform[[/highlight]]>-<[[highlight]]architecture[[/highlight]]>-release.zip
 {% endprettify %}
 
 Examples:

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -1,12 +1,11 @@
 ---
-layout: default
-title: "Install Dart"
-description: "The bundles that support the Dart language."
+title: Install Dart
+description: The bundles that support the Dart language.
 permalink: /install
-
 js:
 - url: /install/archive/assets/install.js
   defer: true
+show_breadcrumbs: false
 ---
 
 <p><em>Current stable version of Dart:

--- a/src/install/linux.md
+++ b/src/install/linux.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Dart on Linux
+short-title: Linux Install
 description: Installing and updating the Dart SDK on Linux with apt-get, a Debian package, and compiling from source.
 permalink: /install/linux
 js:

--- a/src/install/linux.md
+++ b/src/install/linux.md
@@ -1,9 +1,7 @@
 ---
-layout: default
-title: "Installing Dart on Linux"
-description: "Installing and updating the Dart SDK on Linux with apt-get, a Debian package, and compiling from source."
+title: Installing Dart on Linux
+description: Installing and updating the Dart SDK on Linux with apt-get, a Debian package, and compiling from source.
 permalink: /install/linux
-
 js:
 - url: /install/archive/assets/install.js
   defer: true

--- a/src/install/mac.md
+++ b/src/install/mac.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Dart on Mac
+short-title: Mac Install
 description: Installing and updating the Dart SDK on your Mac with homebrew.
 permalink: /install/mac
 ---

--- a/src/install/mac.md
+++ b/src/install/mac.md
@@ -1,7 +1,6 @@
 ---
-layout: default
-title: "Installing Dart on Mac"
-description: "Installing and updating the Dart SDK on your Mac with homebrew."
+title: Installing Dart on Mac
+description: Installing and updating the Dart SDK on your Mac with homebrew.
 permalink: /install/mac
 ---
 

--- a/src/install/windows.md
+++ b/src/install/windows.md
@@ -1,9 +1,7 @@
 ---
-layout: default
-title: "Installing Dart on Windows"
-description: "Installing and updating the Dart SDK on Windows with Chocolatey or an installer."
+title: Installing Dart on Windows
+description: Installing and updating the Dart SDK on Windows with Chocolatey or an installer.
 permalink: /install/windows
-
 js:
 - url: /install/archive/assets/install.js
   defer: true

--- a/src/install/windows.md
+++ b/src/install/windows.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Dart on Windows
+short-title: Windows Install
 description: Installing and updating the Dart SDK on Windows with Chocolatey or an installer.
 permalink: /install/windows
 js:

--- a/src/tools/analyzer.md
+++ b/src/tools/analyzer.md
@@ -1,8 +1,7 @@
 ---
-layout: default
+title: Static Analyzer
+description: The tool that analyzes and validates your Dart code.
 permalink: /tools/analyzer
-title: "Static Analyzer"
-description: "The tool that analyzes and validates your Dart code."
 ---
 
 The static analyzer evaluates your Dart code,

--- a/src/tools/dartpad.md
+++ b/src/tools/dartpad.md
@@ -1,8 +1,7 @@
 ---
-layout: default
+title: DartPad
+description: The tool that lets you interactively play with Dart in a browser.
 permalink: /tools/dartpad
-title: "DartPad"
-description: "The tool that lets you interactively play with Dart in a browser."
 ---
 
 DartPad, an open-source tool,

--- a/src/tools/faq.md
+++ b/src/tools/faq.md
@@ -1,9 +1,8 @@
 ---
-layout: default
+title: Tools FAQ
+short-title: FAQ
+description: FAQ and other tips for using Dart Tools.
 permalink: /tools/faq
-title: "Tools FAQ"
-short-title: "FAQ"
-description: "FAQ and other tips for using Dart Tools."
 ---
 
 ## General

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -1,8 +1,9 @@
 ---
-layout: default
-title: "Dart Tools"
-description: "The tools that support the Dart language."
+title: Dart Tools
+short-title: Tools
+description: The tools that support the Dart language.
 permalink: /tools
+show_breadcrumbs: false
 toc: false
 ---
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -1,6 +1,5 @@
 ---
-title: Dart Tools
-short-title: Tools
+title: Tools
 description: The tools that support the Dart language.
 permalink: /tools
 show_breadcrumbs: false

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -1,8 +1,7 @@
 ---
-layout: default
+title: Dart Plugin from JetBrains
 permalink: /tools/jetbrains-plugin
-title: "Dart Plugin from JetBrains"
-description: "Use Dart with a variety of IDEs and editors from JetBrains."
+description: Use Dart with a variety of IDEs and editors from JetBrains.
 ---
 
 The Dart plugin adds Dart support to JetBrains IDEs such as

--- a/src/tools/pub/index.md
+++ b/src/tools/pub/index.md
@@ -1,8 +1,7 @@
 ---
-layout: default
-title: "Pub Package and Asset Manager"
-description: "Use the pub tool to manage Dart's packages and assets."
-short-title: "Pub"
+title: Pub Package and Asset Manager
+description: Use the pub tool to manage Dart's packages and assets.
+short-title: Pub
 permalink: /tools/pub
 ---
 

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -1,7 +1,6 @@
 ---
-layout: default
-title: "Dart SDK"
-description: "Dart libraries and command-line tools."
+title: Dart SDK
+description: Dart libraries and command-line tools.
 permalink: /tools/sdk
 ---
 


### PR DESCRIPTION
- Made use of existing breadcrumb plugins, but with tweaks:
  - Crumb URL is site relative
  - Crumb name is `page.short-title` if it exists, otherwise `page.title`.
- Added breadcrumbs to pages under
  - Install
  - Tools
- Sidenav: added "Install" under Resources
- Minor tweak in install/archive page: `stable/dev` --> `stable|dev`

"Dart Tools" page has been given the short title of just "Tools". Maybe we should just rename the page to "Tools" instead?

Sample pages on staging server:
 - https://dartlang-org-dev.firebaseapp.com/tools/pub/cmd/pub-uploader
 - https://dartlang-org-dev.firebaseapp.com/install/archive

Fixes  #159 

Example breadcrumb:
> <img width="690" alt="screen shot 2017-10-19 at 13 31 23" src="https://user-images.githubusercontent.com/4140793/31785044-e254cab6-b4d1-11e7-89ba-7037db4d6896.png">

cc @Sfshaza @kevmoo 