### PR TITLE
Effective dart: documentation, reintroduce triple backtick blocks

### DIFF
--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -96,6 +96,21 @@ void miscDeclAnalyzedButNotTested() {
   ///     * They must be indented at least 4 spaces.
   ///     * (Well, 5 including the space after `///`.)
   ///
+  /// Code blocks are fenced in triple backticks:
+  ///
+  /// ```
+  /// this.code
+  ///     .will
+  ///     .retain(its, formatting);
+  /// ```
+  ///
+  /// The code language (for syntax highlighting) defaults to Dart. You can
+  /// specify it by putting the name of the language after the opening backticks:
+  ///
+  /// ```html
+  /// <h1>HTML is magical!</h1>
+  /// ```
+  ///
   /// Links can be:
   ///
   /// * http://www.just-a-bare-url.com

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -372,6 +372,21 @@ a flavor of what's supported:
 ///     * They must be indented at least 4 spaces.
 ///     * (Well, 5 including the space after `///`.)
 ///
+/// Code blocks are fenced in triple backticks:
+///
+/// ```
+/// this.code
+///     .will
+///     .retain(its, formatting);
+/// ```
+///
+/// The code language (for syntax highlighting) defaults to Dart. You can
+/// specify it by putting the name of the language after the opening backticks:
+///
+/// ```html
+/// <h1>HTML is magical!</h1>
+/// ```
+///
 /// Links can be:
 ///
 /// * http://www.just-a-bare-url.com

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -895,7 +895,7 @@ Future main() async {
   print('Listening on port 4048');
   await server.forEach(staticFiles.serveRequest); [!/*4*/!]
 }
-{% endprettify dart %}
+{% endprettify %}
 <div class="prettify-filename">static_file_server.dart</div>
 
 {:.code-notes}


### PR DESCRIPTION
Reintroduces the triple backtick blocks from https://github.com/dart-lang/site-www/pull/719/commits/d3a737a1492ed06c6b5a53563a498e63408ed7ac. /cc @kwalrath 