### PR TITLE
Update example to comply with = for default parameters.

### DIFF
--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -471,12 +471,12 @@ class DateTime0 {
 class Duration0 {
   // #docregion omit-optional-positional
   Duration0(
-      {int days: 0,
-      int hours: 0,
-      int minutes: 0,
-      int seconds: 0,
-      int milliseconds: 0,
-      int microseconds: 0});
+      {int days = 0,
+      int hours = 0,
+      int minutes = 0,
+      int seconds = 0,
+      int milliseconds = 0,
+      int microseconds = 0});
   // #enddocregion omit-optional-positional
 }
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1682,12 +1682,12 @@ DateTime(int year,
     int microsecond = 0]);
 
 Duration(
-    {int days: 0,
-    int hours: 0,
-    int minutes: 0,
-    int seconds: 0,
-    int milliseconds: 0,
-    int microseconds: 0});
+    {int days = 0,
+    int hours = 0,
+    int minutes = 0,
+    int seconds = 0,
+    int milliseconds = 0,
+    int microseconds = 0});
 {% endprettify %}
 
 


### PR DESCRIPTION
Previously stated rule: https://www.dartlang.org/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value

Named parameters should use = to separate parameters from its default value.