### PR TITLE
Enable no-implicit-casts: code fixes that are user visible

### DIFF
--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -2,7 +2,9 @@
 #   http://dart-lang.github.io/linter/lints/
 
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: false
+    # implicit-dynamic: false
   exclude:
     # Exclude the "old" sources. Only the new sources need be analyzed.
     - language_tour/**

--- a/examples/misc/analyzer-1-results.txt
+++ b/examples/misc/analyzer-1-results.txt
@@ -1,0 +1,3 @@
+Analyzing lib, test...
+  error • A value of type 'dynamic' can't be assigned to a variable of type 'Person' at lib/library_tour/core/hash_code.dart:23:21 • invalid_assignment
+1 error found.

--- a/examples/misc/lib/language_tour/classes/point.dart
+++ b/examples/misc/lib/language_tour/classes/point.dart
@@ -22,7 +22,7 @@ class Point {
 
   // Initializer list sets instance variables before
   // the constructor body runs.
-  Point.fromJson(Map json)
+  Point.fromJson(Map<String, num> json)
       : x = json['x'],
         y = json['y'];
   // #docregion class-with-distanceTo

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -18,7 +18,7 @@ class Point {
   // #docregion initializer-list
   // Initializer list sets instance variables before
   // the constructor body runs.
-  Point.fromJson(Map json)
+  Point.fromJson(Map<String, num> json)
       : x = json['x'],
         y = json['y'] {
     print('In Point.fromJson(): ($x, $y)');

--- a/examples/misc/lib/language_tour/classes/point_with_distance_field.dart
+++ b/examples/misc/lib/language_tour/classes/point_with_distance_field.dart
@@ -5,7 +5,7 @@ class Point {
   final num y;
   final num distanceFromOrigin;
 
-  Point(x, y)
+  Point(num x, num y)
       : x = x,
         y = y,
         distanceFromOrigin = sqrt(x * x + y * y);

--- a/examples/misc/test/language_tour/async_test.dart
+++ b/examples/misc/test/language_tour/async_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 void main() {
   test('syncGenerator', () {
     // #docregion sync-generator
-    Iterable naturalsTo(n) sync* {
+    Iterable<int> naturalsTo(int n) sync* {
       int k = 0;
       while (k < n) yield k++;
     }
@@ -17,7 +17,7 @@ void main() {
 
   test('asyncGenerator', () async {
     // #docregion async-generator
-    Stream asynchronousNaturalsTo(n) async* {
+    Stream<int> asynchronousNaturalsTo(int n) async* {
       int k = 0;
       while (k < n) yield k++;
     }
@@ -28,7 +28,7 @@ void main() {
 
   test('recursiveGenerator', () {
     // #docregion recursive-generator
-    Iterable naturalsDownFrom(n) sync* {
+    Iterable<int> naturalsDownFrom(int n) sync* {
       if (n > 0) {
         yield n;
         yield* naturalsDownFrom(n - 1);

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2601,7 +2601,7 @@ initializers with commas.
 {% prettify dart %}
 // Initializer list sets instance variables before
 // the constructor body runs.
-Point.fromJson(Map json)
+Point.fromJson(Map<String, num> json)
     : x = json['x'],
       y = json['y'] {
   print('In Point.fromJson(): ($x, $y)');
@@ -2630,7 +2630,7 @@ class Point {
   final num y;
   final num distanceFromOrigin;
 
-  Point(x, y)
+  Point(num x, num y)
       : x = x,
         y = y,
         distanceFromOrigin = sqrt(x * x + y * y);
@@ -3062,7 +3062,7 @@ class A {
 <aside class="alert alert-info" markdown="1">
   **[Dart 2](/dart-2.0) difference**:
   In Dart 2, you **can't invoke** an unimplemented method unless
-  **one** of the following is true: 
+  **one** of the following is true:
 
   * The receiver has the static type `dynamic`.
 
@@ -3892,7 +3892,7 @@ and use `yield` statements to deliver values:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (sync-generator)"?>
 {% prettify dart %}
-Iterable naturalsTo(n) sync* {
+Iterable<int> naturalsTo(int n) sync* {
   int k = 0;
   while (k < n) yield k++;
 }
@@ -3904,7 +3904,7 @@ and use `yield` statements to deliver values:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (async-generator)"?>
 {% prettify dart %}
-Stream asynchronousNaturalsTo(n) async* {
+Stream<int> asynchronousNaturalsTo(int n) async* {
   int k = 0;
   while (k < n) yield k++;
 }
@@ -3915,7 +3915,7 @@ you can improve its performance by using `yield*`:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (recursive-generator)"?>
 {% prettify dart %}
-Iterable naturalsDownFrom(n) sync* {
+Iterable<int> naturalsDownFrom(int n) sync* {
   if (n > 0) {
     yield n;
     yield* naturalsDownFrom(n - 1);


### PR DESCRIPTION
@kwalrath - I'd like to set strong mode `implicit-casts` to false for the example code. It has already helped identify a bug in our effective Dart code (see #586).

#586 included the bug fix and non-user-visible changes.

I've kept user visible changes for this PR (actually, only the language tour is affect). The changes are minor, but worth it IMHO. PTAL