### PR TITLE
Rename example file

### DIFF
--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -379,7 +379,7 @@ that you author.  Use whatever markup format that you prefer.
 {% prettify none %}
 enchilada/
   example/
-    lunch.dart
+    main.dart
 {% endprettify %}
 
 Code, tests, docs, what else

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -38,7 +38,7 @@ enchilada/
     api/ ***
     getting_started.md
   example/
-    lunch.dart
+    main.dart
   lib/
     enchilada.dart
     tortilla.dart


### PR DESCRIPTION
In the new pub website `lunch.dart` won't be treated as the example.
Update instead to use one of the filenames that can be identified and
shown as an example on the pub site.

https://github.com/dart-lang/pub-dartlang-dart/blob/8ae285f2b846b0e3bf1098162318f6c52eff5776/app/lib/shared/utils.dart#L219