### PR TITLE
/dart-2: Add better intros, change title

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -2,10 +2,10 @@
 {% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
 <div class="banner alert alert-info">
   <p class="banner__text">
-    Welcome to <b>Dart 2</b>!
+    Welcome to <a href="/dart-2"><b>Dart 2</b></a>!
     Still using Dart 1.x? See the
     <a href="{{site.prev-url}}" class="no-automatic-external" target="_blank" rel="noopener">archived site</a>
-    or the <a href="/dart-2">migration guide</a>.
+    or the <a href="/dart-2#migration">migration guide</a>.
   </p>
 </div>
 {% endif %}

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -17,7 +17,7 @@
       <ul class="dropdown-menu">
         {% include _version-menu-items.html %}
         <li role="separator" class="divider"></li>
-        <li><a href="/dart-2">Dart 2 Migration</a></li>
+        <li><a href="/dart-2#migration">Migration guide</a></li>
       </ul>
     </li>
     {% endif %}

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -6,10 +6,6 @@ description: How Dart 2 is different from Dart 1.x, and how you can convert your
 Dart 2 has a few key differences from earlier versions of Dart.
 This page briefly covers those differences and
 gives general advice on migrating your code to Dart 2.
-Also see the migration guide for your platform:
-
-* [Flutter migration instructions][]
-* [Web app migration guide][webdev dart2]
 
 For information on _why_ Dart 2 has changed, see the
 [Dart 2 announcement.][Dart 2 announcement]
@@ -17,9 +13,9 @@ For information on _why_ Dart 2 has changed, see the
 
 ## Differences
 
-The Dart language, library, build system, and web development have changed.
+The Dart language, libraries, build system, and web development tools have changed.
 
-### Language and library
+### Language and libraries
 
 * [Dart's type system][sound Dart] is now sound.
   * [Fixing common type problems][Fixing Common Type Problems]
@@ -40,10 +36,16 @@ The Dart language, library, build system, and web development have changed.
   * Dartium is no longer supported. Instead, use [dartdevc][] and Chrome.
 
 
+<a id="migration"></a>
 ## Migrating your code
 
+First, see the migration guide for your platform:
+
+* [Flutter migration guide][Flutter migration instructions]
+* [Web app migration guide][webdev dart2]
+
 Here's the general process for migrating to Dart 2,
-from either Dart 1.x or an earlier version of Dart 2:
+from either Dart 1.x or an earlier version of Dart 2.
 
 1. Get an up-to-date version of the Flutter or Dart SDK.
    * [Flutter SDK instructions][Flutter SDK install]
@@ -65,9 +67,6 @@ from either Dart 1.x or an earlier version of Dart 2:
 7. Fix issues until your code works.
 
 Each time the SDK has a significant release, repeat the process.
-
-The rest of this page gives an overview of differences between Dart 1.x and Dart 2,
-with links to where you can find more information.
 
 {% comment %}
 TODO:
@@ -107,7 +106,7 @@ TODO:
 [DartPad]: {{site.custom.dartpad.direct-link}}
 [enable strong mode]: /guides/language/analysis-options#enabling-dart-2-semantics
 [Fixing Common Type Problems]: /guides/language/sound-problems
-[Flutter migration instructions]: https://github.com/flutter/flutter/wiki/Trying-the-preview-of-Dart-2-in-Flutter
+[Flutter migration instructions]: https://github.com/flutter/flutter/wiki/Dart-2-Migration
 [Flutter SDK install]: https://flutter.io/upgrading/
 [Dart SDK install]: /tools/sdk#install
 [Leaf's email]: https://groups.google.com/d/msg/flutter-dev/H8dDhWg_c8I/_Ql78q_6AgAJ

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -1,7 +1,46 @@
 ---
-title: Dart 2 Migration
+title: Dart 2
 description: How Dart 2 is different from Dart 1.x, and how you can convert your code to work with Dart 2.
 ---
+
+Dart 2 has a few key differences from earlier versions of Dart.
+This page briefly covers those differences and
+gives general advice on migrating your code to Dart 2.
+Also see the migration guide for your platform:
+
+* [Flutter migration instructions][]
+* [Web app migration guide][webdev dart2]
+
+For information on _why_ Dart 2 has changed, see the
+[Dart 2 announcement.][Dart 2 announcement]
+
+
+## Differences
+
+The Dart language, library, build system, and web development have changed.
+
+### Language and library
+
+* [Dart's type system][sound Dart] is now sound.
+  * [Fixing common type problems][Fixing Common Type Problems]
+  * [Email: Breaking Change: `--preview-dart-2` turned on by default][Leaf's email]
+* Dart no longer has checked mode.
+  * [Assert statements][] are still supported, but you enable them differently.
+* The Dart language and core libraries have changed,
+  partly as a result of the type system changes.
+  * [Dev channel API reference documentation][apiref]
+  * [dart-lang/sdk CHANGELOG][]
+
+### Tools
+
+* Pub no longer supports transformers.
+  Instead, use the [new build system.][build system]
+* Tools related to web development have changed.
+  * The new build system [replaces `pub build` and `pub serve`.][build_runner web]
+  * Dartium is no longer supported. Instead, use [dartdevc][] and Chrome.
+
+
+## Migrating your code
 
 Here's the general process for migrating to Dart 2,
 from either Dart 1.x or an earlier version of Dart 2:
@@ -37,41 +76,14 @@ TODO:
 {% endcomment %}
 
 
-## Differences
-
-### Language and libraries
-
-* [Dart's type system][sound Dart] is now sound.
-  * [Fixing common type problems][Fixing Common Type Problems]
-  * [Email: Breaking Change: `--preview-dart-2` turned on by default][Leaf's email]
-* Dart no longer has checked mode.
-  * [Assert statements][] are still supported, but you enable them differently.
-* The Dart language and core libraries have changed,
-  partly as a result of the type system changes.
-  * [Dev channel API reference documentation][apiref]
-  * [dart-lang/sdk CHANGELOG][]
-
-### Tools
-
-* Pub no longer supports transformers.
-  Instead, use the [new build system.][build system]
-* Tools related to web development have changed.
-  * The new build system [replaces `pub build` and `pub serve`.][build_runner web]
-  * Dartium is no longer supported. Instead, use [dartdevc][] and Chrome.
-
-
 ## More resources
 
 {% comment %} update-for-dart-2
   * [DartPad][]
   * [Dart 2 changes][] section of the [Dart Language Specification][] page
 {% endcomment %}
-* Flutter:
-  * [Trying the preview of Dart 2 in Flutter][Flutter migration instructions]
-* VM and web:
-  * [About Dart SDK release channels and version strings][pre-release]
-  * [SDK constraints][]
-  * [Dart 2 page for web developers][webdev dart2]
+* [About Dart SDK release channels and version strings][pre-release]
+* [SDK constraints][]
 
 [dartdevc]: {{site.dev-webdev}}/tools/dartdevc
 [build system]: https://github.com/dart-lang/build/tree/master/docs
@@ -88,6 +100,7 @@ TODO:
 [build_runner web]: {{site.dev-webdev}}/tools/build_runner
 [creating library packages]: /guides/libraries/create-library-packages
 [Dart 2 changes]: /guides/language/spec#dart-2-changes
+[Dart 2 announcement]: https://medium.com/dartlang/announcing-dart-2-80ba01f43b6
 [Dart Language Specification]: /guides/language/spec
 [dart-lang/sdk CHANGELOG]: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#200
 [Dartium news]: http://news.dartlang.org/2017/06/a-stronger-dart-for-everyone.html

--- a/src/tools/pub/obsolete.md
+++ b/src/tools/pub/obsolete.md
@@ -37,5 +37,5 @@ If you maintain a transformer, see the following:
 
 For help in switching from Dart 1.x to Dart 2, see the Dart 2 migration guides:
 
-* [Language and core library migration guide](/dart-2)
+* [Language and core library migration guide](/dart-2#migration)
 * [Web app migration guide]({{site.dev-webdev}}/dart-2)


### PR DESCRIPTION
I need to do a pass over referring pages to make sure link titles &
references are OK.

Staged at: https://kw-www-dartlang-1.firebaseapp.com/dart-2
/cc @anders-sandholm, @mit-mit, @kevmoo 