### PR TITLE
chore: fix / cleanup page-specific CSS imports

### DIFF
--- a/src/_articles/libraries/converters-and-codecs.md
+++ b/src/_articles/libraries/converters-and-codecs.md
@@ -1,12 +1,9 @@
 ---
-layout: article
-title: "Converters and Codecs"
-description: "Learn how to write efficient conversions."
+title: Converters and Codecs
+description: Learn how to write efficient conversions.
 written: 2014-02-06
 updated: 2015-03-17
 category: libraries
-header:
-  css: ["/articles/styles.css"]
 ---
 
 ### **_How to write efficient conversions_**

--- a/src/_articles/libraries/zones.md
+++ b/src/_articles/libraries/zones.md
@@ -1,11 +1,9 @@
 ---
-layout: article
-title: "Zones"
+title: Zones
 description: "Manage your asynchronous code: handle uncaught errors, override behavior (such as printing and scheduling tasks), and more."
 written: 2014-03-03
 category: libraries
-header:
-  css: ["/articles/styles.css"]
+css: ["/articles/styles.css"]
 ---
 
 ### Asynchronous dynamic extents

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -2,12 +2,12 @@
   <meta charset="utf-8">
   <meta http-equiv="Content-Language" content="en_US" />
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">{% 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">{%
   assign desc = page.description | default: page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160
   %}
   <meta name="description" content="{{desc}}">
   <title>{% if page.short-title %}{{ page.short-title }}{% else %}{{ page.title }}{% endif %} | {{ site.title }}</title>
-  
+
   <!-- Favicon / Touch Icons -->
   <link href="/favicon.ico" rel="shortcut icon">
   <link href="{% asset_path 'touch-icon-iphone.png' %}" rel="apple-touch-icon">
@@ -41,21 +41,20 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700' rel='stylesheet' type='text/css'>
   {% stylesheet style %}
-  {% for css in page.css %}
-    <link href="{{ css.url }}" rel="stylesheet" type="text/css">
-  {% endfor %}
-
+  {% for css in page.css -%}
+    <link href="{{css}}" rel="stylesheet" type="text/css">
+  {%- endfor %}
   <!--
-      Why don't we use Dart here?
+    Why don't we use Dart here?
 
-      The only scripting we use here is stuff like the on-click footnotes on the
-      front page or resizing of the left nav. These happen to be use cases where
-      JavaScript and jQuery are doing just fine. Dart is here for application
-      programming, not page scripting.
+    The only scripting we use here is stuff like the on-click footnotes on the
+    front page or resizing of the left nav. These happen to be use cases where
+    JavaScript and jQuery are doing just fine. Dart is here for application
+    programming, not page scripting.
    -->
   {% javascript main %}
-  {% for js in page.js %}
+  {% for js in page.js -%}
   <script {% if js.defer %}defer{% endif %} src="{{ js.url }}"></script>
-  {% endfor %}
+  {%- endfor %}
   {% include analytics.html %}
 </head>

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -2,13 +2,10 @@
 layout: tutorial
 title: "Write HTTP Clients & Servers"
 description: "Communicate over the internet"
-
 prevpage:
   url: /tutorials/dart-vm/cmdline
   title: "Dart-VM: Write Command-Line Apps"
-
-header:
-  css: ["httpserver.css"]
+css: ["httpserver.css"]
 ---
 
 ### Communicate over the internet

--- a/src/dart-vm/dart-by-example/index.md
+++ b/src/dart-vm/dart-by-example/index.md
@@ -1,16 +1,9 @@
 ---
-layout: default
 title: "Cookbook: Dart by Example"
-short-title: "Cookbook"
+short-title: Cookbook
 permalink: /dart-vm/dart-by-example
-description: "A cookbook, or set of examples, showing idiomatic Dart code."
-
-header:
-  css: ["index.css"]
+description: A cookbook, or set of examples, showing idiomatic Dart code.
 ---
-
-
-
 
 The following examples are all stand-alone apps, such as servers, that run
 from the command line. Most of the examples use the `dart:io` library, which is

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -1,11 +1,7 @@
 ---
-layout: default
 permalink: /tools/pub/cmd/pub-global
-title: "pub global"
-description: "Use pub global to run Dart scripts hosted on pub.dartlang.org from the command line."
-
-header:
-  css: ["../transformers/transformers.css"]
+title: pub global
+description: Use pub global to run Dart scripts hosted on pub.dartlang.org from the command line.
 ---
 
 _Global_ is one of the commands of the _pub_ tool.
@@ -223,20 +219,16 @@ For options that apply to all pub commands, see
   the following command pulls the 0.6.0 version of the `markdown`
   package:
 
-<div class="step-details" markdown="1">
-{% prettify sh %}
-$ pub global activate markdown 0.6.0
-{% endprettify %}
-</div>
+  {% prettify sh %}
+  $ pub global activate markdown 0.6.0
+  {% endprettify %}
 
   If you specify a range, pub picks the best version that meets that
   constraint. For example:
 
-<div class="step-details" markdown="1">
-{% prettify sh %}
-$ pub global activate foo <3.0.0
-{% endprettify %}
-</div>
+  {% prettify sh %}
+  $ pub global activate foo <3.0.0
+  {% endprettify %}
 
 `--executable=<name>` or `-x<name>`
 : Optional for `pub global activate`.
@@ -245,11 +237,9 @@ $ pub global activate foo <3.0.0
   For example, the following command adds `bar` and `baz` (but not
   any other executables that `foo` might define) to your PATH.
 
-<div class="step-details" markdown="1">
-{% prettify sh %}
-$ pub global activate foo -x bar -x baz
-{% endprettify %}
-</div>
+  {% prettify sh %}
+  $ pub global activate foo -x bar -x baz
+  {% endprettify %}
 
 `--no-executables`
 : Optional for `pub global activate`.
@@ -264,6 +254,5 @@ $ pub global activate foo -x bar -x baz
   the new executable overwrites the previously activated executable.
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>


### PR DESCRIPTION
Fixes #228 

For example, [Zone basics](http://localhost:4000/articles/libraries/zones#zone-basics) used to be rendered like this:

<img width="744" alt="screen shot 2017-12-04 at 12 07 40" src="https://user-images.githubusercontent.com/4140793/33567792-5e8952e8-d8f2-11e7-8435-26c4604cdd0f.png">

It is now rendered like this:

<img width="790" alt="screen shot 2017-12-04 at 12 30 13" src="https://user-images.githubusercontent.com/4140793/33567804-679c2662-d8f2-11e7-9710-99b73d6bd071.png">

