### PR TITLE
chore: pin SDK version to 2-dev.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: dart
-dart: dev
+dart: 2.0.0-dev.43.0
 
 cache:
   timeout: 300


### PR DESCRIPTION
Pin SDK version until https://github.com/dart-lang/sdk/issues/32740 is fixed.