### PR TITLE
Add banner to Effective Dart

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -8,6 +8,8 @@ prevpage:
 ---
 <?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 
+{% include effective-dart-banner.html %}
+
 Here are some guidelines for writing consistent, usable APIs for libraries.
 
 * TOC

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -10,6 +10,8 @@ prevpage:
   title: Style
 ---
 
+{% include effective-dart-banner.html %}
+
 It's easy to think your code is obvious today without realizing how much you
 rely on context already in your head. People new to your code, and
 even your forgetful future self won't have that context. A concise, accurate

--- a/src/_guides/language/effective-dart/index.md
+++ b/src/_guides/language/effective-dart/index.md
@@ -10,6 +10,8 @@ nextpage:
   title: "Style"
 ---
 
+{% include effective-dart-banner.html %}
+
 Over the past several years, we've written a ton of Dart code and learned a lot
 about what works well and what doesn't. We're sharing this with you so you can
 write consistent, robust, fast code too.
@@ -62,6 +64,7 @@ We split the guidelines into a few separate pages for easy digestion:
 For links to all the guidelines, see the
 [summary](#summary-of-all-rules).
 
+{% comment %}
 <aside class="alert alert-info" markdown="1">
   **Have feedback on the guides?** <br>
   Please create a [new issue][] or comment on one of our [existing issues][].
@@ -69,6 +72,7 @@ For links to all the guidelines, see the
   [new issue]: {{site.repo}}/issues/new
   [existing issues]: {{site.repo}}/issues?q=is%3Aopen+is%3Aissue+label%3AEffectiveDart
 </aside>
+{% endcomment %}
 
 [dartfmt]: https://github.com/dart-lang/dart_style#readme
 [style guide]: /guides/language/effective-dart/style

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -9,6 +9,8 @@ prevpage:
   title: Overview
 ---
 
+{% include effective-dart-banner.html %}
+
 A surprisingly important part of good code is good style. Consistent naming,
 ordering, and formatting helps code that *is* the same *look* the same. It takes
 advantage of the powerful pattern-matching hardware most of us have in our

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -11,6 +11,8 @@ prevpage:
 ---
 <?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 
+{% include effective-dart-banner.html %}
+
 This is the most "blue-collar" guide in Effective Dart. You'll apply the
 guidelines here every day in the bodies of your Dart code. *Users* of your
 library may not be able to tell that you've internalized the ideas here, but

--- a/src/_includes/effective-dart-banner.html
+++ b/src/_includes/effective-dart-banner.html
@@ -1,0 +1,9 @@
+<div class="banner">
+    <p class="banner__text">
+	<em>Effective Dart</em> has not yet been updated to Dart 2
+	and has some <a target="_blank" 
+        href="https://github.com/dart-lang/site-www/labels/EffectiveDart">known issues.</a>
+        If a guideline appears to be missing or doesn't make sense,
+	please file a bug.
+    </p>
+</div>


### PR DESCRIPTION
Added a banner like the following to all Effective Dart pages. These will be visible once we flip the site to Dart 2.

![image](https://user-images.githubusercontent.com/2164483/37625318-adcd8854-2b88-11e8-9f89-2ea938ac045b.png)

/cc @munificent 