### PR TITLE
Newsletter link

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -14,6 +14,8 @@ Track the Dart project, get help, and talk with other Dart developers.
 * [announce@dartlang.org](https://groups.google.com/a/dartlang.org/d/forum/announce) -
   Low traffic announcements of new releases, breaking changes,
   and other important news. Recommended!
+* [Dart Language & Library Newsletters](https://github.com/dart-lang/sdk/blob/master/docs/newsletter/README.md#dart-language-and-library-newsletters) -
+  Information about existing features and planned changes.
 * [@dart_lang](https://twitter.com/dart_lang) -
   The official Twitter account.
 * [+dartlang](https://plus.google.com/+dartlang) -

--- a/src/dart-2.0.md
+++ b/src/dart-2.0.md
@@ -13,6 +13,8 @@ and how you can migrate your code from Dart 1.x.
 Dart 2.0 pre-releases will have a series of incompatible changes.
 Although we appreciate your willingness to prepare for and test Dart 2.0,
 please don't bet your livelihood on a pre-release.
+For information on potential changes, see
+[Dart Language & Library Newsletters.](https://github.com/dart-lang/sdk/blob/master/docs/newsletter/README.md#dart-language-and-library-newsletters)
 </aside>
 
 * Migration tips


### PR DESCRIPTION
Add links from /dart-2.0 & /community to the newsletters.

Currently links to a non-existent anchor, but once https://dart-review.googlesource.com/c/sdk/+/21784 is in, it'll exist.

Fixes #387.