### PR TITLE
Trigger popovers on click, and fix scrolling even in subviews

### DIFF
--- a/src/_assets/javascripts/main.js
+++ b/src/_assets/javascripts/main.js
@@ -88,12 +88,44 @@ $(document).on('ready', function(){
 
 
   // Popovers
-  $('[data-toggle="popover"]').popover({
-    container: 'body',
-    html: true,
-    placement: 'top',
-    trigger: 'focus hover',
-  });
+
+  const openPopClass = 'popover-open';
+  const popSelector = '[data-toggle="popover"]';
+  const openPopSelector = popSelector + '.' + openPopClass;
+  function setPopovers(root, viewport) {
+    const popovers = root.find(popSelector);
+    // console.log('>> setPopovers: ' + popovers.length + ', ' + viewport);
+    popovers.popover({
+      container: viewport === 'body' ? 'body' : undefined,
+      html: true,
+      placement:
+        // When in a subview, open popovers towards the bottom so that they
+        // can be viewed by scrolling the subview. Scrolling to view the
+        // popover is possible when the popover opens below the trigger element,
+        // not when it appears above.
+        viewport === 'body' ? 'top' : 'bottom',
+      trigger: 'click', // focus doesn't toggle for non-anchor elements
+      viewport: viewport,
+    }).on('shown.bs.popover', function () {
+      // _After_ this popover has been shown, add 'popover-open' class.
+      $(this).addClass(openPopClass);
+    });
+  }
+
+  // Frontpage popovers insdie the #code-sample, should scroll with the enclosing <pre>.
+  setPopovers($('body.homepage #code-sample'), 'pre');
+  // All other popovers should scoll with the page.
+  setPopovers($('body'), 'body');
+
+  $('body')
+    // Hide any open popover before opening a new one. Note event name starts with 'show' not 'shown'.
+    .on('show.bs.popover', function () {
+      $(openPopSelector).removeClass(openPopClass).popover('hide');
+    })
+    // When clicking outside any popovers, close them all.
+    .click(function(e) {
+      $(openPopSelector).removeClass(openPopClass).popover('hide');
+    });
 
   // open - close mobile navigation
   $('#menu-toggle').on('click', function(e) {
@@ -113,4 +145,3 @@ $(document).on('ready', function(){
   $('a[href^="http"], a[target="_blank"]').not('.no-automatic-external').addClass('external');
 
 });
-

--- a/src/_assets/javascripts/main.js
+++ b/src/_assets/javascripts/main.js
@@ -112,9 +112,9 @@ $(document).on('ready', function(){
     });
   }
 
-  // Frontpage popovers insdie the #code-sample, should scroll with the enclosing <pre>.
+  // Frontpage popovers inside the #code-sample should scroll with the enclosing <pre>.
   setPopovers($('body.homepage #code-sample'), 'pre');
-  // All other popovers should scoll with the page.
+  // All other popovers should scroll with the page.
   setPopovers($('body'), 'body');
 
   $('body')

--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -58,19 +58,34 @@ a code {
 	}
 }
 
+@mixin popover-open {
+  &.popover-open {
+    font-weight: 500;
+    border-color: $default-link;
+  }
+}
+
 [data-toggle="popover"] {
 	background: none;
 	border-bottom: 2px dotted $gray;
 	padding: 0;
-	cursor: pointer;
-
-	&:hover { border-color: $default-link; }
-	// &.selected { font-weight: bold; }
+  cursor: pointer;
+  @include popover-open;
 }
 
-body.homepage #code-sample [data-toggle="popover"] {
-  border-color: darken($gray, 10%);
-  &:hover { border-color: $default-link; }
+@media (hover: hover) {
+  [data-toggle="popover"]:hover { border-color: $default-link !important; }
+}
+
+body.homepage #code-sample {
+  [data-toggle="popover"] {
+    border-color: darken($gray, 10%);
+    @include popover-open;
+  }
+  .popover-content {
+    color: $gray-base;
+    code { color: $blue; }
+  }
 }
 
 body.homepage {

--- a/src/_assets/stylesheets/_variables.scss
+++ b/src/_assets/stylesheets/_variables.scss
@@ -63,11 +63,11 @@ $border-radius-small:       0px;
 //##
 
 //** Popover body background color
-$popover-bg:                          #fff;
+$popover-bg:                          #fff !default;
 //** Popover maximum width
 $popover-max-width:                   276px !default;
 //** Popover border color
-$popover-border-color:                rgba(0,0,0,0);
+$popover-border-color:                lighten($brand-primary, 40%);
 //** Popover fallback border color
 $popover-fallback-border-color:       transparent;
 


### PR DESCRIPTION
Fixes #530

As explained in `main.js`, popovers inside the front page sample code block open downwards so that it is always possible to scroll the full popover content into view.

Staged at:
- https://dartlang-org-staging-0.firebaseapp.com
- https://dartlang-org-staging-0.firebaseapp.com/tutorials/libraries/shared-pkgs
- https://dartlang-org-staging-0.firebaseapp.com/tutorials/dart-vm/cmdline

Tested in Chrome, Firefox and Safari.

Continued prep work for #6.

---

Here are examples of front page code example popovers:

<img width="791" alt="screen shot 2018-01-22 at 22 19 38" src="https://user-images.githubusercontent.com/4140793/35257118-7f654504-ffc5-11e7-8aab-84700cd33769.png">

<img width="530" alt="screen shot 2018-01-22 at 22 46 37" src="https://user-images.githubusercontent.com/4140793/35257260-3f9ab26e-ffc6-11e7-910e-e16fb2f99c71.png">

And one from the prose:

<img width="509" alt="screen shot 2018-01-22 at 22 46 51" src="https://user-images.githubusercontent.com/4140793/35257268-4920970e-ffc6-11e7-983d-dc9e3745b0e4.png">
