### PR TITLE
Add support for second-level TOC entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .packages
 .pub
 .sass-cache/
+.vscode
 _asset_bundler_cache
 _bookhtml
 _cache/

--- a/src/_assets/javascripts/main.js
+++ b/src/_assets/javascripts/main.js
@@ -66,8 +66,15 @@ $(document).on('ready', function(){
   });
 
   // TOC: Table of Contents
-  $('.toc-entry').not('.toc-h2').remove();
-  $('.section-nav').addClass('nav').css({opacity: 1});
+  // TODO: consider doing most of the HTML TOC manipulation statically.
+  $('.toc-entry').not('.toc-h2,.toc-h3').remove();
+  var sectionNav = $('.section-nav');
+  $(sectionNav).addClass('nav').css({opacity: 1});
+  // Bootstrap 3 Nav styles are defined for single level lists using
+  // selectors like ".nav > li". (Bootstrap 4 doesn't have this limitation.)
+  // Rather than try to rewrite styles over ".nav > li" as ".nav li",
+  // we've chose to simply apply the .nav class to nested toc ul elements.
+  $(sectionNav).find('ul').addClass('nav');
 
   $('body').scrollspy({
      offset: 100,

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -467,9 +467,19 @@ img {
     padding: 0;
     padding-top: 30px;
   }
+  $border-width: 3px;
   .section-nav {
     opacity: 0;
-    list-style: none;
+    /* Add a bit of extra space between top-level entries */
+    & > li { padding-top: 3px; }
+  }
+  /* Nested toc entries: */
+  .toc-entry ul li {
+    font-size: 0.9em;
+    $padding: $font-size-base * .75;
+    padding-left: $padding;
+    /* Prevent the active entry from shifting right because of double border */
+    &.active { padding-left: $padding - $border-width; }
   }
   h4 {
     // TODO: use mixin and share code with #sidenav .content h4
@@ -483,19 +493,21 @@ img {
   }
   .nav {
     li {
-      border-left: 3px solid $gray-lighter;
+      border-left: $border-width solid $gray-lighter;
       a {
         padding: 3px 15px;
         color: $brand-primary;
       }
       &.active {
-        border-left: 3px solid $gray-dark;
+        border-left: $border-width solid $gray-dark;
         a {
           color: $gray-dark;
         }
       }
     }
   }
+  /* Don't show a double border for nested inactive entries */
+  li li { border-left: none; }
   &::-webkit-scrollbar {
     height: 4px;
     width: 4px;
@@ -570,9 +582,9 @@ input.gsc-search-button {
 /* -----------------------------------------
  Table of Contents
  ----------------------------------------- */
-.toc-entry.toc-h2 {}
+ .toc-entry.toc-h2,
+ .toc-entry.toc-h3 {}
 .toc-entry.toc-h1,
-.toc-entry.toc-h3,
 .toc-entry.toc-h4,
 .toc-entry.toc-h5,
 .toc-entry.toc-h6,


### PR DESCRIPTION
Corresponding webdev PR: https://github.com/dart-lang/site-webdev/pull/1098

As an example, this changes the Language Tour TOC from:
<img width="228" alt="screen shot 2017-11-06 at 08 42 53" src="https://user-images.githubusercontent.com/4140793/32445705-9d7c4250-c2d4-11e7-9b18-ce76a78bcf9b.png">

to

<img width="217" alt="screen shot 2017-11-06 at 09 26 01" src="https://user-images.githubusercontent.com/4140793/32445800-e2a6bb8a-c2d4-11e7-809a-4fac4f87e764.png">
