### PR TITLE
Booleans: JavaScript treats these things as true not false

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -564,7 +564,7 @@ which are both compile-time constants.
 When Dart expects a boolean value, only the value `true` is treated as
 true. All other values are treated as false. Unlike in JavaScript,
 values such as `1`, `"aString"`, and `someObject` are all treated as
-false.
+true.
 
 For example, consider the following code, which is valid both as
 JavaScript and as Dart code:


### PR DESCRIPTION
In JavaScript,
values such as `1`, `"aString"`, and `someObject` are all treated as
true, not false.