### PR TITLE
Fixe misformatting of <pre> elements generated by prettifier

### DIFF
--- a/src/_plugins/prettify.rb
+++ b/src/_plugins/prettify.rb
@@ -35,7 +35,7 @@ module Prettify
       out += '">'
 
       # Strip excess whitespace at the end (which will be present if the code is indented)
-      contents = super.gsub /(\s*\n\s*)+\z/, "\n"
+      contents = super.gsub /(\s*\n\s*)+\z/, ''
       contents = CGI::escapeHTML(contents)
 
       contents.gsub!('[[strike]]', '<code class="nocode strike">')


### PR DESCRIPTION
Fixes #630

---

The \</pre> end tags are gone:

> <img width="393" alt="screen shot 2018-03-06 at 11 59 07" src="https://user-images.githubusercontent.com/4140793/37046227-ce59ecd2-2135-11e8-9cd1-a6dba62aa5c5.png">
