### PR TITLE
Dart 2 site banner announcing Dart 2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 # Site settings
 title: Dart
 description: Dart is a platform for building structured apps. It includes a language, a VM, libraries, tools, and compilers to many targets, including JavaScript.
-# url: https://www.dartlang.org # URL to use once we switch back to the main site
 url: https://dartlang-org-dev.firebaseapp.com
+dev-url: https://dartlang-org-dev.firebaseapp.com
 repo: https://github.com/dart-lang/site-www
 branch: master
 
@@ -10,6 +10,7 @@ branch: master
 # use case:
 #   {{site.webdev}}/downloads
 
+www: https://www.dartlang.org
 v1-url: https://v1-dartlang-org.firebaseapp.com # temporary, use prev-url after the switch
 prev-url: https://www.dartlang.org # will eventually switch to v1-url
 webdev: https://webdev.dartlang.org

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,8 @@ branch: master
 # use case:
 #   {{site.webdev}}/downloads
 
-prev-url: https://www.dartlang.org # will eventually switch to https://v1-dartlang-org.firebaseapp.com
+v1-url: https://v1-dartlang-org.firebaseapp.com # temporary, use prev-url after the switch
+prev-url: https://www.dartlang.org # will eventually switch to v1-url
 webdev: https://webdev.dartlang.org
 dev-webdev: https://webdev-dartlang-org-dev.firebaseapp.com
 dart_vm:  /dart-vm

--- a/src/_includes/_version-menu-items.html
+++ b/src/_includes/_version-menu-items.html
@@ -1,5 +1,5 @@
-{% assign dart1status = 'stable' %}{% comment -%}This will soon be 'archive'{%- endcomment %}
-{% assign dart2status = 'beta' %}{% comment -%}This will soon be 'stable'{%- endcomment %}
+{% assign dart1status = 'archive' %}
+{% assign dart2status = 'beta' %}
 {% if site.branch == '1.x' -%}
   <li><a class="active">{{site.data.pkg-vers.SDK.vers}}&nbsp;&nbsp;({{dart1status}})</a></li>
   {% if site.dev-url and site.data.pkg-vers.SDK.next-vers -%}

--- a/src/_includes/banner-fp.md
+++ b/src/_includes/banner-fp.md
@@ -1,8 +1,12 @@
+{% if site.url == 'https://www.dartlang.org' -%}
+  {% include banner.html -%}
+{% else -%}
 <div class="banner" markdown="1">
   {:.banner__text}
   [**Announcing Dart 2**:][Announcing Dart 2]{:.no-automatic-external target="_blank"}
   Optimized for client-side development.
   [Learn more](/dart-2).
-</div>
 
-[Announcing Dart 2]: https://medium.com/dartlang/announcing-dart-2-80ba01f43b6
+  [Announcing Dart 2]: https://medium.com/dartlang/announcing-dart-2-80ba01f43b6
+</div>
+{% endif %}

--- a/src/_includes/banner-fp.md
+++ b/src/_includes/banner-fp.md
@@ -1,4 +1,4 @@
-{% if site.url == 'https://www.dartlang.org' -%}
+{% if site.url == site.www -%}
   {% include banner.html -%}
 {% else -%}
 <div class="banner" markdown="1">

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -3,9 +3,9 @@
 <div class="banner alert alert-info">
   <p class="banner__text">
     Welcome to <b>Dart 2</b>!
-    Looking for Dart 1.x? See the site
-    <a href="{{site.v1-url}}" class="no-automatic-external" target="_blank" rel="noopener">archive</a>,
-    or the <a href="/dart-2">Migration Guide</a>.
+    Still using Dart 1.x? See the
+    <a href="{{site.v1-url}}" class="no-automatic-external" target="_blank" rel="noopener">archive site</a>,
+    or the <a href="/dart-2">migration guide</a>.
   </p>
 </div>
 {% endif %}

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -4,7 +4,7 @@
   <p class="banner__text">
     Welcome to <b>Dart 2</b>!
     Still using Dart 1.x? See the
-    <a href="{{site.v1-url}}" class="no-automatic-external" target="_blank" rel="noopener">archive site</a>,
+    <a href="{{site.v1-url}}" class="no-automatic-external" target="_blank" rel="noopener">archived site</a>
     or the <a href="/dart-2">migration guide</a>.
   </p>
 </div>

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,4 +1,4 @@
-{% if site.url == 'https://www.dartlang.org' %}
+{% if site.url == site.www %}
 {% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
 <div class="banner alert alert-info">
   <p class="banner__text">

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,8 +1,11 @@
-<div class="banner">
-    <p class="banner__text">
-	Join the Dart team:
-        <a target="_blank" 
-          href="https://www.google.com/about/careers/jobs#t=sq&q=j&li=20&l=false&j=dart&jcoid=7c8c6665-81cf-4e11-8fc9-ec1d6a69120c&jcoid=e43afd0d-d215-45db-a154-5386c9036525">Become
-	    a Developer Advocate</a>
-    </p>
+{% if site.url == 'https://www.dartlang.org' %}
+{% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
+<div class="banner alert alert-info">
+  <p class="banner__text">
+    Welcome to <b>Dart 2</b>!
+    Looking for Dart 1.x? See the site
+    <a href="{{site.v1-url}}" class="no-automatic-external" target="_blank" rel="noopener">archive</a>,
+    or the <a href="/dart-2">Migration Guide</a>.
+  </p>
 </div>
+{% endif %}

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -8,9 +8,10 @@
     <li><a href="/guides/language">Language</a></li>
     <li><a href="/guides/libraries">Libraries</a></li>
     <li><a href="/tools">Tools</a></li>
-    {% comment %}Temporarily make room for the version dropdown
+    {% comment %}Temporarily make room for the version dropdown by omitting Community{% endcomment %}
+    {% if site.url != site.www %}
     <li><a href="/community">Community</a></li>
-    {% endcomment %}
+    {% else %}
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dart 2 <span class="caret"></span></a>
       <ul class="dropdown-menu">
@@ -19,6 +20,7 @@
         <li><a href="/dart-2">Dart 2 Migration</a></li>
       </ul>
     </li>
+    {% endif %}
     <li class="searchfield">
       <form class="navbar-search" action="/search" id="cse-search-box">
         <input type="hidden" name="cx" value="011220921317074318178:_yy-tmb5t_i">

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -8,7 +8,7 @@
       {% include navigation-toc.html %}
       <article>
         <div class="content">
-          {% comment %} <!-- {% include banner.html %} --> {% endcomment %}
+          {% include banner.html %}
           {% include navigation-sub.html %}
           {% include breadcrumbs.html %}
           <div>

--- a/src/_plugins/regex_replace_filter.rb
+++ b/src/_plugins/regex_replace_filter.rb
@@ -1,0 +1,8 @@
+module RegexReplaceFilter
+  # From https://github.com/Shopify/liquid/issues/202#issuecomment-19112872
+  def regex_replace(input, regex, replacement = '')
+    input.to_s.gsub(Regexp.new(regex), replacement.to_s)
+  end
+end
+
+Liquid::Template.register_filter(RegexReplaceFilter)


### PR DESCRIPTION
Add a Dart 2 announcement banner to very page. This PR is the Dart 2 counterpart to the 1.x #764.

> <img width="849" alt="screen shot 2018-04-09 at 12 44 55" src="https://user-images.githubusercontent.com/4140793/38510743-ef5fb028-3bf3-11e8-897b-e33ab0655066.png">

Staged (this _shows_ the banner; merging this PR will NOT show the banner until the sites are switched):
- https://dartlang-org-staging-1.firebaseapp.com
- https://dartlang-org-staging-1.firebaseapp.com/dart-2

Fixes #759

cc @kevmoo 