### PR TITLE
Re-enable homepage "Open in DartPad" button

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,10 +16,7 @@ description: Dart is a language optimized for client-side development for web an
   <div class="row">
     <div class="col-sm-7 col-lg-6">
       <div id="code-sample" class="content">
-        {% comment %}
-        Awaiting fix to https://github.com/dart-lang/site-www/issues/668
         <a href="https://dartpad.dartlang.org/fb763a4a770b5cdd896982e10ccf4118" class='codesample__open-in-dartpad no-automatic-external' target='_blank'>Open in DartPad</a>
-        {% endcomment %}
         {% include_relative _main-example.html %}
       </div>
     </div>


### PR DESCRIPTION
Contributes to #668 

Staged at https://kw-www-dartlang-1.firebaseapp.com.

@chalin, do you think we need testing in place before merging this? This PR does not remove the 2 instances of `new`.