### PR TITLE
Add codelab link to /tutorials

### DIFF
--- a/src/_tutorials/index.md
+++ b/src/_tutorials/index.md
@@ -7,6 +7,8 @@ toc: false
 
 **The Dart Tutorials** teach you how to build applications
 using the Dart language, tools, and APIs.
+If you want a hands-on coding experience, try a
+**[codelab](/codelabs)**.
 
 **Who are you?**
 


### PR DESCRIPTION
The /tutorials page is the 7th most visited page on the site lately, and /codelabs is way down at 42. 49% of /tutorials visits are entries directly to that page; only 21% of /codelabs visits are direct entries to that page.

Quick fix: Link prominently from /tutorials to /codelabs.