### PR TITLE
Update library-tour.md

### DIFF
--- a/examples/misc/lib/library_tour/core/hash_code.dart
+++ b/examples/misc/lib/library_tour/core/hash_code.dart
@@ -1,7 +1,8 @@
 // ignore_for_file: unrelated_type_equality_checks
 // #docregion
 class Person {
-  final String firstName, lastName;
+  final String firstName;
+  final String lastName;
 
   Person(this.firstName, this.lastName);
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -923,7 +923,8 @@ convention, NaN != NaN.
 <?code-excerpt "misc/lib/library_tour/core/hash_code.dart"?>
 {% prettify dart %}
 class Person {
-  final String firstName, lastName;
+  final String firstName;
+  final String lastName;
 
   Person(this.firstName, this.lastName);
 


### PR DESCRIPTION
Fixing "Implementing map keys" example so that two fields aren't declared on the same line.