### PR TITLE
Remove API Reference submenu items from sidenav

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,10 +1,10 @@
 - title: Language
   children:
-    - title: "Overview"
+    - title: Overview
       permalink: /guides/language
-    - title: "Tour"
+    - title: Tour
       permalink: /guides/language/language-tour
-    - title: "Effective Dart"
+    - title: Effective Dart
       permalink: /guides/language/effective-dart
       children:
         - title: Style
@@ -25,26 +25,20 @@
     - title: Tour
       permalink: /guides/libraries/library-tour
 
-- title: "Platforms"
+- title: Platforms
   children:
-    - title: "Overview"
+    - title: Overview
       permalink: /guides/platforms
-    - title: "Web"
-      permalink: https://webdev.dartlang.org/
-    - title: "Mobile (Flutter)"
-      permalink: https://flutter.io/
-      children:
-      - title: "API Reference"
-        permalink: http://docs.flutter.io/flutter/
-    - title: "Dart VM"
+    - title: Web
+      permalink: https://webdev.dartlang.org
+    - title: Mobile (Flutter)
+      permalink: https://flutter.io
+    - title: Dart VM
       permalink: /dart-vm
-      children:
-      - title: "API Reference"
-        permalink: https://api.dartlang.org
 
-- title: "Testing"
+- title: Testing
   children:
-  - title: "Dart Testing"
+  - title: Dart Testing
     permalink: /guides/testing
 
 - title: Resources
@@ -59,5 +53,5 @@
     permalink: /articles
   - title: Tools
     permalink: /tools
-  - title: "Community and Support"
+  - title: Community and Support
     permalink: /community

--- a/src/_guides/libraries/index.md
+++ b/src/_guides/libraries/index.md
@@ -37,6 +37,14 @@ at the following links.
 
 ## Other resources
 
+API reference
+: * [api.dartlang.org:]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}})
+    API docs for dart:* libraries
+  * [docs.flutter.io:](http://docs.flutter.io/)
+    API docs for Flutter libraries
+  * [dartdocs.org:](https://www.dartdocs.org/)
+    API docs for packages published on pub.dartlang.org
+
 [Futures and Error Handling](/guides/libraries/futures-error-handling)
 : How to handle errors when writing asynchronous code.
 
@@ -56,11 +64,3 @@ at the following links.
 
 [Articles about libraries](/articles/libraries)
 : API topics ranging from zones to streams to converters.
-
-API reference documentation
-: * [api.dartlang.org]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}):
-    Generated docs for dart:* libraries
-  * [docs.flutter.io](http://docs.flutter.io/):
-    Generated docs for Flutter libraries
-  * [dartdocs.org](https://www.dartdocs.org/):
-    Generated docs for packages published on pub.dartlang.org

--- a/src/dart-vm/index.md
+++ b/src/dart-vm/index.md
@@ -42,6 +42,9 @@ You might find the following tutorials helpful.
 
 ## More resources
 
+[api.dartlang.org]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}})
+: API reference for dart:* libraries.
+
 [A Tour of the dart:io Library](/dart-vm/io-library-tour)
 : Shows how to use the major features of the dart:io library.
   You can use the dart:io library in command-line scripts, servers, and


### PR DESCRIPTION
Fixes #738

Staged, see:

- https://dartlang-org-staging-1.firebaseapp.com/guides/libraries
- https://dartlang-org-staging-1.firebaseapp.com/dart-vm
- Sidenav on either of the previous pages