### PR TITLE
Add warning about VM deferred libraries

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3542,10 +3542,8 @@ Keep in mind the following when you use deferred loading:
 
 <aside class="alert alert-warning" markdown="1">
 **Dart VM difference:**
-Currently, although the Dart VM recognizes the `deferred` keyword and related APIs,
-the VM eagerly loads deferred libraries and allows them to be used.
-**Don't depend on the Dart VM and generated JavaScript code
-treating deferred libraries in the same way.**
+Currently, the Dart VM allows access to members of deferred libraries
+even before the call to `loadLibrary()`.
 For more information, see
 [issue #33118.](https://github.com/dart-lang/sdk/issues/33118)
 </aside>

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -14,10 +14,6 @@ To learn more about Dart's core libraries, see
 Whenever you want more details about a language feature,
 consult the [Dart Language Specification](/guides/language/spec).
 
-{% comment %}
-update-for-dart-2
-TODO: Uncomment when DartPad supports Dart 2 semantics.
-
 <div class="alert alert-info" markdown="1">
 **Tip:**
 You can play with most of Dart's language features using DartPad
@@ -25,7 +21,6 @@ You can play with most of Dart's language features using DartPad
 
 **<a href="{{ site.custom.dartpad.direct-link }}" target="_blank">Open DartPad</a>**
 </div>
-{% endcomment %}
 
 
 ## A basic Dart program
@@ -3544,6 +3539,16 @@ Keep in mind the following when you use deferred loading:
 * Dart implicitly inserts `loadLibrary()` into the namespace that you define
   using <code>deferred as <em>namespace</em></code>.
   The `loadLibrary()` function returns a [Future](/guides/libraries/library-tour#future).
+
+<aside class="alert alert-warning" markdown="1">
+**Dart VM difference:**
+Currently, although the Dart VM recognizes the `deferred` keyword and related APIs,
+the VM eagerly loads deferred libraries and allows them to be used.
+**Don't depend on the Dart VM and generated JavaScript code
+treating deferred libraries in the same way.**
+For more information, see
+[issue #33118.](https://github.com/dart-lang/sdk/issues/33118)
+</aside>
 
 ### Implementing libraries
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3542,10 +3542,11 @@ Keep in mind the following when you use deferred loading:
 
 <aside class="alert alert-warning" markdown="1">
 **Dart VM difference:**
-Currently, the Dart VM allows access to members of deferred libraries
+Due to [issue #33118](https://github.com/dart-lang/sdk/issues/33118),
+the Dart VM allows access to members of deferred libraries
 even before the call to `loadLibrary()`.
-For more information, see
-[issue #33118.](https://github.com/dart-lang/sdk/issues/33118)
+We expect this bug to be fixed soon, so
+**don't depend on the current VM behavior.**
 </aside>
 
 ### Implementing libraries


### PR DESCRIPTION
Also add back the link to DartPad, now that it supports Dart 2.

Staged: https://kw-staging-dartlang-2.firebaseapp.com/guides/language/language-tour#deferred-loading

Fixes dart-lang/sdk#33561.