### PR TITLE
More revisions to "Effective Dart" based on feedback.

### DIFF
--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -307,6 +307,10 @@ class FilteredObservable {
 typedef Comparison = int Function<T>(T, T);
 // #enddocregion new-typedef
 
+// #docregion new-typedef-param-name
+typedef Comparison = int Function<T>(T a, T b);
+// #enddocregion new-typedef-param-name
+
 // #docregion explicit-field
 class Histogram {
   final Map<String, int> counts = {};

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -308,7 +308,7 @@ typedef Comparison = int Function<T>(T, T);
 // #enddocregion new-typedef
 
 // #docregion new-typedef-param-name
-typedef Comparison = int Function<T>(T a, T b);
+typedef Comparison2 = int Function<T>(T a, T b);
 // #enddocregion new-typedef-param-name
 
 // #docregion explicit-field

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -79,6 +79,36 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion cast-map
   }
 
+  // #docregion cast-at-create
+  List<int> makeList([int a, int b]) {
+    var list = []; // List<dynamic>.
+    if (a != null) list.add(a);
+    if (b != null) list.add(b);
+    return list.cast<int>();
+  }
+  // #enddocregion cast-at-create
+
+  // #docregion cast-iterate
+  int sum(List<Object> objects) {
+    var result = 0;
+    // We happen to know the list only contains ints.
+    for (var n in objects.cast<int>()) {
+      result += n;
+    }
+
+    return result;
+  }
+  // #enddocregion cast-iterate
+
+  // #docregion cast-from
+  int median(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    var ints = new List<int>.from(objects);
+    ints.sort();
+    return ints[ints.length ~/ 2];
+  }
+  // #enddocregion cast-from
+
   {
     // #docregion where-type-2
     var objects = [1, "a", 2, "b", 3];

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -80,23 +80,19 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   // #docregion cast-at-create
-  List<int> makeList([int a, int b]) {
+  List<int> singletonList(int value) {
     var list = []; // List<dynamic>.
-    if (a != null) list.add(a);
-    if (b != null) list.add(b);
+    list.add(value);
     return list.cast<int>();
   }
   // #enddocregion cast-at-create
 
   // #docregion cast-iterate
-  int sum(List<Object> objects) {
-    var result = 0;
+  void printEvens(List<Object> objects) {
     // We happen to know the list only contains ints.
     for (var n in objects.cast<int>()) {
-      result += n;
+      if (n.isEven) print(n);
     }
-
-    return result;
   }
   // #enddocregion cast-iterate
 
@@ -201,6 +197,16 @@ void miscDeclAnalyzedButNotTested() {
           ..addAll(chest.contents);
     // #enddocregion arrow-long
   };
+
+  {
+    // #docregion no-const
+    const primaryColors = const [
+      const Color("red", const [255, 0, 0]),
+      const Color("green", const [0, 255, 0]),
+      const Color("blue", const [0, 0, 255]),
+    ];
+    // #enddocregion no-const
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -79,23 +79,19 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   // #docregion cast-at-create
-  List<int> makeList([int a, int b]) {
+  List<int> singletonList(int value) {
     var list = <int>[];
-    if (a != null) list.add(a);
-    if (b != null) list.add(b);
+    list.add(value);
     return list;
   }
   // #enddocregion cast-at-create
 
   // #docregion cast-iterate
-  int sum(List<Object> objects) {
-    var result = 0;
+  void printEvens(List<Object> objects) {
     // We happen to know the list only contains ints.
-    for (int n in objects) {
-      result += n;
+    for (var n in objects) {
+      if ((n as int).isEven) print(n);
     }
-
-    return result;
   }
   // #enddocregion cast-iterate
 
@@ -222,6 +218,20 @@ void miscDeclAnalyzedButNotTested() {
     }
     // #enddocregion avoid-completer-alt
   }
+
+  // TODO(rnystrom): Uncomment this when the analyzer run on these excerpts
+  // supports optional const.
+  {
+    /*
+    // #docregion no-const
+    const primaryColors = [
+      Color("red", [255, 0, 0]),
+      Color("green", [0, 255, 0]),
+      Color("blue", [0, 0, 255]),
+    ];
+    // #enddocregion no-const
+    */
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -235,6 +245,10 @@ class Animal {
 
 class Person {
   int zip;
+}
+
+class Color {
+  const Color(String name, List<int> channels);
 }
 
 //----------------------------------------------------------------------------
@@ -426,15 +440,32 @@ class Point2 {
 }
 // #enddocregion semicolon-for-empty-body
 
+class Widget {}
+
+class BuildContext {}
+
+class Row extends Widget {
+  Row({children});
+}
+
+class RaisedButton {
+  RaisedButton({child});
+}
+
+class Text {
+  Text(String text);
+}
+
+// TODO(rnystrom): Remove "new" here instead of stripping it out later once
+// we support optional new for excerpts.
 // #docregion no-new
 Widget build(BuildContext context) {
   return new Row(
     children: [
       new RaisedButton(
-        onPressed: increment,
         child: new Text('Increment'),
       ),
-      new Text('Count: $counter'),
+      new Text('Click!'),
     ],
   );
 }

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -78,6 +78,36 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion cast-map
   }
 
+  // #docregion cast-at-create
+  List<int> makeList([int a, int b]) {
+    var list = <int>[];
+    if (a != null) list.add(a);
+    if (b != null) list.add(b);
+    return list;
+  }
+  // #enddocregion cast-at-create
+
+  // #docregion cast-iterate
+  int sum(List<Object> objects) {
+    var result = 0;
+    // We happen to know the list only contains ints.
+    for (int n in objects) {
+      result += n;
+    }
+
+    return result;
+  }
+  // #enddocregion cast-iterate
+
+  // #docregion cast-from
+  int median(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    var ints = objects.cast<int>();
+    ints.sort();
+    return ints[ints.length ~/ 2];
+  }
+  // #enddocregion cast-from
+
   (Iterable<Animal> animals) {
     // #docregion use-higher-order-func
     var aquaticNames = animals
@@ -395,6 +425,20 @@ class Point2 {
   Point2(this.x, this.y);
 }
 // #enddocregion semicolon-for-empty-body
+
+// #docregion no-new
+Widget build(BuildContext context) {
+  return new Row(
+    children: [
+      new RaisedButton(
+        onPressed: increment,
+        child: new Text('Increment'),
+      ),
+      new Text('Count: $counter'),
+    ],
+  );
+}
+// #enddocregion no-new
 
 //----------------------------------------------------------------------------
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -220,6 +220,20 @@ setters are invoked in templates, not from other Dart code.
 </aside>
 
 
+### CONSIDER omitting the verb for a named boolean *parameter*.
+
+This refines the previous rule. For named parameters that are boolean, the name
+is often just as clear without the verb and it reads better at the callsite.
+
+{:.good-style}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
+{% prettify dart %}
+Isolate.spawn(entryPoint, message, paused: false);
+var copy = new List.from(elements, growable: true);
+var regExp = new RegExp(pattern, caseSensitive: false);
+{% endprettify %}
+
+
 ### PREFER the "positive" name for a boolean property or variable.
 
 Most boolean names have conceptually "positive" and "negative" forms where the
@@ -257,23 +271,9 @@ negate the property with `!` everywhere. Instead, it may be better to use the
 negative case for that property.
 
 For some properties, there is no obvious positive form. Is a document that has
-been flushed to disc "saved" or "*un*-changed"? Is a document that *hasn't* been
+been flushed to disk "saved" or "*un*-changed"? Is a document that *hasn't* been
 flushed "*un*-saved" or "changed"? In ambiguous cases, lean towards the choice
 that is less likely to be negated by users or has the shorter name.
-
-
-### CONSIDER omitting the verb for a named boolean *parameter*.
-
-This refines the previous rule. For named parameters that are boolean, the name
-is often just as clear without the verb and it reads better at the callsite.
-
-{:.good-style}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
-{% prettify dart %}
-Isolate.spawn(entryPoint, message, paused: false);
-var copy = new List.from(elements, growable: true);
-var regExp = new RegExp(pattern, caseSensitive: false);
-{% endprettify %}
 
 
 ### PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.
@@ -687,8 +687,8 @@ comment.
 
 If a constructor is added to a class that previously did not define any, that
 breaks any other classes that are mixing it in. This is a seemingly innocuous
-change in the class and the restrictions around mixins aren't widely known. It's
-likely an author may add a constructor without realizing it will break your
+change in the class, and the restrictions around mixins aren't widely known.
+It's likely an author may add a constructor without realizing it will break your
 class that's mixing it in.
 
 Like with subclassing, this means a class needs to be deliberate about whether
@@ -1463,11 +1463,19 @@ The new syntax looks like this:
 typedef Comparison = int Function<T>(T, T);
 {% endprettify %}
 
+If you want to include a parameter's name, you can do that too:
+
+{:.good-style}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef-param-name)"?>
+{% prettify dart %}
+typedef Comparison = int Function<T>(T a, T b);
+{% endprettify %}
+
 The new syntax can express anything the old syntax could express and more, and
 lacks the error-prone misfeature where a single identifier is treated as the
-parameter's name. The same function type syntax after the `=` in the typedef is
-also allowed anywhere a type annotation may appear, giving us a single
-consistent way to write function types anywhere in a program.
+parameter's name instead of its type. The same function type syntax after the
+`=` in the typedef is also allowed anywhere a type annotation may appear, giving
+us a single consistent way to write function types anywhere in a program.
 
 The old typedef syntax is still supported to avoid breaking existing code, but
 it's deprecated.

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -223,7 +223,8 @@ setters are invoked in templates, not from other Dart code.
 ### CONSIDER omitting the verb for a named boolean *parameter*.
 
 This refines the previous rule. For named parameters that are boolean, the name
-is often just as clear without the verb and it reads better at the callsite.
+is often just as clear without the verb, and the code reads better at the call
+site.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -109,7 +109,7 @@ up.
 You don't have to document every single library, top-level variable, type, and
 member, but you should document most of them.
 
-### CONSIDER writing doc comments for public libraries.
+### CONSIDER writing a library-level doc comment.
 
 Unlike languages like Java where the class is the only unit of program
 organization, in Dart, a library is itself an entity that users work with
@@ -122,6 +122,10 @@ provided within. Consider including:
 * A couple of complete code samples that walk through using the API.
 * Links to the most important or most commonly used classes and functions.
 * Links to external references on the domain the library is concerned with.
+
+You document a library by placing a doc comment right above the `library`
+directive at the start of the file. If the library doesn't have a `library`
+directive, you can add one just to hang the doc comment off of it.
 
 ### CONSIDER writing doc comments for private APIs.
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -328,14 +328,14 @@ way the compiler does.
 Formatting is tedious work and is particularly time-consuming during
 refactoring. Fortunately, you don't have to worry about it. We provide a
 sophisticated automated code formatter called [dartfmt][] that does do it for
-you. The official whitespace-handling rules for Dart are *whatever
-[dartfmt][] produces*.
+you. We have [some documentation][dartfmt docs] on the rules it applies, but the
+official whitespace-handling rules for Dart are *whatever dartfmt produces*.
 
 The remaining formatting guidelines are for the few things dartfmt cannot fix
 for you.
 
 [dartfmt]: https://github.com/dart-lang/dart_style
-
+[dartfmt docs]: https://github.com/dart-lang/dart_style/wiki/Formatting-Rules
 
 ### CONSIDER changing your code to make it more formatter-friendly.
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -137,8 +137,8 @@
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-new-in-code-that-doesnt-need-to-support-dart-1'>DON'T use <code>new</code> in code that doesn't need to support Dart 1.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-const-unnecesarily-in-code-that-doesnt-need-to-support-dart-1'>DON'T use <code>const</code> unnecesarily in code that doesn't need to support Dart 1.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
 
 **Error handling**
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -52,7 +52,7 @@
 
 * <a href='/guides/language/effective-dart/documentation#do-use--doc-comments-to-document-members-and-types'>DO use <code>///</code> doc comments to document members and types.</a>
 * <a href='/guides/language/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis'>PREFER writing doc comments for public APIs.</a>
-* <a href='/guides/language/effective-dart/documentation#consider-writing-doc-comments-for-public-libraries'>CONSIDER writing doc comments for public libraries.</a>
+* <a href='/guides/language/effective-dart/documentation#consider-writing-a-library-level-doc-comment'>CONSIDER writing a library-level doc comment.</a>
 * <a href='/guides/language/effective-dart/documentation#consider-writing-doc-comments-for-private-apis'>CONSIDER writing doc comments for private APIs.</a>
 * <a href='/guides/language/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary'>DO start doc comments with a single-sentence summary.</a>
 * <a href='/guides/language/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph'>DO separate the first sentence of a doc comment into its own paragraph.</a>
@@ -89,7 +89,7 @@
 **Libraries**
 
 * <a href='/guides/language/effective-dart/usage#do-use-strings-in-part-of-directives'>DO use strings in <code>part of</code> directives.</a>
-* <a href='/guides/language/effective-dart/usage#dont-import-libraries-inside-the-src-directory-of-another-package'>DON'T import libraries inside the <code>src</code> directory of another package.</a>
+* <a href='/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package'>DON'T import libraries that are inside the <code>src</code> directory of another package.</a>
 * <a href='/guides/language/effective-dart/usage#prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>PREFER relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
 
 **Strings**
@@ -106,8 +106,8 @@
 * <a href='/guides/language/effective-dart/usage#avoid-using-iterableforeach-with-a-function-literal'>AVOID using <code>Iterable.forEach()</code> with a function literal.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-listfrom-unless-you-intend-to-change-the-type-of-the-result'>DON'T use <code>List.from()</code> unless you intend to change the type of the result.</a>
 * <a href='/guides/language/effective-dart/usage#do-use-wheretype-to-filter-a-collection-by-type'>DO use <code>whereType()</code> to filter a collection by type.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-cast-or-retype-when-a-nearby-operation-will-do'>DON'T use <code>cast()</code> or <code>retype()</code> when a nearby operation will do.</a>
-* <a href='/guides/language/effective-dart/usage#avoid-using-cast-or-retype'>AVOID using <code>cast()</code> or <code>retype()</code>.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-cast-when-a-nearby-operation-will-do'>DON'T use <code>cast()</code> when a nearby operation will do.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-using-cast'>AVOID using <code>cast()</code>.</a>
 
 **Functions**
 
@@ -137,7 +137,6 @@
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
-* <a href='/guides/language/effective-dart/usage#do-place-the-super-call-last-in-a-constructor-initialization-list'>DO place the <code>super()</code> call last in a constructor initialization list.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-const-when-not-needed'>DON'T use <code>const</code> when not needed.</a>
 
@@ -172,8 +171,8 @@
 * <a href='/guides/language/effective-dart/design#consider-making-the-code-read-like-a-sentence'>CONSIDER making the code read like a sentence.</a>
 * <a href='/guides/language/effective-dart/design#prefer-a-noun-phrase-for-a-non-boolean-property-or-variable'>PREFER a noun phrase for a non-boolean property or variable.</a>
 * <a href='/guides/language/effective-dart/design#prefer-a-non-imperative-verb-phrase-for-a-boolean-property-or-variable'>PREFER a non-imperative verb phrase for a boolean property or variable.</a>
-* <a href='/guides/language/effective-dart/design#prefer-the-positive-name-for-a-boolean-property-or-variable'>PREFER the "positive" name for a boolean property or variable.</a>
 * <a href='/guides/language/effective-dart/design#consider-omitting-the-verb-for-a-named-boolean-parameter'>CONSIDER omitting the verb for a named boolean <em>parameter</em>.</a>
+* <a href='/guides/language/effective-dart/design#prefer-the-positive-name-for-a-boolean-property-or-variable'>PREFER the "positive" name for a boolean property or variable.</a>
 * <a href='/guides/language/effective-dart/design#prefer-an-imperative-verb-phrase-for-a-function-or-method-whose-main-purpose-is-a-side-effect'>PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.</a>
 * <a href='/guides/language/effective-dart/design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose'>PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.</a>
 * <a href='/guides/language/effective-dart/design#consider-an-imperative-verb-phrase-for-a-function-or-method-if-you-want-to-draw-attention-to-the-work-it-performs'>CONSIDER an imperative verb phrase for a function or method if you want to draw attention to the work it performs.</a>

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -137,8 +137,8 @@
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-const-when-not-needed'>DON'T use <code>const</code> when not needed.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-new-in-code-that-doesnt-need-to-support-dart-1'>DON'T use <code>new</code> in code that doesn't need to support Dart 1.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-const-unnecesarily-in-code-that-doesnt-need-to-support-dart-1'>DON'T use <code>const</code> unnecesarily in code that doesn't need to support Dart 1.</a>
 
 **Error handling**
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -137,8 +137,6 @@
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
 
 **Error handling**
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1080,6 +1080,8 @@ class Point {
 }
 {% endprettify %}
 
+<!-- TODO(rnystrom): Uncomment this when all Dart tools support it. -->
+<!--
 
 ### DON'T use `new`.
 
@@ -1145,6 +1147,7 @@ const primaryColors = const [
 ];
 {% endprettify %}
 
+-->
 
 ## Error handling
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1083,7 +1083,9 @@ class Point {
 <!-- TODO(rnystrom): Uncomment this when all Dart tools support it. -->
 <!--
 
-### DON'T use `new`.
+**TODO: Use "###" for header. Removed so this doesn't go into TOC.**
+
+DON'T use `new`.
 
 Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
 clear because factory constructors mean a `new` invocation may still not
@@ -1108,7 +1110,9 @@ Widget build(BuildContext context) {
 {% endprettify %}
 
 
-### DON'T use `const` redundantly.
+**TODO: Use "###" for header. Removed so this doesn't go into TOC.**
+
+DON'T use `const` redundantly.
 
 In contexts where an expression *must* be constant, the `const` keyword is
 implicit, doesn't need to be written, and shouldn't. Those contexts are any

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -460,16 +460,14 @@ Prefer any of these options instead:
 
 *   **Eagerly cast using `List.from()`.** If you'll eventually access most of
     the elements in the collection, and you don't need the object to be backed
-    by the original live object, convert it using `List.from()`:
+    by the original live object, convert it using `List.from()`.
 
     The `cast()` method returns a lazy collection that checks the element type
     on *every operation*. If you perform only a few operations on only a few
     elements, that laziness can be good. But in many cases, the overhead of lazy
     validation and of wrapping outweighs the benefits.
 
-Here are examples of each approach:
-
-#### Create it with the right type:
+Here is an example of **creating it with the right type:**
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-at-create)"?>
@@ -491,7 +489,7 @@ List<int> singletonList(int value) {
 }
 {% endprettify %}
 
-#### Cast each element on access:
+Here is **casting each element on access:**
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
@@ -515,7 +513,7 @@ void printEvens(List<Object> objects) {
 }
 {% endprettify %}
 
-#### Cast eagerly using `List.from()`:
+Here is **casting eagerly using `List.from()`:**
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-from)"?>
@@ -1083,15 +1081,14 @@ class Point {
 {% endprettify %}
 
 
-### DON'T use `new` in code that doesn't need to support Dart 1.
+### DON'T use `new`.
 
 Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
 clear because factory constructors mean a `new` invocation may still not
 actually return a new object.
 
 The language still permits `new` in order to make migration less painful, but
-consider it deprecated and remove it from your code as soon as you no longer
-need to run on older Dart tools.
+consider it deprecated and remove it from your code.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)" replace="/new //g"?>
@@ -1109,9 +1106,9 @@ Widget build(BuildContext context) {
 {% endprettify %}
 
 
-### DON'T use `const` unnecesarily in code that doesn't need to support Dart 1.
+### DON'T use `const` redundantly.
 
-In contexts where only constant expressions are allowed, the `const` keyword is
+In contexts where an expression *must* be constant, the `const` keyword is
 implicit, doesn't need to be written, and shouldn't. Those contexts are any
 expression inside:
 
@@ -1126,9 +1123,7 @@ expression inside:
 may support non-const default values.)
 
 Basically, any place where it would be an error to write `new` instead of
-`const`, Dart 2 allows you to omit the `const`. If your code does not need to
-run on older versions of Dart, you should take advantage of that and drop the
-`const`.
+`const`, Dart 2 allows you to omit the `const`.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-const)"?>

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2521,13 +2521,6 @@ class Employee extends Person {
 }
 {% endprettify %}
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-When using `super()` in a constructor's initialization list, put it last.
-For more information, see the
-[Dart usage guide](/guides/language/effective-dart/usage#do-place-the-super-call-last-in-a-constructor-initialization-list).
-</div>
-
 <div class="alert alert-warning" markdown="1">
 **Warning:**
 Arguments to the superclass constructor do not have access to `this`.

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -345,10 +345,6 @@ HoneyBadger(Eats food, String name)
       [!super!](food) { ... }
 {% endprettify %}
 
-For more information, see [DO place the super() call last in a
-constructor initialization list](/guides/language/effective-dart/usage#do-place-the-super-call-last-in-a-constructor-initialization-list)
-in [Effective Dart](/guides/language/effective-dart/).
-
 <hr>
 
 <a name="uses-dynamic-as-bottom"></a>


### PR DESCRIPTION
Staged: https://sz-www-1.firebaseapp.com/guides/language/effective-dart

- Move the "positive bool" guideline because it got stuck between two
  guidelines that refer to each other.

- Show that the new typedef syntax still supports parameter names.

- Clarify library doc comment guideline.

- Link to formatting rules on dartfmt wiki.

- Remove guideline on super() placement since the language mandates it
  now.

- Clarify guideline on importing from "src".

- Remove references to deprecated retype() method.

- Include examples for "AVOID using cast()".

- Add example for "DON'T use new".

- Other copy-edits.