### PR TITLE
Upgrade to SDK 2-dev.64.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: dart
-dart: 2.0.0-dev.63.0
+dart: 2.0.0-dev.64.1
 
 cache:
   timeout: 300
@@ -12,8 +12,6 @@ cache:
 
 env:
   global:
-    # https://github.com/dart-lang/sdk/issues/33430
-    # - DART_VM_OPTIONS=--preview-dart-2
     - JEKYLL_ENV=production
     - TZ=US/Pacific # normalize build timestamp
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ script:
   - $TASK
 
 after_script:
-  - if [[ $TASK == *build* ]]; then ./scripts/shared/check-links.sh || travis_terminate 1; fi
+  # Waiting on https://github.com/dart-lang/site-www/issues/952 to re-enable link checking:
+  # - if [[ $TASK == *build* ]]; then ./scripts/shared/check-links.sh || travis_terminate 1; fi
   # Just FYI test. Won't fail the build if it has errors.
   # - if [[ $TASK == *build* ]]; then ./deploy/check_sitemap.rb; fi
   # - if [[ $TASK == *build* ]]; then ./deploy/html_proof.rb; fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ To run only the analyzer:
 
 ```
 cd examples
-dartanalyzer --preview-dart-2 .
+dartanalyzer .
 ```
 
 To run both the analyzer and tests:

--- a/examples/httpserver/pubspec.yaml
+++ b/examples/httpserver/pubspec.yaml
@@ -3,10 +3,10 @@ description: Sample HTTP clients and servers
 homepage: https://www.dartlang.org/docs/tutorials/httpserver/
 
 environment:
-  sdk: '>=2.0.0-dev.51.0 <2.0.0'
+  sdk: '>=2.0.0-dev.64.1 <2.0.0'
 
 dependencies:
   http_server: ^0.9.6
 
 dev_dependencies:
-  test: ^0.12.42
+  test: ^1.0.0

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -1,11 +1,10 @@
 name: examples
 description: dartlang.org example code.
-version: 0.0.1
 
 environment:
-  sdk: '>=2.0.0-dev.51.0 <2.0.0'
+  sdk: '>=2.0.0-dev.64.1 <2.0.0'
 
 dev_dependencies:
-  test: ^0.12.42
+  test: ^1.0.0
   dartlang_examples_util:
     path: ../util

--- a/examples/strong/pubspec.yaml
+++ b/examples/strong/pubspec.yaml
@@ -1,11 +1,10 @@
 name: dartlang_strong
 description: dartlang.org strong mode examples
-version: 0.0.1
 
 environment:
-  sdk: '>=2.0.0-dev.51.0 <2.0.0'
+  sdk: '>=2.0.0-dev.64.1 <2.0.0'
 
 dependencies:
-  test: ^0.12.42
+  test: ^1.0.0
   dartlang_examples_util:
     path: ../util

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dartlang_examples_util
 description: dartlang.org example utilities.
-version: 0.0.1
+version: 0.0.2
 
 environment:
-  sdk: '>=2.0.0-dev.51.0 <2.0.0'
+  sdk: '>=2.0.0-dev.64.1 <2.0.0'
 
 dependencies:
-  test: ^0.12.42
+  test: ^1.0.0

--- a/scripts/analyze-and-test-examples.sh
+++ b/scripts/analyze-and-test-examples.sh
@@ -11,8 +11,7 @@ cd `dirname $0`/..
 ROOT=$(pwd)
 
 # https://github.com/dart-lang/sdk/issues/32235 explicitly add --no-implicit-casts even if option is set to false in config file.
-ANALYZE="dartanalyzer --preview-dart-2 --strong --no-implicit-casts "
-export DART_VM_OPTIONS=--preview-dart-2
+ANALYZE="dartanalyzer --no-implicit-casts "
 DART_MAJOR_VERS=$(dart --version 2>&1 | perl -pe '($_)=/version: (\d)\./')
 EXAMPLES="$ROOT/examples"
 

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "dev",
     "prev-vers": "1.24.3",
-    "vers": "2.0.0-dev.63.0"
+    "vers": "2.0.0-dev.64.1"
   }
 }


### PR DESCRIPTION
- No longer set `DART_VM_OPTIONS=--preview-dart-2`
- Set min SDK to 2-dev.64.1 for examples.
- Upgrade to test 1.0.0