### PR TITLE
Markdown syntax fix for dart-tips-6

### DIFF
--- a/src/resources/dart-tips/dart-tips-6.md
+++ b/src/resources/dart-tips/dart-tips-6.md
@@ -167,8 +167,8 @@ String shout(String msg, {int exclamations}) {
 
 To briefly recap, there are two ways to define optional parameters.
 
-* [ ] for optional positional parameters
-* { } for optional named parameters
+* `[` `]` for optional positional parameters
+* `{` `}` for optional named parameters
 
 There's yet another benefit from the use of optional parameters. But first, the
 setup: Sometimes, there's an obvious or default value for a parameter. Only on

--- a/src/resources/dart-tips/dart-tips-6.md
+++ b/src/resources/dart-tips/dart-tips-6.md
@@ -165,7 +165,7 @@ String shout(String msg, {int exclamations}) {
 }
 {% endprettify %}
 
-To briefly recap, there are two ways to define optional parameters.
+To briefly recap, there are two ways to define optional parameters:
 
 * `[` `]` for optional positional parameters
 * `{` `}` for optional named parameters


### PR DESCRIPTION
Fixes #612.

I also ensured that the docs contained no other occurrences of the GFM syntax for checkboxes.

cc @kwalrath 

Cause: Jekyll's [default config](https://jekyllrb.com/docs/configuration/) has Kramdown (our markdown processor), accept [GFM](https://kramdown.gettalong.org/parser/gfm.html) as input by default.

--- 

Now fixed, this is what it looks like:

> <img width="448" alt="screen shot 2018-02-27 at 09 03 43" src="https://user-images.githubusercontent.com/4140793/36732952-31030ae2-1b9d-11e8-8759-39705c8258bc.png">
