### PR TITLE
Remove mention of non-booleans as booleans (#888)

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1786,8 +1786,8 @@ if (isRaining()) {
 }
 {% endprettify %}
 
-Remember, unlike JavaScript, Dart treats all values other than `true` as
-`false`. See [Booleans](#booleans) for more information.
+Unlike JavaScript, conditions must use boolean values, nothing else. See
+[Booleans](#booleans) for more information.
 
 
 ### For loops


### PR DESCRIPTION
With Dart 2's type-safety, only true and false are allowed where booleans are expected, so remove the language-tour's mention of treatment of non-booleans as booleans.