### PR TITLE
Footer: switch to brand-primary blue + monochrome logo

### DIFF
--- a/src/_assets/stylesheets/_variables.scss
+++ b/src/_assets/stylesheets/_variables.scss
@@ -13,18 +13,22 @@ $teal:                      #1FBAAC;
 $blue:                      #1b87c9;
 $blue-light:                #e2f4fd;
 
-$brand-primary:             #0175C2;
+$brand-primary-dark:        #02569B; // 700
+$brand-primary:             #0175C2; // 600
+$brand-secondary:           #13B9FD; // 400
+$brand-highlight:           #FFC108; // 700
+
+$google-gray:               #202124; // 900
+$google-gray-light:         #60646B; // 600
+$google-gray-lighter:       #D5D7DA; // 100
 
 $default-link:              #0175C2;
 $default-link-visited:      #0175C2;
 
 // Typography
 $font-family-base:          Roboto, sans-serif;
-// $font-family-condensed:     'Trade Gothic W01', sans-serif;
-// $font-family-extended:      'Trade Gothic W01', sans-serif;
-// $font-family-serif:         'Trade Gothic W01', sans-serif;
-
 $font-family-monospace:     Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+$google-font-family:        "Product Sans", $font-family-base;
 
 // Baseline
 $font-size-base:          16px;

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -194,7 +194,7 @@ img {
   position: relative;
   color: $white-base;
   font-weight: 300;
-  background-color: $gray-base;
+  background-color: $brand-primary;
   z-index: 5;
   .brand {
     width: 120px;

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -4,7 +4,7 @@
       <div class="col-sm-12 col-md-3">
         <div class="content">
           <div class="brand">
-            <img src="{% asset_path 'shared/dart/logo+text/horizontal/white.svg' %}" alt="Dart logo" class="brand"/>
+            <img src="{% asset_path 'shared/dart/logo+text/horizontal/mono.svg' %}" alt="Dart logo" class="brand"/>
           </div>
           <h4><a href="/terms">Terms</a> | <a href="http://www.google.com/intl/en/policies/privacy/">Privacy</a></h4>
           <style>.menu .material-icons { font-size: 14px; }</style>


### PR DESCRIPTION
Fixes #848, _Footer: use brand-primary blue background with monochrome logo_.

Staged at https://dartlang-org-staging-0.firebaseapp.com

This matches the flutter.io footer design, and looks like this:

> <img width="1043" alt="screen shot 2018-05-07 at 09 15 05" src="https://user-images.githubusercontent.com/4140793/39703774-4079a77c-51d7-11e8-9e32-46302aff232a.png">

as compared to what we had in the previous iteration:

> <img width="1040" alt="screen shot 2018-05-07 at 09 16 40" src="https://user-images.githubusercontent.com/4140793/39703810-6836385c-51d7-11e8-80b6-98a77051f7f2.png">

cc @anders-sandholm @JekCharlsonYu 