### PR TITLE
Use new typedef syntax everywhere

### DIFF
--- a/examples/misc/lib/language_tour/typedefs/misc.dart
+++ b/examples/misc/lib/language_tour/typedefs/misc.dart
@@ -3,7 +3,7 @@ typedef F = List<T> Function<T>(T);
 // #enddocregion Function
 
 // #docregion compare
-typedef int Compare<T>(T a, T b);
+typedef Compare<T> = int Function(T a, T b);
 
 int sort(int a, int b) => a - b;
 

--- a/examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
+++ b/examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
@@ -1,4 +1,4 @@
-typedef int Compare(Object a, Object b);
+typedef Compare = int Function(Object a, Object b);
 
 class SortedCollection {
   Compare compare;

--- a/examples/strong/analyzer-2-results.txt
+++ b/examples/strong/analyzer-2-results.txt
@@ -10,8 +10,8 @@ Analyzing lib, test...
   error • Invalid override. The type of 'MyAdder.add' ('(int, int) → int') isn't a subtype of 'NumberAdder.add' ('(num, num) → num') at lib/common_problems_analysis.dart:61:3 • strong_mode_invalid_method_override
   error • Invalid override. The type of 'Subclass.method' ('(int) → void') isn't a subtype of 'Superclass<dynamic>.method' ('(dynamic) → void') at lib/common_problems_analysis.dart:74:3 • strong_mode_invalid_method_override
   error • super call must be last in an initializer list (see https://goo.gl/EY6hDP): 'super(food)' at lib/common_problems_analysis.dart:92:9 • strong_mode_invalid_super_invocation
-  error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' at lib/common_problems_analysis.dart:103:17 • invalid_assignment
-  error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) at lib/common_problems_analysis.dart:103:17 • strong_mode_invalid_cast_function_expr
+  error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) at lib/common_problems_analysis.dart:102:17 • strong_mode_invalid_cast_function_expr
+  error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' at lib/common_problems_analysis.dart:102:17 • invalid_assignment
   error • The argument type 'List' can't be assigned to the parameter type 'List<int>' at lib/strong_analysis.dart:27:17 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:38:15 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:54:15 • argument_type_not_assignable

--- a/examples/strong/lib/common_fixes_analysis.dart
+++ b/examples/strong/lib/common_fixes_analysis.dart
@@ -82,13 +82,13 @@ class HoneyBadger extends Animal {
 //-----------------------------------------------
 
 // #docregion func-T
-typedef bool Filter<T>(T any);
+typedef Filter<T> = bool Function(T any);
 Filter<String> filter = (String x) => x.contains('Hello');
 // #enddocregion func-T
 
 //-----------------------------------------------
 
 // #docregion func-cast
-typedef bool Filter1(dynamic any);
+typedef Filter1<T> = bool Function(T any);
 Filter1 filter1 = (x) => (x as String).contains('Hello');
 // #enddocregion func-cast

--- a/examples/strong/lib/common_fixes_analysis.dart
+++ b/examples/strong/lib/common_fixes_analysis.dart
@@ -89,6 +89,6 @@ Filter<String> filter = (String x) => x.contains('Hello');
 //-----------------------------------------------
 
 // #docregion func-cast
-typedef Filter1<T> = bool Function(T any);
+typedef Filter1 = bool Function(dynamic any);
 Filter1 filter1 = (x) => (x as String).contains('Hello');
 // #enddocregion func-cast

--- a/examples/strong/lib/common_problems_analysis.dart
+++ b/examples/strong/lib/common_problems_analysis.dart
@@ -98,6 +98,6 @@ class HoneyBadger extends Animal {
 
 // #docregion func-dynamic
 typedef Filter = bool Function(dynamic any);
-// ignore: strong_mode_invalid_cast_function_expr
+// ignore_for_file: 2, strong_mode_invalid_cast_function_expr
 Filter filter = (String x) => x.contains('Hello');
 // #enddocregion func-dynamic

--- a/examples/strong/lib/common_problems_analysis.dart
+++ b/examples/strong/lib/common_problems_analysis.dart
@@ -96,9 +96,8 @@ class HoneyBadger extends Animal {
 
 //-----------------------------------------------
 
-// NOTE: only in Dart 2 (not Dart 1) strong mode reports this warning
 // #docregion func-dynamic
-typedef bool Filter(dynamic any);
-// ignore_for_file: 2, strong_mode_invalid_cast_function_expr
+typedef Filter = bool Function(dynamic any);
+// ignore: strong_mode_invalid_cast_function_expr
 Filter filter = (String x) => x.contains('Hello');
 // #enddocregion func-dynamic

--- a/scripts/refresh-code-excerpts.sh
+++ b/scripts/refresh-code-excerpts.sh
@@ -47,8 +47,7 @@ ARGS+='/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;' # {/*-...-*/} --> ... (removed brack
 # Replace "//!analysis-issue" by, say, "Analysis issue" (although once we can use embedded DPs this won't be needed)?
 ARGS+='/\/\/!(analysis-issue|runtime-error)[^\n]*//g;' # Removed warning/error marker
 ARGS+='/\x20*\/\/\s+ignore_for_file:[^\n]+\n//g;' # Remove analyzer ignore-issue marker
-ARGS+='/(\S+)\x20*\/\/\s+ignore:[^\n]+/$1/g;' # Remove EOL analyzer ignore-issue marker
-ARGS+='/\x20*\/\/\s+ignore:[^\n]+\n//g;' # Remove (full-line) analyzer ignore-issue marker
+ARGS+='/\x20*\/\/\s+ignore:[^\n]+//g;' # Remove analyzer ignore-issue marker
 
 echo "Source:     $SRC"
 echo "Fragments:  $FRAG"

--- a/scripts/refresh-code-excerpts.sh
+++ b/scripts/refresh-code-excerpts.sh
@@ -47,7 +47,8 @@ ARGS+='/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;' # {/*-...-*/} --> ... (removed brack
 # Replace "//!analysis-issue" by, say, "Analysis issue" (although once we can use embedded DPs this won't be needed)?
 ARGS+='/\/\/!(analysis-issue|runtime-error)[^\n]*//g;' # Removed warning/error marker
 ARGS+='/\x20*\/\/\s+ignore_for_file:[^\n]+\n//g;' # Remove analyzer ignore-issue marker
-ARGS+='/\x20*\/\/\s+ignore:[^\n]+//g;' # Remove analyzer ignore-issue marker
+ARGS+='/(\S+)\x20*\/\/\s+ignore:[^\n]+/$1/g;' # Remove EOL analyzer ignore-issue marker
+ARGS+='/\x20*\/\/\s+ignore:[^\n]+\n//g;' # Remove (full-line) analyzer ignore-issue marker
 
 echo "Source:     $SRC"
 echo "Fragments:  $FRAG"

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3885,7 +3885,7 @@ that information.
 
 <?code-excerpt "misc/lib/language_tour/typedefs/sorted_collection_2.dart"?>
 {% prettify dart %}
-typedef int Compare(Object a, Object b);
+typedef Compare = int Function(Object a, Object b);
 
 class SortedCollection {
   Compare compare;
@@ -3914,7 +3914,7 @@ of any function. For example:
 
 <?code-excerpt "misc/lib/language_tour/typedefs/misc.dart (compare)"?>
 {% prettify dart %}
-typedef int Compare<T>(T a, T b);
+typedef Compare<T> = int Function(T a, T b);
 
 int sort(int a, int b) => a - b;
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -398,7 +398,7 @@ Otherwise use casting:
 {:.passes-sa}
 <?code-excerpt "strong/lib/common_fixes_analysis.dart (func-cast)" replace="/([Ff]ilter)1/$1/g; /as \w+/[!$&!]/g"?>
 {% prettify dart %}
-typedef Filter<T> = bool Function(T any);
+typedef Filter = bool Function(dynamic any);
 Filter filter = (x) => (x [!as String!]).contains('Hello');
 {% endprettify %}
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -371,7 +371,7 @@ in a compile-time error.
 {:.fails-sa}
 <?code-excerpt "strong/lib/common_problems_analysis.dart (func-dynamic)" replace="/String/[!$&!]/g"?>
 {% prettify dart %}
-typedef bool Filter(dynamic any);
+typedef Filter = bool Function(dynamic any);
 Filter filter = ([!String!] x) => x.contains('Hello');
 {% endprettify %}
 
@@ -382,14 +382,14 @@ error • A value of type '(String) → bool' can't be assigned to a variable of
 error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
 ```
 
-#### Fix: Add generic type parameters _or_ cast from dynamic explicitly
+#### Fix: Add type parameters _or_ cast from dynamic explicitly
 
 When possible, avoid this error by adding type parameters:
 
 {:.passes-sa}
 <?code-excerpt "strong/lib/common_fixes_analysis.dart (func-T)" replace="/<\w+\x3E/[!$&!]/g"?>
 {% prettify dart %}
-typedef bool Filter[!<T>!](T any);
+typedef Filter[!<T>!] = bool Function(T any);
 Filter[!<String>!] filter = (String x) => x.contains('Hello');
 {% endprettify %}
 
@@ -398,7 +398,7 @@ Otherwise use casting:
 {:.passes-sa}
 <?code-excerpt "strong/lib/common_fixes_analysis.dart (func-cast)" replace="/([Ff]ilter)1/$1/g; /as \w+/[!$&!]/g"?>
 {% prettify dart %}
-typedef bool Filter(dynamic any);
+typedef Filter<T> = bool Function(T any);
 Filter filter = (x) => (x [!as String!]).contains('Hello');
 {% endprettify %}
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -378,8 +378,8 @@ Filter filter = ([!String!] x) => x.contains('Hello');
 {:.console-output}
 <?code-excerpt "strong/analyzer-2-results.txt" retain="/type '\(String\) → bool'.*common_problems/"?>
 ```nocode
-error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' • invalid_assignment
 error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
+error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' • invalid_assignment
 ```
 
 #### Fix: Add type parameters _or_ cast from dynamic explicitly


### PR DESCRIPTION
Use new typedef syntax everywhere, except places where we are illustrating the old syntax :)