### PR TITLE
Set prev-url to main site for now

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ branch: master
 # use case:
 #   {{site.webdev}}/downloads
 
-prev-url: https://v1-dartlang-org.firebaseapp.com
+prev-url: https://www.dartlang.org # will eventually switch to https://v1-dartlang-org.firebaseapp.com
 webdev: https://webdev.dartlang.org
 dev-webdev: https://webdev-dartlang-org-dev.firebaseapp.com
 dart_vm:  /dart-vm


### PR DESCRIPTION
Set prev-url to www.dartlang.org. It will be changed once the Dart 2 site is deployed.