### PR TITLE
chore: consolidate and document code-excerpt replace regexp conventions, and other misc updates

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,14 @@
 # Examples
 
-This package contains all of the sources that appear in the Language Tour and the Library Tour, including the smallest of code excerpts.
+This folder (`examples`), contains the following packages:
+
+- `misc` contains code for effective dart, the language tour, the library tour, samples and possibly more.
+- `httpserver` is one of the larger samples.
+- `util` is a package of shared utilities used by `misc`, etc.
 
 ## Original sources
 
-Sources originally taken from the Up-and-Running repo (but reworked to contain doc regions)
-are in these folders:
+The original tour sources, taken from the Up-and-Running repo (but reworked to contain doc regions), are in these folders:
 
 - `/examples_archive/language_tour` (now obsolete, see below)
 - `/examples_archive/library_tour`
@@ -13,20 +16,23 @@ are in these folders:
 These original sources don't have tests, and practically each code excerpt is an independent
 package (with its own pubspec).
 
+The original sources for the (large) samples were copied from the
+[dart-tutorials-samples](https://github.com/dart-lang/dart-tutorials-samples) repo.
+
 ## New sources
 
 Consolidated and reworked versions of the original sources have been developed,
 and are found under these folders:
 
-- `lib/language_tour`, `lib/library_tour`
-- `test/language_tour`, `test/library_tour`
+- `examples/*/lib`
+- `examples/*/test`
 
 As can be expected, Travis jobs run the
 
 - Analyzer over both `lib` and `test`
 - Tests under `test`
 
-### Source organisation
+### File organisation for the Tours
 
 The new Language Tour sources are under `lib/language_tour` and `test/language_tour`.
 Below each of these folders, you'll find either a file or a folder with a name
@@ -82,6 +88,20 @@ will display as
 
   <code>int <mark>foo</mark> = bar;</code>
 
-[lib/language_tour/classes/employee.dart]: https://github.com/dart-lang/site-www/blob/master/examples/lib/language_tour/classes/employee.dart
-[lib/util/print.dart]: https://github.com/dart-lang/site-www/blob/master/examples/lib/util/print.dart
-[test/language_tour/classes_test.dart#L95]: https://github.com/dart-lang/site-www/blob/master/examples/test/language_tour/classes_test.dart#L95
+## Code excerpt transformation
+
+The code excerpt extractor can apply regular-expression-based replace transformations.
+There are global transformations applied to all code excerpts. See
+`./scripts/refresh-code-excerpts.sh` for an annotated list of replace expressions passed
+along with the `--replace` command line argumet of the `code_excerpt_updater` command.
+
+File-scope global replace expressions are included at the top of some of site page markdown files.
+For example, `src/_guides/language/effective-dart/design.md` currently use the file-global replace argument:
+
+```html
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
+```
+
+This particular transformation strips the trailing version number off of class names. For
+example `String0` becomes `String`, and `Point1`, `Point2`, etc. all become `Point`. This
+allows the originating source file to contain multiple versions of the same class.

--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -27,7 +27,7 @@ void miscDeclAnalyzedButNotTested() {
 
   () {
     // #docregion cascades
-    var buffer = new StringBuffer0() //!
+    var buffer = new StringBuffer0() //!<br>
         .write('one')
         .write('two')
         .write('three');

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -98,7 +98,7 @@ void miscDeclAnalyzedButNotTested() {
 
   () {
     // #docregion cascades
-    var buffer = new StringBuffer() //!
+    var buffer = new StringBuffer() //!<br>
       ..write('one')
       ..write('two')
       ..write('three');

--- a/examples/misc/lib/effective_dart/docs_bad.dart
+++ b/examples/misc/lib/effective_dart/docs_bad.dart
@@ -15,7 +15,7 @@ class C<ChunkBuilder, Flag, LineWriter> {
   // #docregion first-sentence-a-paragraph
   /// Starts a new block as a child of the current chunk. Nested blocks are
   /// handled using their own independent [LineWriter].
-  ChunkBuilder startBlock() => blockEllipsis;
+  ChunkBuilder startBlock() => ellipsis;
   // #enddocregion first-sentence-a-paragraph
 
   // #docregion no-annotations
@@ -26,7 +26,7 @@ class C<ChunkBuilder, Flag, LineWriter> {
   /// @returns The new flag.
   /// @throws ArgumentError If there is already an option with
   ///     the given name or abbreviation.
-  Flag addFlag(String name, String abbr) => blockEllipsis;
+  Flag addFlag(String name, String abbr) => ellipsis;
   // #enddocregion no-annotations
 
   void newMethod() {}

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -23,17 +23,17 @@ void miscDeclAnalyzedButNotTested() {
     ///
     /// Throws an [ArgumentError] if there is already an option named [name] or
     /// there is already an option using abbreviation [abbr]. Returns the new flag.
-    Flag addFlag(String name, String abbr) => blockEllipsis;
+    Flag addFlag(String name, String abbr) => ellipsis;
     // #enddocregion first-sentence-a-paragraph, no-annotations
   };
 
   <T>() {
     // #docregion third-person
     /// Returns `true` if every element satisfies the [predicate].
-    bool all(bool predicate(T element)) => blockEllipsis;
+    bool all(bool predicate(T element)) => ellipsis;
 
     /// Starts the stopwatch if not already running.
-    void start() => blockEllipsis;
+    void start() => ellipsis;
     // #enddocregion third-person
   };
 
@@ -41,7 +41,7 @@ void miscDeclAnalyzedButNotTested() {
   /// Returns the lesser of two numbers.
   ///
   ///     min(5, 3); // 3.
-  num min(num a, num b) => blockEllipsis;
+  num min(num a, num b) => ellipsis;
   // #enddocregion code-sample
 
   () {
@@ -127,7 +127,7 @@ class C1 {
   int weekday;
 
   /// The number of checked buttons on the page.
-  int get checkedCount => blockEllipsis;
+  int get checkedCount => ellipsis;
 // #enddocregion noun-phrases-for-var-etc
 }
 

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -117,20 +117,20 @@ void miscDeclAnalyzedButNotTested() {
 
   (isDeepFried, hasPieCrust, vegan, containsBacon) {
     // #docregion multi-bin-op
-    var bobLikesIt = isDeepFried || //!
-        (hasPieCrust && !vegan) || //!
+    var bobLikesIt = isDeepFried || //!<br>
+        (hasPieCrust && !vegan) || //!<br>
         containsBacon;
 
     // #docregion four-spaces-for-arrow
-    bobLikes() => //!
+    bobLikes() => //!<br>
         isDeepFried || (hasPieCrust && !vegan) || containsBacon;
     // #enddocregion four-spaces-for-arrow, multi-bin-op
   };
 
   (someCondition, whenTrue, whenFalse) {
     // #docregion ternary-op
-    return someCondition //!
-        ? whenTrue //!
+    return someCondition //!<br>
+        ? whenTrue //!<br>
         : whenFalse;
     // #enddocregion ternary-op
   };
@@ -146,12 +146,12 @@ void miscDeclAnalyzedButNotTested() {
     // #docregion collection-literal
     mapInsideList([
       {
-        'a': 'b', //!
-        'c': 'd' //!
+        'a': 'b', //!<br>
+        'c': 'd' //!<br>
       },
       {
-        'a': 'b', //!
-        'c': 'd' //!
+        'a': 'b', //!<br>
+        'c': 'd' //!<br>
       },
     ]);
     // #enddocregion collection-literal
@@ -188,7 +188,7 @@ void miscDeclAnalyzedButNotTested() {
   (buffer, name) {
     // #docregion cascade
     buffer
-      ..write('Hello, ') //!
+      ..write('Hello, ') //!<br>
       ..write(name)
       ..write('!');
     // #enddocregion cascade
@@ -208,8 +208,8 @@ void miscDeclAnalyzedButNotTested() {
     });
 
     args.addAll([
-      '--mode', //!
-      'release', //!
+      '--mode', //!<br>
+      'release', //!<br>
       '--checked'
     ]);
 

--- a/examples/misc/test/language_tour/exceptions_test.dart
+++ b/examples/misc/test/language_tour/exceptions_test.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: assignment_to_final, unused_local_variable
+// Dart 2 only:
+// ignore_for_file: assignment_to_final_local
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/util/lib/ellipsis.dart
+++ b/examples/util/lib/ellipsis.dart
@@ -1,2 +1,2 @@
 dynamic blockEllipsis; // Use as replace="/=. blockEllipsis;/{ ... }/g"
-dynamic ellipsis; // Use as replace="/ellipsis;/.../g"
+dynamic ellipsis; // Use as replace="/ellipsis;?/.../g"

--- a/scripts/analyze-and-test-examples.sh
+++ b/scripts/analyze-and-test-examples.sh
@@ -7,7 +7,7 @@
 
 [[ -z "$NGIO_ENV_DEFS" ]] && . ./scripts/env-set.sh
 
-function analyze_and_text() {
+function analyze_and_test() {
   pushd "$1" > /dev/null
   travis_fold start analyzeAndTest.get
   pub get
@@ -90,7 +90,7 @@ for d in $EXAMPLES/??*; do
   echo
   echo "PROCESSING $d"
   echo
-  analyze_and_text $d;
+  analyze_and_test $d;
 done
 
 popd > /dev/null

--- a/scripts/refresh-code-excerpts.sh
+++ b/scripts/refresh-code-excerpts.sh
@@ -30,7 +30,12 @@ if [[ $1 == '-h' || $1 == '--help' ]]; then usage; fi
 
 runWebdevGulp;
 
-ARGS='--no-escape-ng-interpolation'
+ARGS='--no-escape-ng-interpolation '
+ARGS+='--replace='
+ARGS+='/\/\/!<br>//g;' # Use //!<br> to force a line break (against dartfmt)
+ARGS+='/ellipsis;?/.../g;' # ellipses; --> ...
+ARGS+='/\/\*(\s*\.\.\.\s*)\*\//$1/g;' # /*...*/ --> ...
+ARGS+='/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;' # {/*-...-*/} --> ... (removed brackets too)
 
 SRC="$1"
 : ${SRC:="$rootDir/src"}

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -6,7 +6,7 @@ prevpage:
   url: /guides/language/effective-dart/usage
   title: Usage
 ---
-<?code-excerpt replace="/\/\/!//g;/ellipsis;?/.../g;/\/\*(\s*\.\.\.\s*)\*\//$1/g;/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 
 Here are some guidelines for writing consistent, usable APIs for libraries.
 

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -9,7 +9,6 @@ prevpage:
   url: /guides/language/effective-dart/style
   title: Style
 ---
-<?code-excerpt replace="/=. blockEllipsis;/{ ... }/g;/ellipsis;/.../g;/\/\*(\s*\.\.\.\s*)\*\//$1/g"?>
 
 It's easy to think your code is obvious today without realizing how much you
 rely on context already in your head. People new to your code, and
@@ -126,7 +125,7 @@ ending with a period. As you can see below, it is often not a complete sentence.
 ///
 /// Throws an [ArgumentError] if there is already an option named [name] or
 /// there is already an option using abbreviation [abbr]. Returns the new flag.
-Flag addFlag(String name, String abbr) { ... }
+Flag addFlag(String name, String abbr) => ...
 {% endprettify %}
 
 {:.bad-style}
@@ -134,7 +133,7 @@ Flag addFlag(String name, String abbr) { ... }
 {% prettify dart %}
 /// Starts a new block as a child of the current chunk. Nested blocks are
 /// handled using their own independent [LineWriter].
-ChunkBuilder startBlock() { ... }
+ChunkBuilder startBlock() => ...
 {% endprettify %}
 
 The description should help the reader understand whether this API might
@@ -149,10 +148,10 @@ The doc comment should focus on what the code *does*.
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (third-person)"?>
 {% prettify dart %}
 /// Returns `true` if every element satisfies the [predicate].
-bool all(bool predicate(T element)) { ... }
+bool all(bool predicate(T element)) => ...
 
 /// Starts the stopwatch if not already running.
-void start() { ... }
+void start() => ...
 {% endprettify %}
 
 ### PREFER starting variable, getter, or setter comments with noun phrases.
@@ -168,7 +167,7 @@ the *result* of that work, not the work itself.
 int weekday;
 
 /// The number of checked buttons on the page.
-int get checkedCount { ... }
+int get checkedCount => ...
 {% endprettify %}
 
 If there's both a setter and a getter, comment only the getter. That way,
@@ -198,7 +197,7 @@ class Chunk { ... }
 /// Returns the lesser of two numbers.
 ///
 ///     min(5, 3); // 3.
-num min(num a, num b) { ... }
+num min(num a, num b) => ...
 {% endprettify %}
 
 Humans are great at generalizing from examples, so even a single code sample
@@ -239,7 +238,7 @@ and returns of a method are.
 /// @returns The new flag.
 /// @throws ArgumentError If there is already an option with
 ///     the given name or abbreviation.
-Flag addFlag(String name, String abbr) { ... }
+Flag addFlag(String name, String abbr) => ...
 {% endprettify %}
 
 The convention in Dart is to integrate that into the description of the method
@@ -252,7 +251,7 @@ and highlight parameters using square brackets.
 ///
 /// Throws an [ArgumentError] if there is already an option named [name] or
 /// there is already an option using abbreviation [abbr]. Returns the new flag.
-Flag addFlag(String name, String abbr) { ... }
+Flag addFlag(String name, String abbr) => ...
 {% endprettify %}
 
 ### AVOID redundantly mentioning types in doc comments.

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -8,7 +8,6 @@ prevpage:
   url: /guides/language/effective-dart
   title: Overview
 ---
-<?code-excerpt  replace="/ellipsis;/.../g;/\/\/!//g;/\/\*(\s*\.\.\.\s*)\*\//$1/g"?>
 
 A surprisingly important part of good code is good style. Consistent naming,
 ordering, and formatting helps code that *is* the same *look* the same. It takes

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -9,7 +9,7 @@ prevpage:
   url: /guides/language/effective-dart/documentation
   title: Documentation
 ---
-<?code-excerpt replace="/\/\*(\s*\.\.\.\s*)\*\//$1/g;/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 
 This is the most "blue-collar" guide in Effective Dart. You'll apply the
 guidelines here every day in the bodies of your Dart code. *Users* of your

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3,7 +3,7 @@ title: A Tour of the Dart Language
 description: A tour of all of the major Dart language features.
 short-title: Language Tour
 ---
-<?code-excerpt replace="/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 
 This page shows you how to use each major Dart feature, from
 variables and operators to classes and libraries, with the assumption

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -886,9 +886,9 @@ class Process {
 
 class ProcessIterator implements Iterator<Process> {
   @override
-  Process get current => /*...*/
+  Process get current => ...
   @override
-  bool moveNext() => /*...*/
+  bool moveNext() => ...
 }
 
 // A mythical class that lets you iterate through all
@@ -1126,9 +1126,9 @@ static method to manage multiple Futures and wait for them to complete:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (wait)" replace="/elideBody;/\/* ... *\//g"?>
 {% prettify dart %}
-Future deleteLotsOfFiles() async => /* ... */
-Future copyLotsOfFiles() async => /* ... */
-Future checksumLotsOfOtherFiles() async => /* ... */
+Future deleteLotsOfFiles() async =>  ...
+Future copyLotsOfFiles() async =>  ...
+Future checksumLotsOfOtherFiles() async =>  ...
 
 await Future.wait([
   deleteLotsOfFiles(),

--- a/src/_tutorials/language/index.md
+++ b/src/_tutorials/language/index.md
@@ -1,7 +1,6 @@
 ---
-layout: default
 title: "Dart Tutorials: Language"
-description: "Tutorials pertaining to the Dart language, such as asynchronous programming."
+description: Tutorials pertaining to the Dart language, such as asynchronous programming.
 permalink: /tutorials/language
 toc: false
 ---
@@ -10,8 +9,8 @@ The Future and Stream classes provide API for performing tasks,
 such as input/output, asynchronously, so as to avoid blocking your
 program. Futures and Streams are fundamental to most Dart programs.
 
-* <a href="/tutorials/language/futures">Asynchronous Programming: Futures</a>
-  <p>A first look at using Futures for asynchronous tasks.</p>
-
-* <a href="/tutorials/language/streams">Asynchronous Programming: Streams</a>
-  <p>Use streams to manage sequences of data.</p>
+- [Asynchronous Programming: Futures](/tutorials/language/futures)<br>
+  A first look at using Futures for asynchronous tasks.
+  
+- [Asynchronous Programming: Streams](/tutorials/language/streams)<br>
+  Use streams to manage sequences of data.

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -1,22 +1,19 @@
 ---
 title: "Asynchronous Programming: Streams"
-description: "Learn how to consume single-subscriber and broadcast streams."
-
+description: Learn how to consume single-subscriber and broadcast streams.
 prevpage:
   url: /tutorials/language/futures
   title: "Asynchronous Programming: Futures"
 ---
 
 <div class="panel" markdown="1">
+  <h4>What's the point?</h4>
 
-#### <a id="whats-the-point" class="anchor" href="#whats-the-point" aria-hidden="true"><span class="octicon octicon-link"></span></a>What's the point?
-
-* Streams provide an asynchronous sequence of data.
-* Data sequences include user-generated events and data read from files.
-* You can process a stream using either **await for** or listen() from the Stream API.
-* Streams provide a way to respond to errors.
-* There are two kinds of streams: single subscription or broadcast.
-
+  * Streams provide an asynchronous sequence of data.
+  * Data sequences include user-generated events and data read from files.
+  * You can process a stream using either **await for** or listen() from the Stream API.
+  * Streams provide a way to respond to errors.
+  * There are two kinds of streams: single subscription or broadcast.
 </div>
 
 Asynchronous programming in Dart is characterized by the


### PR DESCRIPTION
1. Unify, consolidate and document code-excerpt replace regexp conventions
2. Misc markdown cleanup
3. Add new (2.0.0-dev.13.0) analyzer ignore flag `assignment_to_final_local`
4. Fix typo in script

This PR essentially has no user site-page-visible changes other than the code-excerpt changes done in step 1 above: e.g. `/* ... */` uniformly replaced by just `...`.

This PR requires the most recent version of https://github.com/chalin/code_excerpt_updater, so please re-activate it (by rerunning `./scripts/before-install.sh`, for example).
