### PR TITLE
Better support for command-line snippet highlighting

### DIFF
--- a/src/_assets/stylesheets/_code.scss
+++ b/src/_assets/stylesheets/_code.scss
@@ -76,3 +76,35 @@ li.L3,
 li.L5,
 li.L7,
 li.L9 { background-color: #fefefe; }
+
+//
+// Rouge / pygments classes (https://github.com/jneen/rouge)
+//
+
+@mixin console-base {
+  background: $grey-900;
+  color: $light-green-A700;
+}
+.language-console .highlight {
+  @include console-base;
+}
+
+// `terminal` is like `console` with prompts and output colored differently
+.language-terminal .highlight {
+  @include console-base;
+  .gp { color: $grey-500; } /* Generic.Prompt */
+  .nb { color: $light-green-600; } /* Name.Builtin */
+  .go { color: white; } /* Generic.Output */
+}
+
+// Match prettifier classes defined above.
+// TODO: complete this to get proper highlighting for Dart under Rouge.
+.highlight {
+  .s, .s1, .s2 { @extend .str; } /* Literal.String.* */
+  .k, .kc, .kd, .kn, .kp, .kr, .kt { @extend .kwd; } /* Keyword.* */
+  .p { @extend .pun; } /* Punctuation */
+  .c, .c1, .cm { @extend .com; } /* Comment */
+  .l { @extend .lit; } /* Literal */
+  .o { @extend .opn; } /* Operator */
+  .n { @extend .typ; } /* Name */
+}

--- a/src/_assets/stylesheets/_colors.scss
+++ b/src/_assets/stylesheets/_colors.scss
@@ -1,0 +1,157 @@
+/*
+* Material Design Colors
+*
+* Colors based off the material design palette
+* https://material.google.com/style/color.html#color-color-palette
+*
+*/
+
+$amber-50: #FFF8E1;
+$amber-100: #FFECB3;
+$amber-200: #FFE082;
+$amber-300: #FFD54F;
+$amber-400: #FFCA28;
+$amber-500: #FFC107;
+$amber-600: #FFB300;
+$amber-700: #FFA000;
+$amber-800: #FF8F00;
+$amber-900: #FF6F00;
+$amber-A100: #FFE57F;
+$amber-A200: #FFD740;
+$amber-A400: #FFC400;
+$amber-A700: #FFAB00;
+
+$blue-50: #E3F2FD;
+$blue-100: #BBDEFB;
+$blue-200: #90CAF9;
+$blue-300: #64B5F6;
+$blue-400: #42A5F5;
+$blue-500: #2196F3;
+$blue-600: #1E88E5;
+$blue-700: #1976D2;
+$blue-800: #1565C0;
+$blue-900: #0D47A1;
+$blue-A100: #82B1FF;
+$blue-A200: #448AFF;
+$blue-A400: #2979FF;
+$blue-A700: #2962FF;
+
+$blue-grey-50: #ECEFF1;
+$blue-grey-100: #CFD8DC;
+$blue-grey-200: #B0BEC5;
+$blue-grey-300: #90A4AE;
+$blue-grey-400: #78909C;
+$blue-grey-500: #607D8B;
+$blue-grey-600: #546E7A;
+$blue-grey-700: #455A64;
+$blue-grey-800: #37474F;
+$blue-grey-900: #263238;
+
+$cyan-50: #E0F7FA;
+$cyan-100: #B2EBF2;
+$cyan-200: #80DEEA;
+$cyan-300: #4DD0E1;
+$cyan-400: #26C6DA;
+$cyan-500: #00BCD4;
+$cyan-600: #00ACC1;
+$cyan-700: #0097A7;
+$cyan-800: #00838F;
+$cyan-900: #006064;
+$cyan-A100: #84FFFF;
+$cyan-A200: #18FFFF;
+$cyan-A400: #00E5FF;
+$cyan-A700: #00B8D4;
+
+$grey-400: #BDBDBD;
+$grey-500: #9E9E9E;
+$grey-900: #212121;
+
+$green-50: #E8F5E9;
+$green-100: #C8E6C9;
+$green-200: #A5D6A7;
+$green-300: #81C784;
+$green-400: #66BB6A;
+$green-500: #4CAF50;
+$green-600: #43A047;
+$green-700: #388E3C;
+$green-800: #2E7D32;
+$green-900: #1B5E20;
+$green-A100: #B9F6CA;
+$green-A200: #69F0AE;
+$green-A400: #00E676;
+$green-A700: #00C853;
+
+$light-green-50: #F1F8E9;
+$light-green-100: #DCEDC8;
+$light-green-200: #C5E1A5;
+$light-green-300: #AED581;
+$light-green-400: #9CCC65;
+$light-green-500: #8BC34A;
+$light-green-600: #7CB342;
+$light-green-700: #689F38;
+$light-green-800: #558B2F;
+$light-green-900: #33691E;
+$light-green-A100: #CCFF90;
+$light-green-A200: #B2FF59;
+$light-green-A400: #76FF03;
+$light-green-A700: #64DD17;
+
+$pink-50: #FCE4EC;
+$pink-100: #F8BBD0;
+$pink-200: #F48FB1;
+$pink-300: #F06292;
+$pink-400: #EC407A;
+$pink-500: #E91E63;
+$pink-600: #D81B60;
+$pink-700: #C2185B;
+$pink-800: #AD1457;
+$pink-900: #880E4F;
+$pink-A100: #FF80AB;
+$pink-A200: #FF4081;
+$pink-A400: #F50057;
+$pink-A700: #C51162;
+
+$purple-50: #F3E5F5;
+$purple-100: #E1BEE7;
+$purple-200: #CE93D8;
+$purple-300: #BA68C8;
+$purple-400: #AB47BC;
+$purple-500: #9C27B0;
+$purple-600: #8E24AA;
+$purple-700: #7B1FA2;
+$purple-800: #6A1B9A;
+$purple-900: #4A148C;
+$purple-A100: #EA80FC;
+$purple-A200: #E040FB;
+$purple-A400: #D500F9;
+$purple-A700: #AA00FF;
+
+$red-50: #FFEBEE;
+$red-100: #FFCDD2;
+$red-200: #EF9A9A;
+$red-300: #E57373;
+$red-400: #EF5350;
+$red-500: #F44336;
+$red-600: #E53935;
+$red-700: #D32F2F;
+$red-800: #C62828;
+$red-900: #B71C1C;
+$red-A100: #FF8A80;
+$red-A200: #FF5252;
+$red-A400: #FF1744;
+$red-A700: #D50000;
+
+$teal-50: #E0F2F1;
+$teal-100: #B2DFDB;
+$teal-200: #80CBC4;
+$teal-300: #4DB6AC;
+$teal-400: #26A69A;
+$teal-500: #009688;
+$teal-600: #00897B;
+$teal-700: #00796B;
+$teal-800: #00695C;
+$teal-900: #004D40;
+$teal-A100: #A7FFEB;
+$teal-A200: #64FFDA;
+$teal-A400: #1DE9B6;
+$teal-A700: #00BFA5;

--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -377,3 +377,8 @@ body.homepage .get-started-section {
 		display: none;
 	}
 }
+
+/* Overwrite bootstrap: don't wrap code */
+pre code {
+  white-space: pre;
+}

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -1,4 +1,5 @@
 @import '_variables';
+@import '_colors';
 @import "bootstrap-sprockets";
 @import "bootstrap";
 

--- a/src/_tutorials/dart-vm/cmdline.md
+++ b/src/_tutorials/dart-vm/cmdline.md
@@ -77,8 +77,7 @@ void main() {
 </li>
 
 <li markdown="1">
-In the directory that contains the file you just created,
-run the program with the command as shown next.
+In the directory that contains the file you just created, run the program:
 
 ```terminal
 $ dart helloworld.dart

--- a/src/_tutorials/dart-vm/cmdline.md
+++ b/src/_tutorials/dart-vm/cmdline.md
@@ -78,14 +78,12 @@ void main() {
 
 <li markdown="1">
 In the directory that contains the file you just created,
-run the program with the command as shown by the highlighted text.
+run the program with the command as shown next.
 
-{% prettify bash %}
-% [[highlight]]dart helloworld.dart[[/highlight]]
+```terminal
+$ dart helloworld.dart
 Hello, World!
-%
-{% endprettify %}
-
+```
 </li>
 </ol>
 
@@ -349,12 +347,11 @@ In this case,
 the user types in lines of text and the program copies them to stdout.
 The user signals the end of input by typing &lt;ctl-d&gt;.
 
-{% prettify bash %}
-$ [[highlight]]dart dcat.dart[[/highlight]]
-[[highlight]]The quick brown fox jumped over the lazy dog.[[/highlight]]
+```terminal
+$ dart dcat.dart
 The quick brown fox jumped over the lazy dog.
-...
-{% endprettify %}
+The quick brown fox jumped over the lazy dog.
+```
 
 ## Getting info about a file
 

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -98,11 +98,11 @@ with the string `Hello, world!`
 At the command line, run the `hello_world_server.dart` script.
 You will see the following:
 
-{% prettify shell %}
+```terminal
 $ cd httpserver/bin
 $ dart hello_world_server.dart
 listening on localhost, port 4040
-{% endprettify %}
+```
 
 <i class="material-icons">open_in_browser</i>
 **In any browser, visit** [localhost:4040](localhost:4040).
@@ -236,11 +236,11 @@ that you can use to guess the number.
    At the command line, run the `number_thinker.dart` server.
    You should see something similar to the following:
 
-   {% prettify dart %}
+   ```terminal
    $ cd httpserver/bin
    $ dart number_thinker.dart
    I'm thinking of a number: 6
-   {% endprettify %}
+   ```
 
 2. **Launch the web server**
 
@@ -527,24 +527,24 @@ Run the server and client on the command line.
 
 1. First the server:
 
-   {% prettify bash %}
+   ```terminal
    $ cd httpserver/bin
    $ dart basic_writer_server.dart
-   {% endprettify %}
+   ```
 
 2. Then, run the client in a new window:
 
-   {% prettify bash %}
+   ```terminal
    $ cd httpserver/bin
    $ dart basic_writer_client.dart
    Wrote data for Han Solo.
-   {% endprettify %}
+   ```
 
 3. The server writes the data to `file.txt`:
 
-   {% prettify bash %}
+   ```json
    {"name":"Han Solo","job":"reluctant hero","BFF":"Chewbacca","ship":"Millennium Falcon","weakness":"smuggling debts"}
-   {% endprettify %}
+   ```
 
 <hr>
 
@@ -762,10 +762,10 @@ It responds to all requests by returning the contents of the
 
 1. Run the server on the command line:
 
-   {% prettify shell %}
+   ```terminal
    $ cd httpserver/bin
    $ dart mini_file_server.dart
-   {% endprettify %}
+   ```
 
 2. Type [localhost:4044](localhost:4044) into the browser.
    The server displays an HTML file:
@@ -824,10 +824,10 @@ uses the [http_server][] package.
 
 1. Run the server on the command line:
 
-   {% prettify bash %}
+   ```terminal
    $ cd httpserver/bin
    $ dart basic_file_server.dart
-   {% endprettify %}
+   ```
 
 2. Type [localhost:4046](localhost:4046) into the browser.
    The server displays the same index.html file as the previous:

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -95,8 +95,7 @@ _Example file for this section:_
 Let's begin with a small server that responds to all requests
 with the string `Hello, world!`
 
-At the command line, run the `hello_world_server.dart` script.
-You will see the following:
+At the command line, run the `hello_world_server.dart` script:
 
 ```terminal
 $ cd httpserver/bin
@@ -525,14 +524,14 @@ you need to write a client program, of which there are two kinds:
 
 Run the server and client on the command line.
 
-1. First the server:
+1. First, run the server:
 
    ```terminal
    $ cd httpserver/bin
    $ dart basic_writer_server.dart
    ```
 
-2. Then, run the client in a new window:
+2. In a new terminal, run the client:
 
    ```terminal
    $ cd httpserver/bin
@@ -540,7 +539,7 @@ Run the server and client on the command line.
    Wrote data for Han Solo.
    ```
 
-3. The server writes the data to `file.txt`:
+Look at the JSON data that the server wrote to `file.txt`:
 
    ```json
    {"name":"Han Solo","job":"reluctant hero","BFF":"Chewbacca","ship":"Millennium Falcon","weakness":"smuggling debts"}

--- a/src/install/linux.md
+++ b/src/install/linux.md
@@ -39,33 +39,40 @@ To install the Dart SDK with apt-get, you first need to do some setup.
 
 The following one-time commands set up the install for the stable channel.
 
-{% prettify shell %}
-# Enable HTTPS for apt.
-$ sudo apt-get update
-$ sudo apt-get install apt-transport-https
-# Get the Google Linux package signing key.
-$ sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-# Set up the location of the stable repository.
-$ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-$ sudo apt-get update
-{% endprettify %}
+- Enable HTTPS for apt.
+  ```terminal
+  $ sudo apt-get update
+  $ sudo apt-get install apt-transport-https
+  ```
+- Get the Google Linux package signing key.
+  ```terminal
+  $ sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+  ```
+- Set up the location of the stable repository.
+  ```terminal
+  $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+  $ sudo apt-get update
+  ```
 
 The following one-time command sets the correct PATH variable for the dart tools like pub.
 The most common way is to put this line in your .bashrc file.
-{% prettify shell %}
+
+```terminal
 $ export PATH=/usr/lib/dart/bin:$PATH
-{% endprettify %}
+```
 
 ### Setting up for the dev channel
 
 The following one-time command sets up the install for the dev channel.
-Do this in addition to the [set up for stable channel](#setting-up-for-the-stable-channel).
 
-{% prettify shell %}
-# Before running this command, follow the instructions in
-# "Set up for the stable channel".
+<aside class="alert alert-warning" markdown="1">
+Before running this command, follow the instructions in
+[Setting up for the stable channel](#setting-up-for-the-stable-channel).
+</aside>
+
+```terminal
 $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
-{% endprettify %}
+```
 
 
 ### Installing the SDK
@@ -73,9 +80,9 @@ $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/de
 The following command installs the highest available version of the Dart SDK,
 based on your setup.
 
-{% prettify shell %}
+```terminal
 $ sudo apt-get install dart
-{% endprettify %}
+```
 
 If you have set up your environment for both the stable and dev channel
 releases, the previous command always installs the dev channel, as that
@@ -89,18 +96,18 @@ or to install a specific version number, see the next section.
 The dev channel has a higher version number than the stable channel.
 To force installation of the stable version, use the following command.
 
-{% prettify shell %}
+```terminal
 $ sudo apt-get install dart/stable
-{% endprettify %}
+```
 
 To install a particular release, specify the version.
 For example:
 
-{% prettify shell %}
+```terminal
 $ sudo apt-get install dart=1.5.8-1
 $ sudo apt-get install dart=1.6.*
 $ sudo apt-get install dart=1.7.0-dev.0.1.*
-{% endprettify %}
+```
 
 
 ## Installing a Debian package

--- a/src/install/mac.md
+++ b/src/install/mac.md
@@ -19,17 +19,17 @@ documentation generator, package manager, and the core libraries.
 
 [Install homebrew](http://brew.sh/), and then run:
 
-{% prettify shell %}
+```terminal
 $ brew tap dart-lang/dart
 $ brew install dart
-{% endprettify %}
+```
 
 If you use Dart for web development work, you should also install Dartium and Content Shell:
 
-{% prettify shell %}
+```terminal
 $ brew tap dart-lang/dart
 $ brew install dart --with-content-shell --with-dartium
-{% endprettify %}
+```
 
 {% include dartium-2.0.html %}
 
@@ -42,9 +42,9 @@ update-for-dart-2
 To choose the dev channel version of whatever Dart software you install,
 use `--devel`:
 
-{% prettify shell %}
+```terminal
 $ brew install dart --devel
-{% endprettify %}
+```
 
 You can use any combination of the
 `--devel`,
@@ -62,11 +62,11 @@ dev channel releases are not as heavily tested as the stable release.
 
 To update Dart once you've installed it using Homebrew, run:
 
-{% prettify shell %}
+```terminal
 $ brew update
 $ brew upgrade dart
 $ brew cleanup dart
-{% endprettify %}
+```
 
 {% comment %}
 PENDING: clarify what arguments you should supply,
@@ -100,15 +100,15 @@ as your home directory.
    For example, if you want Homebrew and Dart to live under
    `~/homebrew`, go to `~`.
 
-   {% prettify shell %}
+   ```terminal
    $ cd ~    # The directory that will contain Homebrew and Dart
-   {% endprettify %}
+   ```
 
 2. Clone Homebrew. This creates a `homebrew` directory.
 
-   {% prettify shell %}
+   ```terminal
    $ git clone https://github.com/Homebrew/homebrew.git
-   {% endprettify %}
+   ```
 
 3. Add the `homebrew/bin` directory to your PATH.
 

--- a/src/install/windows.md
+++ b/src/install/windows.md
@@ -49,10 +49,10 @@ update-for-dart-2
 
 If you're working on server-side Dart, all you need is the `dart-sdk`:
 
-{% prettify shell %}
-choco install dart-sdk -version <version>
-choco install dartium  -version <version>
-{% endprettify %}
+```terminal
+> choco install dart-sdk -version <version>
+> choco install dartium  -version <version>
+```
 
 The current stable version is
 <span class="editor-build-rev-stable">[calculating]</span>.
@@ -61,10 +61,10 @@ The current stable version is
 To choose the dev channel version,
 use `-dev<dev-version>`. For example:
 
-{% prettify shell %}
-choco install -y dart-sdk -version 1.12.0-dev.2.2
-choco install -y dartium  -version 1.12.0-dev.2.2
-{% endprettify %}
+```terminal
+> choco install -y dart-sdk -version 1.12.0-dev.2.2
+> choco install -y dartium  -version 1.12.0-dev.2.2
+```
 {% endcomment %}
 
 For more information on Chocolatey support for Dart, see:


### PR DESCRIPTION
Fixes #466 

Staged at https://dartlang-org-staging-0.firebaseapp.com, in particular see

- https://dartlang-org-staging-0.firebaseapp.com/tutorials/dart-vm/httpserver
- https://dartlang-org-staging-0.firebaseapp.com/tutorials/dart-vm/cmdline
- https://dartlang-org-staging-0.firebaseapp.com/install/linux
- https://dartlang-org-staging-0.firebaseapp.com/install/mac
- https://dartlang-org-staging-0.firebaseapp.com/install/windows

---

### Example

Styling updated from this:

> <img width="650" alt="screen shot 2017-12-12 at 12 19 17" src="https://user-images.githubusercontent.com/4140793/33898937-e185d0ae-df37-11e7-9ff0-d37cac801fdd.png">

To this:

> <img width="646" alt="screen shot 2017-12-12 at 12 19 47" src="https://user-images.githubusercontent.com/4140793/33898948-ee3e2efe-df37-11e7-8ecc-6e3db37fbcc4.png">
