### PR TITLE
Add an Angular exception for naming boolean setters. <sigh>

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -211,6 +211,16 @@ closingWindow // Returns a bool or a window?
 showPopup     // Sounds like it shows the popup.
 {% endprettify %}
 
+<aside class="alert alert-info" markdown="1">
+
+  There is one exception to this rule. Input properties in [Angular][]
+  components sometimes use imperative verbs for boolean setters because these
+  setters are invoked in templates, not from other Dart code.
+
+  [angular]: http://angular.io
+
+</aside>
+
 
 ### PREFER the "positive" name for a boolean property or variable.
 
@@ -426,14 +436,11 @@ The conventions are:
 *   `E` for the **element** type in a collection:
 
     {:.good-style}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)"?>
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
     {% prettify dart %}
     class IterableBase<E> {}
-
     class List<E> {}
-
     class HashSet<E> {}
-
     class RedBlackTree<E> {}
     {% endprettify %}
 
@@ -441,12 +448,10 @@ The conventions are:
     collection:
 
     {:.good-style}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)"?>
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
     {% prettify dart %}
     class Map<K, V> {}
-
     class Multimap<K, V> {}
-
     class MapEntry<K, V> {}
     {% endprettify %}
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -212,13 +212,11 @@ showPopup     // Sounds like it shows the popup.
 {% endprettify %}
 
 <aside class="alert alert-info" markdown="1">
+There is one exception to this rule. Input properties in [Angular][]
+components sometimes use imperative verbs for boolean setters because these
+setters are invoked in templates, not from other Dart code.
 
-  There is one exception to this rule. Input properties in [Angular][]
-  components sometimes use imperative verbs for boolean setters because these
-  setters are invoked in templates, not from other Dart code.
-
-  [angular]: http://angular.io
-
+[angular]: {{site.webdev}}/angular
 </aside>
 
 
@@ -927,15 +925,13 @@ to. If you have some piece of an object's state that can be modified but not
 exposed in the same way, use a method instead.
 
 <aside class="alert alert-info" markdown="1">
+There is one exception to this rule. An [Angular][] component class may expose
+setters that are invoked from a template to initialize the component. Often,
+these setters are not intended to be invoked from Dart code and don't need a
+corresponding getter. (If they are used from Dart code, they *should* have a
+getter.)
 
-  There is one exception to this rule. An [Angular][] component class may expose
-  setters that are invoked from a template to initialize the component. Often,
-  these setters are not intended to be invoked from Dart code and don't need a
-  corresponding getter. (If they are used from Dart code, they *should* have a
-  getter.)
-
-  [angular]: http://angular.io
-
+[angular]: {{site.webdev}}/angular
 </aside>
 
 ### AVOID returning `null` from members whose return type is `bool`, `double`, `int`, or `num`.


### PR DESCRIPTION
Also, remove some newlines in code excerpts that were breaking the
formatting when used inside a list.