### PR TITLE
Add a guideline for naming type parameters.

### DIFF
--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -190,6 +190,58 @@ class Task {
 
 //----------------------------------------------------------------------------
 
+// #docregion type-parameter-e
+class IterableBase1<E> {}
+
+class List1<E> {}
+
+class HashSet1<E> {}
+
+class RedBlackTree<E> {}
+// #enddocregion type-parameter-e
+
+// #docregion type-parameter-k-v
+class Map1<K, V> {}
+
+class Multimap<K, V> {}
+
+class MapEntry1<K, V> {}
+// #enddocregion type-parameter-k-v
+
+class BinaryExpression {}
+
+class LiteralExpression {}
+
+class UnaryExpression {}
+
+// #docregion type-parameter-r
+abstract class ExpressionVisitor<R> {
+  R visitBinary(BinaryExpression node);
+  R visitLiteral(LiteralExpression node);
+  R visitUnary(UnaryExpression node);
+}
+// #enddocregion type-parameter-r
+
+// #docregion type-parameter-t
+class Future1<T> {
+  Future<S> then<S>(FutureOr<S> onValue(T value)) => ellipsis();
+}
+// #enddocregion type-parameter-t
+
+// #docregion type-parameter-graph
+class Graph<N, E> {
+  final List<N> nodes = [];
+  final List<E> edges = [];
+}
+
+class Graph1<Node, Edge> {
+  final List<Node> nodes = [];
+  final List<Edge> edges = [];
+}
+// #enddocregion type-parameter-graph
+
+//----------------------------------------------------------------------------
+
 // #docregion one-member-abstract-class
 typedef bool Predicate<E>(E element);
 // #enddocregion one-member-abstract-class

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -337,6 +337,78 @@ map.containsValue(value)
 {% endprettify %}
 
 
+### DO follow existing mnemonic conventions when naming type parameters.
+
+Single letter names aren't exactly illuminating, but almost all generic types
+use them. Fortunately, they mostly use them in a consistent, mnemonic way.
+The conventions are:
+
+*   `E` for the **element** type in a collection:
+
+    {:.good-style}
+    {% prettify dart %}
+    class IterableBase<E> {}
+    class List<E> {}
+    class HashSet<E> {}
+    class RedBlackTree<E> {}
+    {% endprettify %}
+
+*   `K` and `V` for the **key** and **value** types in an associative
+    collection:
+
+    {:.good-style}
+    {% prettify dart %}
+    class Map<K, V> {}
+    class Multimap<K, V> {}
+    class MapEntry<K, V> {}
+    {% endprettify %}
+
+*   `R` for a type used as the **return** type of a function or a class's
+    methods. This isn't common, but appears in typedefs sometimes and in classes
+    that implement the visitor pattern:
+
+    {:.good-style}
+    {% prettify dart %}
+    abstract class ExpressionVisitor<R> {
+      R visitBinary(BinaryExpression node);
+      R visitLiteral(LiteralExpression node);
+      R visitUnary(UnaryExpression node);
+    }
+    {% endprettify %}
+
+*   Otherwise, use `T`, `S`, and `U` for generics that have a single type
+    parameter and where the surrounding type makes its meaning obvious. There
+    are multiple letters here to allow nesting without shadowing a surrounding
+    name. For example:
+
+    {:.good-style}
+    {% prettify dart %}
+    class Future<T> {
+      Future<S> then<S>(FutureOr<S> onValue(T value)) => ...
+    }
+    {% endprettify %}
+
+    Here, the generic method `then<S>()` uses `S` to avoid shadowing the `T`
+    on `Future<T>`.
+
+If none of the above cases are a good fit, then either another single-letter
+mnemonic name or a descriptive name is fine:
+
+{:.good-style}
+{% prettify dart %}
+class Graph<N, E> {
+  final List<N> nodes;
+  final List<E> edges;
+}
+
+class Graph<Node, Edge> {
+  final List<Node> nodes;
+  final List<Edge> edges;
+}
+{% endprettify %}
+
+In practice, the existing conventions cover most type parameters.
+
 ## Libraries
 
 The underscore character ( `_` ) indicates that a member is private to its

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -346,10 +346,14 @@ The conventions are:
 *   `E` for the **element** type in a collection:
 
     {:.good-style}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)"?>
     {% prettify dart %}
     class IterableBase<E> {}
+
     class List<E> {}
+
     class HashSet<E> {}
+
     class RedBlackTree<E> {}
     {% endprettify %}
 
@@ -357,9 +361,12 @@ The conventions are:
     collection:
 
     {:.good-style}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)"?>
     {% prettify dart %}
     class Map<K, V> {}
+
     class Multimap<K, V> {}
+
     class MapEntry<K, V> {}
     {% endprettify %}
 
@@ -368,6 +375,7 @@ The conventions are:
     that implement the visitor pattern:
 
     {:.good-style}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-r)"?>
     {% prettify dart %}
     abstract class ExpressionVisitor<R> {
       R visitBinary(BinaryExpression node);
@@ -382,6 +390,7 @@ The conventions are:
     name. For example:
 
     {:.good-style}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-t)"?>
     {% prettify dart %}
     class Future<T> {
       Future<S> then<S>(FutureOr<S> onValue(T value)) => ...
@@ -395,15 +404,16 @@ If none of the above cases are a good fit, then either another single-letter
 mnemonic name or a descriptive name is fine:
 
 {:.good-style}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-graph)"?>
 {% prettify dart %}
 class Graph<N, E> {
-  final List<N> nodes;
-  final List<E> edges;
+  final List<N> nodes = [];
+  final List<E> edges = [];
 }
 
 class Graph<Node, Edge> {
-  final List<Node> nodes;
-  final List<Edge> edges;
+  final List<Node> nodes = [];
+  final List<Edge> edges = [];
 }
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -37,8 +37,8 @@ Identifiers come in three flavors in Dart.
 
 ### DO name types using `UpperCamelCase`.
 
-Classes, enums, typedefs, and type parameters should capitalize the first letter of each word
-(including the first word), and use no separators.
+Classes, enums, typedefs, and type parameters should capitalize the first letter
+of each word (including the first word), and use no separators.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (type-names)"?>

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -177,6 +177,7 @@
 * <a href='/guides/language/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object'>PREFER naming a method <code>to___()</code> if it copies the object's state to a new object.</a>
 * <a href='/guides/language/effective-dart/design#prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object'>PREFER naming a method <code>as___()</code> if it returns a different representation backed by the original object.</a>
 * <a href='/guides/language/effective-dart/design#avoid-describing-the-parameters-in-the-functions-or-methods-name'>AVOID describing the parameters in the function's or method's name.</a>
+* <a href='/guides/language/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters'>DO follow existing mnemonic conventions when naming type parameters.</a>
 
 **Libraries**
 
@@ -208,7 +209,7 @@
 **Type annotations**
 
 * <a href='/guides/language/effective-dart/design#do-type-annotate-public-apis'>DO type annotate public APIs.</a>
-* <a href='/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter'>DON’T specify a return type for a setter.</a>
+* <a href='/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter'>DON'T specify a return type for a setter.</a>
 * <a href='/guides/language/effective-dart/design#prefer-type-annotating-private-declarations'>PREFER type annotating private declarations.</a>
 * <a href='/guides/language/effective-dart/design#avoid-annotating-types-on-function-expressions'>AVOID annotating types on function expressions.</a>
 * <a href='/guides/language/effective-dart/design#avoid-annotating-with-dynamic-when-not-required'>AVOID annotating with <code>dynamic</code> when not required.</a>


### PR DESCRIPTION
Fixes #30.