### PR TITLE
Update "Effective Dart" for optional new/const.

### DIFF
--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -38,7 +38,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion cascades
-    var buffer = new StringBuffer0() //!<br>
+    var buffer = StringBuffer0() //!<br>
         .write('one')
         .write('two')
         .write('three');
@@ -85,13 +85,13 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion redundant
-    Set<String> things = new Set<String>();
+    Set<String> things = Set<String>();
     // #enddocregion redundant
   }
 
   {
     // #docregion explicit
-    var things = new Set();
+    var things = Set();
     // #enddocregion explicit
   }
 
@@ -183,7 +183,7 @@ class Point {
   num x, y;
   Point(this.x, this.y);
   static Point polar(num theta, num radius) =>
-      new Point(radius * cos(theta), radius * sin(theta));
+      Point(radius * cos(theta), radius * sin(theta));
 }
 // #enddocregion named-ctr
 

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -35,8 +35,8 @@ void miscDeclAnalyzedButNotTested() {
   (Func1 entryPoint, message, Iterable elements, String pattern) {
     // #docregion omit-verb-for-bool-param
     Isolate.spawn(entryPoint, message, paused: false);
-    var copy = new List.from(elements, growable: true);
-    var regExp = new RegExp(pattern, caseSensitive: false);
+    var copy = List.from(elements, growable: true);
+    var regExp = RegExp(pattern, caseSensitive: false);
     // #enddocregion omit-verb-for-bool-param
   };
 
@@ -114,7 +114,7 @@ void miscDeclAnalyzedButNotTested() {
 
   () {
     // #docregion cascades
-    var buffer = new StringBuffer() //!<br>
+    var buffer = StringBuffer() //!<br>
       ..write('one')
       ..write('two')
       ..write('three');
@@ -131,7 +131,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion annotate-invocation
     var lists = <num>[1, 2];
-    lists.addAll(new List<num>.filled(3, 4));
+    lists.addAll(List<num>.filled(3, 4));
     lists.cast<int>();
     // #enddocregion annotate-invocation
   }
@@ -196,13 +196,13 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion redundant
-    Set<String> things = new Set();
+    Set<String> things = Set();
     // #enddocregion redundant
   }
 
   {
     // #docregion explicit
-    var things = new Set<String>();
+    var things = Set<String>();
     // #enddocregion explicit
   }
 
@@ -226,7 +226,7 @@ void miscDeclAnalyzedButNotTested() {
       } else if (errorHandler is Function(Object, StackTrace)) {
         errorHandler(err, stack);
       } else {
-        throw new ArgumentError("errorHandler has wrong signature.");
+        throw ArgumentError("errorHandler has wrong signature.");
       }
     }
   }
@@ -243,7 +243,7 @@ void miscDeclAnalyzedButNotTested() {
     bool convertToBool(dynamic arg) {
       if (arg is bool) return arg;
       if (arg is String) return arg == 'true';
-      throw new ArgumentError('Cannot convert $arg to a bool.');
+      throw ArgumentError('Cannot convert $arg to a bool.');
     }
     // #enddocregion Object-vs-dynamic
   };
@@ -263,10 +263,10 @@ void miscDeclAnalyzedButNotTested() {
 
   () {
     // #docregion avoid-positional-bool-param
-    new Task.oneShot();
-    new Task.repeating();
-    new ListBox(scroll: true, showScrollbars: true);
-    new Button(ButtonState.enabled);
+    Task.oneShot();
+    Task.repeating();
+    ListBox(scroll: true, showScrollbars: true);
+    Button(ButtonState.enabled);
     // #enddocregion avoid-positional-bool-param
   };
 

--- a/examples/misc/lib/effective_dart/style_bad.dart
+++ b/examples/misc/lib/effective_dart/style_bad.dart
@@ -4,10 +4,10 @@ import 'dart:math';
 // #docregion const-names
 const PI = 3.14;
 const kDefaultTimeout = 1000;
-final URL_SCHEME = new RegExp('^([a-z]+):');
+final URL_SCHEME = RegExp('^([a-z]+):');
 
 class Dice {
-  static final NUMBER_GENERATOR = new Random();
+  static final NUMBER_GENERATOR = Random();
 }
 // #enddocregion const-names
 

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -84,7 +84,7 @@ class B {/* ... */}
 //----------------------------------------------------------------------------
 
 // #docregion annotation-const
-const foo = const Foo();
+const foo = Foo();
 
 @foo
 class C {/* ... */}
@@ -95,9 +95,9 @@ class C {/* ... */}
 // #docregion const-names
 const pi = 3.14;
 const defaultTimeout = 1000;
-final urlScheme = new RegExp('^([a-z]+):');
+final urlScheme = RegExp('^([a-z]+):');
 
 class Dice {
-  static final numberGenerator = new Random();
+  static final numberGenerator = Random();
 }
 // #enddocregion const-names

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -198,6 +198,19 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion arrow-long
   };
 
+  // #docregion no-new
+  Widget build(BuildContext context) {
+    return new Row(
+      children: [
+        new RaisedButton(
+          child: new Text('Increment'),
+        ),
+        new Text('Click!'),
+      ],
+    );
+  }
+  // #enddocregion no-new
+
   {
     // #docregion no-const
     const primaryColors = const [

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -30,15 +30,15 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion collection-literals
-    var points = new List();
-    var addresses = new Map();
+    var points = List();
+    var addresses = Map();
     // #enddocregion collection-literals
   }
 
   {
     // #docregion generic-collection-literals
-    var points = new List<Point>();
-    var addresses = new Map<String, Address>();
+    var points = List<Point>();
+    var addresses = Map<String, Address>();
     // #enddocregion generic-collection-literals
   }
 
@@ -166,9 +166,9 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion avoid-completer
     Future<bool> fileContainsBear(String path) {
-      var completer = new Completer<bool>();
+      var completer = Completer<bool>();
 
-      new File(path).readAsString().then((contents) {
+      File(path).readAsString().then((contents) {
         completer.complete(contents.contains('bear'));
       });
 
@@ -193,7 +193,7 @@ void miscDeclAnalyzedButNotTested() {
   (Map<Chest, Treasure> _opened) {
     // #docregion arrow-long
     Treasure openChest(Chest chest, Point where) =>
-        _opened.containsKey(chest) ? null : _opened[chest] = new Treasure(where)
+        _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
           ..addAll(chest.contents);
     // #enddocregion arrow-long
   };
@@ -219,7 +219,7 @@ class BadTeam extends Team {
   // #docregion async-await
   Future<int> countActivePlayers(String teamName) {
     return downloadTeam(teamName).then((team) {
-      if (team == null) return new Future.value(0);
+      if (team == null) return Future.value(0);
 
       return team.roster.then((players) {
         return players.where((player) => player.isActive).length;

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -14,7 +14,8 @@ Func1<bool, dynamic> canHandle, verifyResult;
 void miscDeclAnalyzedButNotTested() {
   {
     // #docregion adjacent-strings-literals
-    raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
+    raiseAlarm(
+        'ERROR: Parts of the spaceship are on fire. Other '
         'parts are overrun by martians. Unclear which are which.');
     // #enddocregion adjacent-strings-literals
   }

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -452,8 +452,6 @@ class Text {
   Text(String text);
 }
 
-// TODO(rnystrom): Remove "new" here instead of stripping it out later once
-// we support optional new for excerpts.
 // #docregion no-new
 Widget build(BuildContext context) {
   return Row(

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -14,8 +14,7 @@ Func1<bool, dynamic> canHandle, verifyResult;
 void miscDeclAnalyzedButNotTested() {
   {
     // #docregion adjacent-strings-literals
-    raiseAlarm(
-        'ERROR: Parts of the spaceship are on fire. Other '
+    raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
         'parts are overrun by martians. Unclear which are which.');
     // #enddocregion adjacent-strings-literals
   }
@@ -67,7 +66,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion cast-list
     var stuff = <dynamic>[1, 2];
-    var ints = new List<int>.from(stuff);
+    var ints = List<int>.from(stuff);
     // #enddocregion cast-list
   }
 
@@ -98,7 +97,7 @@ void miscDeclAnalyzedButNotTested() {
   // #docregion cast-from
   int median(List<Object> objects) {
     // We happen to know the list only contains ints.
-    var ints = new List<int>.from(objects);
+    var ints = List<int>.from(objects);
     ints.sort();
     return ints[ints.length ~/ 2];
   }
@@ -190,7 +189,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion avoid-completer
     Future<bool> fileContainsBear(String path) {
-      return new File(path).readAsString().then((contents) {
+      return File(path).readAsString().then((contents) {
         return contents.contains('bear');
       });
     }
@@ -213,16 +212,13 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion avoid-completer-alt
     Future<bool> fileContainsBear(String path) async {
-      var contents = await new File(path).readAsString();
+      var contents = await File(path).readAsString();
       return contents.contains('bear');
     }
     // #enddocregion avoid-completer-alt
   }
 
-  // TODO(rnystrom): Uncomment this when the analyzer run on these excerpts
-  // supports optional const.
   {
-    /*
     // #docregion no-const
     const primaryColors = [
       Color("red", [255, 0, 0]),
@@ -230,7 +226,6 @@ void miscDeclAnalyzedButNotTested() {
       Color("blue", [0, 0, 255]),
     ];
     // #enddocregion no-const
-    */
   }
 }
 
@@ -352,14 +347,14 @@ class C {
 
   // #docregion arrow-setter
   num get x => center.x;
-  set x(num value) => center = new Point(value, center.y);
+  set x(num value) => center = Point(value, center.y);
   // #enddocregion arrow-setter
 
   // #docregion arrow-long
   Treasure openChest(Chest chest, Point where) {
     if (_opened.containsKey(chest)) return null;
 
-    var treasure = new Treasure(where);
+    var treasure = Treasure(where);
     treasure.addAll(chest.contents);
     _opened[chest] = treasure;
     return treasure;
@@ -460,12 +455,12 @@ class Text {
 // we support optional new for excerpts.
 // #docregion no-new
 Widget build(BuildContext context) {
-  return new Row(
+  return Row(
     children: [
-      new RaisedButton(
-        child: new Text('Increment'),
+      RaisedButton(
+        child: Text('Increment'),
       ),
-      new Text('Click!'),
+      Text('Click!'),
     ],
   );
 }

--- a/scripts/analyze-and-test-examples.sh
+++ b/scripts/analyze-and-test-examples.sh
@@ -12,7 +12,6 @@ ROOT=$(pwd)
 
 # https://github.com/dart-lang/sdk/issues/32235 explicitly add --no-implicit-casts even if option is set to false in config file.
 ANALYZE="dartanalyzer --preview-dart-2 --strong --no-implicit-casts "
-export DART_VM_OPTIONS=--preview-dart-2
 DART_MAJOR_VERS=$(dart --version 2>&1 | perl -pe '($_)=/version: (\d)\./')
 EXAMPLES="$ROOT/examples"
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -230,8 +230,8 @@ site.
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
 {% prettify dart %}
 Isolate.spawn(entryPoint, message, paused: false);
-var copy = new List.from(elements, growable: true);
-var regExp = new RegExp(pattern, caseSensitive: false);
+var copy = List.from(elements, growable: true);
+var regExp = RegExp(pattern, caseSensitive: false);
 {% endprettify %}
 
 
@@ -760,7 +760,7 @@ class Point {
   num x, y;
   Point(this.x, this.y);
   static Point polar(num theta, num radius) =>
-      new Point(radius * cos(theta), radius * sin(theta));
+      Point(radius * cos(theta), radius * sin(theta));
 }
 {% endprettify %}
 
@@ -963,7 +963,7 @@ Method cascades are a better solution for chaining method calls.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (cascades)"?>
 {% prettify dart %}
-var buffer = new StringBuffer()
+var buffer = StringBuffer()
   ..write('one')
   ..write('two')
   ..write('three');
@@ -972,7 +972,7 @@ var buffer = new StringBuffer()
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (cascades)"?>
 {% prettify dart %}
-var buffer = new StringBuffer()
+var buffer = StringBuffer()
     .write('one')
     .write('two')
     .write('three');
@@ -1008,7 +1008,7 @@ runtime.
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-invocation)"?>
 {% prettify dart %}
 var lists = <num>[1, 2];
-lists.addAll(new List<num>.filled(3, 4));
+lists.addAll(List<num>.filled(3, 4));
 lists.cast<int>();
 {% endprettify %}
 
@@ -1229,13 +1229,13 @@ to a function, then inference usually fills in the type for you:
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (redundant)"?>
 {% prettify dart %}
-Set<String> things = new Set();
+Set<String> things = Set();
 {% endprettify %}
 
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (redundant)"?>
 {% prettify dart %}
-Set<String> things = new Set<String>();
+Set<String> things = Set<String>();
 {% endprettify %}
 
 Here, the type annotation on the variable is used to infer the type argument of
@@ -1247,13 +1247,13 @@ should write the type argument:
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (explicit)"?>
 {% prettify dart %}
-var things = new Set<String>();
+var things = Set<String>();
 {% endprettify %}
 
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (explicit)"?>
 {% prettify dart %}
-var things = new Set();
+var things = Set();
 {% endprettify %}
 
 Here, since the variable has no type annotation, there isn't enough context to
@@ -1378,7 +1378,7 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
     } else if (errorHandler is [!Function(Object, StackTrace)!]) {
       errorHandler(err, stack);
     } else {
-      throw new ArgumentError("errorHandler has wrong signature.");
+      throw ArgumentError("errorHandler has wrong signature.");
     }
   }
 }
@@ -1549,7 +1549,7 @@ void log(Object object) {
 bool convertToBool(dynamic arg) {
   if (arg is bool) return arg;
   if (arg is String) return arg == 'true';
-  throw new ArgumentError('Cannot convert $arg to a bool.');
+  throw ArgumentError('Cannot convert $arg to a bool.');
 }
 {% endprettify %}
 
@@ -1644,10 +1644,10 @@ to clarify what the call is doing.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-positional-bool-param)"?>
 {% prettify dart %}
-new Task.oneShot();
-new Task.repeating();
-new ListBox(scroll: true, showScrollbars: true);
-new Button(ButtonState.enabled);
+Task.oneShot();
+Task.repeating();
+ListBox(scroll: true, showScrollbars: true);
+Button(ButtonState.enabled);
 {% endprettify %}
 
 Note that this doesn't apply to setters, where the name makes it clear what the

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -73,7 +73,7 @@ create a separate `lowerCamelCase` constant for it.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-const)"?>
 {% prettify dart %}
-const foo = const Foo();
+const foo = Foo();
 
 @foo
 class C { ... }
@@ -163,10 +163,10 @@ stay consistent.
 {% prettify dart %}
 const pi = 3.14;
 const defaultTimeout = 1000;
-final urlScheme = new RegExp('^([a-z]+):');
+final urlScheme = RegExp('^([a-z]+):');
 
 class Dice {
-  static final numberGenerator = new Random();
+  static final numberGenerator = Random();
 }
 {% endprettify %}
 
@@ -175,10 +175,10 @@ class Dice {
 {% prettify dart %}
 const PI = 3.14;
 const kDefaultTimeout = 1000;
-final URL_SCHEME = new RegExp('^([a-z]+):');
+final URL_SCHEME = RegExp('^([a-z]+):');
 
 class Dice {
-  static final NUMBER_GENERATOR = new Random();
+  static final NUMBER_GENERATOR = Random();
 }
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -136,6 +136,8 @@
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
 
 **Error handling**
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -137,7 +137,8 @@ a single long string that doesn't fit on one line.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (adjacent-strings-literals)"?>
 {% prettify dart %}
-raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other '
     'parts are overrun by martians. Unclear which are which.');
 {% endprettify %}
 
@@ -617,7 +618,7 @@ void insert(Object item, {int at = 0}) { ... }
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-separator)"?>
 {% prettify dart %}
-void insert(Object item, {int at = 0}) { ... }
+void insert(Object item, {int at: 0}) { ... }
 {% endprettify %}
 
 
@@ -1088,7 +1089,7 @@ The language still permits `new` in order to make migration less painful, but
 consider it deprecated and remove it from your code.
 
 {:.good-style}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)" replace="/new //g"?>
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)"?>
 {% prettify dart %}
 Widget build(BuildContext context) {
   return Row(
@@ -1097,6 +1098,21 @@ Widget build(BuildContext context) {
         child: Text('Increment'),
       ),
       Text('Click!'),
+    ],
+  );
+}
+{% endprettify %}
+
+{:.bad-style}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)"?>
+{% prettify dart %}
+Widget build(BuildContext context) {
+  return new Row(
+    children: [
+      new RaisedButton(
+        child: new Text('Increment'),
+      ),
+      new Text('Click!'),
     ],
   );
 }

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -137,8 +137,7 @@ a single long string that doesn't fit on one line.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (adjacent-strings-literals)"?>
 {% prettify dart %}
-raiseAlarm(
-    'ERROR: Parts of the spaceship are on fire. Other '
+raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
     'parts are overrun by martians. Unclear which are which.');
 {% endprettify %}
 
@@ -213,8 +212,8 @@ var addresses = {};
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (collection-literals)"?>
 {% prettify dart %}
-var points = new List();
-var addresses = new Map();
+var points = List();
+var addresses = Map();
 {% endprettify %}
 
 You can even provide a type argument for them if that matters.
@@ -229,8 +228,8 @@ var addresses = <String, Address>{};
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (generic-collection-literals)"?>
 {% prettify dart %}
-var points = new List<Point>();
-var addresses = new Map<String, Address>();
+var points = List<Point>();
+var addresses = Map<String, Address>();
 {% endprettify %}
 
 Note that this doesn't apply to the *named* constructors for those classes.
@@ -413,7 +412,7 @@ If you're already calling `toList()`, replace that with a call to
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-list)"?>
 {% prettify dart %}
 var stuff = <dynamic>[1, 2];
-var ints = new List<int>.from(stuff);
+var ints = List<int>.from(stuff);
 {% endprettify %}
 
 {:.bad-style}
@@ -519,7 +518,7 @@ Here is **casting eagerly using `List.from()`:**
 {% prettify dart %}
 int median(List<Object> objects) {
   // We happen to know the list only contains ints.
-  var ints = new List<int>.from(objects);
+  var ints = List<int>.from(objects);
   ints.sort();
   return ints[ints.length ~/ 2];
 }
@@ -618,7 +617,7 @@ void insert(Object item, {int at = 0}) { ... }
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-separator)"?>
 {% prettify dart %}
-void insert(Object item, {int at: 0}) { ... }
+void insert(Object item, {int at = 0}) { ... }
 {% endprettify %}
 
 
@@ -871,7 +870,7 @@ your code a favor and use a block body and some statements.
 Treasure openChest(Chest chest, Point where) {
   if (_opened.containsKey(chest)) return null;
 
-  var treasure = new Treasure(where);
+  var treasure = Treasure(where);
   treasure.addAll(chest.contents);
   _opened[chest] = treasure;
   return treasure;
@@ -882,7 +881,7 @@ Treasure openChest(Chest chest, Point where) {
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (arrow-long)"?>
 {% prettify dart %}
 Treasure openChest(Chest chest, Point where) =>
-    _opened.containsKey(chest) ? null : _opened[chest] = new Treasure(where)
+    _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
       ..addAll(chest.contents);
 {% endprettify %}
 
@@ -893,7 +892,7 @@ when a setter is small and has a corresponding getter that uses `=>`.
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-setter)"?>
 {% prettify dart %}
 num get x => center.x;
-set x(num value) => center = new Point(value, center.y);
+set x(num value) => center = Point(value, center.y);
 {% endprettify %}
 
 It's rarely a good idea to use `=>` for non-setter void members. The `=>`
@@ -1079,12 +1078,7 @@ class Point {
 }
 {% endprettify %}
 
-<!-- TODO(rnystrom): Uncomment this when all Dart tools support it. -->
-<!--
-
-**TODO: Use "###" for header. Removed so this doesn't go into TOC.**
-
-DON'T use `new`.
+### DON'T use `new`.
 
 Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
 clear because factory constructors mean a `new` invocation may still not
@@ -1109,9 +1103,7 @@ Widget build(BuildContext context) {
 {% endprettify %}
 
 
-**TODO: Use "###" for header. Removed so this doesn't go into TOC.**
-
-DON'T use `const` redundantly.
+### DON'T use `const` redundantly.
 
 In contexts where an expression *must* be constant, the `const` keyword is
 implicit, doesn't need to be written, and shouldn't. Those contexts are any
@@ -1149,8 +1141,6 @@ const primaryColors = const [
   const Color("blue", const [0, 0, 255]),
 ];
 {% endprettify %}
-
--->
 
 ## Error handling
 
@@ -1274,7 +1264,7 @@ Future<int> countActivePlayers(String teamName) [!async!] {
 {% prettify dart %}
 Future<int> countActivePlayers(String teamName) {
   return downloadTeam(teamName).then((team) {
-    if (team == null) return new Future.value(0);
+    if (team == null) return Future.value(0);
 
     return team.roster.then((players) {
       return players.where((player) => player.isActive).length;
@@ -1348,9 +1338,9 @@ eventually find the Completer class and use that.
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-completer)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) {
-  var completer = new Completer<bool>();
+  var completer = Completer<bool>();
 
-  new File(path).readAsString().then((contents) {
+  File(path).readAsString().then((contents) {
     completer.complete(contents.contains('bear'));
   });
 
@@ -1369,7 +1359,7 @@ they're clearer and make error handling easier.
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) {
-  return new File(path).readAsString().then((contents) {
+  return File(path).readAsString().then((contents) {
     return contents.contains('bear');
   });
 }
@@ -1379,7 +1369,7 @@ Future<bool> fileContainsBear(String path) {
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer-alt)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) async {
-  var contents = await new File(path).readAsString();
+  var contents = await File(path).readAsString();
   return contents.contains('bear');
 }
 {% endprettify %}


### PR DESCRIPTION
- Remove unneeded "new"/"const" from excerpts (except for deliberately
  bad examples).
- Add guidelines for optional "new" and optional "const".
- Fix scripts/analyze-and-test-examples.sh now that the VM does not
  accept --preview-dart-2.