### PR TITLE
chore: prettify plugin support for nocode and general markdown cleanup

### DIFF
--- a/src/_articles/language/await-async.md
+++ b/src/_articles/language/await-async.md
@@ -32,7 +32,7 @@ An **async** function is a function whose body is marked with an **async**
 modifier.
 
 {% prettify dart %}
-foo() [[highlight]]async[[/highlight]] => 42;
+foo() [!async!] => 42;
 {% endprettify %}
 
 When you call an **async** function, it immediately returns a Future;
@@ -89,7 +89,7 @@ operations completes, get the result, and resume execution.
 An `await` expression lets you do exactly that:
 
 {% prettify dart %}
-([[highlight]]await[[/highlight]] myFile.copy(newPath)).path == newPath;
+([!await!] myFile.copy(newPath)).path == newPath;
 {% endprettify %}
 
 When the **await** expression runs, `myFile.copy()` is invoked, yielding
@@ -151,7 +151,7 @@ First, notice that the modifier goes between the function signature and
 its body. We could also have written `foo()` as
 
 {% prettify dart %}
-foo() [[highlight]]async[[/highlight]] { return 42; }
+foo() [!async!] { return 42; }
 {% endprettify %}
 
 In short, the modifier comes before the => or the curly brace that opens

--- a/src/_articles/language/beyond-async.md
+++ b/src/_articles/language/beyond-async.md
@@ -61,9 +61,9 @@ Suppose we want to produce the first <em>n</em> natural numbers.
 It is quite easy to do this with a synchronous generator.
 
 {% prettify dart %}
-Iterable naturalsTo(n) [[highlight]]sync*[[/highlight]] {
+Iterable naturalsTo(n) [!sync*!] {
   int k = 0;
-  [[highlight]]while[[/highlight]] (k < n) [[highlight]]yield[[/highlight]] k++;
+  [!while!] (k < n) [!yield!] k++;
 }
 {% endprettify %}
 
@@ -115,9 +115,9 @@ Let’s try generating natural numbers again, asynchronously this time.
 
 
 {% prettify dart %}
-Stream asynchronousNaturalsTo(n) [[highlight]]async*[[/highlight]] {
+Stream asynchronousNaturalsTo(n) [!async*!] {
   int k = 0;
-  [[highlight]]while[[/highlight]] (k < n) [[highlight]]yield[[/highlight]] k++;
+  [!while!] (k < n) [!yield!] k++;
 }
 {% endprettify %}
 
@@ -140,8 +140,8 @@ the stream pushes the value to the listener function at its pleasure.
 As a variant, consider
 
 {% prettify dart %}
-Stream [[highlight]]get[[/highlight]] naturals [[highlight]]async*[[/highlight]] {
-  int k = 0; [[highlight]]while[[/highlight]] ([[highlight]]true[[/highlight]]) { [[highlight]]yield await[[/highlight]] k++; }
+Stream [!get!] naturals [!async*!] {
+  int k = 0; [!while!] ([!true!]) { [!yield await!] k++; }
 }
 {% endprettify %}
 
@@ -171,7 +171,7 @@ loop is designed to play well with streams.
 Given a stream, one can loop over its values:
 
 {% prettify dart %}
-[[highlight]]await for[[/highlight]] (int i [[highlight]]in[[/highlight]] naturals) { print(‘event loop $i’); }
+[!await for!] (int i [!in!] naturals) { print(‘event loop $i’); }
 {% endprettify %}
 
 Every time an element is added to the stream, the loop body is run. After each
@@ -187,10 +187,10 @@ Consider the following function,
 designed to count backwards from <em>n</em> to 1.
 
 {% prettify dart %}
-Iterable naturalsDownFrom(n) [[highlight]]sync*[[/highlight]] {
-  [[highlight]]if[[/highlight]] (n > 0) {
-     [[highlight]]yield[[/highlight]] n;
-     [[highlight]]for[[/highlight]] (int i in naturalsDownFrom(n-1)) { [[highlight]]yield[[/highlight]] i; }
+Iterable naturalsDownFrom(n) [!sync*!] {
+  [!if!] (n > 0) {
+     [!yield!] n;
+     [!for!] (int i in naturalsDownFrom(n-1)) { [!yield!] i; }
   }
 }
 {% endprettify %}
@@ -215,10 +215,10 @@ We can rewrite our code using yield-each as follows:
 
 
 {% prettify dart %}
-Iterable naturalsDownFrom(n) [[highlight]]sync*[[/highlight]] {
-  [[highlight]]if[[/highlight]] ( n > 0) {
-    [[highlight]]yield[[/highlight]] n;
-    [[highlight]]yield*[[/highlight]] naturalsDownFrom(n-1);
+Iterable naturalsDownFrom(n) [!sync*!] {
+  [!if!] ( n > 0) {
+    [!yield!] n;
+    [!yield*!] naturalsDownFrom(n-1);
  }
 }
 {% endprettify %}

--- a/src/_articles/libraries/zones.md
+++ b/src/_articles/libraries/zones.md
@@ -24,12 +24,12 @@ a simple HTTP server
 might use the following code:
 
 {% prettify dart %}
-[[highlight]]runZoned(() {[[/highlight]]
+[!runZoned(() {!]
   HttpServer.bind('0.0.0.0', port).then((server) {
     server.listen(staticFiles.serveRequest);
   });
-[[highlight]]},
-onError: (e, stackTrace) => print('Oh noes! $e $stackTrace'));[[/highlight]]
+[!},
+onError: (e, stackTrace) => print('Oh noes! $e $stackTrace'));!]
 {% endprettify %}
 
 Running the HTTP server in a zone
@@ -232,7 +232,7 @@ you see this output:
 {% prettify xml %}
 Outside runZoned
 Inside non-error zone
-[[highlight]]Inside error zone (not called)[[/highlight]]
+[!Inside error zone (not called)!]
 Uncaught Error: 499
 Unhandled exception:
 499
@@ -415,14 +415,14 @@ Future splitLinesStream(stream) {
   return stream
       .transform(ASCII.decoder)
       .transform(const LineSplitter())
-[[highlight]]      .map((line) => '${Zone.current[#filename]}: $line')[[/highlight]]
+[!      .map((line) => '${Zone.current[#filename]}: $line')!]
       .toList();
 }
 
 Future splitLines(filename) {
-[[highlight]]  return runZoned(() {[[/highlight]]
+[!  return runZoned(() {!]
     return splitLinesStream(new File(filename).openRead());
-[[highlight]]  }, zoneValues: { #filename: filename });[[/highlight]]
+[!  }, zoneValues: { #filename: filename });!]
 }
 
 main() {

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -1,7 +1,6 @@
 ---
-layout: default
-title: "Futures and Error Handling"
-description: "Everything you wanted to know about handling errors and exceptions when writing asynchronous code."
+title: Futures and Error Handling
+description: Everything you wanted to know about handling errors and exceptions when writing asynchronous code.
 ---
 
 This guide describes how to handle errors when writing asynchronous code.
@@ -45,7 +44,7 @@ and await expressions. For example:
 Future main() async {
   var dir = new Directory('/tmp');
 
-  [[highlight]]try[[/highlight]] {
+  [!try!] {
     var dirList = dir.list();
     await for (FileSystemEntity f in dirList) {
       if (f is File) {
@@ -54,7 +53,7 @@ Future main() async {
         print('Found dir ${f.path}');
       }
     }
-  } [[highlight]]catch[[/highlight]] (e) {
+  } [!catch!] (e) {
     print(e.toString());
   }
 }

--- a/src/_plugins/prettify.rb
+++ b/src/_plugins/prettify.rb
@@ -15,22 +15,22 @@ module Prettify
   # {% endprettify %}
   #
   # The language name can be ommitted if it is not known.
+  # Use 'nocode' or 'none' as the language to turn of prettifying.
+
   class Tag < Liquid::Block
 
     Syntax = /\s*(\w+)\s*/o
 
     def initialize(tag_name, markup, tokens)
       super
-      if markup =~ Syntax
-        @lang = $1
-      end
+      @lang = $1 if markup =~ Syntax
     end
 
     def render(context)
-      # out = '<pre class="prettyprint linenums'
-      out = '<pre class="prettyprint'
-      unless @lang.nil?
-        out += ' lang-' + @lang
+      out = '<pre class="'
+      unless @lang == 'nocode' || @lang == 'none'
+        out += 'prettyprint'
+        out += ' lang-' + @lang if @lang
       end
       out += '">'
 

--- a/src/_tutorials/dart-vm/cmdline.md
+++ b/src/_tutorials/dart-vm/cmdline.md
@@ -1,14 +1,13 @@
 ---
 layout: tutorial
-title: "Write Command-Line Apps"
-description: "Basics for command-line apps"
-
+title: Write Command-Line Apps
+description: Basics for command-line apps
 nextpage:
   url: /tutorials/dart-vm/httpserver
   title: "Dart-VM: Write HTTP Clients & Servers"
 prevpage:
   url: /tutorials/dart-vm/get-started
-  title: "Get Started"
+  title: Get Started
 ---
 
 ### An introduction to standalone apps
@@ -268,10 +267,10 @@ the `stdout` (if the -n flag is set) followed by the line from the file.
 
 {% prettify dart %}
 if (showLineNumbers) {
-  [[highlight]]stdout.write('${lineNumber++} ');[[/highlight]]
+  [!stdout.write('${lineNumber++} ');!]
 }
 
-[[highlight]]stdout.writeln(line);[[/highlight]]
+[!stdout.writeln(line);!]
 {% endprettify %}
 
 The `write()` and `writeln()` methods take an object of any type,
@@ -303,7 +302,7 @@ tries to list a directory.
 
 {% prettify dart %}
 if (await FileSystemEntity.isDirectory(path)) {
-  [[highlight]]stderr.writeln('error: $path is a directory');[[/highlight]]
+  [!stderr.writeln('error: $path is a directory');!]
 } else {
   exitCode = 2;
 }
@@ -339,7 +338,7 @@ the program instead reads synchronously from stdin
 using the `pipe()` method.
 
 {% prettify dart %}
-[[highlight]]stdin[[/highlight]].pipe(stdout);
+[!stdin!].pipe(stdout);
 {% endprettify %}
 
 In this case,
@@ -372,7 +371,7 @@ Because the check is asynchronous, the code calls `isDirectory()`
 using `await`.
 
 {% prettify dart %}
-if (await [[highlight]]FileSystemEntity.isDirectory(path)[[/highlight]]) {
+if (await [!FileSystemEntity.isDirectory(path)!]) {
   stderr.writeln('error: $path is a directory');
 } else {
   exitCode = 2;
@@ -401,11 +400,11 @@ for (var path in paths) {
       .transform(UTF8.decoder)
       .transform(const LineSplitter());
   try {
-    [[highlight]]await for (var line in lines) {[[/highlight]]
-      [[highlight]]if (showLineNumbers) {[[/highlight]]
-        [[highlight]]stdout.write('${lineNumber++} ');[[/highlight]]
-      [[highlight]]}[[/highlight]]
-      [[highlight]]stdout.writeln(line);[[/highlight]]
+    [!await for (var line in lines) {!]
+      [!if (showLineNumbers) {!]
+        [!stdout.write('${lineNumber++} ');!]
+      [!}!]
+      [!stdout.writeln(line);!]
     }
   } catch (_) {
     _handleError(path);
@@ -423,8 +422,8 @@ for (var path in paths) {
   int lineNumber = 1;
   Stream lines = new File(path)
       .openRead()
-      [[highlight]].transform(UTF8.decoder)[[/highlight]]
-      [[highlight]].transform(const LineSplitter());[[/highlight]]
+      [!.transform(UTF8.decoder)!]
+      [!.transform(const LineSplitter());!]
   try {
     await for (var line in lines) {
       if (showLineNumbers) {
@@ -536,7 +535,7 @@ Future _handleError(String path) async {
   if (await FileSystemEntity.isDirectory(path)) {
     stderr.writeln('error: $path is a directory');
   } else {
-    [[highlight]]exitCode = 2;[[/highlight]]
+    [!exitCode = 2;!]
   }
 }
 {% endprettify %}

--- a/src/_tutorials/language/futures.md
+++ b/src/_tutorials/language/futures.md
@@ -1,35 +1,31 @@
 ---
 title: "Asynchronous Programming: Futures"
-description: "A first look at Futures and how to use them to make your asynchronous code better."
-
+description: A first look at Futures and how to use them to make your asynchronous code better.
 nextpage:
   url: /tutorials/language/streams
   title: "Asynchronous Programming: Streams"
 ---
 
 <div class="panel" markdown="1">
+  <h4>What's the point?</h4>
 
-#### <a id="whats-the-point" class="anchor" href="#whats-the-point" aria-hidden="true"><span class="octicon octicon-link"></span></a>What's the point?
-
-* Dart is single-threaded.
-* Synchronous code can make your program freeze.
-* Use Futures to perform asynchronous operations.
-* Use `await` in an async function to pause execution until a Future completes.
-* Or use Future's `then()` method.
-* Use try-catch expressions in async functions to catch errors.
-* Or use Future's `catchError()` method.
-* You can chain Futures to run asynchronous functions in order.
-
+  * Dart is single-threaded.
+  * Synchronous code can make your program freeze.
+  * Use Futures to perform asynchronous operations.
+  * Use `await` in an async function to pause execution until a Future completes.
+  * Or use Future's `then()` method.
+  * Use try-catch expressions in async functions to catch errors.
+  * Or use Future's `catchError()` method.
+  * You can chain Futures to run asynchronous functions in order.
 </div>
 
-Dart is a single-threaded programming language.
-If any code blocks the thread of execution
-(for example, by waiting for a time-consuming operation
-or blocking on I/O) the program effectively freezes.
-Asynchronous operations let your program run without getting blocked.
-Dart uses Future objects to represent asynchronous operations.
+Dart is a single-threaded programming language. If any code blocks the thread
+of execution (for example, by waiting for a time-consuming operation or
+blocking on I/O) the program effectively freezes. Asynchronous operations let
+your program run without getting blocked. Dart uses Future objects to
+represent asynchronous operations.
 
-## Introduction {#introduction}
+## Introduction
 
 Let's look at some code that could possibly cause a program to freeze:
 
@@ -48,27 +44,25 @@ main() {
 }
 {% endprettify %}
 
-Our program gathers the news of the day, prints it,
-and then prints a bunch of other items of interest to the user:
+Our program gathers the news of the day, prints it, and then prints a bunch of
+other items of interest to the user:
 
-{% prettify none %}
+```nocode
 <gathered news goes here>
 Winning lotto numbers: [23, 63, 87, 26, 2]
 Tomorrow's forecast: 70F, sunny.
 Baseball score: Red Sox 10, Yankees 0
-{% endprettify %}
+```
 
-Our code is problematic: since `gatherNewsReports()` blocks,
-the remaining code runs only when `gatherNewsReports()`
-returns with the contents of the file,
-_however long that takes_.  And if reading the file takes a long time, the
-user waits passively, wondering if she won the lottery, what tomorrow's weather
-will be like, and who won today's game. Not good.
+Our code is problematic: since `gatherNewsReports()` blocks, the remaining
+code runs only when `gatherNewsReports()` returns with the contents of the
+file, _however long that takes_. And if reading the file takes a long time,
+the user waits passively, wondering if she won the lottery, what tomorrow's
+weather will be like, and who won today's game. Not good.
 
 To help keep the application responsive, Dart library authors use an
 asynchronous model when defining functions that do potentially expensive work.
-Such functions return their value using a
-<a href="{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html" target="_blank">Future</a>.
+Such functions return their value using a [Future.][Future]
 
 ## What is a Future? {#what-is-a-future}
 
@@ -87,10 +81,10 @@ To get the value that the Future represents, you have two options:
 
 ## Async and await {#async-await}
 
-The `async` and `await` keywords are part of the Dart language's
-[asynchrony support](/guides/language/language-tour#asynchrony-support).
-They allow you to write asynchronous code that looks like synchronous
-code and doesn't use the Future API.
+The `async` and `await` keywords are part of the Dart language's [asynchrony
+support](/guides/language/language-tour#asynchrony-support). They allow you
+to write asynchronous code that looks like synchronous code and doesn't use
+the Future API.
 
 {% include async-await-2.0.html %}
 
@@ -98,9 +92,9 @@ code and doesn't use the Future API.
 update-for-dart-2
 {% endcomment %}
 
-The following app simulates reading the news by using async and await
-to read the contents of a file on www.dartlang.org.
-Click run ( {% img 'red-run.png' %} ) to start the app.
+The following app simulates reading the news by using async and await to read
+the contents of a file on www.dartlang.org. Click run ( {% img 'red-run.png'
+%} ) to start the app.
 
 {% comment %}
 https://gist.github.com/Sfshaza/c0e8f5c38489ddeccb5a
@@ -124,57 +118,53 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?id=c0e8f5c38489ddeccb5a&horizonta
     style="border: 1px solid #ccc;">
 </iframe>
 
-Notice that `printDailyNewsDigest` is the first function called,
-but the news is the last thing to print, even though
-the file contains only a single line. This is because the code that reads
-and prints the file is running asynchronously.
+Notice that `printDailyNewsDigest` is the first function called, but the news
+is the last thing to print, even though the file contains only a single
+line. This is because the code that reads and prints the file is running
+asynchronously.
 
-In this example,
-the `printDailyNewsDigest()` function calls `gatherNewsReports()`,
-which is non-blocking.
-Calling `gatherNewsReports()` queues up the work to be done but
-doesn't stop the rest of the code from executing. The program prints the
-lottery numbers, the forecast, and the baseball score; when
-`gatherNewsReports()` finishes gathering news, the program prints.
-If `gatherNewsReports()` takes a little while to complete its work,
-no great harm is done: the user gets to read other things before the daily
-news digest is printed.
+In this example, the `printDailyNewsDigest()` function calls
+`gatherNewsReports()`, which is non-blocking.  Calling `gatherNewsReports()`
+queues up the work to be done but doesn't stop the rest of the code from
+executing. The program prints the lottery numbers, the forecast, and the
+baseball score; when `gatherNewsReports()` finishes gathering news, the
+program prints.  If `gatherNewsReports()` takes a little while to complete its
+work, no great harm is done: the user gets to read other things before the
+daily news digest is printed.
 
-The following diagram shows the flow of execution through the code.
-Each number corresponds to a step below.
+The following diagram shows the flow of execution through the code.  Each
+number corresponds to a step below.
 
 <img src="../images/async-await.png"
      alt="diagram showing flow of control through the main() and printDailyNewsDigest functions" />
 
 1. The app begins executing.
-1. The main function calls `printDailyNewsDigest()`,
-   which (because it's marked `async`),
-   immediately returns a Future, _before any code is executed_.
-1. The remaining print functions execute. Because they're synchronous,
-   each function executes fully before moving on to the next print
-   function. For example,
-   the winning lottery numbers are all printed before the weather forecast
-   is printed.
+1. The main function calls `printDailyNewsDigest()`, which (because it's
+   marked `async`), immediately returns a Future, _before any code is
+   executed_.
+1. The remaining print functions execute. Because they're synchronous, each
+   function executes fully before moving on to the next print function. For
+   example, the winning lottery numbers are all printed before the weather
+   forecast is printed.
 1. The body of the `printDailyNewsDigest()` function starts executing.
+
 1. After reaching the await expression (`await gatherNewsReports()`) and
-   calling `gatherNewsReports()`, the program pauses,
-   waiting for the Future returned by `gatherNewsReports()` to complete.
+   calling `gatherNewsReports()`, the program pauses, waiting for the Future
+   returned by `gatherNewsReports()` to complete.
 1. Once that Future completes, execution of `printDailyNewsDigest()`
    continues, printing the news.
 1. When the `printDailyNewsDigest()` function body has completed executing,
    the Future that it originally returned completes, and the app exits.
 
 <aside class="alert alert-info" markdown="1">
-**Note:**
-If an async function doesn't explicitly return a value,
-it returns a Future wrapped around a null value.
+  **Note:** If an async function doesn't explicitly return a value, it returns
+  a Future wrapped around a null value.
 </aside>
 
 ### Handling errors {#handling-errors-async}
 
-If a Future-returning function completes with an error,
-you probably want to capture that error.
-Async functions can use try-catch to capture the error.
+If a Future-returning function completes with an error, you probably want to
+capture that error.  Async functions can use try-catch to capture the error.
 
 {% comment %}
 https://gist.github.com/Sfshaza/847e8d9a356f025ad5d6
@@ -204,9 +194,8 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?id=847e8d9a356f025ad5d6&horizonta
     style="border: 1px solid #ccc;">
 </iframe>
 
-The try-catch code behaves in the same way with asynchronous code that
-it does for synchronous code:
-If the code within the `try` block throws an exception,
+The try-catch code behaves in the same way with asynchronous code that it does
+for synchronous code: If the code within the `try` block throws an exception,
 the code inside the `catch` clause executes.
 
 ### Sequential processing {#sequential-processing-async}
@@ -228,20 +217,18 @@ finished, and so on.
 
 ---
 
-## The Future API {#the-future-api}
+## The Future API
 
-Before async and await were added in Dart 1.9,
-you had to use the Future API.
-You might still see the Future API used in older code
-and in code that needs more functionality than async-await offers.
+Before async and await were added in Dart 1.9, you had to use the Future API.
+You might still see the Future API used in older code and in code that needs
+more functionality than async-await offers.
 
-To write asynchronous code using the Future API,
-you use the `then()` method to register a callback.
-This callback fires when the Future completes.
+To write asynchronous code using the Future API, you use the `then()` method
+to register a callback.  This callback fires when the Future completes.
 
-The following app simulates reading the news by using the Future API
-to read the contents of a file on www.dartlang.org.
-Click run ( {% img 'red-run.png' %} ) to start the app.
+The following app simulates reading the news by using the Future API to read
+the contents of a file on www.dartlang.org.  Click run ( {% img 'red-run.png'
+%} ) to start the app.
 
 {% comment %}
 https://gist.github.com/Sfshaza/ba1b258f810e34231a62
@@ -266,67 +253,56 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?id=ba1b258f810e34231a62&horizonta
     style="border: 1px solid #ccc;">
 </iframe>
 
-Notice that `printDailyNewsDigest` is the first function called,
-but the news is the last thing to print, even though
-the file contains only a single line. This is because the code that reads
-the file is running asynchronously.
+Notice that `printDailyNewsDigest` is the first function called, but the news
+is the last thing to print, even though the file contains only a single
+line. This is because the code that reads the file is running asynchronously.
 
 This app executes as follows:
 
 1. The app begins executing.
-1. The main function calls the `printDailyNewsDigest()` function,
-   which does not return immediately, but calls `gatherNewsReports()`.
+1. The main function calls the `printDailyNewsDigest()` function, which does
+   not return immediately, but calls `gatherNewsReports()`.
 1. `gatherNewsReports()` starts gathering news and returns a Future.
-1. `printDailyNewsDigest()` uses `then()` to specify a response to
-   the Future. Calling `then()` returns a new Future that will complete
-   with the value returned by `then()`'s callback.
-1. The remaining print functions execute. Because they're synchronous,
-   each function executes fully before moving on to the next print
-   function. For example,
-   the winning lottery numbers are all printed before the weather forecast
-   is printed.
+1. `printDailyNewsDigest()` uses `then()` to specify a response to the
+   Future. Calling `then()` returns a new Future that will complete with the
+   value returned by `then()`'s callback.
+1. The remaining print functions execute. Because they're synchronous, each
+   function executes fully before moving on to the next print function. For
+   example, the winning lottery numbers are all printed before the weather
+   forecast is printed.
 1. When all of the news has arrived, the Future returned by
-   `gatherNewsReports()` completes with a string containing
-   the gathered news.
-1. The code specified by `then()` in `printDailyNewsDigest()` runs,
-   printing the news.
+   `gatherNewsReports()` completes with a string containing the gathered news.
+1. The code specified by `then()` in `printDailyNewsDigest()` runs, printing
+   the news.
 1. The app exits.
 
-In the `printDailyNewsDigest()` function,
-the code inside `then()` could be written in a couple different ways.
+In the `printDailyNewsDigest()` function, the code inside `then()` could be
+written in a couple different ways.
 
-<ul markdown="1">
-<li markdown="1">Using curly braces.
-    This is useful if you want to perform more than one operation.
-    **Try it!**
-    Replace the `printDailyNewsDigest()` method with the following:
+- Using curly braces. This is useful if you want to perform more than one
+  operation.  **Try it!** Replace the `printDailyNewsDigest()` method with the
+  following:
 
+  {% prettify dart %}
+  printDailyNewsDigest() {
+    var future = gatherNewsReports();
+    future.then((content) {
+      print(content);
+      // ... do something else ...
+    });
+  }
+  {% endprettify %}
 
-{% prettify dart %}
-printDailyNewsDigest() {
-  var future = gatherNewsReports();
-  future.then((content) {
-    print(content);
-    // ... do something else ...
-  });
-}
-{% endprettify %}
+- Passing the `print` function directly, since it takes a single
+  argument&mdash;the completed value of the Future.  Try this version of
+  `printDailyNewsDigest()`:
 
-</li>
-<li markdown="1">Passing the `print` function directly,
-    since it takes a single argument&mdash;the completed value
-    of the Future.
-    Try this version of `printDailyNewsDigest()`:
-
-{% prettify dart %}
-printDailyNewsDigest() {
-  var future = gatherNewsReports();
-  future.then(print);
-}
-{% endprettify %}
-
-</li>
-</ul>
+  {% prettify dart %}
+  printDailyNewsDigest() {
+    var future = gatherNewsReports();
+    future.then(print);
+  }
+  {% endprettify %}
 
 ### Handling errors {#handling-errors-future-api}
 
@@ -357,39 +333,37 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?id=a9d90ac89aded272d1ca&horizonta
 </iframe>
 
 
-If `dailyNewsDigest.txt` doesn't exist or isn't available for reading,
-the code above executes as follows:
+If `dailyNewsDigest.txt` doesn't exist or isn't available for reading, the
+code above executes as follows:
 
 1. `gatherNewsReports()`'s Future completes with an error.
 1. `then()`'s Future completes with an error.
-1.  `catchError()`'s callback handles the error, `catchError()`'s Future
-completes normally, and the error does not propagate.
+1. `catchError()`'s callback handles the error, `catchError()`'s Future
+    completes normally, and the error does not propagate.
 
 <aside class="alert alert-info" markdown="1">
-  Chaining catchError() to then() is a common pattern when using the Future API.
-  <strong>
-    Consider this pairing the Future API's equivalent of try-catch blocks.
-  </strong>
+  Chaining catchError() to then() is a common pattern when using the Future
+  API.  **Consider this pairing the Future API's equivalent of try-catch
+  blocks.**
 </aside>
 
-Like `then()`, `catchError()` returns a new Future that completes with
-the return value of its callback.
+Like `then()`, `catchError()` returns a new Future that completes with the
+return value of its callback.
 
-For more details and examples, read
-[Futures and Error Handling](/guides/libraries/futures-error-handling).
+For more details and examples, read [Futures and Error Handling][].
 
 ### Calling multiple functions that return Futures {#calling-multiple-funcs}
 
-Consider three functions,  `expensiveA()`, `expensiveB()`, and `expensiveC()`,
+Consider three functions, `expensiveA()`, `expensiveB()`, and `expensiveC()`,
 that return Futures.  You can invoke them sequentially (one function starts
 when a previous one completes), or you can kick off all of them at the same
-time and do something once all the values return. The Future interface
-is fluid enough to deal with both use cases.
+time and do something once all the values return. The Future interface is
+fluid enough to deal with both use cases.
 
 #### Chaining function calls using then()
 
-When Future-returning functions need to run in order, use chained
-`then()` calls:
+When Future-returning functions need to run in order, use chained `then()`
+calls:
 
 {% prettify dart %}
 expensiveA().then((aValue) => expensiveB())
@@ -401,13 +375,12 @@ Nested callbacks also work, but they're harder to read and not as Dart-y.
 
 #### Waiting on multiple Futures to complete using Future.wait()
 
-If the order of execution of the functions is not important,
-you can use `Future.wait()`.
+If the order of execution of the functions is not important, you can use
+`Future.wait()`.
 
-The functions get triggered in quick succession; when all of them
-complete with a value, `Future.wait()` returns a new Future.
-This Future completes with a list containing the values produced by
-each function.
+The functions get triggered in quick succession; when all of them complete
+with a value, `Future.wait()` returns a new Future.  This Future completes
+with a list containing the values produced by each function.
 
 {% prettify dart %}
 // Parallel processing using the Future API
@@ -422,19 +395,21 @@ the error.
 
 ## Other resources {#other-resources}
 
-Read the following documentation for more details on using Futures
-and asynchronous programming in Dart:
+Read the following documentation for more details on using Futures and
+asynchronous programming in Dart:
 
-* [Futures and Error Handling](/guides/libraries/futures-error-handling),
-  an article that starts where this tutorial ends
-* [The Event Loop and Dart]({{site.webdev}}/articles/performance/event-loop),
+* [Futures and Error Handling][], an article that starts where this tutorial
+  ends
+* [The Event Loop and Dart,]({{site.webdev}}/articles/performance/event-loop)
   an article that describes how to schedule tasks using Futures
 * [Asynchrony support](/guides/language/language-tour#asynchrony-support),
   a section in the [language tour](/guides/language/language-tour)
-* [Future API reference]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html)
+* [Future API reference][Future]
 
 ## What next? {#what-next}
 
-* The next tutorial,
-[Asynchronous Programming: Streams](streams),
-shows you how to work with an event stream.
+* The next tutorial, [Asynchronous Programming: Streams](streams), shows you
+  how to work with an event stream.
+
+[Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
+[Futures and Error Handling]: /guides/libraries/futures-error-handling

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -41,9 +41,9 @@ iterates over the events of a stream like the **for loop** iterates
 over an Iterable. For example:
 
 {% prettify dart %}
-Future<int> sumStream(Stream<int> stream) [[highlight]]async[[/highlight]] {
+Future<int> sumStream(Stream<int> stream) [!async!] {
   var sum = 0;
-  [[highlight]]await for[[/highlight]] (var value in stream) {
+  [!await for!] (var value in stream) {
     sum += value;
   }
   return sum;

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -52,16 +52,16 @@ such as WebStorm.
 
 Install Stagehand using [pub global activate](/tools/pub/cmd/pub-global):
 
-{% prettify huge %}
+```terminal
 $ pub global activate stagehand
-{% endprettify %}
+```
 
 Now run the `stagehand` command to see what kinds of template files
 it can generate:
 
-{% prettify huge %}
+```terminal
 $ stagehand
-{% endprettify %}
+```
 
 You'll see a list of generators, including various web and server apps.
 One of the web app generators is named **web-simple**.
@@ -69,23 +69,18 @@ One of the web app generators is named **web-simple**.
 In a new directory named `vector_victor`,
 use Stagehand to generate a bare-bones web app:
 
-{% prettify huge %}
+```terminal
 $ mkdir vector_victor
 $ cd vector_victor
 $ stagehand web-simple
-{% endprettify %}
+```
 
 The pubspec.yaml file contains the package specification written in YAML.
 (Visit <a href="/tools/pub/pubspec">Pubspec Format</a>
 for in-depth coverage.)
 The contents of your pubspec.yaml file should look something like this:
 
-{% comment %}
-NOTE: I used lang-html because you seem to need either that or lang-dart
-to get the colors right for the highlighted text. Also, lang-yaml doesn't
-treat the URL too well.
-{% endcomment %}
-<pre class="prettyprint lang-html allow-scroll">
+<pre class="prettyprint lang-yaml allow-scroll">
 <a href="#" class="dart-popover" data-toggle="popover" data-html="true" data-trigger="hover focus" data-content="Package name (required)">name: 'vector_victor'</a>
 version: 0.0.1
 description: An absolute bare-bones web app.
@@ -115,24 +110,16 @@ which is available at pub.dartlang.org.
 
 1. Get the current installation details for the package:
 
-   <ul type="a">
-   <li> Go to
-   <a href="https://pub.dartlang.org/packages/vector_math"
-   target="_blank">vector_math's pub.dartlang.org entry</a>.
-   </li>
+   {: type="a"}
+   1. Go to [vector_math's pub.dartlang.org entry.](https://pub.dartlang.org/packages/vector_math)
+   2. Click the **Installing** tab.
+   3. Copy the **vector_math** line from the sample **dependencies** entry.
+      The entry should look something like this:
 
-   <li> Click the <b>Installing</b> tab.
-   </li>
-
-   <li> Copy the <b>vector_math</b> line from
-   the sample <b>dependencies</b> entry.
-   The entry should look something like this:
-
-   {% prettify html %}
-dependencies:
-  [[highlight]]vector_math: "^1.4.3"[[/highlight]]
-   {% endprettify %}
-   </li>
+      {% prettify yaml %}
+      dependencies:
+        [!vector_math: ^1.4.3!]
+      {% endprettify %}
 
 2. Edit `pubspec.yaml`.
 
@@ -142,10 +129,10 @@ dependencies:
    YAML is picky!
    For example:
 
-   {% prettify html %}
-dependencies:
-  browser: '>=0.10.0 <0.11.0'
-  [[highlight]]vector_math: "^1.4.3"[[/highlight]]
+   {% prettify yaml %}
+   dependencies:
+     browser: '>=0.10.0 <0.11.0'
+     [!vector_math: ^1.4.3!]
    {% endprettify %}
 
 See [Pub Versioning Philosophy](/tools/pub/versioning)
@@ -168,8 +155,8 @@ it might automatically install the packages your app depends on.
 If not, do it yourself by running
 [pub get](/tools/pub/cmd/pub-get):
 
-{% prettify none %}
-$ [[highlight]]pub get[[/highlight]]
+```terminal
+$ pub get
 Resolving dependencies... (1.4s)
 + browser 0.10.0+2
 + vector_math 1.4.3
@@ -177,8 +164,7 @@ Downloading vector_math 1.4.3...
 Changed 2 dependencies!
 Precompiling executables...
 Loading source assets...
-$
-{% endprettify %}
+```
 
 The `pub get` command installs the
 packages in your app's dependencies list.
@@ -276,49 +262,31 @@ are identified with the special `dart:` prefix.
 For external libraries installed by pub,
 use the `package:` prefix.
 
-<ol>
-  <li>
-  Get the import details for the package's main library:
+1. Get the import details for the package's main library:
 
-  <ol type="a">
-  <li> Go to
-  <a href="https://pub.dartlang.org/packages/vector_math"
-  target="_blank">vector_math's pub.dartlang.org entry</a>.
-  </li>
+   {: type="a"}
+   1. Go to [vector_math's pub.dartlang.org entry.](https://pub.dartlang.org/packages/vector_math)
+   2. Click the **Installing** tab.
+   3. Copy the **import** line. It should look something like this:
 
-   <li> Click the <b>Installing</b> tab.
-   </li>
+      {% prettify dart %}
+      import 'package:vector_math/vector_math.dart';
+      {% endprettify %}
 
-   <li> Copy the <b>import</b> line.
-   It should look something like this:
+2. Edit your main Dart file (web/main.dart).
 
-{% prettify dart %}
-import 'package:vector_math/vector_math.dart';
-{% endprettify %}
-   </li>
-  </ol>
-  </li>
+3. Import the library from the package.
+   By convention, package imports appear after dart:* imports:
 
-  <li>
-  Edit your main Dart file (web/main.dart).
-  </li>
+   {% prettify dart %}
+   import 'dart:html';
 
-  <li>
-  Import the library from the package.
-  By convention, package imports appear after dart:* imports:
-
-{% prettify dart %}
-import 'dart:html';
-
-[[highlight]]import 'package:vector_math/vector_math.dart';[[/highlight]]
-{% endprettify %}
-  </li>
-</ol>
+   [!import 'package:vector_math/vector_math.dart';!]
+   {% endprettify %}
 
 <aside class="alert alert-info" markdown="1">
-**Note:**
-You specify the filename, not the library name,
-when you import a library.
+  **Note:** You specify the filename, not the library name,
+  when you import a library.
 </aside>
 
 

--- a/src/install/archive/index.md
+++ b/src/install/archive/index.md
@@ -43,7 +43,7 @@ You can find the zip files at predictable URLs using the
 following pattern:
 
 {% prettify none %}
-https://storage.googleapis.com/dart-archive/channels/<[[highlight]]stable|dev[[/highlight]]>/release/<[[highlight]]release[[/highlight]]>/sdk/dartsdk-<[[highlight]]platform[[/highlight]]>-<[[highlight]]architecture[[/highlight]]>-release.zip
+https://storage.googleapis.com/dart-archive/channels/<[!stable|dev!]>/release/<[!release!]>/sdk/dartsdk-<[!platform!]>-<[!architecture!]>-release.zip
 {% endprettify %}
 
 Examples:

--- a/src/tools/pub/assets-and-transformers.md
+++ b/src/tools/pub/assets-and-transformers.md
@@ -19,12 +19,12 @@ and, if necessary, to configure the transformers. (See
 {% prettify yaml %}
 name: myapp
 dependencies:
-  [[highlight]]polymer: ^0.16.3
+  [!polymer: ^0.16.3
 transformers:
-- polymer:[[/highlight]]
-    [[highlight]]entry_points:[[/highlight]]
-    [[highlight]]- web/index.html[[/highlight]]
-    [[highlight]]- web/index2.html[[/highlight]]
+- polymer:!]
+    [!entry_points:!]
+    [!- web/index.html!]
+    [!- web/index2.html!]
 {% endprettify %}
 
 A package's assets can be in any directory in the root package.
@@ -98,10 +98,10 @@ polymer package (along with the rest of polymer.dart):
 {% prettify yaml %}
 name: myapp
 dependencies:
-  [[highlight]]polymer: ^0.16.3[[/highlight]]
-[[highlight]]transformers:
-- polymer:[[/highlight]]
-    [[highlight]]entry_points: web/index.html[[/highlight]]
+  [!polymer: ^0.16.3!]
+[!transformers:
+- polymer:!]
+    [!entry_points: web/index.html!]
 {% endprettify %}
 
 The following example configures the

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -1,18 +1,17 @@
 ---
-layout: default
+title: pub cache
+description: Use pub cache to manage your system cache.
 permalink: /tools/pub/cmd/pub-cache
-title: "pub cache"
-description: "Use pub cache to manage your system cache."
 toc: false
 ---
 
 _Cache_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+```
 $ pub cache add <package> [--version <constraint>] [--all]
 $ pub cache repair
-{% endprettify %}
+```
 
 The `pub cache` command works with the
 [system cache](/tools/pub/glossary#system-cache).
@@ -37,7 +36,7 @@ matching versions of a library.</dd>
 <dd>Optional. Use with <code>pub add</code> to install the best
 version matching the specified constraint. For example:
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub cache add barback --version "<=0.8.0 <0.110"
 {% endprettify %}
 
@@ -52,6 +51,5 @@ the system cache. The <code>pub cache repair</code> command performs a clean
 reinstall of all hosted and git packages in the system cache.</dd>
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -1,15 +1,14 @@
 ---
-layout: default
+title: pub deps
+description: Use pub deps to print a dependency graph for a package.
 permalink: /tools/pub/cmd/pub-deps
-title: "pub deps"
-description: "Use pub deps to print a dependency graph for a package."
 toc: false
 ---
 
 _Deps_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify none %}
 $ pub deps [--style=<style>]
 {% endprettify %}
 
@@ -26,7 +25,7 @@ list.
 For example, the pubspec for the markdown_converter example specifies
 the following dependencies:
 
-{% prettify none %}
+{% prettify yaml %}
 dependencies:
   barback: ^0.15.2
   markdown: ^0.7.2
@@ -34,11 +33,7 @@ dependencies:
 
 Here's an example of the `pub deps` output for markdown_converter:
 
-{% comment %}
-The <pre style...> is a workaround for prettify treating the
-quotes like they start strings.
-{% endcomment %}
-<pre style="color:#222">
+```terminal
 $ pub deps
 markdown_converter 0.0.0
 |-- barback 0.15.2+6
@@ -51,8 +46,7 @@ markdown_converter 0.0.0
 |   '-- stack_trace 1.4.2
 |       '-- path...
 '-- markdown 0.7.2
-</pre>
-
+```
 
 ## Options
 

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -1,8 +1,7 @@
 ---
-layout: default
+title: pub downgrade
+description: Use pub downgrade to get the lowest versions of all dependencies used by your Dart application.
 permalink: /tools/pub/cmd/pub-downgrade
-title: "pub downgrade"
-description: "Use pub downgrade to get the lowest versions of all dependencies used by your Dart application."
 ---
 
 _Downgrade_ is one of the commands of the _pub_ tool.
@@ -18,7 +17,7 @@ in the current working directory, as well as their [transitive
 dependencies](/tools/pub/glossary#transitive-dependency).
 For example:
 
-{% prettify sh %}
+```terminal
 $ pub downgrade
 Resolving dependencies... (1.2s)
 + barback 0.13.0
@@ -28,7 +27,7 @@ Resolving dependencies... (1.2s)
 + source_span 1.0.0
 + stack_trace 0.9.1
 Changed 6 dependencies!
-{% endprettify %}
+```
 
 The `pub downgrade` command creates a lockfile. If one already exists,
 pub ignores that file and generates a new one from scratch, using the lowest
@@ -44,7 +43,7 @@ It's possible to tell `pub downgrade` to downgrade specific dependencies to the
 lowest version while leaving the rest of the dependencies alone as much as
 possible. For example:
 
-{% prettify sh %}
+```terminal
 $ pub downgrade test
 Resolving dependencies...
   barback 0.15.2+2
@@ -61,7 +60,7 @@ Resolving dependencies...
 These packages are no longer being depended on:
 - matcher 0.11.3
 Changed 3 dependencies!
-{% endprettify %}
+```
 
 If you are downgrading a specific dependency, pub tries to find the
 highest versions of any transitive dependencies that fit the new dependency
@@ -111,6 +110,5 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -1,14 +1,13 @@
 ---
-layout: default
+title: pub get
+description: Use pub get to retrieve the dependencies used by your Dart application.
 permalink: /tools/pub/cmd/pub-get
-title: "pub get"
-description: "Use pub get to retrieve the dependencies used by your Dart application."
 ---
 
 _Get_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub get [--offline] [--packages-dir]
 {% endprettify %}
 
@@ -18,10 +17,10 @@ directory, as well as their
 [transitive dependencies](/tools/pub/glossary#transitive-dependency).
 For example:
 
-{% prettify sh %}
+```terminal
 $ pub get
 Got dependencies!
-{% endprettify %}
+```
 
 If the [system cache](/tools/pub/glossary#system-cache)
 doesn't already contain the dependencies, `pub get`

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -1,7 +1,7 @@
 ---
-permalink: /tools/pub/cmd/pub-global
 title: pub global
 description: Use pub global to run Dart scripts hosted on pub.dartlang.org from the command line.
+permalink: /tools/pub/cmd/pub-global
 ---
 
 _Global_ is one of the commands of the _pub_ tool.
@@ -18,10 +18,10 @@ For example, say you want to run
 [Stagehand](https://pub.dartlang.org/packages/stagehand)
 the Dart project generator, from the command line.
 
-{% prettify sh %}
+```terminal
 $ pub global activate stagehand
 $ stagehand
-{% endprettify %}
+```
 
 If this doesn't work, you may need to
 [set up your path](#running-a-script-from-your-path).
@@ -31,9 +31,9 @@ package that your package depends on, see [pub run](/tools/pub/cmd/pub-run).
 
 ## Activating a package
 
-{% prettify sh %}
-$ pub global activate [--noexecutables] [--executable=<name>] [--overwrite] <package> [constraint]
-{% endprettify %}
+```nocode
+pub global activate [--noexecutables] [--executable=<name>] [--overwrite] <package> [constraint]
+```
 
 You can activate packages that live on
 [pub.dartlang.org](https://pub.dartlang.org/), a Git repository,
@@ -47,46 +47,46 @@ constraint.  See the [constraint](#options) flag for usage examples.
 
 ### Activating a package on pub.dartlang.org
 
-{% prettify sh %}
+```terminal
 $ pub global activate <pub.dartlang package>
-{% endprettify %}
+```
 
 Specify a package on pub.dartlang.org to activate it. For example:
 
-{% prettify sh %}
+```terminal
 $ pub global activate markdown
-{% endprettify %}
+```
 
 ### Activating a package with Git
 
-{% prettify sh %}
+```terminal
 $ pub global activate --source git <Git URL>
 $ pub global activate -sgit <Git URL>
-{% endprettify %}
+```
 
 Use `--source git` (or `-sgit`, for short) to activate
 a package in a Git repository. The following examples,
 which activate the `async_await` package on
 [GitHub](https://github.com/), are equivalent:
 
-{% prettify sh %}
-pub global activate --source git https://github.com/dart-lang/async_await.git
-pub global activate -sgit https://github.com/dart-lang/async_await.git
-{% endprettify %}
+```terminal
+$ pub global activate --source git https://github.com/dart-lang/async_await.git
+$ pub global activate -sgit https://github.com/dart-lang/async_await.git
+```
 
 ### Activating a package on your local machine
 
-{% prettify sh %}
+```terminal
 $ pub global activate --source path <path>
-{% endprettify %}
+```
 
 Use `activate --source path <path>` to activate a package on your local machine.
 The following example activates the `stopwatch` package from the
 `~/dart` directory:
 
-{% prettify sh %}
-pub global activate --source path ~/dart/stopwatch
-{% endprettify %}
+```terminal
+$ pub global activate --source path ~/dart/stopwatch
+```
 
 ### Updating an activated package
 
@@ -107,18 +107,18 @@ for the [system cache](/tools/pub/glossary#system-cache) to your path.
 For example, say you've activated the Stagehand script,
 but you still can't run the command:
 
-{% prettify sh %}
+```terminal
 $ pub global activate stagehand
 $ stagehand
 -bash: stagehand: command not found
-{% endprettify %}
+```
 
 Verify that the `bin` directory for the system cache is in your path.
 The following path, on macOS, includes the system cache.
 
-{% prettify sh %}
+{% prettify none %}
 $ echo $PATH
-[[highlight]]/Users/<user>/.pub-cache/bin[[/highlight]]:/Users/<user>/homebrew/bin:/usr/local/bin:/usr/bin:/bin
+[!/Users/<user>/.pub-cache/bin!]:/Users/<user>/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 {% endprettify %}
 
 If this directory is missing from your path,
@@ -127,7 +127,7 @@ locate the file for your platform and add it.
 |-------------------+---------------------------|
 |      Platform     |      Cache location       |
 |-------------------|---------------------------|
-| macOS or Linux | `${HOME}/.pub-cache/bin`        |
+| macOS or Linux | `$HOME/.pub-cache/bin`        |
 | Windows<sup><strong>*</strong></sup> | `%APPDATA%\Pub\Cache\bin` |
 {:.table .table-striped}
 
@@ -136,10 +136,10 @@ may vary for different versions of Windows.
 
 You can now directly invoke the command:
 
-{% prettify sh %}
+{% prettify none %}
 $ mkdir angular_project
 $ cd angular_project
-$ [[highlight]]stagehand web-angular[[/highlight]]
+$ [!stagehand web-angular!]
 {% endprettify %}
 
 If the script still fails to run from the command line, the
@@ -148,18 +148,18 @@ this feature. You can still run the script using `pub global run`.
 
 ### Running a script using `pub global run`
 
-{% prettify sh %}
+```nocode
 $ pub global run <package>:<executable> [args...]
-{% endprettify %}
+```
 
 Even if a script is not configured to be run from the command line,
 you can still use `pub global run`.
 The following command runs the `bin/bar.dart` script from the
 `foo` package, passing in two arguments.
 
-{% prettify sh %}
+```terminal
 $ pub global run foo:bar arg1 arg2
-{% endprettify %}
+```
 
 ### Configuring package executables
 
@@ -186,25 +186,25 @@ directly from the command line.
 
 ## Deactivating a package
 
-{% prettify sh %}
+```terminal
 $ pub global deactivate <package>
-{% endprettify %}
+```
 
 Use `deactivate` to remove a package from the list of available
 global packages. For example:
 
-{% prettify sh %}
+```terminal
 $ pub global deactivate markdown
-{% endprettify %}
+```
 
 You can no longer invoke the package's scripts using `pub global run`,
 or at the command line.
 
 ## Listing active packages
 
-{% prettify sh %}
+```terminal
 $ pub global list
-{% endprettify %}
+```
 
 Use `list` to list all currently active packages.
 
@@ -219,16 +219,16 @@ For options that apply to all pub commands, see
   the following command pulls the 0.6.0 version of the `markdown`
   package:
 
-  {% prettify sh %}
+  ```terminal
   $ pub global activate markdown 0.6.0
-  {% endprettify %}
+  ```
 
   If you specify a range, pub picks the best version that meets that
   constraint. For example:
 
-  {% prettify sh %}
+  ```terminal
   $ pub global activate foo <3.0.0
-  {% endprettify %}
+  ```
 
 `--executable=<name>` or `-x<name>`
 : Optional for `pub global activate`.
@@ -237,9 +237,9 @@ For options that apply to all pub commands, see
   For example, the following command adds `bar` and `baz` (but not
   any other executables that `foo` might define) to your PATH.
 
-  {% prettify sh %}
+  ```terminal
   $ pub global activate foo -x bar -x baz
-  {% endprettify %}
+  ```
 
 `--no-executables`
 : Optional for `pub global activate`.

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -1,15 +1,14 @@
 ---
-layout: default
+title: pub publish
+description: Use pub publish to publish your Dart package to pub.dartlang.org.
 permalink: /tools/pub/cmd/pub-lish
-title: "pub publish"
-description: "Use pub publish to publish your Dart package to pub.dartlang.org."
 toc: false
 ---
 
 _Publish_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub publish [--dry-run] [--force] [--server <url>]
 {% endprettify %}
 
@@ -53,7 +52,6 @@ The main pub server is itself open source and available [here][pub repo].
 [pub repo]: https://github.com/dart-lang/pub-dartlang
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>
 

--- a/src/tools/pub/cmd/pub-run.md
+++ b/src/tools/pub/cmd/pub-run.md
@@ -1,14 +1,13 @@
 ---
-layout: default
+title: pub run
+description: Use pub run to run a Dart script in your package.
 permalink: /tools/pub/cmd/pub-run
-title: "pub run"
-description: "Use pub run to run a Dart script in your package."
 ---
 
 _Run_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub run [--mode=<mode>] [--checked] <executable> [args...]
 {% endprettify %}
 
@@ -27,9 +26,9 @@ This is the simplest use case.
 From the root of a package that contains `foo.dart`
 in the `bin` directory, run the app using the following command:
 
-{% prettify sh %}
+```terminal
 $ pub run foo arg1 arg2
-{% endprettify %}
+```
 
 This command looks in your package's `bin` directory for the
 specified script and invokes it, passing in any arguments.
@@ -41,9 +40,9 @@ bin directory (but within the package), prepend the path
 to the name of the script.
 For example, to run `foo.dart` in the `example/sub` directory:
 
-{% prettify sh %}
+```terminal
 $ pub run example/sub/foo arg1 arg2
-{% endprettify %}
+```
 
 ## Running a script in a dependency
 
@@ -51,9 +50,9 @@ To run a script from the `bin` directory of a package that you depend on
 in the pubspec, specify the package name.
 For example, to run `bar.dart` in the foo package:
 
-{% prettify sh %}
+```terminal
 $ pub run foo:bar arg
-{% endprettify %}
+```
 
 You can only run scripts out of another package's `bin` directory.
 All other directories are private.
@@ -101,6 +100,5 @@ update-for-dart-2
 {% endcomment %}
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -1,14 +1,13 @@
 ---
-layout: default
+title: pub upgrade
+description: Use pub upgrade to get the latest versions of all dependencies used by your Dart application.
 permalink: /tools/pub/cmd/pub-upgrade
-title: "pub upgrade"
-description: "Use pub upgrade to get the latest versions of all dependencies used by your Dart application."
 ---
 
 _Upgrade_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub upgrade [args] [dependencies]
 {% endprettify %}
 
@@ -25,10 +24,10 @@ directory, as well as their [transitive
 dependencies](/tools/pub/glossary#transitive-dependency).
 For example:
 
-{% prettify sh %}
+```terminal
 $ pub upgrade
 Dependencies upgraded!
-{% endprettify %}
+```
 
 When `pub upgrade` upgrades dependency versions, it writes a lockfile to ensure that
 [`pub get`](/tools/pub/cmd/pub-get) will use the same versions of those
@@ -57,8 +56,10 @@ You can tell `pub upgrade` to upgrade specific dependencies to the
 latest version while leaving the rest of the dependencies alone as much as
 possible. For example:
 
-    $ pub upgrade test args
-    Dependencies upgraded!
+```terminal
+  $ pub upgrade test args
+  Dependencies upgraded!
+```
 
 Upgrading a dependency upgrades its transitive dependencies to their latest
 versions as well. Usually, no other dependencies are updated; they stay at the

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -1,15 +1,14 @@
 ---
-layout: default
+title: pub uploader
+description: Use pub uploader to add or remove uploaders for your Dart package on pub.dartlang.org.
 permalink: /tools/pub/cmd/pub-uploader
-title: "pub uploader"
-description: "Use pub uploader to add or remove uploaders for your Dart package on pub.dartlang.org."
 toc: false
 ---
 
 _Uploader_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
-{% prettify sh %}
+{% prettify nocode %}
 $ pub uploader [options] {add/remove} <email>
 {% endprettify %}
 
@@ -20,13 +19,13 @@ other uploaders for that package. It has two sub-commands,
 `add` and `remove`, that take the email address of the person to
 add/remove as an uploader. For example:
 
-{% prettify sh %}
+```terminal
 ~/code/transmogrify$ pub uploader add bob@example.com
 'bob@example.com' added as an uploader for package 'transmogrify'.
 
 ~/code/transmogrify$ pub uploader remove bob@example.com
 'bob@example.com' is no longer an uploader for package 'transmogrify'.
-{% endprettify %}
+```
 
 If a package has only one uploader, that uploader can't be removed. You may
 remove yourself as an uploader (as long as other uploaders are available),
@@ -36,10 +35,10 @@ By default, the package in the current working directory will have its
 uploaders modified. You can also pass the `--package` flag to choose a
 package by name. For example:
 
-{% prettify sh %}
+```terminal
 $ pub uploader --package=transmogrify add bob@example.com
 'bob@example.com' added as an uploader for package 'transmogrify'.
-{% endprettify %}
+```
 
 Note that uploaders are identified by their Google accounts, so use a Gmail or
 Google Apps email address for any new uploaders.
@@ -50,6 +49,5 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 <aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
 </aside>


### PR DESCRIPTION
This is in part as preparation for continued work over #407.

There are no user-visible doc changes introduced by this PR.

- Added support for `none` and `nocode` as parameter to prettifier plugin: e.g., `{% prettify nocode%}` (`none` was already used in site-www, even if it wasn't supported by the plugin; `nocode` is what we've been using on the site-webdev side).
- Converted `[[highlight]]...[[/highlight]]` markers to `[!...!]`.
- Switched to using pure markdown in some cases where HTML had been used (unnecessarily).
- Switched to using `terminal` class highlighting, mainly in pub pages; e.g.
  <img width="355" alt="screen shot 2017-12-18 at 08 32 07" src="https://user-images.githubusercontent.com/4140793/34108433-fc2fe27e-e3cd-11e7-801f-3a1f774eb7a0.png">


