### PR TITLE
Fix acronym capitalization prose and example of Effective Dart Style

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -195,9 +195,10 @@ class Dice {
 
 ### DO capitalize acronyms and abbreviations longer than two letters like words.
 
-Capitalized acronyms can be harder to read, and are ambiguous when you have
-multiple adjacent acronyms. Given the name `HTTPSFTPConnection`, there's no way
-to tell if that's an HTTPS FTP connection or an HTTP SFTP one.
+Capitalized acronyms can be hard to read, and
+multiple adjacent acronyms can lead to ambiguous names.
+For example, given a name that starts with `HTTPSFTP`, there's no way
+to tell if it's referring to HTTPS FTP or HTTP SFTP.
 
 To avoid this, acronyms and abbreviations are capitalized like regular words,
 except for two-letter acronyms. (Two-letter *abbreviations* like


### PR DESCRIPTION
Fixes #391. Admittedly, HTTPS/FTP or HTTP/SFTP may be unlikely to occur in the same name, but this is good enough to make the point about acronym capitalization.