### PR TITLE
[1.x] Banner warning that this is 1.x site

### DIFF
--- a/src/_includes/banner-fp.md
+++ b/src/_includes/banner-fp.md
@@ -1,8 +1,12 @@
-<div class="banner" markdown="1">
-  {:.banner__text}
-  [**Announcing Dart 2**:][Announcing Dart 2]{:.no-automatic-external target="_blank"}
-  Optimized for client-side development.
-  [Learn more](/dart-2).
-</div>
+{% if site.url != 'https://www.dartlang.org' -%}
+  {% include banner.html -%}
+{% else -%}
+  <div class="banner" markdown="1">
+    {:.banner__text}
+    [**Announcing Dart 2**:][Announcing Dart 2]{:.no-automatic-external target="_blank"}
+    Optimized for client-side development.
+    [Learn more](/dart-2).
 
-[Announcing Dart 2]: https://medium.com/dartlang/announcing-dart-2-80ba01f43b6
+    [Announcing Dart 2]: https://medium.com/dartlang/announcing-dart-2-80ba01f43b6
+  </div>
+{% endif %}

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,8 +1,11 @@
-<div class="banner">
-    <p class="banner__text">
-	Join the Dart team:
-        <a target="_blank" 
-          href="https://www.google.com/about/careers/jobs#t=sq&q=j&li=20&l=false&j=dart&jcoid=7c8c6665-81cf-4e11-8fc9-ec1d6a69120c&jcoid=e43afd0d-d215-45db-a154-5386c9036525">Become
-	    a Developer Advocate</a>
-    </p>
+{% if site.url != 'https://www.dartlang.org' %}
+{% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
+<div class="banner alert alert-info">
+  <p class="banner__text">
+    This is the <b>Dart 1.x</b> archive of
+    <a href="{{site.url}}" class="no-automatic-external" target="_blank" rel="noopener">
+      {{site.url | regex_replace: '^https?://'}}.
+    </a>
+  </p>
 </div>
+{% endif %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -8,7 +8,7 @@
       {% include navigation-toc.html %}
       <article>
         <div class="content">
-          {% comment %} <!-- {% include banner.html %} --> {% endcomment %}
+          {% include banner.html %}
           {% include navigation-sub.html %}
           {% include breadcrumbs.html %}
           <div>

--- a/src/_plugins/regex_replace_filter.rb
+++ b/src/_plugins/regex_replace_filter.rb
@@ -1,0 +1,8 @@
+module RegexReplaceFilter
+  # From https://github.com/Shopify/liquid/issues/202#issuecomment-19112872
+  def regex_replace(input, regex, replacement = '')
+    input.to_s.gsub(Regexp.new(regex), replacement.to_s)
+  end
+end
+
+Liquid::Template.register_filter(RegexReplaceFilter)


### PR DESCRIPTION
Preparation for #654. The banner will automatically appear once the `site.url` is changed.

This adds a banner to _every_ page:

> <img width="468" alt="screen shot 2018-04-06 at 17 00 23" src="https://user-images.githubusercontent.com/4140793/38444268-a8d9125e-39bc-11e8-8fdf-eb366f8e198c.png">

The banner text was approved by @kwalrath after discussion with @kevmoo.

A staged version of what the banners will look like is given here: https://dartlang-org-staging-1.firebaseapp.com (I can't stage the actual PR because it doesn't show the banner yet.)