### PR TITLE
More exposition and guidelines around type annotations.

### DIFF
--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -84,8 +84,8 @@ void miscDeclAnalyzedButNotTested() {
   num highScore(List<num> scores) {
     var highest = 0;
     for (var score in scores) {
-      // Error: Can't assign num to int:
-      // if (score > highest) highest = score;
+      // ignore: invalid_assignment
+      if (score > highest) highest = score;
     }
     return highest;
   }

--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -34,28 +34,36 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion positive
   };
 
-  () {
+  {
     // #docregion cascades
     var buffer = new StringBuffer0() //!<br>
         .write('one')
         .write('two')
         .write('three');
     // #enddocregion cascades
-  };
+  }
 
-  () {
+  {
     // #docregion type_annotate_public_apis
     install(id, destination) => ellipsis();
     // #enddocregion type_annotate_public_apis
-  };
+  }
 
-  () {
+  {
     // #docregion func-expr-no-param-type
     var names = people.map((Person person) {
       return person.name;
     });
     // #enddocregion func-expr-no-param-type
-  };
+  }
+
+  {
+    // #docregion generic-invocation
+    var strings = <String>["str", "ing"];
+    var threes = new List<int>.filled(3, 2);
+    var pointThrees = threes.map<double>((i) => i * 0.1);
+    // #enddocregion generic-invocation
+  }
 
   {
     // #docregion omit-types-on-locals
@@ -72,11 +80,22 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion omit-types-on-locals
   }
 
-  () {
+  // #docregion inferred-wrong
+  num highScore(List<num> scores) {
+    var highest = 0;
+    for (var score in scores) {
+      // Error: Can't assign num to int:
+      // if (score > highest) highest = score;
+    }
+    return highest;
+  }
+  // #enddocregion inferred-wrong
+
+  {
     // #docregion prefer-dynamic
     mergeJson(original, changes) => ellipsis();
     // #enddocregion prefer-dynamic
-  };
+  }
 
   // #docregion avoid-Function
   bool isValid(String value, Function test) => ellipsis();
@@ -111,6 +130,12 @@ typedef int Comparison<T>(T a, T b);
 // #docregion typedef-param
 typedef bool TestNumber(num);
 // #enddocregion typedef-param
+
+// #docregion explicit-field
+class Histogram {
+  final counts = <String, int>{};
+}
+// #enddocregion explicit-field
 
 //----------------------------------------------------------------------------
 

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -122,6 +122,21 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion cascades
   };
 
+  // #docregion annotate-declaration
+  bool isEmpty(String parameter) {
+    bool result = parameter.length == 0;
+    return result;
+  }
+  // #enddocregion annotate-declaration
+
+  // #docregion annotate-invocation
+  {
+    var lists = <num>[1, 2];
+    lists.addAll(new List<num>.filled(3, 4));
+    lists.cast<int>();
+  }
+  // #enddocregion annotate-invocation
+
   <PackageId>() {
     // #docregion type_annotate_public_apis
     Future<bool> install(PackageId id, String destination) => ellipsis();
@@ -227,8 +242,8 @@ void miscDeclAnalyzedButNotTested() {
   // #enddocregion future-or
 
   // #docregion future-or-contra
-  Stream<S> asyncMap<T, S>(Iterable<T> iterable,
-      FutureOr<S> Function(T) callback) async* {
+  Stream<S> asyncMap<T, S>(
+      Iterable<T> iterable, FutureOr<S> Function(T) callback) async* {
     for (var element in iterable) {
       yield await callback(element);
     }

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -132,11 +132,19 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion inferred
   };
 
-  () {
+  {
     // #docregion func-expr-no-param-type
     var names = people.map((person) => person.name);
     // #enddocregion func-expr-no-param-type
-  };
+  }
+
+  {
+    // #docregion generic-invocation
+    var strings = ["str", "ing"];
+    var threes = new List.filled(3, 2);
+    var pointThrees = threes.map((i) => i * 0.1);
+    // #enddocregion generic-invocation
+  }
 
   {
     // #docregion omit-types-on-locals
@@ -164,11 +172,21 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion uninitialized-local
   };
 
-  () {
+  // #docregion inferred-wrong
+  num highScore(List<num> scores) {
+    num highest = 0;
+    for (var score in scores) {
+      if (score > highest) highest = score;
+    }
+    return highest;
+  }
+  // #enddocregion inferred-wrong
+
+  {
     // #docregion prefer-dynamic
     dynamic mergeJson(dynamic original, dynamic changes) => ellipsis();
     // #enddocregion prefer-dynamic
-  };
+  }
 
   // #docregion avoid-Function
   bool isValid(String value, bool Function(String string) test) => ellipsis();
@@ -267,6 +285,19 @@ class FilteredObservable {
 // #docregion new-typedef
 typedef Comparison = int Function<T>(T, T);
 // #enddocregion new-typedef
+
+// #docregion explicit-field
+class Histogram {
+  final Map<String, int> counts = {};
+}
+// #enddocregion explicit-field
+
+// #docregion explicit-local
+void countOccurrences(List<String> words) {
+  var wordCounts = <String, int>{};
+  // ...
+}
+// #enddocregion explicit-local
 
 //----------------------------------------------------------------------------
 // Supporting declarations

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -129,13 +129,13 @@ void miscDeclAnalyzedButNotTested() {
   }
   // #enddocregion annotate-declaration
 
-  // #docregion annotate-invocation
   {
+    // #docregion annotate-invocation
     var lists = <num>[1, 2];
     lists.addAll(new List<num>.filled(3, 4));
     lists.cast<int>();
+    // #enddocregion annotate-invocation
   }
-  // #enddocregion annotate-invocation
 
   <PackageId>() {
     // #docregion type_annotate_public_apis

--- a/scripts/analyze-and-test-examples.sh
+++ b/scripts/analyze-and-test-examples.sh
@@ -41,7 +41,7 @@ function analyze_and_test() {
   PROJECT_ROOT="$1"
   pushd "$PROJECT_ROOT" > /dev/null
   travis_fold start analyzeAndTest.get
-  pub $PUB_ARGS
+  # pub $PUB_ARGS
   travis_fold end analyzeAndTest.get
 
   DIR=()

--- a/scripts/analyze-and-test-examples.sh
+++ b/scripts/analyze-and-test-examples.sh
@@ -41,7 +41,7 @@ function analyze_and_test() {
   PROJECT_ROOT="$1"
   pushd "$PROJECT_ROOT" > /dev/null
   travis_fold start analyzeAndTest.get
-  # pub $PUB_ARGS
+  pub $PUB_ARGS
   travis_fold end analyzeAndTest.get
 
   DIR=()

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -982,8 +982,8 @@ types". You can type annotate a variable, parameter, field, or return type. In
 the following example, `bool` and `String` are type annotations. They hang off
 the static declarative structure of the code and aren't "executed" at runtime.
 
-{% prettify dart %}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-declaration)"?>
+{% prettify dart %}
 bool isEmpty(String parameter) {
   bool result = parameter.length == 0;
   return result;
@@ -996,8 +996,8 @@ and `int` are type arguments on generic invocations. Even though they are types,
 they are first-class entities that get reified and passed to the invocation at
 runtime.
 
-{% prettify dart %}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-invocation)"?>
+{% prettify dart %}
 var lists = <num>[1, 2];
 lists.addAll(new List<num>.filled(3, 4));
 lists.cast<int>();
@@ -1006,8 +1006,8 @@ lists.cast<int>();
 We stress the "generic invocation" part here, because type arguments can *also*
 appear in type annotations:
 
-{% prettify dart %}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-type-arg)"?>
+{% prettify dart %}
 List<int> ints = [1, 2];
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -212,10 +212,14 @@
 
 **Type annotations**
 
+* <a href='/guides/language/effective-dart/design#do-annotate-when-dart-infers-the-wrong-type'>DO annotate when Dart infers the wrong type.</a>
 * <a href='/guides/language/effective-dart/design#do-type-annotate-public-declarations-whose-type-isnt-inferred'>DO type annotate public declarations whose type isn't inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-type-annotating-private-declarations-whose-type-isnt-inferred'>PREFER type annotating private declarations whose type isn't inferred.</a>
 * <a href='/guides/language/effective-dart/design#avoid-annotating-types-for-initialized-local-variables'>AVOID annotating types for initialized local variables.</a>
-* <a href='/guides/language/effective-dart/design#avoid-annotating-inferrable-parameter-types-on-function-expressions'>AVOID annotating inferrable parameter types on function expressions.</a>
+* <a href='/guides/language/effective-dart/design#avoid-annotating-inferred-parameter-types-on-function-expressions'>AVOID annotating inferred parameter types on function expressions.</a>
+* <a href='/guides/language/effective-dart/design#avoid-type-annotating-generic-invocations-that-can-be-inferred'>AVOID type annotating generic invocations that can be inferred.</a>
+* <a href='/guides/language/effective-dart/design#prefer-type-annotating-declarations-for-top-level-variables-and-fields-that-cant-be-inferred'>PREFER type annotating declarations for top-level variables and fields that can't be inferred.</a>
+* <a href='/guides/language/effective-dart/design#prefer-type-annotating-generic-invocations-for-local-variables-that-cant-be-inferred'>PREFER type annotating generic invocations for local variables that can't be inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-annotating-with-dynamic-instead-of-letting-inference-fail'>PREFER annotating with <code>dynamic</code> instead of letting inference fail.</a>
 * <a href='/guides/language/effective-dart/design#prefer-signatures-in-function-type-annotations'>PREFER signatures in function type annotations.</a>
 * <a href='/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter'>DON'T specify a return type for a setter.</a>

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -210,14 +210,14 @@
 * <a href='/guides/language/effective-dart/design#avoid-returning-null-from-members-whose-return-type-is-bool-double-int-or-num'>AVOID returning <code>null</code> from members whose return type is <code>bool</code>, <code>double</code>, <code>int</code>, or <code>num</code>.</a>
 * <a href='/guides/language/effective-dart/design#avoid-returning-this-from-methods-just-to-enable-a-fluent-interface'>AVOID returning <code>this</code> from methods just to enable a fluent interface.</a>
 
-**Type annotations**
+**Types**
 
 * <a href='/guides/language/effective-dart/design#do-annotate-when-dart-infers-the-wrong-type'>DO annotate when Dart infers the wrong type.</a>
 * <a href='/guides/language/effective-dart/design#do-type-annotate-public-declarations-whose-type-isnt-inferred'>DO type annotate public declarations whose type isn't inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-type-annotating-private-declarations-whose-type-isnt-inferred'>PREFER type annotating private declarations whose type isn't inferred.</a>
 * <a href='/guides/language/effective-dart/design#avoid-annotating-types-for-initialized-local-variables'>AVOID annotating types for initialized local variables.</a>
 * <a href='/guides/language/effective-dart/design#avoid-annotating-inferred-parameter-types-on-function-expressions'>AVOID annotating inferred parameter types on function expressions.</a>
-* <a href='/guides/language/effective-dart/design#avoid-type-annotating-generic-invocations-that-can-be-inferred'>AVOID type annotating generic invocations that can be inferred.</a>
+* <a href='/guides/language/effective-dart/design#avoid-type-arguments-on-generic-invocations-that-can-be-inferred'>AVOID type arguments on generic invocations that can be inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-type-annotating-declarations-for-top-level-variables-and-fields-that-cant-be-inferred'>PREFER type annotating declarations for top-level variables and fields that can't be inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-type-annotating-generic-invocations-for-local-variables-that-cant-be-inferred'>PREFER type annotating generic invocations for local variables that can't be inferred.</a>
 * <a href='/guides/language/effective-dart/design#prefer-annotating-with-dynamic-instead-of-letting-inference-fail'>PREFER annotating with <code>dynamic</code> instead of letting inference fail.</a>


### PR DESCRIPTION
* Explain the two kinds of places where you can write types.
* Handle cases where inference succeeds but gives a type you don't want.
* Don't pass type arguments explicitly unless needed.
* Prefer typing "on the left" for fields and top level variables.
* Type "on the right" for locals.
