### PR TITLE
Simplify Get Started page

### DIFF
--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -230,38 +230,33 @@ body.homepage .get-started-section {
 
 .get-started-table {
 	margin-top: 20px;
-
-	@media (min-width: $screen-sm-min) {
-		float: right;
-		max-width: 55%;
-	}
+	margin-bottom: 20px;
 
 	td {
 		padding: 10px;
 		padding-left: 0;
-
+		padding-right: 2em;
 		border-bottom: 1px solid $gray-light;
 	}
 
-	tr:last-child td {
-		border-bottom: none;
+	td:first-child {
+		@media (min-width: $screen-xs-min) {
+		  padding-right: 0;
+		}
 	}
 
-	td:first-child {
-		width: 3em;
+  /* icon column */
+	td:nth-child(2) {
+		width: 4em;
 		display: none;
+		text-align: center;
 
 		@media (min-width: $screen-xs-min) {
 			display: table-cell;
 		}
 	}
 
-	td:nth-child(2) {
-		width: 20%;
-	}
-
 	td:last-child {
-		text-align: right;
 		padding-left: 10px;
 		a {
 			width: 100%;

--- a/src/_guides/get-started.md
+++ b/src/_guides/get-started.md
@@ -1,14 +1,15 @@
 ---
 layout: guide
 title: Get Started
-description: "A guide for getting started with Dart."
+description: "A guide to getting started with Dart."
 toc: false
 ---
 
 Jump right in. Use the embedded DartPad below to play with Dart and to experience the language and core APIs.
-[DartPad](/tools/dartpad) is a quick and easy way to
-become familiar with Dart language features.
-You can also open <a href="http://dartpad.dartlang.org" target="_blank">DartPad in a new window</a>.
+DartPad is a quick and easy way to
+become familiar with Dart language features
+([more info](/tools/dartpad)).
+You can also open <a href="http://dartpad.dartlang.org" target="_blank">DartPad in a new window.</a>
 
 <iframe
 src="{{site.custom.dartpad.embed-dart-prefix}}?horizontalRatio=70&verticalRatio=65"
@@ -20,63 +21,26 @@ src="{{site.custom.dartpad.embed-dart-prefix}}?horizontalRatio=70&verticalRatio=
 Note that DartPad supports only a few core libraries.
 If you want to use other libraries,
 such as dart:io or libraries from packages,
-you'll need to [install](/install) an SDK.
+you'll need to download platform-specific tools.
 
 
-<div class="get-started-table__text">
-  <h2>Ready for something more?</h2>
-  <p>
-    This website (<a href="/">www.dartlang.org</a>) contains
-    information about the fundamental Dart technologies:
-  </p>
-  <ul>
-    <li>the <a href="/guides/language">language</a></li>
-    <li><a href="/guides/libraries">core libraries</a></li>
-  </ul>
-  <p>
-    But where do you go when you have a use case in mind?
-  </p>
-</div>
+## What next?
 
-| | | **Use case** | **Get started** |
-| <i class="fa fa-code" aria-hidden="true"></i> | **Web** | Create an app that runs in any modern browser | <a href="{{site.webdev}}/guides/get-started" class="btn btn-primary no-automatic-external">Dart webdev</a> |
-| <i class="fa fa-android" aria-hidden="true"></i> <i class="fa fa-apple" aria-hidden="true"></i> | **Mobile** | Create an app from a single codebase that runs on both iOS and Android | <a href="https://flutter.io/getting-started/" class="btn btn-primary no-automatic-external">Flutter</a> |
-| <i class="fa fa-terminal" aria-hidden="true"></i> | **Server** | Create a command-line app or server | <a href="/tutorials/dart-vm/get-started" class="btn btn-primary">Dart VM</a> |
+To learn about the Dart [language](/guides/language) and
+[core libraries](/guides/libraries),
+stay on this site.
+
+Once you have a use case in mind, go to the "get started" instructions
+for the appropriate Dart platform:
+
+| **Platform** | | **Use case** | **Get started** |
+| **Mobile** | <i class="fa fa-android" aria-hidden="true"></i> <i class="fa fa-apple" aria-hidden="true"></i> | Create an app from a single codebase that runs on both iOS and Android. | <a href="https://flutter.io/getting-started/" class="btn btn-primary no-automatic-external">Flutter</a> |
+| **Web** | <i class="fa fa-code" aria-hidden="true"></i> | Create an app that runs in any modern browser. | <a href="{{site.webdev}}/guides/get-started" class="btn btn-primary no-automatic-external">Dart webdev</a> |
+| **Server** | <i class="fa fa-terminal" aria-hidden="true"></i> | Create a command-line tool or server. | <a href="/tutorials/dart-vm/get-started" class="btn btn-primary">Dart VM</a> |
 {:.get-started-table}
 
-{% comment %}
-<sup>*</sup>If you have a favorite IDE, there is probably a Dart plugin for that.
-See the link for tips on how to configure the recommended IDE.
-For general IDE advice, see [Tools](/tools).
-{% endcomment %}
+Here are some other resources:
 
-<div style='clear:right'></div>
-
-## Helpful flowchart
-
-{% comment %}
-The original Lucid Chart is here:
-https://www.lucidchart.com/documents/edit/0f170001-d5f4-4b17-8cdc-72d5575f2e78?shared=true&#
-Created by filiph, the Lucid app is available to Googlers in mystuff.
-{% endcomment %}
-
-<object class="get-started-flowchart" type="image/svg+xml" data="images/get-started-flowchart.svg">
-  <img src="images/get-started-flowchart.png" alt="flowchart showing how to learn Dart">
-</object>
-
-## Books
-
-If you're looking for a more guided approach to learning Dart, we recommend you
-pick up one of the many [books about Dart](/resources/books).
-
-## Samples
-
-Check out the Dart [samples](/samples).
-
-## Get help
-
-There are a number of communities and platforms where you can ask,
-or answer, Dart-related questions. For a list, see
-[Community and Support](/community).
-
-<div style='clear:right'></div>
+* [Books](/resources/books)
+* [Sample Code](/samples)
+* [Community and Support](/community)

--- a/src/_guides/get-started.md
+++ b/src/_guides/get-started.md
@@ -26,10 +26,8 @@ you'll need to download platform-specific tools.
 
 ## What next?
 
-To learn about the Dart [language](/guides/language) and
-[core libraries](/guides/libraries),
-stay on this site.
-
+Learn about the Dart [language](/guides/language) and
+[core libraries](/guides/libraries) on this site.
 Once you have a use case in mind, go to the "get started" instructions
 for the appropriate Dart platform:
 

--- a/src/tools/dartpad.md
+++ b/src/tools/dartpad.md
@@ -13,6 +13,16 @@ Here's what DartPad looks like:
 <img src="images/DartPadWindow.png" alt="DartPad screenshot" />
 
 
+## Library support
+
+DartPad supports [dart:* libraries]({{site.dart_api}}) that work with web apps;
+it doesn't support [dart:io]({{site.dart_api}}/stable/dart-io) or
+libraries from [packages.]({{site.pub}})
+If you want to use dart:io, use the [Dart SDK](/tools/sdk) instead.
+If you want to use a package, get the SDK for a
+[platform](/guides/platforms) that the package supports.
+
+
 ## Getting started
 
 To get familiar with DartPad, try these steps:
@@ -31,15 +41,6 @@ To get familiar with DartPad, try these steps:
   A sample appears on the left and the output appears on the right.
   If you've played with DartPad before,
   you can click **New Pad** to get back to the original sample.
-
-  <aside class="alert alert-info" markdown="1">
-  **What about mobile?**
-  DartPad has a slightly different user interface on mobile devices.
-  To run an app, click the red button, which takes you to the output.
-  {% comment %}
-  TODO: Update if/when mobile UI changes.
-  {% endcomment %}
-  </aside>
   </li>
 
   <li markdown="1">
@@ -166,13 +167,3 @@ To create a simple web app, start with the Hello World HTML sample.
     </ol>
   </li>
 </ol>
-
-
-## Library support
-
-DartPad supports [dart:* libraries]({{site.dart_api}}) that work with web apps;
-it doesn't support [dart:io]({{site.dart_api}}/stable/dart-io) or
-libraries from [packages.]({{site.pub}})
-If you want to use dart:io, use the [Dart SDK](/tools/sdk) instead.
-If you want to use a package, get the SDK for a
-[platform](/guides/platforms) that the package supports.


### PR DESCRIPTION
Also (re)moved stuff in the DartPad docs. Staged at:

https://kw-staging-dartlang-2.firebaseapp.com/guides/get-started
https://kw-staging-dartlang-2.firebaseapp.com/tools/dartpad

Fixes #552

