### PR TITLE
Update language tour: Dart 2 changes to @proxy & noSuchMethod

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -3,7 +3,8 @@
     "default": "www-dartlang-org",
     "dev": "dartlang-org-dev",
     "staging-0": "dartlang-org-staging-0",
-    "kw-staging": "kw-www-dartlang-1",
+    "kw": "kw-www-dartlang-1",
+    "kw2": "kw-staging-dartlang-2",
     "sz" : "sz-www-1",
     "sz2" : "sz-www-2"
   }

--- a/examples/misc/lib/language_tour/classes/no_such_method.dart
+++ b/examples/misc/lib/language_tour/classes/no_such_method.dart
@@ -8,8 +8,8 @@ class A {
   // Unless you override noSuchMethod, using a
   // non-existent member results in a NoSuchMethodError.
   @override
-  void noSuchMethod(Invocation mirror) {
+  void noSuchMethod(Invocation invocation) {
     print('You tried to use a non-existent member: ' +
-        '${mirror.memberName}');
+        '${invocation.memberName}');
   }
 }

--- a/examples/misc/lib/language_tour/classes/proxy.dart
+++ b/examples/misc/lib/language_tour/classes/proxy.dart
@@ -11,9 +11,9 @@ void main() {
 @proxy
 class A {
   @override
-  void noSuchMethod(Invocation mirror) {
+  void noSuchMethod(Invocation invocation) {
     // #enddocregion
-    print('handling invocation: ${mirror.memberName}');
+    print('handling invocation: ${invocation.memberName}');
     // #docregion
   }
 }

--- a/examples/misc/lib/language_tour/classes/proxy_alt.dart
+++ b/examples/misc/lib/language_tour/classes/proxy_alt.dart
@@ -15,9 +15,9 @@ class SomeOtherClass {
 // #docregion
 class A implements SomeClass, SomeOtherClass {
   @override
-  void noSuchMethod(Invocation mirror) {
+  void noSuchMethod(Invocation invocation) {
     // #enddocregion
-    print('handling invocation: ${mirror.memberName}');
+    print('handling invocation: ${invocation.memberName}');
     // #docregion
   }
 }

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -110,7 +110,7 @@ mind:
 -   In [strong mode](/guides/language/sound-dart), static and runtime
     checks ensure that your code is type safe, helping you catch bugs
     in development, rather than at runtime. Strong mode is optional in
-    Dart 1.x, but not optional in [Dart 2.0](/dart-2.0).
+    Dart 1.x, but not optional in [Dart 2](/dart-2.0).
 
 -   Dart parses all your code before running it. You can provide tips to
     Dart—for example, by using types or compile-time constants—to catch
@@ -2929,7 +2929,7 @@ update-for-dart-2
 {% endcomment %}
 
 <aside class="alert alert-info" markdown="1">
-  **[Dart 2.0](/dart-2.0) difference**:
+  **[Dart 2](/dart-2.0) difference**:
   Only abstract classes can have abstract methods.
   An error is reported otherwise.
 </aside>
@@ -3053,9 +3053,25 @@ class A {
 }
 {% endprettify %}
 
+<aside class="alert alert-info" markdown="1">
+  **[Dart 2](/dart-2.0) difference**:
+  In Dart 2, you **can't invoke** an unimplemented method **unless**
+  the receiver is of type `dynamic` and
+  any of its **supertypes define that method** (even if abstractly).
+  For more information, see the
+  [informal feature specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
+</aside>
+
 If you use `noSuchMethod()` to implement every possible getter, setter,
 and method for one or more types,
 then you can use the `@proxy` annotation to avoid warnings:
+
+<aside class="alert alert-info" markdown="1">
+  **[Dart 2](/dart-2.0) difference**:
+  The `@proxy` annotation will be removed.
+  For more information, see
+  [site issue #442.](https://github.com/dart-lang/site-www/issues/442)
+</aside>
 
 <?code-excerpt "misc/lib/language_tour/classes/proxy.dart" replace="/@proxy/[!$&!]/g"?>
 {% prettify dart %}
@@ -3972,9 +3988,9 @@ annotation begins with the character `@`, followed by either a reference
 to a compile-time constant (such as `deprecated`) or a call to a
 constant constructor.
 
-Three annotations are available to all Dart code: `@deprecated`,
-`@override`, and `@proxy`. For examples of using `@override` and
-`@proxy`, see [Extending a class](#extending-a-class).
+Two annotations are available to all Dart code: `@deprecated` and
+`@override`. For examples of using `@override`,
+see [Extending a class](#extending-a-class).
 Here’s an example of using the `@deprecated`
 annotation:
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3051,20 +3051,27 @@ class A {
   // Unless you override noSuchMethod, using a
   // non-existent member results in a NoSuchMethodError.
   @override
-  void [!noSuchMethod!](Invocation mirror) {
+  void [!noSuchMethod!](Invocation invocation) {
     print('You tried to use a non-existent member: ' +
-        '${mirror.memberName}');
+        '${invocation.memberName}');
   }
 }
 {% endprettify %}
 
 <aside class="alert alert-info" markdown="1">
   **[Dart 2](/dart-2.0) difference**:
-  In Dart 2, you **can't invoke** an unimplemented method **unless**
-  the receiver is of type `dynamic` and
-  any of its **supertypes define that method** (even if abstractly).
-  For more information, see the
-  [informal feature specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
+  In Dart 2, you **can't invoke** an unimplemented method unless
+  **one** of the following is true: 
+
+  * The receiver has the static type `dynamic`.
+
+  * The receiver has a static type that
+  defines the unimplemented method (abstract is OK),
+  and the dynamic type of the receiver has an implemention of `noSuchMethod()`
+  that's different from the one in class `Object`.
+
+  For more information, see the informal
+  [nosuchMethod forwarding specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
 </aside>
 
 If you use `noSuchMethod()` to implement every possible getter, setter,
@@ -3083,7 +3090,7 @@ then you can use the `@proxy` annotation to avoid warnings:
 [!@proxy!]
 class A {
   @override
-  void noSuchMethod(Invocation mirror) {
+  void noSuchMethod(Invocation invocation) {
     // ···
   }
 }
@@ -3096,7 +3103,7 @@ is to just declare that the class implements those types.
 {% prettify dart %}
 class A [!implements SomeClass, SomeOtherClass !]{
   @override
-  void noSuchMethod(Invocation mirror) {
+  void noSuchMethod(Invocation invocation) {
     // ···
   }
 }


### PR DESCRIPTION
Fixes #442

Also changed "Dart 2.0" to "Dart 2" everywhere in the language tour.

Staged at https://kw-staging-dartlang-2.firebaseapp.com/guides/language/language-tour#nosuchmethod
