### PR TITLE
Update AngularDart link and description

### DIFF
--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -113,8 +113,8 @@ Google internal sales tool
 [WorkTrail](https://worktrail.net)
 : Time tracking app.
 
-[AngularDart](https://github.com/angular/angular.dart)
-: AngularDart is a port of the popular framework to Dart.
+[AngularDart](https://webdev.dartlang.org/angular)
+: AngularDart is a web app framework that focuses on productivity, performance, and stability.
 
 [Google Elections](http://news.dartlang.org/2013/09/googles-german-election-map-powered-by.html)
 : Elections results maps built with Dart.


### PR DESCRIPTION
The old link was to the old repo location, so I changed it to the webdev link commonly used elsewhere. I also modified the description to the description presented on webdev as AngularDart has become quite distinct from the JS Angular and it seems other mentions have moved away from the idea of it being a "port" anyway.