### PR TITLE
chore: ignore site-shared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ tmp
 trash
 
 firebase-debug.log
+site-shared/


### PR DESCRIPTION
This will make it easier to to switch between  branches.