### PR TITLE
fix 404s to events

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -780,16 +780,6 @@
         "type": 301
       },
       {
-        "source": "/events/2013/**",
-        "destination": "/",
-        "type": 301
-      },
-      {
-        "source": "/events/2014/**",
-        "destination": "/",
-        "type": 301
-      },
-      {
         "source": "/events/2015/**",
         "destination": "https://www.youtube.com/watch?list=PLOU2XLYxmsIIQorIS8gagUiMau9S84vZV&v=FiXiI2Atexc",
         "type": 301
@@ -799,6 +789,8 @@
         "destination": "https://events.dartlang.org/2016/summit",
         "type": 301
       },
+      { "source": "/events", "destination": "https://events.dartlang.org", "type": 301 },
+      { "source": "/events/**", "destination": "https://events.dartlang.org", "type": 301 },
       {
         "source": "/googleapis",
         "destination": "https://github.com/dart-lang/googleapis",


### PR DESCRIPTION
Fixes #518

Staged at
- https://dartlang-org-staging-0.firebaseapp.com/events/2015/ --> still goes to 2015 DartConf
- https://dartlang-org-staging-0.firebaseapp.com/events/2016/ --> still goes to 2016 Dart Summit
- https://dartlang-org-staging-0.firebaseapp.com/events and everything else under /events goes to events.dartlang.org