### PR TITLE
Upgrade: Dart SDK to 2-dev.49, and site-shared

### DIFF
--- a/examples/strong/analyzer-2-results.txt
+++ b/examples/strong/analyzer-2-results.txt
@@ -10,6 +10,8 @@ Analyzing lib, test...
   error • Invalid override. The type of 'MyAdder.add' ('(int, int) → int') isn't a subtype of 'NumberAdder.add' ('(num, num) → num') at lib/common_problems_analysis.dart:61:3 • strong_mode_invalid_method_override
   error • Invalid override. The type of 'Subclass.method' ('(int) → void') isn't a subtype of 'Superclass<dynamic>.method' ('(dynamic) → void') at lib/common_problems_analysis.dart:74:3 • strong_mode_invalid_method_override
   error • super call must be last in an initializer list (see https://goo.gl/EY6hDP): 'super(food)' at lib/common_problems_analysis.dart:92:9 • strong_mode_invalid_super_invocation
+  error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' at lib/common_problems_analysis.dart:103:17 • invalid_assignment
+  error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) at lib/common_problems_analysis.dart:103:17 • strong_mode_invalid_cast_function_expr
   error • The argument type 'List' can't be assigned to the parameter type 'List<int>' at lib/strong_analysis.dart:27:17 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:38:15 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:54:15 • argument_type_not_assignable
@@ -21,5 +23,4 @@ Analyzing lib, test...
   error • A value of type 'List' can't be assigned to a variable of type 'List<int>' at test/strong_test.dart:41:27 • invalid_assignment
   error • A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>' at test/strong_test.dart:63:26 • invalid_assignment
   error • A value of type 'List<Object>' can't be assigned to a variable of type 'List<String>' at test/strong_test.dart:157:26 • invalid_assignment
-  warning • A function of type '(String) → bool' can't be assigned to a location of type '(dynamic) → bool' at lib/common_problems_analysis.dart:103:17 • strong_mode_uses_dynamic_as_bottom
-22 errors and 1 warning found.
+24 errors found.

--- a/examples/strong/lib/common_problems_analysis.dart
+++ b/examples/strong/lib/common_problems_analysis.dart
@@ -99,6 +99,6 @@ class HoneyBadger extends Animal {
 // NOTE: only in Dart 2 (not Dart 1) strong mode reports this warning
 // #docregion func-dynamic
 typedef bool Filter(dynamic any);
-// ignore_for_file: 2, strong_mode_uses_dynamic_as_bottom
+// ignore_for_file: 2, strong_mode_invalid_cast_function_expr
 Filter filter = (String x) => x.contains('Hello');
 // #enddocregion func-dynamic

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "dev",
     "prev-vers": "1.24.3",
-    "vers": "2.0.0-dev.48.0"
+    "vers": "2.0.0-dev.49.0"
   }
 }

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -354,9 +354,9 @@ in [Effective Dart](/guides/language/effective-dart/).
 <a name="uses-dynamic-as-bottom"></a>
 ### A function of type ... can't be assigned
 
-<?code-excerpt "strong/analyzer-2-results.txt" retain="/A function of type.*common_problems/" replace="/'\S+ → \S+'/'...'/g"?>
+<?code-excerpt "strong/analyzer-2-results.txt" retain="/The function expression type.*common_problems/" replace="/'\S+ → \S+'/'...'/g"?>
 ```nocode
-warning • A function of type '...' can't be assigned to a location of type '...' • strong_mode_uses_dynamic_as_bottom
+error • The function expression type '...' isn't of type '...'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
 ```
 
 In Dart 1.x `dynamic` was both a [top type][] (supertype of all types) and a
@@ -367,7 +367,7 @@ function type with a parameter of `dynamic`.
 
 However, in Dart 2 passing something other than `dynamic` (or another _top_
 type, such as `Object`, or a specific bottom type, such as `Null`) results
-in a compile-time warning.
+in a compile-time error.
 
 #### Example
 
@@ -379,14 +379,15 @@ Filter filter = ([!String!] x) => x.contains('Hello');
 {% endprettify %}
 
 {:.console-output}
-<?code-excerpt "strong/analyzer-2-results.txt" retain="/A function of type.*common_problems/"?>
+<?code-excerpt "strong/analyzer-2-results.txt" retain="/type '\(String\) → bool'.*common_problems/"?>
 ```nocode
-warning • A function of type '(String) → bool' can't be assigned to a location of type '(dynamic) → bool' • strong_mode_uses_dynamic_as_bottom
+error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' • invalid_assignment
+error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
 ```
 
 #### Fix: Add generic type parameters _or_ cast from dynamic explicitly
 
-When possible, avoid this warning by adding type parameters:
+When possible, avoid this error by adding type parameters:
 
 {:.passes-sa}
 <?code-excerpt "strong/lib/common_fixes_analysis.dart (func-T)" replace="/<\w+\x3E/[!$&!]/g"?>
@@ -429,7 +430,7 @@ Since neither `List<int>` nor `List<String>` is a subtype of the other,
 Dart rules this out statically. You can see other examples of these
 static analysis errors in [Unexpected collection element type](#unexpected-collection-element-type).
 
-The errors discussed in the remainder of this section are reported at 
+The errors discussed in the remainder of this section are reported at
 [runtime](sound-dart#runtime-checks).
 
 ### Invalid casts


### PR DESCRIPTION
A compile time warning became an error in dev.49.

This fixes the build.