### PR TITLE
Spec updates for Dart 2

### DIFF
--- a/examples/misc/lib/language_tour/classes/proxy.dart
+++ b/examples/misc/lib/language_tour/classes/proxy.dart
@@ -1,5 +1,5 @@
 // update-for-dart-2
-// Dart 2.0: hint • 'proxy' is deprecated and shouldn't be used
+// Dart 2 note: 'proxy' is deprecated and shouldn't be used
 // ignore_for_file: deprecated_member_use
 
 void main() {

--- a/firebase.json
+++ b/firebase.json
@@ -12,15 +12,6 @@
             "value": "*"
           }
         ]
-      },
-      {
-        "source": "/dart-2.0",
-        "headers": [
-          {
-            "key": "Content-Type",
-            "value": "text/html; charset=utf-8"
-          }
-        ]
       }
     ],
     "redirects": [
@@ -1158,7 +1149,12 @@
       },
       {
         "source": "/2.0",
-        "destination": "/dart-2.0",
+        "destination": "/dart-2",
+        "type": 301
+      },
+      {
+        "source": "/dart-2.0",
+        "destination": "/dart-2",
         "type": 301
       }
     ]

--- a/src/_articles/dart-vm/benchmarking.md
+++ b/src/_articles/dart-vm/benchmarking.md
@@ -18,7 +18,7 @@ update-for-dart-2.0
 **Note:**
 This article was initially targeted for the standalone VM under the
 1.x Dart SDK.  It does not reflect the Flutter VM,
-nor does it reflect the changes that are coming in [Dart 2.0](/dart-2.0).
+nor does it reflect the changes that are coming in [Dart 2](/dart-2.0).
 </aside>
 
 Programmers often create benchmarks that exercise an important algorithm in a

--- a/src/_articles/dart-vm/benchmarking.md
+++ b/src/_articles/dart-vm/benchmarking.md
@@ -18,7 +18,7 @@ update-for-dart-2.0
 **Note:**
 This article was initially targeted for the standalone VM under the
 1.x Dart SDK.  It does not reflect the Flutter VM,
-nor does it reflect the changes that are coming in [Dart 2](/dart-2.0).
+nor does it reflect the changes that are coming in [Dart 2](/dart-2).
 </aside>
 
 Programmers often create benchmarks that exercise an important algorithm in a

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -47,7 +47,7 @@ add static analysis to your tool, see the
 **Note:**
 The analyzer error codes are listed in the [Dart SDK
 repo,](https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/lib/error/error.dart)
-but they are likely to change for Dart 2.0.
+but they are likely to change for Dart 2.
 
 {% comment %}
 update-for-dart-2

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -736,7 +736,7 @@ View(Style style, List children)
 
 {% comment %}update-for-dart-2{% endcomment %}
 <div class="alert alert-danger" markdown="1">
-**Dart 2.0 note:** The call to `super()` _must be last_ in Dart 2.0, otherwise
+**Dart 2 note:** The call to `super()` _must be last_ in Dart 2, otherwise
 an error is reported.
 </div>
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -110,7 +110,7 @@ mind:
 -   In [strong mode](/guides/language/sound-dart), static and runtime
     checks ensure that your code is type safe, helping you catch bugs
     in development, rather than at runtime. Strong mode is optional in
-    Dart 1.x, but not optional in [Dart 2](/dart-2.0).
+    Dart 1.x, but not optional in [Dart 2](/dart-2).
 
 -   Dart parses all your code before running it. You can provide tips to
     Dart—for example, by using types or compile-time constants—to catch
@@ -263,7 +263,7 @@ completion and early warnings for bugs and code completion.
 This page follows the
 [style guide recommendation](/guides/language/effective-dart/design#type-annotations)
 of using `var`, rather than type annotations, for local variables.
-Even under [strong mode](/dart-2.0), you can specify `var`&mdash;the
+Even under [strong mode](/dart-2), you can specify `var`&mdash;the
 analyzer infers the type where possible.
 </div>
 
@@ -2934,7 +2934,7 @@ update-for-dart-2
 {% endcomment %}
 
 <aside class="alert alert-info" markdown="1">
-  **[Dart 2](/dart-2.0) difference**:
+  **[Dart 2](/dart-2) difference**:
   Only abstract classes can have abstract methods.
   An error is reported otherwise.
 </aside>
@@ -3749,7 +3749,7 @@ any of its body executes.
 
 
 <aside class="alert alert-info" markdown="1">
-  **[Dart 2](/dart-2.0) difference**:
+  **[Dart 2](/dart-2) difference**:
     Async functions won't return immediately.
     Instead, an async function will continue executing until
     it either suspends or completes.

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -718,7 +718,7 @@ strong mode:
 * [Strong Mode Dart: Fixing Common
   Problems](/guides/language/sound-problems) - Errors you may encounter when
   writing sound Dart code, and how to fix them.
-* [Dart 2 Updates](/dart-2.0) - How you can start updating your projects
+* [Dart 2 Updates](/dart-2) - How you can start updating your projects
   to Dart 2 now.
 * [Strong Mode Dart](https://www.youtube.com/watch?v=DKG5CMyol9U) - Leaf
   Peterson's talk from 2016 Dart Summit.

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -718,8 +718,8 @@ strong mode:
 * [Strong Mode Dart: Fixing Common
   Problems](/guides/language/sound-problems) - Errors you may encounter when
   writing sound Dart code, and how to fix them.
-* [Dart 2.0 Updates](/dart-2.0) - How you can start updating your projects
-  to Dart 2.0 now.
+* [Dart 2 Updates](/dart-2.0) - How you can start updating your projects
+  to Dart 2 now.
 * [Strong Mode Dart](https://www.youtube.com/watch?v=DKG5CMyol9U) - Leaf
   Peterson's talk from 2016 Dart Summit.
 * [Customize Static Analysis](/guides/language/analysis-options) - How

--- a/src/_guides/language/sound-faq.md
+++ b/src/_guides/language/sound-faq.md
@@ -208,7 +208,7 @@ to start migrating your code now to take advantage of the new type system that
 finds errors at compile time. It will also make the transition to Dart 2 go
 much more smoothly. For more information, see [The benefits of
 soundness](/guides/language/sound-dart#the-benefits-of-soundness)
-and [Dart 2 Updates.](/dart-2.0)
+and [Dart 2 Updates.](/dart-2)
 
 <a name="how-much-work"></a>
 ### How much work is it to switch to strong mode?
@@ -278,7 +278,7 @@ The following image shows examples of type inference in strong mode clean code:
 
 Only for awhile. Types are no longer optional in Dart 2, so we
 recommend migrating your code now. For help on getting
-ready for Dart 2, see [Dart 2 Updates](/dart-2.0).
+ready for Dart 2, see [Dart 2 Updates](/dart-2).
 For more information, see [A stronger Dart for
 everyone](http://news.dartlang.org/2017/06/a-stronger-dart-for-everyone.html).
 

--- a/src/_guides/language/sound-faq.md
+++ b/src/_guides/language/sound-faq.md
@@ -203,12 +203,12 @@ including incremental compiles, that is under development.
 ### Is Dart still optionally typed?
 Typing is optional in Dart 1.x,
 so you can continue to write Dart code as before.
-However, Dart 2.0 won't be optionally typed. We encourage you
+However, Dart 2 won't be optionally typed. We encourage you
 to start migrating your code now to take advantage of the new type system that
-finds errors at compile time. It will also make the transition to Dart 2.0 go
+finds errors at compile time. It will also make the transition to Dart 2 go
 much more smoothly. For more information, see [The benefits of
 soundness](/guides/language/sound-dart#the-benefits-of-soundness)
-and [Dart 2.0 Updates.](/dart-2.0)
+and [Dart 2 Updates.](/dart-2.0)
 
 <a name="how-much-work"></a>
 ### How much work is it to switch to strong mode?
@@ -227,7 +227,7 @@ migrating your code to sound Dart, see
 It depends. In Dart 1.x, you can [exclude files from static
 analysis](/guides/language/analysis-options#excluding-files), but
 if you're using dartdevc, the code must be entirely strong mode clean.
-In Dart 2.0, all of your code must be strong mode clean.
+In Dart 2, all of your code must be strong mode clean.
 
 <a name="are-core-libraries-compliant"></a>
 ### Are the Dart core libraries compliant with strong mode?
@@ -250,7 +250,7 @@ As for executing code, the dart2js and Dart VM tools don’t currently
 support strong mode so, yes, you can mix and match.
 The dartdevc tool requires strong mode compliance and
 won’t compile code that is unsound.
-In Dart 2.0, all code must be strong mode clean.
+In Dart 2, all code must be strong mode clean.
 
 <a name="is-it-darts-new-type-system"></a>
 ### Is strong mode Dart's new type system?
@@ -276,9 +276,9 @@ The following image shows examples of type inference in strong mode clean code:
 <a name="is-it-optional"></a>
 ### I liked Dart before. Can I still write Dart code the way I always did?
 
-Only for awhile. Types are no longer optional in Dart 2.0, so we
+Only for awhile. Types are no longer optional in Dart 2, so we
 recommend migrating your code now. For help on getting
-ready for Dart 2.0, see [Dart 2.0 Updates](/dart-2.0).
+ready for Dart 2, see [Dart 2 Updates](/dart-2.0).
 For more information, see [A stronger Dart for
 everyone](http://news.dartlang.org/2017/06/a-stronger-dart-for-everyone.html).
 

--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -2,7 +2,6 @@
 layout: default
 title: "Dart Language Specification"
 description: "The Dart language specification and proposed changes."
-toc: false
 ---
 
 Download the _Dart Programming Language Specification_ from
@@ -16,6 +15,20 @@ For a gentler introduction to the Dart language, see the
 
 You can find previous editions of the specification at
 [Standard ECMA-408](http://www.ecma-international.org/publications/standards/Ecma-408-arch.htm).
+
+
+## Dart 2 changes
+
+Dart 2 is changing the Dart language in many ways,
+some of which are not backward-compatible.
+For information about what is changing and the implementation status,
+see the following resources:
+
+* [Dart 2 Updates](/dart-2.0)
+* [Dart Language and Library Newsletters](https://github.com/dart-lang/sdk/tree/master/docs/newsletter#dart-language-and-library-newsletters)
+* [Language specification source file (TeX format)](https://github.com/dart-lang/sdk/blob/master/docs/language/dartLangSpec.tex)
+* [Informal specifications](https://github.com/dart-lang/sdk/tree/master/docs/language/informal)
+
 
 ## Changes in the 4<sup>th</sup> edition
 
@@ -58,11 +71,3 @@ the following new language features:
   Implemented in 1.6. For details, see the language tour:
   [Lazily loading a library](/guides/language/language-tour#deferred-loading).
 {% endcomment %}
-
-## Proposed enhancements to the Dart language
-
-Interested in learning about new features that may be added to Dart?
-
-You can track all Dart Enhancement Proposals (DEPs) in the
-[dart_enhancement_proposals](https://github.com/dart-lang/dart_enhancement_proposals)
-repo on GitHub.

--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -24,7 +24,7 @@ some of which are not backward-compatible.
 For information about what is changing and the implementation status,
 see the following resources:
 
-* [Dart 2 Updates](/dart-2.0)
+* [Dart 2 Updates](/dart-2)
 * [Dart Language and Library Newsletters](https://github.com/dart-lang/sdk/tree/master/docs/newsletter#dart-language-and-library-newsletters)
 * [Language specification source file (TeX format)](https://github.com/dart-lang/sdk/blob/master/docs/language/dartLangSpec.tex)
 * [Informal specifications](https://github.com/dart-lang/sdk/tree/master/docs/language/informal)

--- a/src/_includes/async-await-2.0.html
+++ b/src/_includes/async-await-2.0.html
@@ -1,6 +1,6 @@
 <aside class="alert alert-info" markdown="1">
-**Note for Dart 2.0:**
-There is a slight breaking change for async in Dart 2.0.
+**Note for Dart 2:**
+There is a slight breaking change for async in Dart 2.
 Instead of immediately suspending, async functions execute synchronously
 until the first await. In most cases, you won't notice a change in
 behavior&mdash;as long as you await each time you call an async method,

--- a/src/_includes/checked-mode-2.0.html
+++ b/src/_includes/checked-mode-2.0.html
@@ -1,5 +1,5 @@
 <aside class="alert alert-info" markdown="1">
-  **Dart 2.0 note**:
-  Checked mode won't be in Dart 2.0. For more information,
-  see [Dart 2.0 Updates.](/dart-2.0)
+  **Dart 2 note**:
+  Checked mode won't be in Dart 2. For more information,
+  see [Dart 2 Updates.](/dart-2.0)
 </aside>

--- a/src/_includes/checked-mode-2.0.html
+++ b/src/_includes/checked-mode-2.0.html
@@ -1,5 +1,5 @@
 <aside class="alert alert-info" markdown="1">
   **Dart 2 note**:
   Checked mode won't be in Dart 2. For more information,
-  see [Dart 2 Updates.](/dart-2.0)
+  see [Dart 2 Updates.](/dart-2)
 </aside>

--- a/src/_includes/dartium-2.0.html
+++ b/src/_includes/dartium-2.0.html
@@ -3,5 +3,5 @@
   In Dart 2, you'll use Chrome or other standard browsers for testing
   instead of Dartium, thanks to a new development compiler called
   [_dartdevc_]({{site.webdev}}/tools/dartdevc).
-  For information on Dartium's removal, see [Dart 2 Updates.](/dart-2.0)
+  For information on Dartium's removal, see [Dart 2 Updates.](/dart-2)
 </aside>

--- a/src/_includes/dartium-2.0.html
+++ b/src/_includes/dartium-2.0.html
@@ -1,7 +1,7 @@
 <aside class="alert alert-info" markdown="1">
-  **Dartium is going away in Dart 2.0:**
-  In Dart 2.0, you'll use Chrome or other standard browsers for testing
+  **Dartium is going away in Dart 2:**
+  In Dart 2, you'll use Chrome or other standard browsers for testing
   instead of Dartium, thanks to a new development compiler called
   [_dartdevc_]({{site.webdev}}/tools/dartdevc).
-  For information on Dartium's removal, see [Dart 2.0 Updates.](/dart-2.0)
+  For information on Dartium's removal, see [Dart 2 Updates.](/dart-2.0)
 </aside>

--- a/src/_includes/optional-types-2.0.html
+++ b/src/_includes/optional-types-2.0.html
@@ -2,5 +2,5 @@
   **Dart 2 note**:
   Types won't be optional in Dart 2, but you'll still be able to omit
   some type annotations, thanks to type inference. For more information, see
-  [Dart 2 Updates.](/dart-2.0)
+  [Dart 2 Updates.](/dart-2)
 </aside>

--- a/src/_includes/optional-types-2.0.html
+++ b/src/_includes/optional-types-2.0.html
@@ -1,6 +1,6 @@
 <aside class="alert alert-info" markdown="1">
-  **Dart 2.0 note**:
-  Types won't be optional in Dart 2.0, but you'll still be able to omit
+  **Dart 2 note**:
+  Types won't be optional in Dart 2, but you'll still be able to omit
   some type annotations, thanks to type inference. For more information, see
-  [Dart 2.0 Updates.](/dart-2.0)
+  [Dart 2 Updates.](/dart-2.0)
 </aside>

--- a/src/_includes/pub-in-prereleases.html
+++ b/src/_includes/pub-in-prereleases.html
@@ -1,10 +1,10 @@
 <aside class="alert alert-warning" markdown="1">
   **SDK constraints and Dart 2 pre-releases:**
-  The pub version solver in 2.0 pre-releases can choose package versions that
-  haven’t been verified to work with 2.0.
+  The pub version solver in Dart 2 pre-releases can choose package versions that
+  haven’t been verified to work with Dart 2.
 
   If you find a package that has Dart 2 issues,
   please report those issues immediately to the package maintainer,
   and let the Dart community know about any workarounds you find.
-  For more information, see [Dart 2 Updates.](/dart-2.0)
+  For more information, see [Dart 2 Updates.](/dart-2)
 </aside>

--- a/src/_includes/pub-in-prereleases.html
+++ b/src/_includes/pub-in-prereleases.html
@@ -1,10 +1,10 @@
 <aside class="alert alert-warning" markdown="1">
-  **SDK constraints and Dart 2.0 pre-releases:**
+  **SDK constraints and Dart 2 pre-releases:**
   The pub version solver in 2.0 pre-releases can choose package versions that
   haven’t been verified to work with 2.0.
 
-  If you find a package that has Dart 2.0 issues,
+  If you find a package that has Dart 2 issues,
   please report those issues immediately to the package maintainer,
   and let the Dart community know about any workarounds you find.
-  For more information, see [Dart 2.0 Updates.](/dart-2.0)
+  For more information, see [Dart 2 Updates.](/dart-2.0)
 </aside>

--- a/src/dart-2.0.md
+++ b/src/dart-2.0.md
@@ -1,17 +1,17 @@
 ---
 layout: default
 permalink: /dart-2.0
-title: Dart 2.0 Updates
-description: How Dart 2.0 is different from Dart 1.x, and how you can prepare.
+title: Dart 2 Updates
+description: How Dart 2 is different from Dart 1.x, and how you can prepare.
 ---
 
-This page has information about changes that are coming in Dart 2.0,
+This page has information about changes that are coming in Dart 2,
 and how you can migrate your code from Dart 1.x.
 
 <aside class="alert alert-warning" markdown="1">
 **Don't rely on 2.0 until it's stable.**
-Dart 2.0 pre-releases will have a series of incompatible changes.
-Although we appreciate your willingness to prepare for and test Dart 2.0,
+Dart 2 pre-releases will have a series of incompatible changes.
+Although we appreciate your willingness to prepare for and test Dart 2,
 please don't bet your livelihood on a pre-release.
 For information on potential changes, see
 [Dart Language & Library Newsletters.](https://github.com/dart-lang/sdk/blob/master/docs/newsletter/README.md#dart-language-and-library-newsletters)
@@ -21,21 +21,21 @@ For information on potential changes, see
   * [Web](#migration-tips-web)
   * [Servers and command-line scripts](#migration-tips-servers-and-command-line-scripts)
   * [Packages](#migration-tips-packages)
-* [Testing with Dart 2.0 pre-releases](#testing)
-* Dart 2.0 differences
+* [Testing with Dart 2 pre-releases](#testing)
+* Dart 2 differences
   * [Obsolete features](#obsolete-features)
   * [Strong mode and static typing](#strong-mode-and-static-typing)
 
 <aside class="alert alert-info" markdown="1">
 **Flutter note:** You don't need to do anything to prepare Flutter code
-for Dart 2.0. If changes become necessary,
+for Dart 2. If changes become necessary,
 we'll add Flutter details to this page.
 </aside>
 
 
 ## Migration tips: web
 
-If you develop for the web, you can start migrating to Dart 2.0 now:
+If you develop for the web, you can start migrating to Dart 2 now:
 
 Convert your code to be strong mode compliant.
 : For more information,
@@ -66,7 +66,7 @@ will eventually be phased out.
 ## Migration tips: servers and command-line scripts
 
 If you develop servers or command-line scripts,
-you can start migrating to Dart 2.0 now:
+you can start migrating to Dart 2 now:
 
 Convert your code to be strong mode compliant.
 : For more information, see [Strong mode and static
@@ -105,12 +105,12 @@ If a backward-compatible change isn't possible,
 ### Upper constraints on the SDK version
 
 Don't update an already-published package
-solely to indicate that it can be used with Dart 2.0 pre-releases.
+solely to indicate that it can be used with Dart 2 pre-releases.
 As long as a package has either no [SDK constraints][]
 or an upper constraint of `<2.0.0`,
-`pub get` and similar pub commands in any Dart 2.0 pre-release
+`pub get` and similar pub commands in any Dart 2 pre-release
 can download the package.
-(The package won't be usable with Dart 2.0 stable releases,
+(The package won't be usable with Dart 2 stable releases,
 but you can fix that later.)
 
 When you update an existing package or publish a new one,
@@ -125,13 +125,13 @@ sdk: '>=2.0.0-dev.1.2 <2.0.0'
 ```
 
 Eventually, you'll need to publish new versions of your packages to
-declare Dart 2.0 compatibility, most likely using a `<3.0.0` SDK constraint.
-Because incompatible changes might occur in any Dart 2.0 pre-release,
-don't declare Dart 2.0 compatibility until we announce that it's safe to do so.
+declare Dart 2 compatibility, most likely using a `<3.0.0` SDK constraint.
+Because incompatible changes might occur in any Dart 2 pre-release,
+don't declare Dart 2 compatibility until we announce that it's safe to do so.
 
 ### Summary
 
-If you publish packages, get ready for Dart 2.0:
+If you publish packages, get ready for Dart 2:
 
 * Make it easy for users to report issues.
 * Respond quickly to issues.
@@ -145,11 +145,11 @@ If you publish packages, get ready for Dart 2.0:
 [pubspec format]: /tools/pub/pubspec
 
 
-## Testing with Dart 2.0 pre-releases {#testing}
+## Testing with Dart 2 pre-releases {#testing}
 
-To test your code with Dart 2.0, you can use a
+To test your code with Dart 2, you can use a
 [pre-release](/install#about-sdk-release-channels-and-version-strings)
-of the Dart 2.0 SDK.
+of the Dart 2 SDK.
 
 When running `pub get`, `pub upgrade`, or other pub commands
 from a 2.0 pre-release, you might get packages that
@@ -161,7 +161,7 @@ and let the Dart community know about any workarounds you find.
 
 ## Obsolete features
 
-The following features are redundant and won't be in Dart 2.0:
+The following features are redundant and won't be in Dart 2:
 
 Checked mode
 : Strong mode replaces checked mode. To learn how they differ, see
@@ -181,23 +181,23 @@ Dartium
 In Dart 1.x, types are optional. You can remove all type annotations
 from a Dart 1.x program without affecting its behavior.
 
-In Dart 2.0, _types_ are mandatory,
+In Dart 2, _types_ are mandatory,
 but type _annotations_ are still optional.
 When a type annotation is absent, tools infer the type.
 With both static and runtime type checks,
-Dart 2.0 has a sound type system.
+Dart 2 has a sound type system.
 This type system enables better tooling, as well as
 clearer, earlier feedback when you write code.
 
-You can prepare for Dart 2.0 by using Dart 1.x with
+You can prepare for Dart 2 by using Dart 1.x with
 [strong mode](/guides/language/sound-dart).
 
 
 <aside class="alert alert-info" markdown="1">
 **A quick summary of the gnarly details:**
-Dart 2.0 supports [type inference](/guides/language/sound-dart#type-inference)
+Dart 2 supports [type inference](/guides/language/sound-dart#type-inference)
 and, in many cases, doesn't require type annotations. For example,
-the following is valid code in both Dart 1.x and Dart 2.0:
+the following is valid code in both Dart 1.x and Dart 2:
 
 <pre>
 var i = 1;   // In 2.0, inferred to be int;
@@ -209,16 +209,16 @@ x = "Hello";
 
 As the example shows, you can use the static `dynamic` type
 to indicate that the runtime type is unknown.
-One big difference between optionally typed Dart and Dart 2.0
+One big difference between optionally typed Dart and Dart 2
 is that, in the former, the analyzer infers the `dynamic` type.
-In Dart 2.0, tools like the analyzer can often infer
+In Dart 2, tools like the analyzer can often infer
 types that are more specific than `dynamic`,
 following rules in the language specification.
 
-While Dart 2.0 is statically typed, type inference and
+While Dart 2 is statically typed, type inference and
 less precise types such as `dynamic` and `num`
 take away much of the burden of specifying exact types.
-Dart 2.0 has the advantages of a strongly typed language,
+Dart 2 has the advantages of a strongly typed language,
 but requires only a bit more work than Dart 1.x.
 
 To experiment with strong mode,
@@ -228,7 +228,7 @@ and check the **Strong mode** box at the lower right.
 
 Migrate your code to strong mode, and you may identify some
 lurking bugs that are now more easily identifiable and addressable.
-You'll also find it much easier to transition to Dart 2.0.
+You'll also find it much easier to transition to Dart 2.
 For more information, see [A stronger Dart for
 everyone](http://news.dartlang.org/2017/06/a-stronger-dart-for-everyone.html)
 and [Strong Mode Dart.](/guides/language/sound-dart)

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -13,8 +13,9 @@ and how you can migrate your code from Dart 1.x.
 Dart 2 pre-releases will have a series of incompatible changes.
 Although we appreciate your willingness to prepare for and test Dart 2,
 please don't bet your livelihood on a pre-release.
-For information on potential changes, see
-[Dart Language & Library Newsletters.](https://github.com/dart-lang/sdk/blob/master/docs/newsletter/README.md#dart-language-and-library-newsletters)
+For information on potential changes, see the
+[Dart 2 changes](/guides/language/spec#dart-2-changes) section of the
+[Dart Language Specification](/guides/language/spec) page.
 </aside>
 
 * Migration tips

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-permalink: /dart-2.0
+permalink: /dart-2
 title: Dart 2 Updates
 description: How Dart 2 is different from Dart 1.x, and how you can prepare.
 ---
@@ -9,7 +9,7 @@ This page has information about changes that are coming in Dart 2,
 and how you can migrate your code from Dart 1.x.
 
 <aside class="alert alert-warning" markdown="1">
-**Don't rely on 2.0 until it's stable.**
+**Don't rely on Dart 2 until it's stable.**
 Dart 2 pre-releases will have a series of incompatible changes.
 Although we appreciate your willingness to prepare for and test Dart 2,
 please don't bet your livelihood on a pre-release.
@@ -87,7 +87,7 @@ As a package owner, you need to do the following:
 ### Changes and backward compatibility
 
 If you have to change your package's code,
-**try to make it work in 1.x**, as well as 2.0.
+**try to make it work in 1.x**, as well as Dart 2.
 For example, you might be able to add type annotations
 or (if an API has been removed) to use an alternative 1.x API.
 
@@ -152,9 +152,9 @@ To test your code with Dart 2, you can use a
 of the Dart 2 SDK.
 
 When running `pub get`, `pub upgrade`, or other pub commands
-from a 2.0 pre-release, you might get packages that
-haven’t been verified to work with 2.0.
-If you find a package that has 2.0 issues,
+from a Dart 2 pre-release, you might get packages that
+haven’t been verified to work with Dart 2.
+If you find a package that has Dart 2 issues,
 please report those issues immediately to the package maintainer,
 and let the Dart community know about any workarounds you find.
 
@@ -200,7 +200,7 @@ and, in many cases, doesn't require type annotations. For example,
 the following is valid code in both Dart 1.x and Dart 2:
 
 <pre>
-var i = 1;   // In 2.0, inferred to be int;
+var i = 1;   // In Dart 2, inferred to be int;
              // previously, inferred to be dynamic.
 
 dynamic x = 1;

--- a/src/faq.md
+++ b/src/faq.md
@@ -123,7 +123,7 @@ support mirrors.](https://flutter.io/faq/#does-flutter-come-with-a-reflectionmir
 
 ### Q. Can Dart add tuples, pattern matching, non-nullable types, partial evaluation, optional semicolons, ...?
 
-The Dart language is now at 1.x, and [Dart 2.0](/dart-2.0) is in development.
+The Dart language is now at 1.x, and [Dart 2](/dart-2.0) is in development.
 
 Future releases might be able to include your feature,
 although we can't include everything.
@@ -154,7 +154,7 @@ and use a compiler (such as the Dart development compiler,
 that has static and runtime checks. With both types of checks,
 Dart has a sound type system, which guarantees that an expression of one
 type cannot produce a value of another type. (So, no surprises!)
-Types won't be optional in Dart 2.0.
+Types won't be optional in Dart 2.
 [Flutter]&mdash;a cross-platform mobile development system&mdash;already uses
 strong mode.
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -123,7 +123,7 @@ support mirrors.](https://flutter.io/faq/#does-flutter-come-with-a-reflectionmir
 
 ### Q. Can Dart add tuples, pattern matching, non-nullable types, partial evaluation, optional semicolons, ...?
 
-The Dart language is now at 1.x, and [Dart 2](/dart-2.0) is in development.
+The Dart language is now at 1.x, and [Dart 2](/dart-2) is in development.
 
 Future releases might be able to include your feature,
 although we can't include everything.

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -81,7 +81,7 @@ Now that breaking changes are expected,
 we’ve switched to version strings beginning with `2.0.0-dev`.
 
 For more information, see
-[Dart 2.0 Updates](/dart-2.0)
+[Dart 2 Updates](/dart-2.0)
 and the [installation instructions](#) for your platform.
 {% comment %}
 [PENDING: add link to the news post?]

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -81,7 +81,7 @@ Now that breaking changes are expected,
 we’ve switched to version strings beginning with `2.0.0-dev`.
 
 For more information, see
-[Dart 2 Updates](/dart-2.0)
+[Dart 2 Updates](/dart-2)
 and the [installation instructions](#) for your platform.
 {% comment %}
 [PENDING: add link to the news post?]

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -270,7 +270,7 @@ with the version of the Dart SDK that you have installed.
 and **do include an upper bound** (`<2.0.0`, usually).
 Packages that break these rules might stop working in the future
 and, for that reason, might not be allowed on pub.dartlang.org.
-For more information, see [Dart 2.0 Updates.](/dart-2.0)
+For more information, see [Dart 2 Updates.](/dart-2.0)
 </aside>
 
 

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -270,7 +270,7 @@ with the version of the Dart SDK that you have installed.
 and **do include an upper bound** (`<2.0.0`, usually).
 Packages that break these rules might stop working in the future
 and, for that reason, might not be allowed on pub.dartlang.org.
-For more information, see [Dart 2 Updates.](/dart-2.0)
+For more information, see [Dart 2 Updates.](/dart-2)
 </aside>
 
 


### PR DESCRIPTION
Staged: https://kw-www-dartlang-1.firebaseapp.com/guides/language/spec
Compare to: https://www.dartlang.org/guides/language/spec

* Added a section to the spec page for Dart 2 updates.
* Removed an obsolete section about DEPs.
* Changed _Dart 2.0_ to _Dart 2_ everywhere in the site.

Fixes #514 
Fixes #522 

/cc @timsneath