### PR TITLE
Simplify /codelabs

### DIFF
--- a/src/_codelabs/index.md
+++ b/src/_codelabs/index.md
@@ -6,84 +6,20 @@ permalink: /codelabs
 toc: false
 ---
 
-<style> main article .content h2 { margin-bottom: 1em; }</style>
+For a guided, hands-on coding experience,
+go through one of the Dart codelabs.
 
-The latest Dart codelabs are on the Google Developers site.
-
-## General
-
-<div class="item-with-pic" markdown="1">
-<img src="https://webdev.dartlang.org/codelabs/images/from-java-to-dart.png"
-     width="150px"
-     alt="Bicycle image from codelab">
-<div class="details" markdown="1">
+<img src="https://webdev.dartlang.org/codelabs/images/from-java-to-dart.png" width="150px" alt="Bicycle image from codelab" align="right">
 #### [Intro to Dart for Java Developers](https://codelabs.developers.google.com/codelabs/from-java-to-dart/)
-{: .title}
+
 
 Use DartPad (no download required!) to explore how
 Dart makes writing modern apps easy and fun.
-</div>
-</div>
 
+#### Other codelabs
 
-## Flutter
+If you're ready to download an SDK, try one of the platform-specific codelabs:
 
-<div class="item-with-pic" markdown="1">
-<img src="/codelabs/images/flutter.png"
-     width="150px"
-     alt="Screenshot of Friendlychat app">
-<div class="details" markdown="1">
-#### [Building Beautiful UIs with Flutter](https://codelabs.developers.google.com/codelabs/flutter/)
-{: .title}
+* [Flutter codelabs](https://flutter.io/docs)
+* [AngularDart codelabs](https://webdev.dartlang.org/codelabs)
 
-Write, debug, and run a Flutter app that looks natural on both iOS and Android.
-</div>
-</div>
-
-<div class="item-with-pic" markdown="1">
-<img src="/codelabs/images/flutter-firebase.png"
-     width="150px"
-     alt="Screenshot of Friendlychat app">
-<div class="details" markdown="1">
-#### [Firebase for Flutter](https://codelabs.developers.google.com/codelabs/flutter-firebase/)
-{: .title}
-
-Enable Firebase features in an existing simple Flutter app.
-Also add support for images.
-</div>
-</div>
-
-{% comment %}
-flutter.io doesn't yet have a place dedicated to listing codelabs
-(aside from the left nav). If and when it does, link to that.
-{% endcomment %}
-
-
-## AngularDart
-
-<div class="item-with-pic" markdown="1">
-<img src="https://webdev.dartlang.org/codelabs/images/startup-namer.png"
-     width="150px"
-     alt="Screenshot of startup_namer app">
-<div class="details" markdown="1">
-#### [Write a Material Design AngularDart Web App](https://codelabs.developers.google.com/codelabs/your-first-angulardart-web-app/)
-{: .title}
-
-Create a web app that uses AngularDart and material design components.
-</div>
-</div>
-
-<div class="item-with-pic" markdown="1">
-<img src="https://webdev.dartlang.org/codelabs/images/firebase-counter.png"
-     width="150px"
-     alt="Screenshot of firebase_counter app">
-<div class="details" markdown="1">
-#### [Build an AngularDart & Firebase Web App](https://codelabs.developers.google.com/codelabs/angulardart-firebase-web-app/)
-{: .title}
-
-Use AngularDart and Firebase to create a web app with a realtime shared counter.
-</div>
-</div>
-
-For a full list of Dart web codelabs, see
-[webdev.dartlang.org/codelabs.](https://webdev.dartlang.org/codelabs)


### PR DESCRIPTION
Instead of linking to individual platform-specific codelabs, link to platform-specific pages.

Staged at: https://kw-staging-dartlang-2.firebaseapp.com/codelabs

Once https://github.com/flutter/flutter/issues/16287 is fixed, we'll need to update this page to refer to the new URL.