### PR TITLE
Add api.dartlang.org link to every page

### DIFF
--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -50,6 +50,7 @@
         <div class="content">
           <h4>Resources</h4>
           <ul>
+            <li><a href="{{site.dart_api}}">API reference</a></li>
             <li><a href="https://dartpad.dartlang.org/">DartPad</a></li>
             <li><a href="https://pub.dartlang.org/">Pub packages</a></li>
             <li><a href="http://news.dartlang.org/">Dart news</a></li>

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -50,7 +50,7 @@
         <div class="content">
           <h4>Resources</h4>
           <ul>
-            <li><a href="{{site.dart_api}}">API reference</a></li>
+            <li><a href="{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}">API reference</a></li>
             <li><a href="https://dartpad.dartlang.org/">DartPad</a></li>
             <li><a href="https://pub.dartlang.org/">Pub packages</a></li>
             <li><a href="http://news.dartlang.org/">Dart news</a></li>


### PR DESCRIPTION
Fixes #913.

I considered linking to `{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}`, but I think it's better to just link to the API homepage, which has the big note about versions.