### PR TITLE
Update assert and checked mode info

### DIFF
--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -1,8 +1,8 @@
 {
   "SDK": {
     "doc-path": "install",
-    "channel": "stable",
-    "vers": "1.24.2",
-    "next-vers": "2.0.0-dev.6.0"
+    "channel": "dev",
+    "prev-vers": "1.24.3",
+    "vers": "2.0.0-dev.43.0"
   }
 }

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -12,8 +12,7 @@ that you already know how to program in another language.
 <div class="alert alert-info" markdown="1">
 **Dart 2 note:**
 This tour is being updated for [Dart 2 changes](/dart-2),
-such as type safety, optional `new` and `const`,
-and changes to assertion support.
+such as optional `new` and `const`.
 </div>
 
 To learn more about Dart's core libraries, see
@@ -2021,8 +2020,13 @@ assert(urlString.startsWith('https'));
 
 <div class="alert alert-info" markdown="1">
 **Note:**
-Assert statements work only during development. They have no effect in
-production code.
+Assert statements have no effect in production code;
+they're for development only.
+Flutter enables asserts in [debug mode.][flutter debug mode]
+Development-only tools such as [dartdevc][]
+typically support asserts by default.
+Some tools, such as [dart][] and [dart2js,][dart2js]
+support asserts through a command-line flag: `--enable-asserts`.
 </div>
 
 To attach a message to an assert,
@@ -2033,13 +2037,6 @@ add a string as the second argument.
 assert(urlString.startsWith('https'),
     'URL ($urlString) should start with "https".');
 {% endprettify %}
-
-<div class="alert alert-info" markdown="1">
-**Version note:**
-The second argument was introduced in SDK 1.22.
-<!-- [TODO: make "introduced in SDK 1.22" a link to
-a post on http://news.dartlang.org.] -->
-</div>
 
 The first argument to `assert` can be any expression that
 resolves to a boolean value. If the expression’s value
@@ -3409,14 +3406,6 @@ allows you to use the type argument `T` in several places:
 * In the type of an argument (`List<T>`).
 * In the type of a local variable (`T tmp`).
 
-<div class="alert alert-info" markdown="1">
-**Version note:**
-The new syntax for generic methods was [introduced in
-SDK 1.21.](http://news.dartlang.org/2016/12/dart-121-generic-method-syntax.html)
-If you use generic methods,
-[specify an SDK version of 1.21 or higher.](/tools/pub/pubspec#sdk-constraints)
-</div>
-
 For more information about generics, see
 [Using Generic Methods.](https://github.com/dart-lang/sdk/blob/master/pkg/dev_compiler/doc/GENERIC_METHODS.md)
 
@@ -3857,7 +3846,7 @@ For more information on treating classes like functions, see
 
 ## Isolates
 
-Modern web browsers, even on mobile platforms, run on multi-core CPUs.
+Most computers, even on mobile platforms, have multi-core CPUs.
 To take advantage of all those cores, developers traditionally use
 shared-memory threads running concurrently. However, shared-state
 concurrency is error prone and can lead to complicated code.
@@ -3865,6 +3854,9 @@ concurrency is error prone and can lead to complicated code.
 Instead of threads, all Dart code runs inside of *isolates*. Each
 isolate has its own memory heap, ensuring that no isolate’s state is
 accessible from any other isolate.
+
+For more information, see the
+[dart:isolate library documentation.][dart:isolate]
 
 
 ## Typedefs
@@ -4125,11 +4117,16 @@ To learn more about Dart's core libraries, see
 [A Tour of the Dart Libraries](/guides/libraries/library-tour).
 
 [AssertionError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
-[dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/dart-html-library.html
-[dart:math]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/dart-math-library.html
+[dart2js]: {{site.dev-webdev}}/tools/dart2js
+[dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html
+[dart:isolate]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-isolate
+[dart:math]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math
+[dart]: /dart-vm/tools/dart-vm
+[dartdevc]: {{site.dev-webdev}}/tools/dartdevc
 [double]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
 [Error]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
 [Exception]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
+[flutter debug mode]: https://flutter.io/debugging/#debug-mode-assertions
 [forEach()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/forEach.html
 [Function]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 [Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -503,7 +503,7 @@ assumeStrings(list);
 
 In cases where you are working with a collection that you don't create, such
 as from JSON or an external data source, you can use the
-[cast()]({{site.dart_api}}/dev/dart-core/List/cast.html) method
+[cast()]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List/cast.html) method
 provided by `List` and other collection classes.
 
 Here's an example of the preferred solution: tightening the object's type.

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -28,6 +28,8 @@ It aims to help developers migrating from Dart 1.x to Dart 2.
 * [Dart's type system][sound Dart] is now sound.
   * [Fixing common type problems][Fixing Common Type Problems]
   * [Email: Breaking Change: --preview-dart-2 turned on by default][Leaf's email]
+* Dart no longer has checked mode.
+  * [Assert statements][] are still supported, but you enable them differently.
 * The Dart language and core libraries have changed,
   partly as a result of the type system changes.
   * [Dev channel API reference documentation][apiref]
@@ -55,6 +57,7 @@ It aims to help developers migrating from Dart 1.x to Dart 2.
 
 [angular-examples repos]: https://github.com/angular-examples
 [apiref]: {{site.dart_api}}/dev
+[assert statements]: /guides/language/language-tour#assert
 [build_runner web]: {{site.dev-webdev}}/tools/build_runner
 [creating library packages]: /guides/libraries/create-library-packages
 [Dart 2 changes]: /guides/language/spec#dart-2-changes

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -75,4 +75,4 @@ It aims to help developers migrating from Dart 1.x to Dart 2.
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [sound Dart]: /guides/language/sound-dart
 [testing]: /guides/testing
-[webdev dart2]: {{site.webdev}}/dart-2
+[webdev dart2]: {{site.dev-webdev}}/dart-2

--- a/src/dart-vm/tools/dart-vm.md
+++ b/src/dart-vm/tools/dart-vm.md
@@ -13,29 +13,24 @@ server-side scripts, programs, and servers.
 
 Here’s an example of running a Dart file on the command line:
 
-{% prettify sh %}
-dart test.dart
-{% endprettify %}
+```terminal
+dart --enable-asserts test.dart
+```
 
 <aside class="alert alert-info" markdown="1">
-**Note:** You can't use `dart` to run web apps&mdash;apps
-that include `dart:html`, or that depend on libraries
-that use the browser environment. For more information, see
-[About Dart applications](/tutorials/dart-vm/get-started#about-dart-applications).
+**Note:** You can't use `dart` to run mobile apps or web apps
+(apps that include `dart:html`, or that depend on libraries
+that use the browser environment).
 </aside>
 
 ### Options
 
 Common command-line options for dart include:
 
-`-c` or `--checked`
-: Enables _both_ assertions and type checks (checked mode).
-
-{% include checked-mode-2.0.html %}
-
-{% comment %}
-update-for-dart-2
-{% endcomment %}
+`--enable-asserts`
+: Enables `assert` statements. When asserts are enabled, an
+  [assert statement](/guides/language/language-tour#assert)
+  checks a boolean condition, raising an exception if the condition is false.
 
 `--packages=<path>`
 : Specifies the path to the package resolution configuration file.
@@ -97,11 +92,11 @@ instruct the VM to delay the start up, or the exit, of an isolate:
 
 The following is an example Observatory run:
 
-{% prettify sh %}
+```terminal
 $ dart --observe <script>.dart
-{% endprettify %}
+```
 
-For more information, see [Observatory](https://dart-lang.github.io/observatory/).
+For more information, see [Observatory.](https://dart-lang.github.io/observatory/)
 
 ### Snapshot option
 
@@ -111,30 +106,3 @@ You can also generate snapshots:
 : Generates a snapshot in the specified file. For information
   on generating and running snapshots, see
   [Snapshots](https://github.com/dart-lang/sdk/wiki/Snapshots) on GitHub.
-
-## Enabling checked mode
-
-{% include checked-mode-2.0.html %}
-
-{% comment %}
-update-for-dart-2
-{% endcomment %}
-
-Dart programs run in one of two modes: checked or production. By default, the
-Dart VM runs in production mode. We recommend that you enable checked mode for
-development and testing.
-
-In checked mode, assignments are dynamically checked, and certain violations of
-the type system raise exceptions at runtime. In production mode, static type
-annotations have no effect.
-
-Assert statements are also enabled in checked mode. An
-[assert statement](/guides/language/language-tour#assert)
-checks a boolean condition, raising an exception if the condition is false.
-Assertions do not run in production mode.
-
-You can run the VM in checked mode with the `--checked` command-line flag:
-
-{% prettify sh %}
-dart --checked test.dart
-{% endprettify %}

--- a/src/dart-vm/tools/dart-vm.md
+++ b/src/dart-vm/tools/dart-vm.md
@@ -14,7 +14,7 @@ server-side scripts, programs, and servers.
 Here’s an example of running a Dart file on the command line:
 
 ```terminal
-dart --enable-asserts test.dart
+$ dart --enable-asserts test.dart
 ```
 
 <aside class="alert alert-info" markdown="1">

--- a/src/dart-vm/tools/index.md
+++ b/src/dart-vm/tools/index.md
@@ -13,7 +13,7 @@ need to write Dart scripts and servers.
 The following tools have special support for
 running scripts and servers.
 
-[Standalone Dart VM: `dart`](/dart-vm)
+[Standalone Dart VM: `dart`](/dart-vm/tools/dart-vm)
 : Executes Dart code.
   IDEs that support Dart,
   and some of the `pub` commands, use this

--- a/src/tools/dartpad.md
+++ b/src/tools/dartpad.md
@@ -15,13 +15,21 @@ Here's what DartPad looks like:
 
 ## Library support
 
-DartPad supports [dart:* libraries]({{site.dart_api}}) that work with web apps;
-it doesn't support [dart:io]({{site.dart_api}}/stable/dart-io) or
+DartPad supports
+[dart:* libraries]({{site.dart_api}})
+that work with web apps; it doesn't support
+[dart:io]({{site.dart_api}}/stable/dart-io) or
 libraries from [packages.]({{site.pub}})
 If you want to use dart:io, use the [Dart SDK](/tools/sdk) instead.
 If you want to use a package, get the SDK for a
 [platform](/guides/platforms) that the package supports.
 
+{% comment %}
+update-for-dart-2
+Once DartPad is based on Dart 2, change all occurrences of
+{{site.dart_api}}/... to be
+{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/....
+{% endcomment %}
 
 ## Getting started
 


### PR DESCRIPTION
Also fixed some random issues I happened to notice, mostly wrt API doc
URLs and the link to `dart`.

Staged at URLs like:
https://kw-www-dartlang-1.firebaseapp.com/guides/language/language-tour#assert
https://kw-www-dartlang-1.firebaseapp.com/dart-vm/tools/dart-vm
https://kw-www-dartlang-1.firebaseapp.com/dart-2

@chalin are my changes to `pkg-vers.json` OK?

Fixes #355
