### PR TITLE
chore: markdown and some CSS cleanup of Strong-Mode Dart pages

### DIFF
--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -811,8 +811,8 @@ main .content {
 @include dart-style-for(good-style, $alert-success-bg, 'good');
 @include dart-style-for(bad-style, $alert-danger-bg, 'bad');
 
-@include dart-style-for(passes-sa, $alert-success-bg, '\2714  passes static analysis');
-@include dart-style-for(fails-sa, $alert-danger-bg, '\2717  static analysis errors or warnings');
+@include dart-style-for(passes-sa, $alert-success-bg, '\2714  static analysis: success');
+@include dart-style-for(fails-sa, $alert-danger-bg, '\2717  static analysis: error/warning');
 
 // Deprecated, use good-style
 .good {

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -793,21 +793,26 @@ main .content {
  }
 }
 
-@mixin dart-style-for($kind, $bg-color) {
-  .#{$kind}-style {
+@mixin dart-style-for($kind, $bg-color, $msg) {
+  .#{$kind} {
     background-color: $bg-color;
     &:after {
-      content: '#{$kind}';
+      font-family: $font-family-base;
+      content: $msg;
       position: absolute;
-      top: $font-size-base / 4;
-      right: $font-size-base / 2;
+      top: 0;
+      right: $font-size-base / 4;
       color: darken($bg-color, 25%);
     }
   }
 }
 
-@include dart-style-for(good, $alert-success-bg);
-@include dart-style-for(bad, $alert-danger-bg);
+// TODO: reclaim and use the class names good and bad (rather than good-style and bad-style):
+@include dart-style-for(good-style, $alert-success-bg, 'good');
+@include dart-style-for(bad-style, $alert-danger-bg, 'bad');
+
+@include dart-style-for(passes-sa, $alert-success-bg, '\2714  passes static analysis');
+@include dart-style-for(fails-sa, $alert-danger-bg, '\2717  static analysis errors or warnings');
 
 // Deprecated, use good-style
 .good {
@@ -829,25 +834,6 @@ main .content {
   }
 }
 
-.passes-sa {
-  position: relative;
-  padding:10px;
-  margin-bottom: 11px;
-  @extend .alert-success;
-  &:after {
-    content: 'passes static analysis';
-    display: inline-block;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    color: darken($alert-success-bg, 25%);
-  }
-  pre {
-    margin-bottom: 0;
-    background-color: transparent;
-  }
-}
-
 // Deprecated, use bad-style
 .bad {
   position: relative;
@@ -856,25 +842,6 @@ main .content {
   @extend .alert-danger;
   &:after {
     content: 'bad';
-    display: inline-block;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    color: darken($alert-danger-bg, 25%);
-  }
-  pre {
-    margin-bottom: 0;
-    background-color: transparent;
-  }
-}
-
-.fails-sa {
-  position: relative;
-  padding:10px;
-  margin-bottom: 11px;
-  @extend .alert-danger;
-  &:after {
-    content: 'fails static analysis with errors or warnings';
     display: inline-block;
     position: absolute;
     top: 10px;

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -1,7 +1,6 @@
 ---
-layout: guide
-title: "Strong Mode Dart"
-description: "Why and how to write sound Dart code."
+title: Strong Mode Dart
+description: Why and how to write sound Dart code.
 ---
 
 {% comment %}
@@ -13,19 +12,19 @@ You'll learn how to use strong mode to enable soundness, as well as
 how to substitute types safely when overriding methods.
 
 <aside class="alert alert-info" markdown="1">
-**Note:** The terms "sound Dart", "strong mode Dart", and "type safe Dart"
-are sometimes used interchangeably. _Strong mode_ is a sound static
-type system that uses a combination of static and runtime checks to
-ensure your code is type safe&mdash;that you can never see a value
-whose runtime type does not match its static type.
-With strong mode enabled (in an implementation that has both the
-static and runtime checks), Dart is a sound language.
-Currently, the Dart dev compiler
-([dartdevc,]({{site.webdev}}/tools/dartdevc) also known as _DDC_)
-is the only full implementation of strong mode.
-VM and dart2js support are on their way.
+  **Note:** The terms "sound Dart", "strong mode Dart", and "type safe Dart"
+  are sometimes used interchangeably. _Strong mode_ is a sound static
+  type system that uses a combination of static and runtime checks to
+  ensure your code is type safe&mdash;that you can never see a value
+  whose runtime type does not match its static type.
+  With strong mode enabled (in an implementation that has both the
+  static and runtime checks), Dart is a sound language.
+  Currently, the Dart dev compiler
+  ([dartdevc,]({{site.webdev}}/tools/dartdevc) also known as _DDC_)
+  is the only full implementation of strong mode.
+  VM and dart2js support are on their way.
 
-"Classic Dart" refers to Dart before soundness was added to the language.
+  "Classic Dart" refers to Dart before soundness was added to the language.
 </aside>
 
 By writing sound Dart code today, you'll reap some benefits now,
@@ -42,7 +41,7 @@ annotations to your Lists and Maps. The following code shows valid
 but unsound Dart code. The `fn()` function prints an integer list.
 The `main()` function creates a list of integers and passes it to `fn()`:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 void fn(List<int> a) {
   print(a);
@@ -52,10 +51,9 @@ main() {
   var list = [];
   list.add(1);
   list.add("2");
-  fn([[highlight]]list[[/highlight]]);
+  fn([!list!]);
 }
 {% endprettify %}
-</div>
 
 In classic Dart, this code passes analysis with no errors. Once you enable
 strong mode, a warning appears on `list` (highlighted above) in the call to
@@ -69,20 +67,19 @@ When adding a type annotation (`<int>`) on creation of the list
 the parameter type `int`. Removing the quotes in `list.add("2")` results
 in code that passes static analysis with no errors or warnings.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 void fn(List<int> a) {
   print(a);
 }
 
 void main() {
-  var list = [[highlight]]<int>[[/highlight]][];
+  var list = [!<int>!][];
   list.add(1);
-  list.add([[highlight]]2[[/highlight]]);
+  list.add([!2!]);
   fn(list);
 }
 {% endprettify %}
-</div>
 
 {% comment %}
 Note: Can't use embedded DP because it does not provide a Strong mode
@@ -124,17 +121,16 @@ of type `int`. Iterating through the list and substracting 10 from
 each item causes a runtime exception because the minus operator isn't
 defined for strings.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 main () {
   List<dynamic> strings = ["not", "ints"];
-  [[highlight]]List<int> numbers = strings;[[/highlight]]
+  [!List<int> numbers = strings;!]
   for (var number in numbers) {
-    [[highlight]]print(number - 10); // <— Boom![[/highlight]]
+    [!print(number - 10); // <— Boom!!]
   }
 }
 {% endprettify %}
-</div>
 
 Once strong mode is enabled, the analyzer warns you that this assignment
 is a problem, avoiding the runtime error.
@@ -196,7 +192,6 @@ type hierarchy:
 <a name="use-proper-return-types"></a>
 #### Use proper return types when overriding methods
 
-<br>
 The return type of a method in a subclass must the same type or a
 subtype of the return type of the method in the superclass. Consider
 the getter method in the Animal class:
@@ -204,7 +199,7 @@ the getter method in the Animal class:
 {% prettify dart %}
 class Animal {
   void chase(Animal a) {}
-  [[highlight]]Animal get parent => ...[[/highlight]]
+  [!Animal get parent => ...!]
 }
 {% endprettify %}
 
@@ -212,43 +207,40 @@ The `parent` getter method returns an Animal. In the HoneyBadger subclass,
 you can replace the getter's return type with HoneyBadger (or any other subtype
 of Animal), but an unrelated type is not allowed.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 class HoneyBadger extends Animal {
   void chase(Animal a) {}
-  [[highlight]]HoneyBadger[[/highlight]] get parent => ...
+  [!HoneyBadger!] get parent => ...
 }
 {% endprettify %}
-</div>
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 class HoneyBadger extends Animal {
   void chase(Animal a) {}
-  [[highlight]]Roots[[/highlight]] get parent => ...
+  [!Roots!] get parent => ...
 }
 {% endprettify %}
-</div>
 
 <a name="use-proper-param-types"></a>
 #### Use proper parameter types when overriding methods
 
-<br>
 The parameter of an overridden method must have either the same type
 or a supertype of the corresponding parameter in the superclass.
 Don't "tighten" the parameter type by replacing the type with a
 subtype of the original parameter.
 
 <aside class="alert alert-info" markdown="1">
-**Note:** If you have a valid reason to use a subtype, you can use the
-[`covariant` keyword](/guides/language/sound-problems#the-covariant-keyword).
+  **Note:** If you have a valid reason to use a subtype, you can use the
+  [`covariant` keyword](/guides/language/sound-problems#the-covariant-keyword).
 </aside>
 
 Consider the `chase(Animal)` method for the Animal class:
 
 {% prettify dart %}
 class Animal {
-  [[highlight]]void chase(Animal a) {}[[/highlight]]
+  [!void chase(Animal a) {}!]
   Animal get parent => ...
 }
 {% endprettify %}
@@ -256,19 +248,18 @@ class Animal {
 The `chase()` method takes an Animal. A HoneyBadger chases anything.
 It's OK to override the `chase` method to take anything (Object).
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 class HoneyBadger extends Animal {
-  void chase([[highlight]]Object[[/highlight]] a) {}
+  void chase([!Object!] a) {}
   Animal get parent => ...
 }
 {% endprettify %}
-</div>
 
 The following code tightens the parameter on the `chase` method
 from Animal to Mouse, a subclass of Animal.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 class Animal {
   void chase(Animal x) {}
@@ -277,24 +268,21 @@ class Animal {
 class Mouse extends Animal {}
 
 class Cat extends Animal {
-  void chase([[highlight]]Mouse[[/highlight]] x) {}
+  void chase([!Mouse!] x) {}
 }
 {% endprettify %}
-</div>
 
 This code is not type safe because it would then be possible to define
 a cat and send it after an alligator:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 Animal a = new Cat();
-a.chase(new [[highlight]]Alligator[[/highlight]]());   // NOT TYPE SAFE (or feline safe)
+a.chase(new [!Alligator!]());   // NOT TYPE SAFE (or feline safe)
 {% endprettify %}
-</div>
 
 #### Don't use a dynamic list as a typed list
 
-<br>
 Strong mode won't allow you to use a dynamic list as a typed list.
 You can use a dynamic list when you want to have a list with
 different kinds of things in it, but strong mode won't let you use
@@ -305,7 +293,7 @@ This rule also applies to instances of generic types.
 The following code creates a dynamic list of Dog, and assigns it to
 a list of type Cat, which generates an error during static analysis.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 class Animal {}
 
@@ -314,11 +302,10 @@ class Dog extends Animal {}
 class Cat extends Animal {}
 
 void main() {
-  List<Cat> foo = [[highlight]]<dynamic>[[/highlight]][new Dog()]; // Error
+  List<Cat> foo = [!<dynamic>!][new Dog()]; // Error
   List<dynamic> bar = <dynamic>[new Dog(), new Cat()]; // OK
 }
 {% endprettify %}
-</div>
 
 ## Runtime checks
 
@@ -336,8 +323,8 @@ class Dog extends Animal {}
 class Cat extends Animal {}
 
 void main() {
-  [[highlight]]List<Animal> animals = [new Dog()];[[/highlight]]
-  [[highlight]]List<Cat> cats = animals;[[/highlight]]
+  [!List<Animal> animals = [new Dog()];!]
+  [!List<Cat> cats = animals;!]
 }
 {% endprettify %}
 
@@ -345,8 +332,8 @@ However, the app throws an exception at runtime because it is an error
 to assign a list of Dogs to a list of Cats.
 
 <aside class="alert alert-info" markdown="1">
-**Note:** As of release 1.24, only dartdevc implements these runtime checks,
-but support in other tools is coming.
+  **Note:** As of release 1.24, only dartdevc implements these runtime checks,
+  but support in other tools is coming.
 </aside>
 
 ## Type inference
@@ -407,7 +394,6 @@ using `var`, the resulting map has type Map<String, Object>.
 
 ### Example 3: From List&lt;dynamic> to `var`
 
-
 Original definition:
 {% prettify dart %}
 List<dynamic> arguments = methodCall['args'];
@@ -444,19 +430,17 @@ Subsequent assignments are not taken into account.
 This may mean that too precise a type may be inferred.
 If so, you can add a type annotation.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 var x = 3;    // x is inferred as an int
 x = 4.0;
 {% endprettify %}
-</div>
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 num y = 3; // y is defined as num, which can be double or int
 y = 4.0;
 {% endprettify %}
-</div>
 
 ### Type argument inference
 
@@ -467,7 +451,7 @@ of occurrence, and upwards information from the arguments to the constructor
 or generic method. If inference is not doing what you want or expect,
 you can always explicitly specify the type arguments.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 // Inferred as if you wrote <int>[].
 List<int> listOfInt = [];
@@ -480,7 +464,6 @@ var listOfDouble = [3.0];
 // Type argument to map() is inferred as <int> using upwards information.
 var listOfInt2 = listOfDouble.map((x) => x.toInt());
 {% endprettify %}
-</div>
 
 ## How to enable strong mode
 
@@ -559,31 +542,28 @@ specific type (Cat) with something that consumes anything (Animal),
 so replacing `Cat c` with `Animal c` is allowed, because Animal is
 a supertype of Cat.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 Animal c = new Cat();
 {% endprettify %}
-</div>
 
 But replacing `Cat c` with `MaineCoon c` breaks type safety, because the
 superclass may provide a type of Cat with different behaviors, such
 as Lion:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 MaineCoon c = new Cat();
 {% endprettify %}
-</div>
 
 In a producing position, it's safe to replace something that produces a
 type (Cat) with a more specific type (MaineCoon). So, the following
 is allowed:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 Cat c = new MaineCoon();
 {% endprettify %}
-</div>
 
 ### Generic type assignment
 
@@ -597,7 +577,7 @@ In the following example, you can substitute
 `new List<Cat>()` with `new List<MaineCoon>()` because
 `List<MaineCoon>` is a subtype of `List<Cat>`.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 class Animal {
   void feed() {}
@@ -615,7 +595,7 @@ void feedAnimals(Iterable<Animal> animals) {
 
 main(List<String> args) {
   // Was: List<Cat> myCats = new List<Cat>();
-  List<Cat> myCats = new List<[[highlight]]MaineCoon[[/highlight]]>();
+  List<Cat> myCats = new List<[!MaineCoon!]>();
   Cat muffin = new Cat();
   Cat winky = new Cat();
   Cat bongo = new Cat();
@@ -624,7 +604,6 @@ main(List<String> args) {
   feedAnimals(myCats);
 }
 {% endprettify %}
-</div>
 
 {% comment %}
 Gist:  https://gist.github.com/4a2a9bc2242042ba5338533d091213c0
@@ -700,7 +679,7 @@ static tooling and checked mode would enforce this.
 However, in the following context, the info method prints
 "helloworld" in checked mode, without any static errors or warnings.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 import 'dart:collection';
 import 'util.dart';
@@ -719,7 +698,6 @@ void main() {
    info(list);
 }
 {% endprettify %}
-</div>
 
 This code raises no issues when run in checked mode, but generates
 numerous errors when analyzed under strong mode.
@@ -761,4 +739,3 @@ but most of the information applies to anyone using strong mode Dart:
 * [Using Generic Methods](https://github.com/dart-lang/sdk/blob/master/pkg/dev_compiler/doc/GENERIC_METHODS.md) -
   Details beyond what the [generic methods](/guides/language/language-tour#using-generic-methods) section
   of the language tour provides.
-

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -1,7 +1,6 @@
 ---
-layout: guide
 title: "Strong Mode Dart: Fixing Common Problems"
-description: "Common problems you may have when converting to strong mode and how to fix them."
+description: Common problems you may have when converting to strong mode and how to fix them.
 toc: false
 ---
 
@@ -16,30 +15,8 @@ this page can help. Be sure to also check out
 Dart" means, and how strong mode contributes to making Dart a sound
 language.
 
-## Contents
-
-<p>Troubleshooting:</p>
-
-<ul>
-<li><a href="#am-i-using-strong-mode">Am I really using strong mode?</a></li>
-<li><a href="#not-using-strong-mode">I'm not using strong mode and I think I should be</a></li>
-</ul>
-
-<p>Common errors and warnings:</p>
-
-<ul>
-<li><a href="#undefined-member">Undefined member</a></li>
-<li><a href="#invalid-method-override">Invalid method override</a></li>
-<li><a href="#missing-type-arguments">Missing type arguments</a></li>
-<li><a href="#assigning-mismatched-types">Assigning mismatched types</a></li>
-<li><a href="#constructor-initialization-list">Constructor initialization list super() call</a></li>
-</ul>
-
-<p>Appendix:</p>
-
-<ul>
-<li><a href="#the-covariant-keyword">The covariant keyword</a></li>
-</ul>
+* TOC
+{:toc}
 
 For a complete list of sources about strong mode and sound Dart,
 see [other resources](/guides/language/sound-dart#other-resources)
@@ -54,19 +31,18 @@ If you're not seeing strong mode errors or warnings,
 make sure that you're using strong mode.
 A good test is to add the following code to a file:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 void test() {
   bool b = [0][0];
 }
 {% endprettify %}
-</div>
 
 If you're using strong mode, you'll see the following warning from the analyzer:
 
-{% prettify none %}
+```nocode
 [warning] A value of type 'int' can't be assigned to a variable of type 'bool'.
-{% endprettify %}
+```
 
 <hr>
 
@@ -82,26 +58,15 @@ How you troubleshoot strong mode depends on whether you are running
 If you are running dartanalyzer from the command line and you don't see
 expected strong mode errors, try the following:
 
-<ul markdown="1">
-<li markdown="1">
-  If your project contains an [analysis
+- If your project contains an [analysis
   options file,](/guides/language/analysis-options#the-analysis-options-file)
   make sure you've specified `strong mode: true` correctly.
   For more information, see [Specifying strong
   mode.](/guides/language/analysis-options#specifying-strong-mode)
-
-</li>
-
-<li markdown="1">
-  Run the analyzer with the `--strong` tag:
-
-{% prettify sh %}
-dartanalyzer --strong <file-or-directory>
-{% endprettify %}
-
-</li>
-
-</ul>
+- Run the analyzer with the `--strong` tag:
+  ```nocode
+  dartanalyzer --strong <file-or-directory>
+  ```
 
 For information on how to set up an analysis options file,
 see [Customize Static Analysis](/guides/language/analysis-options).
@@ -143,8 +108,7 @@ when enabling strong mode.
 <a name="undefined-member"></a>
 ### Undefined member
 
-**Error:**
-<code>&lt;<em>member</em>&gt; isn't defined for the class &lt;<em>class</em>&gt;</code>
+**Error:** <code>&lt;<em>member</em>&gt; isn't defined for the class &lt;<em>class</em>&gt;</code>
 
 These errors usually appear in code where a variable is statically known
 to be some supertype but the code assumes a subtype.
@@ -155,12 +119,11 @@ declaration or a downcast.
 For example, the analyzer complains that `context2D` in the following
 code is undefined:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 var canvas = querySelector("canvas");
-canvas.[[highlight]]context2D[[/highlight]]; // <-- Error.
+canvas.[!context2D!]; // <-- Error.
 {% endprettify %}
-</div>
 
 The `querySelector()` method statically returns an Element,
 but the code assumes it returns the subtype CanvasElement
@@ -171,21 +134,19 @@ Strong mode Dart infers `canvas` to be an Element.
 
 Fix this error with an explicit type declaration:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
-[[highlight]]CanvasElement[[/highlight]] canvas = querySelector("canvas");
+[!CanvasElement!] canvas = querySelector("canvas");
 canvas.context2D;
 {% endprettify %}
-</div>
 
 If you actually want a dynamic type, specify `dynamic`:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
-[[highlight]]dynamic[[/highlight]] canvas = querySelector("canvas");
+[!dynamic!] canvas = querySelector("canvas");
 canvas.context2D;
 {% endprettify %}
-</div>
 
 <hr>
 
@@ -212,47 +173,45 @@ are changed from `num` to `int`, a subtype of `num`.
 This code passes static analysis in classic Dart,
 but is unsafe and fails analysis in strong mode Dart.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 abstract class NumberAdder {
   num add(num a, num b);
 }
 
 class IntAdder extends NumberAdder {
-  int add([[highlight]]int[[/highlight]] a, [[highlight]]int[[/highlight]] b) => a + b;
+  int add([!int!] a, [!int!] b) => a + b;
 }
 {% endprettify %}
-</div>
 
 Consider the following scenario where floating
 point values are passed to an IntAdder:
 
 {% prettify dart %}
 NumberAdder adder = new IntAdder(); // Upcast
-adder.add([[highlight]]1.2[[/highlight]], [[highlight]]3.4[[/highlight]]);                // Kaboom!
+adder.add([!1.2!], [!3.4!]); // Kaboom!
 {% endprettify %}
 
 If the override were allowed, this code would crash at runtime.
 
 Fix this error by widening the types in the subclass:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 abstract class NumberAdder {
   num add(num a, num b);
 }
 
 class IntAdder extends NumberAdder {
-  num add([[highlight]]num[[/highlight]] a, [[highlight]]num[[/highlight]] b) => a + b;
+  num add([!num!] a, [!num!] b) => a + b;
 }
 {% endprettify %}
-</div>
 
 For more information, see [Use proper input parameter types when overriding methods](/guides/language/sound-dart#use-proper-param-types).
 
 <aside class="alert alert-info" markdown="1">
-**Note:** If you have a valid reason to use a subtype, you can use the
-[covariant keyword](#the-covariant-keyword).
+  **Note:** If you have a valid reason to use a subtype, you can use the
+  [covariant keyword](#the-covariant-keyword).
 </aside>
 
 
@@ -273,31 +232,29 @@ In the following example, `Subclass` extends `Superclass<T>` but doesn't
 specify a type argument. The analyzer infers `Subclass<dynamic>`,
 which results in an invalid override error on `method(int)`.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 class Superclass<T> {
   void method(T t) {}
 }
 
 class Subclass extends Superclass {
-  [[highlight]]void method(int i) {}[[/highlight]] // <-- Error.
+  [!void method(int i) {}!] // <-- Error.
 }
 {% endprettify %}
-</div>
 
 You can fix this by specifying the type on the subclass:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 class Superclass<T> {
   void method(T t) {}
 }
 
-class Subclass extends Superclass[[highlight]]<int>[[/highlight]] {
+class Subclass extends Superclass[!<int>!] {
   void method(int i) {}
 }
 {% endprettify %}
-</div>
 
 <hr>
 
@@ -319,7 +276,7 @@ For example, the following code initializes a map with several
 `<String, int>` but the code assumes `<String, dynamic>`.
 When the code then adds a (String, float) pair, the analyzer complains.
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 void main() {
   var map = {
@@ -328,18 +285,17 @@ void main() {
     'c': 13
   }; // <= inferred to be Map<String, int>
 
-  [[highlight]]map['d'] = 1.5;[[/highlight]]  // 1.5 is not int!
+  [!map['d'] = 1.5;!]  // 1.5 is not int!
 }
 {% endprettify %}
-</div>
 
 This can be fixed by explicitly defining the map's type to be
 `<String, dynamic>`.
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 void main() {
-  var map = [[highlight]]<String, dynamic>[[/highlight]]{
+  var map = [!<String, dynamic>!]{
     'a': 7,
     'b': 11,
     'c': 13
@@ -348,7 +304,6 @@ void main() {
   map['d'] = 1.5;
 }
 {% endprettify %}
-</div>
 
 Alternatively, if you only want this map to accept integers and floats,
 you can specify the type as `<String, num>`.
@@ -370,23 +325,21 @@ The Dart dev compiler generates simpler code if
 it relies on the `super()` call appearing last.
 The following example generates an error in strong mode Dart:
 
-<div class="fails-sa" markdown="1">
+{:.fails-sa}
 {% prettify dart %}
 HoneyBadger(Eats food, String name)
-  : [[highlight]]super[[/highlight]](food),
+  : [!super!](food),
     _name = name { ... }
 {% endprettify %}
-</div>
 
 Fix the error by moving the `super()` call:
 
-<div class="passes-sa" markdown="1">
+{:.passes-sa}
 {% prettify dart %}
 HoneyBadger(Eats food, String name)
   : _name = name,
-    [[highlight]]super[[/highlight]](food) { ... }
+    [!super!](food) { ... }
 {% endprettify %}
-</div>
 
 For more information, see [DO place the super() call last in a
 constructor initialization list](/guides/language/effective-dart/usage#do-place-the-super-call-last-in-a-constructor-initialization-list)
@@ -413,15 +366,15 @@ This removes the static error and instead checks for an invalid
 parameter type at runtime.
 
 <aside class="alert alert-info" markdown="1">
-**Version note:**
-The `covariant` keyword was introduced in 1.22.
-It replaces the `@checked` annotation.
+  **Version note:**
+  The `covariant` keyword was introduced in 1.22.
+  It replaces the `@checked` annotation.
 </aside>
 
 The following shows how you might use `covariant`:
 
 {% prettify dart %}
-[[highlight]]import 'package:meta/meta.dart';[[/highlight]]
+[!import 'package:meta/meta.dart';!]
 
 class Animal {
   void chase(Animal x) {}
@@ -430,7 +383,7 @@ class Animal {
 class Mouse extends Animal {}
 
 class Cat extends Animal {
-  void chase([[highlight]]covariant[[/highlight]] Mouse x) {}
+  void chase([!covariant!] Mouse x) {}
 }
 {% endprettify %}
 


### PR DESCRIPTION
This is preparation for continued work over #407.

@kwalrath - maybe we should rename the pages (and permalinks of) `sound-dart.md` and `sound-problems.md` to `strong-mode-dart.md` and `strong-mode-problems.md`?

In addition to fairly minor markdown cleanup, this PR has slight changes to the styles for the "passes/fails static analysis" classes. Notice the check mark and cross as the start of teach short message; also the "fails" case text is shorter.

<img width="656" alt="screen shot 2017-12-18 at 08 49 23" src="https://user-images.githubusercontent.com/4140793/34109151-b1ef61e6-e3d0-11e7-9b5b-5696f9195ce9.png">
