### PR TITLE
Minor style fix for code-excerpt popover element anchors

### DIFF
--- a/src/_assets/stylesheets/_overwrites.scss
+++ b/src/_assets/stylesheets/_overwrites.scss
@@ -100,7 +100,7 @@ body.homepage {
 			}
 			@include front-page-first-section-height;
 			overflow: auto;
-			&.prettyprint a { background: inherit; }
+			&.prettyprint a { background: transparent; }
 		}
 	}
 }


### PR DESCRIPTION
Fixes this overlap problem
<img width="137" alt="screen shot 2018-02-05 at 14 26 25" src="https://user-images.githubusercontent.com/4140793/35824447-e73547ae-0a80-11e8-8a0d-8efe93d3aae8.png">

so that it now we can see the `Iterable` fully underlined:

<img width="148" alt="screen shot 2018-02-05 at 14 29 47" src="https://user-images.githubusercontent.com/4140793/35824500-0ce17072-0a81-11e8-9325-4e0061b6b7d4.png">
