### PR TITLE
Clarifies rules for if statements without curlies

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -368,7 +368,7 @@ if (isWeekDay) {
 {% endprettify %}
 
 There is one exception to this: `if` statements with no `else` clause that fit
-on one line may omit the braces.
+on one 80-character line may omit the braces.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if)"?>


### PR DESCRIPTION
I'm pretty sure this is clear?

**IMPORTANT!** Submit your PR against the right branch:
- `master` is for Dart 2-dev
- `1.x` is for Dart 1.x