### PR TITLE
Update dependencies.md

### DIFF
--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -173,9 +173,8 @@ The ref can be anything that Git allows to [identify a commit][commit].
 
 [commit]: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html#naming-commits
 
-Pub assumes that the package is in the root of the git repository.  if this is
-not true, the path may be specified with the `path` argument:
-
+Pub assumes that the package is in the root of the Git repository.  To specify a different
+location in the repo use the `path` argument:
 
 {% prettify yaml %}
 dependencies:

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -180,9 +180,8 @@ location in the repo use the `path` argument:
 dependencies:
   kittens:
     git:
-      url: git://github.com/munificent/kittens.git
-      ref: some-branch
-      path: path/to/my/plugin/
+      url: git://github.com/munificent/cats.git
+      path: path/to/kittens
 {% endprettify %}
 
 The path is relative to the git repo's root.

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -156,8 +156,7 @@ dependencies:
 {% endprettify %}
 
 The `git` here says this package is found using Git, and the URL after that is
-the Git URL that can be used to clone the package. Pub assumes that the package
-is in the root of the git repository.
+the Git URL that can be used to clone the package.
 
 If you want to depend on a specific commit, branch, or tag, you can also
 provide a `ref` argument:
@@ -173,6 +172,21 @@ dependencies:
 The ref can be anything that Git allows to [identify a commit][commit].
 
 [commit]: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html#naming-commits
+
+Pub assumes that the package is in the root of the git repository.  if this is
+not true, the path may be specified with the `path` argument:
+
+
+{% prettify yaml %}
+dependencies:
+  kittens:
+    git:
+      url: git://github.com/munificent/kittens.git
+      ref: some-branch
+      path: path/to/my/plugin/
+{% endprettify %}
+
+The path is relative to the git repo's root.
 
 ### Path packages
 


### PR DESCRIPTION
Added description of path option for git repository dependencies as this was added in https://github.com/dart-lang/pub/pull/1650 and it is no longer required for a package to be at the root of a repo.