### PR TITLE
 Reinstate Install Dart button + warn Flutter devs

### DIFF
--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -985,6 +985,7 @@ li.card {
 .alert-with-image {
   display: table-row;
   > img {
+    margin-right: $content-padding * 2;
     width: $font-size-base * 3;
     @media(max-width: $screen-xs-min) { display: none; }
   }

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -983,12 +983,15 @@ li.card {
 }
 
 .alert-with-image {
+  display: table-row;
   > img {
-    float: left;
     width: $font-size-base * 3;
+    @media(max-width: $screen-xs-min) { display: none; }
   }
   > div {
-    padding-left: $font-size-base * 4;
+    display: table-cell;
+    @media(min-width: $screen-xs-min) { padding-left: $content-padding; }
+    vertical-align: top;
   }
 }
 

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -982,6 +982,16 @@ li.card {
   }
 }
 
+.alert-with-image {
+  > img {
+    float: left;
+    width: $font-size-base * 3;
+  }
+  > div {
+    padding-left: $font-size-base * 4;
+  }
+}
+
 /* Used for inlined icon markers, usually at the start of a paragraph */
 .content > p > i.material-icons {
   vertical-align: bottom;

--- a/src/index.html
+++ b/src/index.html
@@ -28,14 +28,16 @@ description: Dart is an application programming language that’s easy to learn,
             <h3>
               Dart helps you craft beautiful, high-quality experiences
               across all screens, with:
-
               <ul>
                 <li> A <a tabindex="0" role="button" data-toggle="popover" data-content="Dart started out being optimized for web apps, and is evolving to provide great support for mobile apps. Dart also runs on the command line and server-side.">client-optimized</a> language </li>
                 <li> Rich, powerful <a tabindex="0" role="button" data-toggle="popover" data-content="For mobile apps, we recommend <a href='https://flutter.io'>Flutter</a>. For desktop apps, <a href='https://webdev.dartlang.org/angular'>AngularDart</a>.">frameworks</a> </li>
                 <li> Delightful, flexible <a tabindex="0" role="button" data-toggle="popover" data-content="These range from <a href='/tools'>general-purpose tools</a> to framework-specific ones like the <a href='https://flutter.io/getting-started'><code>flutter</code> tool</a>.">tooling</a>
                 </li>
               </ul>
-              <p><a href="/guides/get-started" class="frontpage-slogan__get-started btn btn-default btn-lg">Get started</a> </p>
+              <p>
+                <a href="/guides/get-started" class="frontpage-slogan__get-started btn btn-default btn-lg">Get started</a>
+                <a href="/install" class="btn btn-lg">Install Dart</a>
+              </p>
             </h3>
             <p> <em>Click the
               <a tabindex="0" role="button" data-toggle="popover" data-content="In the text above and in the code sample, click dotted underlines to get more details.">underlined text</a>

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -8,14 +8,21 @@ js:
 show_breadcrumbs: false
 ---
 
-<p><em>Current stable version of Dart:
-<span class="editor-build-rev-stable">[calculating]</span></em></p>
+_Current stable version of Dart:
+<span class="editor-build-rev-stable">[calculating]</span>_
 
-If you’re a Flutter developer, you get Dart when you
-[install Flutter](https://flutter.io/setup/)
-or [upgrade Flutter.](https://flutter.io/upgrading/)
+<aside class="alert alert-with-image alert-warning">
+  <img src="{% asset_path flutter-logo.png %}" width="48px" alt="[Flutter]">
+  <div markdown="1">
+  **Important:**
+  If you’re a _Flutter_ developer, you get Dart when you
+  [install Flutter](https://flutter.io/setup/)
+  or [upgrade Flutter.](https://flutter.io/upgrading/)
+  </div>
+</aside>
 
-Otherwise, install the **Dart SDK** to get everything you need to write and run Dart code:
+For non-Flutter developers, install the **Dart SDK** to get
+everything you need to write and run Dart code:
 VM, libraries, analyzer, package manager, doc generator,
 formatter, debugger, and more.
 

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -14,8 +14,8 @@ _Current stable version of Dart:
 <aside class="alert alert-warning"><div class="alert-with-image">
   <img src="{% asset_path flutter-logo.png %}" alt="[Flutter]">
   <div markdown="1">
-  **Important:**
-  If you’re a _Flutter_ developer, you get Dart when you
+  **Important:** The Flutter SDK contains Dart. To develop Flutter apps,
+  **don't install the Dart SDK separately.** Instead,
   [install Flutter](https://flutter.io/setup/)
   or [upgrade Flutter.](https://flutter.io/upgrading/)
   </div>

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -21,7 +21,7 @@ _Current stable version of Dart:
   </div>
 </div></aside>
 
-For non-Flutter developers, install the **Dart SDK** to get
+To use Dart for web or server-side development, install the **Dart SDK** to get
 everything you need to write and run Dart code:
 VM, libraries, analyzer, package manager, doc generator,
 formatter, debugger, and more.

--- a/src/install/index.md
+++ b/src/install/index.md
@@ -11,15 +11,15 @@ show_breadcrumbs: false
 _Current stable version of Dart:
 <span class="editor-build-rev-stable">[calculating]</span>_
 
-<aside class="alert alert-with-image alert-warning">
-  <img src="{% asset_path flutter-logo.png %}" width="48px" alt="[Flutter]">
+<aside class="alert alert-warning"><div class="alert-with-image">
+  <img src="{% asset_path flutter-logo.png %}" alt="[Flutter]">
   <div markdown="1">
   **Important:**
   If you’re a _Flutter_ developer, you get Dart when you
   [install Flutter](https://flutter.io/setup/)
   or [upgrade Flutter.](https://flutter.io/upgrading/)
   </div>
-</aside>
+</div></aside>
 
 For non-Flutter developers, install the **Dart SDK** to get
 everything you need to write and run Dart code:


### PR DESCRIPTION
This PR reinstates the frontpage Install Dart button which had been removed in #533. It also adds a clear visual warning for Flutter devs.

Fixes #576 

Staged at:
- https://dartlang-org-staging-0.firebaseapp.com
- https://dartlang-org-staging-0.firebaseapp.com/install

---

Here is the alert for Flutter devs:
> <img width="756" alt="screen shot 2018-02-21 at 11 37 08" src="https://user-images.githubusercontent.com/4140793/36492939-5fc118e2-16fc-11e8-8d4e-2bedce5f98ee.png">
