### PR TITLE
Add guideline to prefer backtick fences for code blocks.

### DIFF
--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -372,11 +372,20 @@ a flavor of what's supported:
 ///     * They must be indented at least 4 spaces.
 ///     * (Well, 5 including the space after `///`.)
 ///
-/// Code blocks are indented the same way:
+/// Code blocks are fenced in triple backticks:
 ///
-///     this.code
-///         .will
-///         .retain(its, formatting);
+/// ```
+/// this.code
+///     .will
+///     .retain(its, formatting);
+/// ```
+///
+/// The code language (for syntax highlighting) defaults to Dart. You can
+/// specify it by putting the name of the language after the opening backticks:
+///
+/// ```html
+/// <h1>HTML is magical!</h1>
+/// ```
 ///
 /// Links can be:
 ///
@@ -405,6 +414,35 @@ replace it. Words are what matters.
 It *may* be useful to use it in rare cases for things like tables, but in almost
 all cases, if it's too complex too express in Markdown, you're better off not
 expressing it.
+
+### PREFER backtick fences for code blocks.
+
+Markdown has two ways to indicate a block of code: indenting the code four
+spaces on each line, or surrounding it in a pair of triple-backtick "fence"
+lines. The former syntax is brittle when used inside things like Markdown lists
+where indentation is already meaningful or when the code block itself contains
+indented code.
+
+The backtick syntax avoids those indentation woes, lets you indicate the code's
+language, and is consistent with using backticks for inline code.
+
+{:.good-style}
+{% prettify dart %}
+/// You can use [CodeBlockExample] like this:
+///
+/// ```
+/// var example = new CodeBlockExample();
+/// print(example.isItGreat); // "Yes."
+/// ```
+{% endprettify %}
+
+{:.bad-style}
+{% prettify dart %}
+/// You can use [CodeBlockExample] like this:
+///
+///     var example = new CodeBlockExample();
+///     print(example.isItGreat); // "Yes."
+{% endprettify %}
 
 ## Writing
 


### PR DESCRIPTION
Fix #345.
