### PR TITLE
Adjust site page footer, and add build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .packages
 .pub
 .sass-cache/
+.vscode
 _asset_bundler_cache
 _bookhtml
 _cache/
@@ -18,6 +19,8 @@ pubspec.lock
 scripts/packages
 
 src/site/events/2015/summit/node_modules
+
+/src/_data/ci.yaml
 
 # ============= OCUPOP =============
 # RVM users

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 install:
   - bundle install
   - npm install -g firebase-tools superstatic --no-optional
+  - ./scripts/write-ci-info.sh -v
 
 script:
   - ./deploy/cibuild

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: Dart
 description: "Dart is a platform for building structured apps. It includes a language, a VM, libraries, tools, and compilers to many targets, including JavaScript."
 url: https://www.dartlang.org
+repo: https://github.com/dart-lang/site-www
 
 # Global variables
 # use case:

--- a/scripts/write-ci-info.sh
+++ b/scripts/write-ci-info.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+if [[ $CI_TASK != build* ]]; then exit; fi
+
+FILE=src/_data/ci.yaml
+
+echo "# WARNING: the sample values in this file get regenerated at build time.
+build-id: $TRAVIS_BUILD_ID
+build-number: $TRAVIS_BUILD_NUMBER
+build-time: $(date)
+commit-sha: $TRAVIS_COMMIT
+job-id: $TRAVIS_JOB_ID
+repo-slug: $TRAVIS_REPO_SLUG" > $FILE
+
+if [[ "$1" == '-v' ]]; then
+  echo "$FILE:"
+  cat $FILE
+fi
+
+# Sample values from a master build:
+#
+# TRAVIS_BUILD_ID=280419528
+# TRAVIS_BUILD_NUMBER=2286
+# TRAVIS_COMMIT=b197a41666c52d42234fe9261b2008620b0f6aaa
+# TRAVIS_COMMIT_MESSAGE='chore: upgrade to latest stable jekyll (3.6.0) and ruby (2.4.2) (#1077)'
+# TRAVIS_COMMIT_RANGE=ff3b5a372baa...b197a41666c5
+# TRAVIS_EVENT_TYPE=push
+# TRAVIS_FILTERED=redirect_io
+# TRAVIS_JOB_ID=280419536
+# TRAVIS_JOB_NUMBER=2286.1
+# TRAVIS_LANGUAGE=node_js
+# TRAVIS_NODE_VERSION=6
+# TRAVIS_OS_NAME=linux
+# TRAVIS_PRE_CHEF_BOOTSTRAP_TIME=2017-08-29T02:15:46
+# TRAVIS_PULL_REQUEST=false
+# TRAVIS_PULL_REQUEST_BRANCH=
+# TRAVIS_PULL_REQUEST_SHA=
+# TRAVIS_PULL_REQUEST_SLUG=
+# TRAVIS_REPO_SLUG=dart-lang/site-webdev
+
+# Sample values from a PR:
+#
+# TRAVIS_BRANCH=master
+# TRAVIS_BUILD_ID=280464741
+# TRAVIS_BUILD_NUMBER=2291
+# TRAVIS_COMMIT=00c076794bc7a4f80bac005220128f057c18b3ed
+# TRAVIS_COMMIT_MESSAGE='Merge 4bbfbd729b507df32fe3b3beefc79b0ed40a67a7 into 30420326f124b963cc124359d5887f3a07fe4cc8'
+# TRAVIS_COMMIT_RANGE=30420326f124b963cc124359d5887f3a07fe4cc8...4bbfbd729b507df32fe3b3beefc79b0ed40a67a7
+# TRAVIS_EVENT_TYPE=pull_request
+# TRAVIS_JOB_ID=280464746
+# TRAVIS_JOB_NUMBER=2291.2
+# TRAVIS_PULL_REQUEST=1078
+# TRAVIS_PULL_REQUEST_BRANCH=chalin-chore-content-shell-0927
+# TRAVIS_PULL_REQUEST_SHA=4bbfbd729b507df32fe3b3beefc79b0ed40a67a7
+# TRAVIS_PULL_REQUEST_SLUG=chalin/site-webdev
+# TRAVIS_REPO_SLUG=dart-lang/site-webdev

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -206,7 +206,7 @@ img {
   h4 {
     color: #fff;
     text-transform: uppercase;
-    font-size: 15px;
+    font-size: inherit;
     a {
       color: $white-base;
       &:hover, &:focus, &:active {

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -7,10 +7,27 @@
             <img src="{% asset_path 'logo-white.svg' %}" alt="Dart logo" class="brand"/>
           </div>
           <h4><a href="/terms">Terms</a> | <a href="http://www.google.com/intl/en/policies/privacy/">Privacy</a></h4>
-          <p><small>Except as otherwise noted, the content of this page is licensed under the Creative Commons Attribution 3.0 License, and code samples are licensed under the BSD License.</small></p>
-          <h4>Problems with this site?</h4>
-          <ul>
-            <li><a href="https://github.com/dart-lang/site-www/issues">File a bug</a></li>
+          <style>.menu .material-icons { font-size: 14px; }</style>
+          {%- assign dateFormat = '%Y/%m/%d %R %Z' -%}
+          <ul class="menu">
+            <li>Site&nbsp;<a href="http://creativecommons.org/licenses/by/3.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;3.0</a></li>
+            <li>
+              <a href="{{site.repo}}"
+                 title="This site's source is on GitHub."
+                 class="no-automatic-external"><i class="fa fa-github"></i></a>
+              &nbsp;
+              <a href="{{site.repo}}/issues"
+                 title="File an issue about this site."
+                 class="no-automatic-external"><i class="fa fa-bug"></i></a>
+              &nbsp;
+              <a {% if site.data.ci.job-id %}
+                 href="{{site.repo | regex_replace: 'github.com','travis-ci.org'}}/jobs/{{site.data.ci.job-id}}"
+                 title="Site build #{{site.data.ci.build-number}} ({{site.data.ci.build-time | date: dateFormat}})"
+                 {% else %}
+                 title="Site built on {{site.time | date: dateFormat}}"
+                 {% endif %}
+                 class="no-automatic-external"><i class="material-icons">build</i></a>
+            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Corresponding webdev issue https://github.com/dart-lang/site-webdev/issues/1003 (see issue for related PRs).

- Shortens the CC BY 3.0 text.
- Add icons linking to GitHub repo, Issues and Travis job.

Only changes the left-most column of the footer from:

<img width="591" alt="screen shot 2017-11-06 at 11 50 16" src="https://user-images.githubusercontent.com/4140793/32453329-eb962cde-c2e9-11e7-9466-11c57b09ad73.png">

to

<img width="611" alt="screen shot 2017-11-06 at 11 49 58" src="https://user-images.githubusercontent.com/4140793/32453351-f374305e-c2e9-11e7-8f22-d0b7e40347f0.png">
