### PR TITLE
Update type cast errors section

### DIFF
--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -394,7 +394,7 @@ In other cases, however, Dart needs to insert a _runtime_ check. Consider:
 {:.passes-sa}
 {% prettify dart %}
 assumeStrings(List<Object> objects) {
-  List<String> [!strings = objects!]; // <!-- Implicit downcast
+  List<String> [!strings = objects!]; // <- Implicit downcast
   String string = strings[0];         // Expect to get a type 'String' out.
 }
 {% endprettify %}

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -451,7 +451,7 @@ You can also more precisely type the local variable, and let inference help:
 
 In cases where you are working with a collection that you don't create, such
 as from JSON or an external data source, you can use the
-[`cast` method](https://api.dartlang.org/dev/dart-core/List/cast.html)
+[`cast` method](...) --> [cast()]({{site.dart_api}}/dev/dart-core/List/cast.html) method
 provided by `List` (and other collection classes).
 
 Here's an example of the preferred solution: tightening the object's type.

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -387,7 +387,7 @@ main() {
  
 Since neither `List<int>` nor `List<String>` is a subtype of the other,
 Dart rules this out statically. You can see other examples of these
-static analysis errors in [Assigning Mismatched Types](##assigning-mismatched-types).
+static analysis errors in [Assigning Mismatched Types](#assigning-mismatched-types).
 
 In other cases, however, Dart needs to insert a _runtime_ check. Consider:
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -451,7 +451,7 @@ You can also more precisely type the local variable, and let inference help:
 
 In cases where you are working with a collection that you don't create, such
 as from JSON or an external data source, you can use the
-[`cast` method](...) --> [cast()]({{site.dart_api}}/dev/dart-core/List/cast.html) method
+[`cast` method](...) --> [cast()]({{site.dart_api}}/dev/dart-core/List/cast.html)
 provided by `List` (and other collection classes).
 
 Here's an example of the preferred solution: tightening the object's type.

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -113,7 +113,7 @@ you might see from the analyzer or an IDE with strong mode enabled.
 
 Static analysis can't catch all errors.
 For help fixing strong-mode errors that appear only at runtime,
-see [Runtime errors](#common-errors-and-warnings). 
+see [Runtime errors](#common-errors-and-warnings).
 
 
 <a name="undefined-member"></a>
@@ -384,7 +384,7 @@ main() {
   List<String> [!string = numbers!]; // <-- Static analysis error
 }
 {% endprettify %}
- 
+
 Since neither `List<int>` nor `List<String>` is a subtype of the other,
 Dart rules this out statically. You can see other examples of these
 static analysis errors in [Assigning Mismatched Types](#assigning-mismatched-types).
@@ -451,7 +451,7 @@ You can also more precisely type the local variable, and let inference help:
 
 In cases where you are working with a collection that you don't create, such
 as from JSON or an external data source, you can use the
-[`cast` method](...) --> [cast()]({{site.dart_api}}/dev/dart-core/List/cast.html)
+[cast()]({{site.dart_api}}/dev/dart-core/List/cast.html) method
 provided by `List` (and other collection classes).
 
 Here's an example of the preferred solution: tightening the object's type.


### PR DESCRIPTION
... based on @munificent's internal doc, which I think does a much better job than I originally did (plus lots of my terminology is actually related to `uses_dynamic_as_bottom`, *not* this class of error/warning, so I'll save it for a future PR).

Work towards https://github.com/dart-lang/site-www/issues/562.