### PR TITLE
HTTP tutorial: remove "not Dart-2" warning since it was updated a while ago

### DIFF
--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -10,8 +10,6 @@ prevpage:
   https://github.com/dart-lang/dart-tutorials-samples/blob/master/httpserver
 {%- endcapture -%}
 
-{% include tutorial-banner.html %}
-
 ### Communicate over the internet
 
 <div class="mini-toc" markdown="1">


### PR DESCRIPTION
The code was "migrated" to Dart 2 via #463, and its completion status was marked as done in #664.