### PR TITLE
chore(firebase): fix redirect rule pattern

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -105,7 +105,7 @@
         "type": 301
       },
       {
-        "source": "/articles/doc-comment-guidelines/**",
+        "source": "/articles/doc-comment-guidelines",
         "destination": "/guides/language/effective-dart/documentation",
         "type": 301
       },


### PR DESCRIPTION
Contributes to #517.

There was a rule already, but it only matched links "below" the page we wished to redirect. The rule has been tweaked to match only the target page (I assume that there are no subpages).

Staged at https://dartlang-org-staging-0.firebaseapp.com/articles/doc-comment-guidelines, which now redirects properly.
