### PR TITLE
[1.x] Pub transformer warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,9 @@ branch: 1.x
 #   {{site.webdev}}/downloads
 
 dartlang: ""
+dartlang_2: "https://dartlang-org-dev.firebaseapp.com"
 webdev: "https://webdev.dartlang.org"
+webdev_dev: "https://webdev-dartlang-org-dev.firebaseapp.com"
 dart_vm:  "/dart-vm"
 flutter:  "https://flutter.io"
 dart_api: "https://api.dartlang.org"

--- a/_config.yml
+++ b/_config.yml
@@ -10,9 +10,9 @@ branch: 1.x
 #   {{site.webdev}}/downloads
 
 dartlang: ""
-dartlang_2: "https://dartlang-org-dev.firebaseapp.com"
+dev-dartlang: "https://dartlang-org-dev.firebaseapp.com"
 webdev: "https://webdev.dartlang.org"
-webdev_dev: "https://webdev-dartlang-org-dev.firebaseapp.com"
+dev-webdev: "https://webdev-dartlang-org-dev.firebaseapp.com"
 dart_vm:  "/dart-vm"
 flutter:  "https://flutter.io"
 dart_api: "https://api.dartlang.org"

--- a/src/_includes/tools/jetbrains-reporting-issues.html
+++ b/src/_includes/tools/jetbrains-reporting-issues.html
@@ -1,1 +1,4 @@
-jetbrains-reporting-issues.html
+Please report issues and feedback via the official
+<a href="https://youtrack.jetbrains.com/issues/WEB?q=Subsystem%3A+Dart">JetBrains issue tracker for Dart.</a>
+Include details of the expected behavior, the actual behavior,
+and screenshots if appropriate.

--- a/src/_includes/tools/transformers-going-away.md
+++ b/src/_includes/tools/transformers-going-away.md
@@ -4,5 +4,5 @@
   which includes the **build_runner** tool.
   For details, see the
   [build_runner README](https://github.com/dart-lang/build/blob/master/build_runner/README.md#build_runner) or the
-  [web-specific build_runner documentation.]({{site.webdev_dev}}/tools/build_runner)
+  [web-specific build_runner documentation.]({{site.dev-webdev}}/tools/build_runner)
 </aside>

--- a/src/_includes/tools/transformers-going-away.md
+++ b/src/_includes/tools/transformers-going-away.md
@@ -1,0 +1,8 @@
+<aside class="alert alert-warning" markdown="1">
+  **Dart 2 note:** Pub in Dart 2 no longer supports `pub build`, `pub serve`, or transformers.
+  Instead, use the new [build system,](https://github.com/dart-lang/build)
+  which includes the **build_runner** tool.
+  For details, see the
+  [build_runner README](https://github.com/dart-lang/build/blob/master/build_runner/README.md#build_runner) or the
+  [web-specific build_runner documentation.]({{site.webdev_dev}}/tools/build_runner)
+</aside>

--- a/src/tools/pub/assets-and-transformers.md
+++ b/src/tools/pub/assets-and-transformers.md
@@ -5,6 +5,8 @@ title: "Assets and Transformers"
 description: "How pub transforms and generates assets and files during development and build time."
 ---
 
+{% include tools/transformers-going-away.md %}
+
 The [`pub serve`]({{site.webdev}}/tools/pub/pub-serve),
 [`pub build`]({{site.webdev}}/tools/pub/pub-build),
 and [`pub run`](/tools/pub/cmd/pub-run) commands use [transformers][]

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -115,6 +115,8 @@ transformers before invoking the specified script.
 With pub you can publish packages, build deployable web apps, and
 deploy command-line apps.
 
+{% include tools/transformers-going-away.md %}
+
 ### Sharing packages
 
 To share your Dart packages with the world, you can

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -50,6 +50,8 @@ Assets fall into four groups, with some overlap:
 For more information, see
 [Pub Assets and Transformers](/tools/pub/assets-and-transformers).
 
+{% include tools/transformers-going-away.md %}
+
 ## Dependency
 
 Another package that your package relies on. If your package wants to import
@@ -178,6 +180,8 @@ command puts the generated assets into files.
 The [`pub serve`]({{site.webdev}}/tools/pub/pub-serve) command,
 on the other hand, doesn't produce files;
 its generated assets are served directly by the dev server.
+
+{% include tools/transformers-going-away.md %}
 
 ## Transitive dependency
 

--- a/src/tools/pub/index.md
+++ b/src/tools/pub/index.md
@@ -73,6 +73,8 @@ are specific to web development. For more information, see
 
 ## Writing transformers
 
+{% include tools/transformers-going-away.md %}
+
 When `pub` serves or builds an app, it can run one or more
 transformers&mdash;for example, one transformer converts Dart
 files into a single JavaScript file.

--- a/src/tools/pub/transformers/aggregate.md
+++ b/src/tools/pub/transformers/aggregate.md
@@ -5,6 +5,8 @@ description: How to write a Pub transformer to processes multiple input assets.
 permalink: /tools/pub/transformers/aggregate
 ---
 
+{% include tools/transformers-going-away.md %}
+
 An aggregate transformer processes multiple assets in a single
 pass&ndash;for example, collaging multiple images into a single image.
 

--- a/src/tools/pub/transformers/examples.md
+++ b/src/tools/pub/transformers/examples.md
@@ -6,6 +6,8 @@ permalink: /tools/pub/transformers/examples
 toc: false
 ---
 
+{% include tools/transformers-going-away.md %}
+
 When _pub_ serves, builds, or runs an app, it can run one or more
 transformers. ([Learn more about pub](/tools/pub).)
 

--- a/src/tools/pub/transformers/index.md
+++ b/src/tools/pub/transformers/index.md
@@ -5,6 +5,8 @@ description: "How to write a Pub transformer that processes a single input asset
 permalink: /tools/pub/transformers
 ---
 
+{% include tools/transformers-going-away.md %}
+
 Every time you prepare a Dart app for testing or deployment,
 you are using transformers behind the scenes. The [`pub`](/tools/pub)
 tool uses the [`dart2js`]({{site.webdev}}/tools/dart2js)

--- a/src/tools/pub/transformers/lazy-transformer.md
+++ b/src/tools/pub/transformers/lazy-transformer.md
@@ -5,6 +5,8 @@ description: "How to write a Pub transformer that runs lazily to improve your ap
 permalink: /tools/pub/transformers/lazy-transformer
 ---
 
+{% include tools/transformers-going-away.md %}
+
 If you have a transformer that runs slowly&mdash;perhaps because the algorithm
 is complex, has many steps, or the data set is large&mdash;you can improve
 your app's startup time during the development cycle by making the


### PR DESCRIPTION
1.x-only text to warn about the demise of pub build, pub serve, and pub support for transformers. Related to #703, which removes these docs from the Dart 2 version of the site.

This change will be visible on www.dartlang.org as soon as it's committed. 

Staged:
https://v1-dartlang-org.firebaseapp.com/tools/pub/assets-and-transformers
https://v1-dartlang-org.firebaseapp.com/tools/pub/transformers
https://v1-dartlang-org.firebaseapp.com/tools/pub#writing-transformers
https://v1-dartlang-org.firebaseapp.com/tools/pub/cmd#building-and-deploying-apps-and-packages
...
https://v1-dartlang-org.firebaseapp.com/tools/jetbrains-plugin#reporting-issues