### PR TITLE
Example(httpserver): minor cleanup

### DIFF
--- a/examples/httpserver/bin/static_file_server.dart
+++ b/examples/httpserver/bin/static_file_server.dart
@@ -16,8 +16,7 @@ Future main() async {
 
   var staticFiles = new VirtualDirectory(pathToBuild);
   staticFiles.allowDirectoryListing = true; /*1*/
-  staticFiles.directoryHandler = (dir, request) {
-    /*2*/
+  staticFiles.directoryHandler = (dir, request) /*2*/ {
     var indexUri = new Uri.file(dir.path).resolve('index.html');
     staticFiles.serveFile(new File(indexUri.toFilePath()), request); /*3*/
   };

--- a/examples/httpserver/pubspec.yaml
+++ b/examples/httpserver/pubspec.yaml
@@ -1,5 +1,5 @@
 name: httpserver
-description: A sample application
+description: Sample HTTP clients and servers
 
 homepage: https://www.dartlang.org/docs/tutorials/httpserver/
 
@@ -8,5 +8,3 @@ dependencies:
 
 dev_dependencies:
   test: ^0.12.0
-  dartlang_examples_util:
-    path: ../util

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -885,8 +885,7 @@ Future main() async {
 
   var staticFiles = new VirtualDirectory(pathToBuild);
   staticFiles.allowDirectoryListing = true; [!/*1*/!]
-  staticFiles.directoryHandler = (dir, request) {
-    [!/*2*/!]
+  staticFiles.directoryHandler = (dir, request) [!/*2*/!] {
     var indexUri = new Uri.file(dir.path).resolve('index.html');
     staticFiles.serveFile(new File(indexUri.toFilePath()), request); [!/*3*/!]
   };


### PR DESCRIPTION
Contributes to #407. Followup to #463.

- Remove unnecessary pubspec dependency.
- Fix marker placement.