### PR TITLE
fix main example tooltip formatting

### DIFF
--- a/examples/misc/lib/pi_monte_carlo.dart
+++ b/examples/misc/lib/pi_monte_carlo.dart
@@ -7,16 +7,13 @@
 import 'dart:async'; //!tip("import")
 import 'dart:html'; //!web-only
 import 'dart:math' show Random; //!tip("dart:math")
-
 //!web-only
 int numIterations = 500; //!web-only
 
-main() async {
-  //!tip("main()")
+main() async { //!tip("main()")
   print('Compute π using the Monte Carlo method.'); //!tip("π")
   var output = querySelector("#value-of-pi"); //!web-only
-  await for (var estimate in computePi().take(numIterations)) {
-    //!tip("await")
+  await for (var estimate in computePi().take(numIterations)) { //!tip("await")
     print('π ≅ $estimate'); //!tip("$estimate")
     output.text = estimate.toStringAsFixed(5); //!web-only
     await window.animationFrame; //!web-only
@@ -24,12 +21,10 @@ main() async {
 }
 
 /// Generates a stream of increasingly accurate estimates of π. //!tip("///")
-Stream<double> computePi({int batch: 100000}) async* {
-  //!tip("async*") //!tip("{int batch: 100000}") //!tip("<double>")
+Stream<double> computePi({int batch: 100000}) async* { //!tip("async*") //!tip("{int batch: 100000}") //!tip("<double>")
   var total = 0; //!tip("var")
   var count = 0;
-  while (true) {
-    //!tip("while (true)")
+  while (true) { //!tip("while (true)")
     var points = generateRandom().take(batch); //!tip("take")
     var inside = points.where((p) => p.isInsideUnitCircle); //!tip("=>")
     total += batch;
@@ -44,17 +39,16 @@ Stream<double> computePi({int batch: 100000}) async* {
   }
 }
 
-Iterable<Point> generateRandom([int seed]) sync* {
-  //!tip("sync*") //!tip("[int seed]") //!tip("Iterable")
+Iterable<Point> generateRandom([int seed]) sync* { //!tip("sync*") //!tip("[int seed]") //!tip("Iterable")
   final random = new Random(seed); //!tip("final")
   while (true) {
     yield new Point(random.nextDouble(), random.nextDouble()); //!tip("yield")
   }
 }
 
-class Point {
-  //!tip("class")
+class Point { //!tip("class")
   final double x, y; //!tip("double")
   const Point(this.x, this.y); //!tip("this.x") //!tip("const")
   bool get isInsideUnitCircle => x * x + y * y <= 1; //!tip("get")
 }
+

--- a/scripts/create_site_main_example.dart
+++ b/scripts/create_site_main_example.dart
@@ -67,7 +67,7 @@ class Main {
 }
 
 Iterable<String> getMainExampleSrcLines() {
-  final _mainExampleFile = '../examples/lib/pi_monte_carlo.dart';
+  final _mainExampleFile = '../examples/misc/lib/pi_monte_carlo.dart';
   return new File(_mainExampleFile)
       .readAsLinesSync()
       .skipWhile((line) => !line.startsWith('import')) // initial comment block
@@ -76,7 +76,7 @@ Iterable<String> getMainExampleSrcLines() {
 }
 
 List<List<String>> _getTooltips() {
-  final _tooltipFile = '../examples/lib/pi_monte_carlo_tooltips.html';
+  final _tooltipFile = '../examples/misc/lib/pi_monte_carlo_tooltips.html';
   final _tooltipLineRE = new RegExp(r'^\s*<li name="(.*?)">(.*)</li>');
 
   // Read tooltips.


### PR DESCRIPTION
- Undid the effects of `dartfmt` which was apparently run over `examples/misc/lib/pi_monte_carlo.dart` by mistake. (Eventually we could get rid of this limitation by adapting the script, but it doesn't seem worth it atm.)
- Fixed path to Dart source and tooltip file.