### PR TITLE
Upgrade to SDK 2-dev.48, with minor code changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: dart
-dart: 2.0.0-dev.47.0
+dart: dev
 
 cache:
   timeout: 300

--- a/examples/httpserver/bin/note_server.dart
+++ b/examples/httpserver/bin/note_server.dart
@@ -86,12 +86,7 @@ void saveNote(HttpRequest request, String myNote) {
 }
 
 void getNote(HttpRequest request, String getNote) {
-  var requestedNote = int.parse(getNote, onError: (_) {
-    print('error');
-  });
-  if (requestedNote == null) {
-    requestedNote = 0;
-  }
+  final requestedNote = int.tryParse(getNote) ?? 0;
   if (requestedNote >= 0 && requestedNote < count) {
     List<String> lines = new File('notes.txt').readAsLinesSync();
     request.response
@@ -102,7 +97,7 @@ void getNote(HttpRequest request, String getNote) {
 }
 
 void defaultHandler(HttpRequest request) {
-  var response = request.response;
+  final response = request.response;
   addCorsHeaders(response);
   response
     ..statusCode = HttpStatus.NOT_FOUND
@@ -111,7 +106,7 @@ void defaultHandler(HttpRequest request) {
 }
 
 void handleOptions(HttpRequest request) {
-  var response = request.response;
+  final response = request.response;
   addCorsHeaders(response);
   print('${request.method}: ${request.uri.path}');
   response

--- a/examples/httpserver/web/note_client.dart
+++ b/examples/httpserver/web/note_client.dart
@@ -37,10 +37,7 @@ void saveNote(Event e) {
 void requestNote(Event e) {
   if (chooseNote.value.isEmpty) return;
 
-  int getNoteNumber = int.parse(chooseNote.value, onError: (_) {
-    print('NaN');
-  });
-  if (getNoteNumber == null) getNoteNumber = 0;
+  int getNoteNumber = int.tryParse(chooseNote.value) ?? 0;
 
   request = new HttpRequest();
   request.onReadyStateChange.listen(onData);

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "dev",
     "prev-vers": "1.24.3",
-    "vers": "2.0.0-dev.46.0"
+    "vers": "2.0.0-dev.48.0"
   }
 }


### PR DESCRIPTION
Example code changes: because `onError` is deprecated, replaced `int.parse(..., onError: ...)` by `int.tryParse()`.