### PR TITLE
run dartfmt --fix on examples

### DIFF
--- a/examples/httpserver/bin/basic_file_server.dart
+++ b/examples/httpserver/bin/basic_file_server.dart
@@ -13,10 +13,10 @@ import 'dart:async';
 import 'dart:io';
 import 'package:http_server/http_server.dart';
 
-File targetFile = new File('index.html');
+File targetFile = File('index.html');
 
 Future main() async {
-  VirtualDirectory staticFiles = new VirtualDirectory('.');
+  VirtualDirectory staticFiles = VirtualDirectory('.');
 
   var serverRequests =
       await HttpServer.bind(InternetAddress.loopbackIPv4, 4046);

--- a/examples/httpserver/bin/basic_writer_client.dart
+++ b/examples/httpserver/bin/basic_writer_client.dart
@@ -23,10 +23,9 @@ Map jsonData = {
 };
 
 Future main() async {
-  HttpClientRequest request =
-      await new HttpClient().post(_host, 4049, path) /*1*/
-        ..headers.contentType = ContentType.json /*2*/
-        ..write(jsonEncode(jsonData)); /*3*/
+  HttpClientRequest request = await HttpClient().post(_host, 4049, path) /*1*/
+    ..headers.contentType = ContentType.json /*2*/
+    ..write(jsonEncode(jsonData)); /*3*/
   HttpClientResponse response = await request.close(); /*4*/
   await response.transform(utf8.decoder /*5*/).forEach(print);
 }

--- a/examples/httpserver/bin/basic_writer_server.dart
+++ b/examples/httpserver/bin/basic_writer_server.dart
@@ -26,7 +26,7 @@ Future main() async {
             await req.transform(utf8.decoder).join(); /*2*/
         var data = jsonDecode(content) as Map; /*3*/
         var fileName = req.uri.pathSegments.last; /*4*/
-        await new File(fileName)
+        await File(fileName)
             .writeAsString(content, mode: FileMode.write);
         req.response
           ..statusCode = HttpStatus.ok

--- a/examples/httpserver/bin/hello_world_server_secure.dart
+++ b/examples/httpserver/bin/hello_world_server_secure.dart
@@ -18,7 +18,7 @@ String certificateChain = 'server_chain.pem';
 String serverKey = 'server_key.pem';
 
 Future main() async {
-  var serverContext = new SecurityContext(); /*1*/
+  var serverContext = SecurityContext(); /*1*/
   serverContext.useCertificateChain(certificateChain); /*2*/
   serverContext.usePrivateKey(serverKey, password: 'dartdart'); /*3*/
 

--- a/examples/httpserver/bin/mini_file_server.dart
+++ b/examples/httpserver/bin/mini_file_server.dart
@@ -11,7 +11,7 @@
 import 'dart:async';
 import 'dart:io';
 
-File targetFile = new File('index.html');
+File targetFile = File('index.html');
 
 Future main() async {
   var server;

--- a/examples/httpserver/bin/note_server.dart
+++ b/examples/httpserver/bin/note_server.dart
@@ -14,7 +14,7 @@ int count = 0;
 Future main() async {
   // One note per line.
   try {
-    List<String> lines = new File('notes.txt').readAsLinesSync();
+    List<String> lines = File('notes.txt').readAsLinesSync();
     count = lines.length;
   } on FileSystemException {
     print('Could not open notes.txt.');
@@ -67,7 +67,7 @@ Future handlePost(HttpRequest request) async {
 
 void saveNote(HttpRequest request, String myNote) {
   try {
-    new File('notes.txt')
+    File('notes.txt')
         .writeAsStringSync(myNote, mode: FileMode.append);
   } catch (e) {
     print('Couldn\'t open notes.txt: $e');
@@ -88,7 +88,7 @@ void saveNote(HttpRequest request, String myNote) {
 void getNote(HttpRequest request, String getNote) {
   final requestedNote = int.tryParse(getNote) ?? 0;
   if (requestedNote >= 0 && requestedNote < count) {
-    List<String> lines = new File('notes.txt').readAsLinesSync();
+    List<String> lines = File('notes.txt').readAsLinesSync();
     request.response
       ..statusCode = HttpStatus.ok
       ..writeln(lines[requestedNote])

--- a/examples/httpserver/bin/number_guesser.dart
+++ b/examples/httpserver/bin/number_guesser.dart
@@ -10,12 +10,12 @@ import 'dart:io';
 import 'dart:math';
 
 Duration oneSecond = const Duration(seconds: 1);
-Random myRandomGenerator = new Random();
-HttpClient client = new HttpClient();
+Random myRandomGenerator = Random();
+HttpClient client = HttpClient();
 
 Future main() async {
   // Delay successive guesses by oneSecond.
-  final guesses = new Stream.periodic(oneSecond, (_) => guess());
+  final guesses = Stream.periodic(oneSecond, (_) => guess());
 
   // Guess until we get it right
   await for (final guess in guesses) {

--- a/examples/httpserver/bin/number_thinker.dart
+++ b/examples/httpserver/bin/number_thinker.dart
@@ -12,7 +12,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' show Random;
 
-Random intGenerator = new Random();
+Random intGenerator = Random();
 int myNumber = intGenerator.nextInt(10);
 
 Future main() async {

--- a/examples/httpserver/bin/static_file_server.dart
+++ b/examples/httpserver/bin/static_file_server.dart
@@ -14,11 +14,11 @@ import 'package:path/path.dart';
 Future main() async {
   var pathToBuild = join(dirname(Platform.script.toFilePath()));
 
-  var staticFiles = new VirtualDirectory(pathToBuild);
+  var staticFiles = VirtualDirectory(pathToBuild);
   staticFiles.allowDirectoryListing = true; /*1*/
   staticFiles.directoryHandler = (dir, request) /*2*/ {
-    var indexUri = new Uri.file(dir.path).resolve('index.html');
-    staticFiles.serveFile(new File(indexUri.toFilePath()), request); /*3*/
+    var indexUri = Uri.file(dir.path).resolve('index.html');
+    staticFiles.serveFile(File(indexUri.toFilePath()), request); /*3*/
   };
 
   var server = await HttpServer.bind(InternetAddress.loopbackIPv4, 4048);

--- a/examples/httpserver/test/httpserver_test.dart
+++ b/examples/httpserver/test/httpserver_test.dart
@@ -80,7 +80,7 @@ void main() {
   });
 
   group('basic_writer_client and server:', () {
-    final file = new File('file.txt');
+    final file = File('file.txt');
     final port = 4049;
 
     // Only resolve the server once for all tests in this group to avoid
@@ -130,7 +130,7 @@ void main() {
   });
 
   test('mini_file_server', () {
-    final file = new File('bin/index.html');
+    final file = File('bin/index.html');
 
     _server() {
       mini_file_server.targetFile = file;
@@ -150,7 +150,7 @@ void main() {
   });
 
   test('basic_file_server', () async {
-    final file = new File('bin/index.html');
+    final file = File('bin/index.html');
 
     _server() {
       basic_file_server.targetFile = file;
@@ -179,8 +179,8 @@ void main() {
     }
 
     _test() async {
-      final client = new HttpClient();
-      final url = new Uri.https('localhost:$port', '');
+      final client = HttpClient();
+      final url = Uri.https('localhost:$port', '');
       final response = await client.getUrl(url);
       // expect(..., 'Hello, world!');
       await response.close();
@@ -200,7 +200,7 @@ Future<String> getUrl([
   int port = 8080,
   String path = '',
 ]) async {
-  final client = new HttpClient();
+  final client = HttpClient();
   final request = await client.get(host, port, path);
   final response = await request.close();
   final data = await response.transform(utf8.decoder).toList();

--- a/examples/httpserver/web/note_client.dart
+++ b/examples/httpserver/web/note_client.dart
@@ -27,7 +27,7 @@ void main() {
 }
 
 void saveNote(Event e) {
-  request = new HttpRequest();
+  request = HttpRequest();
   request.onReadyStateChange.listen(onData);
 
   request.open('POST', url);
@@ -39,7 +39,7 @@ void requestNote(Event e) {
 
   int getNoteNumber = int.tryParse(chooseNote.value) ?? 0;
 
-  request = new HttpRequest();
+  request = HttpRequest();
   request.onReadyStateChange.listen(onData);
 
   request.open('POST', url);

--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -49,7 +49,7 @@ void miscDeclAnalyzedButNotTested() {
     var aNum = 0;
     var aBool = true;
     var aString = 'a string';
-    const aConstList = const [1, 2, 3];
+    const aConstList = [1, 2, 3];
 
     const validConstString = '$aConstNum $aConstBool $aConstString';
     // const invalidConstString = '$aNum $aBool $aString $aConstList';

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -40,7 +40,7 @@ void miscDeclAnalyzedButNotTested() {
     // const [] creates an empty, immutable list (EIL).
     var foo = const []; // foo is currently an EIL.
     final bar = const []; // bar will always be an EIL.
-    const baz = const []; // baz is a compile-time constant EIL.
+    const baz = []; // baz is a compile-time constant EIL.
 
     // You can change the value of a non-final, non-const variable,
     // even if it used to have a const value.

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -51,7 +51,7 @@ void miscDeclAnalyzedButNotTested() {
     name = 'Alice'; // Error: a final variable can only be set once.
     // #enddocregion cant-assign-to-final
     // #docregion cant-assign-to-const
-    baz = []; // Error: Constant variables can't be assigned a value.
+    baz = [42]; // Error: Constant variables can't be assigned a value.
     // #enddocregion cant-assign-to-const
   }
 }

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -22,7 +22,6 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion final
     final name = 'Bob'; // Without a type annotation
-    // name = 'Alice';  // Uncommenting this causes an error
     final String nickname = 'Bobby';
     // #enddocregion final
   }
@@ -36,19 +35,23 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion const-vs-final
-    // Note: [] creates an empty list.
-    // const [] creates an empty, immutable list (EIL).
-    var foo = const []; // foo is currently an EIL.
-    final bar = const []; // bar will always be an EIL.
-    const baz = []; // baz is a compile-time constant EIL.
-
-    // You can change the value of a non-final, non-const variable,
-    // even if it used to have a const value.
-    foo = [];
-
-    // You can't change the value of a final or const variable.
-    // bar = []; // Unhandled exception.
-    // baz = []; // Unhandled exception.
+    var foo = const [];
+    final bar = const [];
+    const baz = []; // Equivalent to `const []`
     // #enddocregion const-vs-final
+
+    // #docregion reassign-to-non-final
+    foo = [1, 2, 3]; // Was const []
+    // #enddocregion reassign-to-non-final
+  }
+
+  {
+    var bar, baz, name;
+    // #docregion cant-assign-to-final
+    name = 'Alice'; // Error: a final variable can only be set once.
+    // #enddocregion cant-assign-to-final
+    // #docregion cant-assign-to-const
+    baz = []; // Error: Constant variables can't be assigned a value.
+    // #enddocregion cant-assign-to-const
   }
 }

--- a/examples/misc/lib/library_tour/async/stream.dart
+++ b/examples/misc/lib/library_tour/async/stream.dart
@@ -15,7 +15,7 @@ void miscDeclAnalyzedButNotTested() {
       // ...
       FileSystemEntity.isDirectory(searchPath).then((isDir) {
         if (isDir) {
-          final startingDir = new Directory(searchPath);
+          final startingDir = Directory(searchPath);
           startingDir
               .list(
                   recursive: argResults[recursive],
@@ -26,7 +26,7 @@ void miscDeclAnalyzedButNotTested() {
             }
           });
         } else {
-          searchFile(new File(searchPath), searchTerms);
+          searchFile(File(searchPath), searchTerms);
         }
       });
     }
@@ -38,7 +38,7 @@ void miscDeclAnalyzedButNotTested() {
     Future main(List<String> arguments) async {
       // ...
       if (await FileSystemEntity.isDirectory(searchPath)) {
-        final startingDir = new Directory(searchPath);
+        final startingDir = Directory(searchPath);
         await for (var entity in startingDir.list(
             recursive: argResults[recursive],
             followLinks: argResults[followLinks])) {
@@ -47,7 +47,7 @@ void miscDeclAnalyzedButNotTested() {
           }
         }
       } else {
-        searchFile(new File(searchPath), searchTerms);
+        searchFile(File(searchPath), searchTerms);
       }
     }
     // #enddocregion await-for
@@ -56,13 +56,13 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion readFileAwaitFor
     Future readFileAwaitFor() async {
-      var config = new File('config.txt');
+      var config = File('config.txt');
       Stream<List<int>> inputStream = config.openRead();
 
       // #docregion transform
       var lines = inputStream
           .transform(utf8.decoder)
-          .transform(new LineSplitter());
+          .transform(LineSplitter());
       // #enddocregion transform
       try {
         await for (var line in lines) {
@@ -78,12 +78,12 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion onDone
-    var config = new File('config.txt');
+    var config = File('config.txt');
     Stream<List<int>> inputStream = config.openRead();
 
     inputStream
         .transform(utf8.decoder)
-        .transform(new LineSplitter())
+        .transform(LineSplitter())
         .listen((String line) {
       print('Got ${line.length} characters from stream');
     }, onDone: () {

--- a/examples/misc/lib/library_tour/core/hash_code.dart
+++ b/examples/misc/lib/library_tour/core/hash_code.dart
@@ -29,8 +29,8 @@ class Person {
 }
 
 void main() {
-  var p1 = new Person('Bob', 'Smith');
-  var p2 = new Person('Bob', 'Smith');
+  var p1 = Person('Bob', 'Smith');
+  var p2 = Person('Bob', 'Smith');
   var p3 = 'not a person';
   assert(p1.hashCode == p2.hashCode);
   assert(p1 == p2);

--- a/examples/misc/lib/library_tour/core/iterator.dart
+++ b/examples/misc/lib/library_tour/core/iterator.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 
 final Iterator<Process> _it =
-    [new Process(), new Process(), new Process()].iterator;
+    [Process(), Process(), Process()].iterator;
 
 // #docregion
 class Process {
@@ -29,12 +29,12 @@ class ProcessIterator implements Iterator<Process> {
 // processes. Extends a subclass of [Iterable].
 class Processes extends IterableBase<Process> {
   @override
-  final Iterator<Process> iterator = new ProcessIterator();
+  final Iterator<Process> iterator = ProcessIterator();
 }
 
 void main() {
   // Iterable objects can be used with for-in.
-  for (var process in new Processes()) {
+  for (var process in Processes()) {
     // Do something with the process.
     // #enddocregion
     print(process.id);

--- a/examples/misc/lib/library_tour/io/http_server.dart
+++ b/examples/misc/lib/library_tour/io/http_server.dart
@@ -18,7 +18,7 @@ void processRequest(HttpRequest request) {
   final response = request.response;
   if (request.uri.path == '/dart') {
     response
-      ..headers.contentType = new ContentType(
+      ..headers.contentType = ContentType(
         'text',
         'plain',
       )

--- a/examples/misc/lib/samples/spacecraft.dart
+++ b/examples/misc/lib/samples/spacecraft.dart
@@ -18,10 +18,9 @@ class Spacecraft {
   void describe() {
     print('Spacecraft: $name');
     if (launchDate != null) {
-      int years = new DateTime.now()
-              .difference(launchDate)
-              .inDays ~/
-          365;
+      int years =
+          DateTime.now().difference(launchDate).inDays ~/
+              365;
       print('Launched: $launchYear ($years years ago)');
     } else {
       print('Unlaunched');

--- a/examples/misc/lib/tutorial/cat_no_hash.dart
+++ b/examples/misc/lib/tutorial/cat_no_hash.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 Future<void> main(List<String> args) async {
-  var file = new File(args[0]);
+  var file = File(args[0]);
   var lines = file
       .openRead()
       .transform(utf8.decoder) //!<br>

--- a/examples/misc/lib/tutorial/daily_news.dart
+++ b/examples/misc/lib/tutorial/daily_news.dart
@@ -83,7 +83,7 @@ Duration oneSecond = const Duration(seconds: 1);
 String _gatherNewsReportsSync() => news;
 
 // #docregion main-async, main-future-api
-final newsStream = new Stream<String>.periodic(oneSecond, (_) => news);
+final newsStream = Stream<String>.periodic(oneSecond, (_) => news);
 
 // Imagine that this function is more complex and slow. :)
 Future<String> _gatherNewsReportsAsync() => newsStream.first;

--- a/examples/misc/lib/tutorial/sum_stream_with_catch.dart
+++ b/examples/misc/lib/tutorial/sum_stream_with_catch.dart
@@ -17,7 +17,7 @@ Future<int> sumStream(Stream<int> stream) async {
 Stream<int> countStream(int to) async* {
   for (int i = 1; i <= to; i++) {
     if (i == 4) {
-      throw new Exception('Intentional exception');
+      throw Exception('Intentional exception');
     } else {
       yield i;
     }

--- a/examples/misc/test/effective_dart_test.dart
+++ b/examples/misc/test/effective_dart_test.dart
@@ -18,7 +18,7 @@ void main() {
       var iterable = [1, 2];
       // #docregion list-from-1
       var copy1 = iterable.toList();
-      var copy2 = new List.from(iterable);
+      var copy2 = List.from(iterable);
       // #enddocregion list-from-1
       expect(copy1, orderedEquals([1, 2]));
       expect(copy2, orderedEquals([1, 2]));
@@ -34,7 +34,7 @@ void main() {
         print(iterable.toList().runtimeType);
 
         // Prints "List<dynamic>":
-        print(new List.from(iterable).runtimeType);
+        print(List.from(iterable).runtimeType);
         // #enddocregion list-from-2
       }
 
@@ -45,7 +45,7 @@ void main() {
       // #docregion list-from-3
       var numbers = [1, 2.3, 4]; // List<num>.
       numbers.removeAt(1); // Now it only contains integers.
-      var ints = new List<int>.from(numbers);
+      var ints = List<int>.from(numbers);
       // #enddocregion list-from-3
 
       expect(ints, orderedEquals([1, 4]));

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -149,7 +149,7 @@ void main() {
       // #docregion replace
       var greetingTemplate = 'Hello, NAME!';
       var greeting =
-          greetingTemplate.replaceAll(new RegExp('NAME'), 'Bob');
+          greetingTemplate.replaceAll(RegExp('NAME'), 'Bob');
 
       // greetingTemplate didn't change.
       assert(greeting != greetingTemplate);
@@ -158,7 +158,7 @@ void main() {
 
     test('StringBuffer', () {
       // #docregion StringBuffer
-      var sb = new StringBuffer();
+      var sb = StringBuffer();
       sb
         ..write('Use a StringBuffer for ')
         ..writeAll(['efficient', 'string', 'creation'], ' ')
@@ -174,7 +174,7 @@ void main() {
     test('RegExp', () {
       // #docregion RegExp
       // Here's a regular expression for one or more digits.
-      var numbers = new RegExp(r'\d+');
+      var numbers = RegExp(r'\d+');
 
       var allCharacters = 'llamas live fifteen to twenty years';
       var someDigits = 'llamas live 15 to 20 years';
@@ -192,7 +192,7 @@ void main() {
     test('match', () {
       _test() {
         // #docregion match
-        var numbers = new RegExp(r'\d+');
+        var numbers = RegExp(r'\d+');
         var someDigits = 'llamas live 15 to 20 years';
 
         // Check whether the reg exp has a match in a string.
@@ -213,7 +213,7 @@ void main() {
     test('constructor', () {
       // #docregion List
       // Use a List constructor.
-      var vegetables = new List();
+      var vegetables = List();
 
       // Or simply use a list literal.
       var fruits = ['apples', 'oranges'];
@@ -264,7 +264,7 @@ void main() {
     test('ListOfString', () {
       // #docregion ListOfString
       // This list should contain only strings.
-      var fruits = new List<String>();
+      var fruits = List<String>();
 
       fruits.add('apples');
       var fruit = fruits[0];
@@ -283,7 +283,7 @@ void main() {
   group('Collections: Set', () {
     test('constructor', () {
       // #docregion Set
-      var ingredients = new Set();
+      var ingredients = Set();
       ingredients.addAll(['gold', 'titanium', 'xenon']);
       assert(ingredients.length == 3);
 
@@ -299,7 +299,7 @@ void main() {
 
     test('contains', () {
       // #docregion contains
-      var ingredients = new Set();
+      var ingredients = Set();
       ingredients.addAll(['gold', 'titanium', 'xenon']);
 
       // Check whether an item is in the set.
@@ -312,11 +312,11 @@ void main() {
 
     test('intersection', () {
       // #docregion intersection
-      var ingredients = new Set();
+      var ingredients = Set();
       ingredients.addAll(['gold', 'titanium', 'xenon']);
 
       // Create the intersection of two sets.
-      var nobleGases = new Set.from(['xenon', 'argon']);
+      var nobleGases = Set.from(['xenon', 'argon']);
       var intersection = ingredients.intersection(nobleGases);
       assert(intersection.length == 1);
       assert(intersection.contains('xenon'));
@@ -335,11 +335,11 @@ void main() {
       };
 
       // Maps can be built from a constructor.
-      var searchTerms = new Map();
+      var searchTerms = Map();
 
       // Maps are parameterized types; you can specify what
       // types the key and value should be.
-      var nobleGases = new Map<int, String>();
+      var nobleGases = Map<int, String>();
       // #enddocregion Map
       assert(hawaiianBeaches.isNotEmpty);
       assert(searchTerms.isEmpty);
@@ -375,7 +375,7 @@ void main() {
       var keys = hawaiianBeaches.keys;
 
       assert(keys.length == 3);
-      assert(new Set.from(keys).contains('Oahu'));
+      assert(Set.from(keys).contains('Oahu'));
 
       // Get all the values as an unordered collection
       // (an Iterable of Lists).
@@ -550,7 +550,7 @@ void main() {
 
     test('constructor', () {
       // #docregion Uri
-      var uri = new Uri(
+      var uri = Uri(
           scheme: 'http',
           host: 'example.org',
           path: '/foo/bar',
@@ -565,19 +565,19 @@ void main() {
     test('DateTime', () {
       // #docregion DateTime
       // Get the current date and time.
-      var now = new DateTime.now();
+      var now = DateTime.now();
 
       // Create a new DateTime with the local time zone.
-      var y2k = new DateTime(2000); // January 1, 2000
+      var y2k = DateTime(2000); // January 1, 2000
 
       // Specify the month and day.
-      y2k = new DateTime(2000, 1, 2); // January 2, 2000
+      y2k = DateTime(2000, 1, 2); // January 2, 2000
 
       // Specify the date as a UTC time.
-      y2k = new DateTime.utc(2000); // 1/1/2000, UTC
+      y2k = DateTime.utc(2000); // 1/1/2000, UTC
 
       // Specify a date and time in ms since the Unix epoch.
-      y2k = new DateTime.fromMillisecondsSinceEpoch(946684800000,
+      y2k = DateTime.fromMillisecondsSinceEpoch(946684800000,
           isUtc: true);
 
       // Parse an ISO 8601 date.
@@ -590,18 +590,18 @@ void main() {
     test('millisecondsSinceEpoch', () {
       // #docregion millisecondsSinceEpoch
       // 1/1/2000, UTC
-      var y2k = new DateTime.utc(2000);
+      var y2k = DateTime.utc(2000);
       assert(y2k.millisecondsSinceEpoch == 946684800000);
 
       // 1/1/1970, UTC
-      var unixEpoch = new DateTime.utc(1970);
+      var unixEpoch = DateTime.utc(1970);
       assert(unixEpoch.millisecondsSinceEpoch == 0);
       // #enddocregion millisecondsSinceEpoch
     });
 
     test('Duration', () {
       // #docregion Duration
-      var y2k = new DateTime.utc(2000);
+      var y2k = DateTime.utc(2000);
 
       // Add one year.
       var y2001 = y2k.add(const Duration(days: 366));

--- a/examples/misc/test/library_tour/io_test.dart
+++ b/examples/misc/test/library_tour/io_test.dart
@@ -16,7 +16,7 @@ void main() {
   test('readAsString, readAsLines', () async {
     // #docregion readAsString
     Future main() async {
-      var config = new File('test_data/config.txt');
+      var config = File('test_data/config.txt');
       var contents;
 
       // Put the whole file in a single string.
@@ -40,7 +40,7 @@ void main() {
   test('readAsBytes', () {
     // #docregion readAsBytes
     Future main() async {
-      var config = new File('test_data/config.txt');
+      var config = File('test_data/config.txt');
 
       var contents = await config.readAsBytes();
       print('The file is ${contents.length} bytes long.');
@@ -53,7 +53,7 @@ void main() {
   test('try-catch', () {
     // #docregion try-catch
     Future main() async {
-      var config = new File('does-not-exist.txt');
+      var config = File('does-not-exist.txt');
       try {
         var contents = await config.readAsString();
         print(contents);
@@ -70,17 +70,16 @@ void main() {
     expect(
         main_test_read_from_stream,
         prints(allOf([
-          contains(
-              new RegExp(r'Got \d+ characters from stream')),
+          contains(RegExp(r'Got \d+ characters from stream')),
           contains('file is now closed'),
         ])));
   });
 
   test('write-file', () async {
     // #docregion write-file
-    var logFile = new File('test_data/log.txt');
+    var logFile = File('test_data/log.txt');
     var sink = logFile.openWrite();
-    sink.write('FILE ACCESSED ${new DateTime.now()}\n');
+    sink.write('FILE ACCESSED ${DateTime.now()}\n');
     await sink.flush();
     await sink.close();
     // #enddocregion write-file
@@ -96,7 +95,7 @@ void main() {
   test('list-dir', () {
     // #docregion list-dir
     Future main() async {
-      var dir = new Directory('test_data');
+      var dir = Directory('test_data');
 
       try {
         var dirList = dir.list();
@@ -120,7 +119,7 @@ void main() {
     // #docregion client
     Future main() async {
       var url = Uri.parse('http://localhost:8888/dart');
-      var httpClient = new HttpClient();
+      var httpClient = HttpClient();
       var request = await httpClient.getUrl(url);
       var response = await request.close();
       var data = await response.transform(utf8.decoder).toList();
@@ -149,13 +148,13 @@ void main() {
 
 // #docregion read-from-stream
 Future main_test_read_from_stream() async {
-  var config = new File('test_data/config.txt');
+  var config = File('test_data/config.txt');
   Stream<List<int>> inputStream = config.openRead();
 
   // #docregion utf8-decoder
   var lines = inputStream
       .transform(utf8.decoder)
-      .transform(new LineSplitter());
+      .transform(LineSplitter());
   try {
     await for (var line in lines) {
       print('Got ${line.length} characters from stream');
@@ -171,7 +170,7 @@ Future main_test_read_from_stream() async {
 /// No tests below this point. Excerpts only illustrate declarations.
 void miscDeclAnalyzedButNotTested() {
   {
-    var logFile = new File('test_data/log.txt');
+    var logFile = File('test_data/log.txt');
     // #docregion append
     var sink = logFile.openWrite(mode: FileMode.append);
     // #enddocregion append

--- a/examples/misc/test/library_tour/math_test.dart
+++ b/examples/misc/test/library_tour/math_test.dart
@@ -40,7 +40,7 @@ void main() {
 
   test('Random', () {
     // #docregion Random
-    var random = new Random();
+    var random = Random();
     random.nextDouble(); // Between 0.0 and 1.0: [0, 1)
     random.nextInt(10); // Between 0 and 9.
     // #enddocregion Random
@@ -48,7 +48,7 @@ void main() {
 
   test('Random-bool', () {
     // #docregion Random-bool
-    var random = new Random();
+    var random = Random();
     random.nextBool(); // true or false
     // #enddocregion Random-bool
   });

--- a/examples/misc/test/samples_test.dart
+++ b/examples/misc/test/samples_test.dart
@@ -18,8 +18,8 @@ Iterable flatten(Iterable it) => it.expand((e) => e is Iterable ? e : [e]);
 void main() {
   // oneSecond is shown in the code excerpts as 1 second, but we don't need
   // to delay the actual test execution, so we set the delay to 0.
-  const oneSecond = const Duration(seconds: 0);
-  final someDate = new DateTime(1999);
+  const oneSecond = Duration(seconds: 0);
+  final someDate = DateTime(1999);
 
   test('hello world', () {
     // #docregion hello-world
@@ -108,10 +108,10 @@ void main() {
   test('use class', () {
     _test() {
       // #docregion use-class
-      var voyager = new Spacecraft('Voyager I', new DateTime(1977, 9, 5));
+      var voyager = Spacecraft('Voyager I', DateTime(1977, 9, 5));
       voyager.describe();
 
-      var voyager3 = new Spacecraft.unlaunched('Voyager III');
+      var voyager3 = Spacecraft.unlaunched('Voyager III');
       voyager3.describe();
       // #enddocregion use-class
     }
@@ -127,25 +127,25 @@ void main() {
   });
 
   test('extends', () {
-    final o = new Orbiter('O', someDate, 42);
+    final o = Orbiter('O', someDate, 42);
     expect(o.launchYear, someDate.year);
   });
 
   test('mixin', () {
-    final o = new PilotedCraft('shuttle', someDate);
+    final o = PilotedCraft('shuttle', someDate);
     expect(o.launchYear, someDate.year);
     expect(o.astronauts, 1);
   });
 
   test('implements', () {
-    final o = new MockSpaceship('Enterprise');
+    final o = MockSpaceship('Enterprise');
     expect(o.describe, m.prints('Enterprise'));
   });
 
   {
     // Show declaration on first use.
     // #docregion async
-    const oneSecond = const Duration(seconds: 1);
+    const oneSecond = Duration(seconds: 1);
     // #enddocregion async
     assert(oneSecond.inSeconds == 1);
   }
@@ -153,7 +153,7 @@ void main() {
   test('async', () {
     // #docregion async
     Future<Null> printWithDelay(String message) async {
-      await new Future.delayed(oneSecond);
+      await Future.delayed(oneSecond);
       print(message);
     }
     // #enddocregion async
@@ -164,7 +164,7 @@ void main() {
   test('Future.then', () {
     // #docregion Future-then
     Future<Null> printWithDelay(String message) {
-      return new Future.delayed(oneSecond).then((_) {
+      return Future.delayed(oneSecond).then((_) {
         print(message);
       });
     }
@@ -175,7 +175,7 @@ void main() {
 
   group('await:', () {
     final testFileBase = 'test_data/fileCreationTest';
-    final testFile = new File('$testFileBase.txt');
+    final testFile = File('$testFileBase.txt');
 
     void safeDeleteTestFile() {
       if (testFile.existsSync()) testFile.deleteSync();
@@ -189,7 +189,7 @@ void main() {
       Future<Null> createDescriptions(Iterable<String> objects) async {
         for (var object in objects) {
           try {
-            var file = new File('$object.txt');
+            var file = File('$object.txt');
             if (await file.exists()) {
               var modified = await file.lastModified();
               print(
@@ -220,13 +220,13 @@ void main() {
   });
 
   test('async*', () async {
-    var voyager = new Spacecraft('Voyager I', new DateTime(1977, 9, 5));
+    var voyager = Spacecraft('Voyager I', DateTime(1977, 9, 5));
     var flybyObjects = ['Jupiter', 'Saturn', 'Uranus', 'Neptune'];
 
     // #docregion async-
     Stream<String> report(Spacecraft craft, Iterable<String> objects) async* {
       for (var object in objects) {
-        await new Future.delayed(oneSecond);
+        await Future.delayed(oneSecond);
         yield '${craft.name} flies by $object';
       }
     }
@@ -239,7 +239,7 @@ void main() {
   void throwTest(int astronauts) {
     // #docregion throw
     if (astronauts == 0) {
-      throw new StateError('No astronauts.');
+      throw StateError('No astronauts.');
     }
     // #enddocregion throw
   }
@@ -254,7 +254,7 @@ void main() {
       // #docregion try
       try {
         for (var object in flybyObjects) {
-          var description = await new File('$object.txt').readAsString();
+          var description = await File('$object.txt').readAsString();
           print(description);
         }
       } on IOException catch (e) {

--- a/examples/strong/lib/animal_bad.dart
+++ b/examples/strong/lib/animal_bad.dart
@@ -31,8 +31,8 @@ class Cat extends Animal {
 // due to the static type error on Cat.chase().
 void main() {
   // #docregion chase-Alligator
-  Animal a = new Cat();
-  a.chase(new Alligator()); // Not type safe or feline safe
+  Animal a = Cat();
+  a.chase(Alligator()); // Not type safe or feline safe
   // #enddocregion chase-Alligator
 }
 
@@ -46,7 +46,7 @@ class Dog1 extends Animal {/* ... */}
 void main1() {
   // ignore_for_file: 1, invalid_assignment
   // ignore_for_file: 2, strong_mode_invalid_cast_literal_list
-  List<Cat> foo = <dynamic>[new Dog1()]; // Error//!analysis-issue
-  List<dynamic> bar = <dynamic>[new Dog1(), new Cat1()]; // OK
+  List<Cat> foo = <dynamic>[Dog1()]; // Error//!analysis-issue
+  List<dynamic> bar = <dynamic>[Dog1(), Cat1()]; // OK
 }
 // #enddocregion dynamic-list

--- a/examples/strong/lib/bounded/instantiate_to_bound.dart
+++ b/examples/strong/lib/bounded/instantiate_to_bound.dart
@@ -2,7 +2,7 @@ import 'my_collection.dart';
 
 void cannotRunThis() {
   // #docregion undefined_method
-  var c = new C(Iterable.empty()).collection;
+  var c = C(Iterable.empty()).collection;
   // ignore_for_file: 2, undefined_method
   c.add(2); //!analysis-issue
   // #enddocregion undefined_method

--- a/examples/strong/lib/common_problems_analysis.dart
+++ b/examples/strong/lib/common_problems_analysis.dart
@@ -26,7 +26,7 @@ void _samplesFromCommonProblemsPage() {
 
   {
     // #docregion unsafe-method-call
-    NumberAdder adder = new MyAdder();
+    NumberAdder adder = MyAdder();
     adder.add(1.2, 3.4);
     // #enddocregion unsafe-method-call
   }

--- a/examples/strong/lib/dart_1_my_list_hello_world.dart
+++ b/examples/strong/lib/dart_1_my_list_hello_world.dart
@@ -15,7 +15,7 @@ class MyList extends ListBase<int> implements List {
 }
 
 void main() {
-  List<int> list = new MyList('hello');
+  List<int> list = MyList('hello');
   info(list);
 }
 // #enddocregion MyList-and-main

--- a/examples/strong/lib/strong_analysis.dart
+++ b/examples/strong/lib/strong_analysis.dart
@@ -108,7 +108,7 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion Animal-Cat-ok
-    Animal c = new Cat();
+    Animal c = Cat();
     // #enddocregion Animal-Cat-ok
   }
 
@@ -116,19 +116,19 @@ void _miscDeclAnalyzedButNotTested() {
     // #docregion MaineCoon-Cat-err
     // ignore_for_file: 1, invalid_assignment
     // ignore_for_file: 2, strong_mode_invalid_cast_new_expr
-    MaineCoon c = new Cat();
+    MaineCoon c = Cat();
     // #enddocregion MaineCoon-Cat-err
   }
 
   {
     // #docregion Cat-MaineCoon-ok
-    Cat c = new MaineCoon();
+    Cat c = MaineCoon();
     // #enddocregion Cat-MaineCoon-ok
   }
 
   {
     // #docregion generic-type-assignment-MaineCoon
-    List<Cat> myCats = new List<MaineCoon>();
+    List<Cat> myCats = List<MaineCoon>();
     // #enddocregion generic-type-assignment-MaineCoon
   }
 
@@ -136,13 +136,13 @@ void _miscDeclAnalyzedButNotTested() {
     // Since we're using --no-implicit-casts, the following causes a static error.
     // #docregion generic-type-assignment-Animal
     // ignore_for_file: 2, invalid_assignment
-    List<Cat> myCats = new List<Animal>();
+    List<Cat> myCats = List<Animal>();
     // #enddocregion generic-type-assignment-Animal
   }
 
   {
     // #docregion generic-type-assignment-implied-cast
-    List<Cat> myCats = new List<Animal>() as List<Cat>;
+    List<Cat> myCats = List<Animal>() as List<Cat>;
     // #enddocregion generic-type-assignment-implied-cast
   }
 

--- a/examples/strong/test/strong_test.dart
+++ b/examples/strong/test/strong_test.dart
@@ -12,7 +12,7 @@ String runtimeChecksSkipStatus() => dartMajorVers == 1
 
 Matcher _throwsA<T>(String msg) => throwsA(
       allOf(
-          new TypeMatcher<T>(),
+          TypeMatcher<T>(),
           predicate(
             (e) => e.toString().contains(msg),
           )),
@@ -59,7 +59,7 @@ void main() {
     test('introductory example', () {
       // #docregion runtime-checks
       void main() {
-        List<Animal> animals = [new Dog()];
+        List<Animal> animals = [Dog()];
         // ignore_for_file: 1, 2, invalid_assignment
         List<Cat> cats = animals;
       }
@@ -149,14 +149,14 @@ void main() {
     });
 
     test('instantiate-to-bound sanity', () {
-      final b = new B();
+      final b = B();
       expect(b.typeOfS, 'int');
       expect(b.typeOfT, 'dynamic');
     });
 
     test('instantiate-to-bound fix: add type arg', () {
       // #docregion add-type-arg
-      var c = new C<List>([]).collection;
+      var c = C<List>([]).collection;
       c.add(2);
       // #enddocregion add-type-arg
       expect(c, [2]);
@@ -164,7 +164,7 @@ void main() {
 
     test('instantiate-to-bound fix 2', () {
       // #docregion use-iterable
-      var c = new C(Iterable.empty()).collection;
+      var c = C(Iterable.empty()).collection;
       // Use c as an iterable...
       // #enddocregion use-iterable
       expect(c, const TypeMatcher<Iterable>());

--- a/examples/util/lib/dart_version.dart
+++ b/examples/util/lib/dart_version.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-final _majorVersNum = new RegExp(r'(\d+)\.');
+final _majorVersNum = RegExp(r'(\d+)\.');
 
 final int dartMajorVers =
     int.parse(_majorVersNum.firstMatch(Platform.version)[1]);

--- a/examples/util/lib/logger.dart
+++ b/examples/util/lib/logger.dart
@@ -2,7 +2,7 @@
 class Logger {
   final List<String> _log = [];
 
-  List<String> get log => new List.from(_log);
+  List<String> get log => List.from(_log);
   void clear() => _log.clear();
   void print(Object o) => _log.add(o.toString());
 

--- a/src/_assets/stylesheets/main.scss
+++ b/src/_assets/stylesheets/main.scss
@@ -496,7 +496,7 @@ img {
     $padding: $font-size-base * .75;
     padding-left: $padding;
     /* Prevent the active entry from shifting right because of double border */
-    &.active { padding-left: $padding - $border-width; }
+    &.active { padding-left: $padding; }
   }
   h4 {
     // TODO: use mixin and share code with #sidenav .content h4

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1104,15 +1104,15 @@ Widget build(BuildContext context) {
 {% endprettify %}
 
 {:.bad-style}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)"?>
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
 {% prettify dart %}
 Widget build(BuildContext context) {
-  return new Row(
+  return [!new!] Row(
     children: [
-      new RaisedButton(
-        child: new Text('Increment'),
+      [!new!] RaisedButton(
+        child: [!new!] Text('Increment'),
       ),
-      new Text('Click!'),
+      [!new!] Text('Click!'),
     ],
   );
 }
@@ -1149,12 +1149,12 @@ const primaryColors = [
 {% endprettify %}
 
 {:.bad-style}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-const)"?>
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
 {% prettify dart %}
-const primaryColors = const [
-  const Color("red", const [255, 0, 0]),
-  const Color("green", const [0, 255, 0]),
-  const Color("blue", const [0, 0, 255]),
+const primaryColors = [!const!] [
+  [!const!] Color("red", [!const!] [255, 0, 0]),
+  [!const!] Color("green", [!const!] [0, 255, 0]),
+  [!const!] Color("blue", [!const!] [0, 0, 255]),
 ];
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -323,7 +323,7 @@ contains the same elements:
 <?code-excerpt "misc/test/effective_dart_test.dart (list-from-1)"?>
 {% prettify dart %}
 var copy1 = iterable.toList();
-var copy2 = new List.from(iterable);
+var copy2 = List.from(iterable);
 {% endprettify %}
 
 The obvious difference is that the first one is shorter. The *important*
@@ -339,7 +339,7 @@ var iterable = [1, 2, 3];
 print(iterable.toList().runtimeType);
 
 // Prints "List<dynamic>":
-print(new List.from(iterable).runtimeType);
+print(List.from(iterable).runtimeType);
 {% endprettify %}
 
 If you *want* to change the type, then calling `List.from()` is useful:
@@ -348,7 +348,7 @@ If you *want* to change the type, then calling `List.from()` is useful:
 {% prettify dart %}
 var numbers = [1, 2.3, 4]; // List<num>.
 numbers.removeAt(1); // Now it only contains integers.
-var ints = new List<int>.from(numbers);
+var ints = List<int>.from(numbers);
 {% endprettify %}
 
 But if your goal is just to copy the iterable and preserve its original type, or

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -194,9 +194,9 @@ The following best practices apply to collections.
 
 ### DO use collection literals when possible.
 
-There are two ways to make an empty growable list: `[]` and `new List()`.
-Likewise, there are three ways to make an empty linked hash map: `{}`, `new
-Map()`, and `new LinkedHashMap()`.
+There are two ways to make an empty growable list: `[]` and `List()`.
+Likewise, there are three ways to make an empty linked hash map: `{}`,
+`Map()`, and `LinkedHashMap()`.
 
 If you want to create a non-growable list, or some other custom collection type
 then, by all means, use a constructor. Otherwise, use the nice literal syntax.
@@ -235,7 +235,7 @@ var addresses = Map<String, Address>();
 
 Note that this doesn't apply to the *named* constructors for those classes.
 `List.from()`, `Map.fromIterable()`, and friends all have their uses. Likewise,
-if you're passing a size to `new List()` to create a non-growable one, then it
+if you're passing a size to `List()` to create a non-growable one, then it
 makes sense to use that.
 
 ### DON'T use `.length` to see if a collection is empty.
@@ -1319,10 +1319,10 @@ Cases where `async` *is* useful include:
 * You are using `await`. (This is the obvious one.)
 
 * You are returning an error asynchronously. `async` and then `throw` is shorter
-  than `return new Future.error(...)`.
+  than `return Future.error(...)`.
 
 * You are returning a value and you want it implicitly wrapped in a future.
-  `async` is shorter than `new Future.value(...)`.
+  `async` is shorter than `Future.value(...)`.
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (async)"?>

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -286,7 +286,7 @@ Any variable can have a constant value.
 // const [] creates an empty, immutable list (EIL).
 var foo = const []; // foo is currently an EIL.
 final bar = const []; // bar will always be an EIL.
-const baz = const []; // baz is a compile-time constant EIL.
+const baz = []; // baz is a compile-time constant EIL.
 
 // You can change the value of a non-final, non-const variable,
 // even if it used to have a const value.
@@ -516,7 +516,7 @@ const aConstString = 'a constant string';
 var aNum = 0;
 var aBool = true;
 var aString = 'a string';
-const aConstList = const [1, 2, 3];
+const aConstList = [1, 2, 3];
 
 const validConstString = '$aConstNum $aConstBool $aConstString';
 // const invalidConstString = '$aNum $aBool $aString $aConstList';

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -305,12 +305,12 @@ even if it used to have a const value:
 foo = [1, 2, 3]; // Was const []
 {% endprettify %}
 
-Being compile-time constants, you can't assign to a const variable:
+You can't change the value of a const variable:
 
 {:.fails-sa}
 <?code-excerpt "misc/lib/language_tour/variables.dart (cant-assign-to-const)"?>
 {% prettify dart %}
-baz = []; // Error: Constant variables can't be assigned a value.
+baz = [42]; // Error: Constant variables can't be assigned a value.
 {% endprettify %}
 
 For more information on using `const` to create constant values, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -259,11 +259,18 @@ Here's an example of creating and setting a final variable:
 <?code-excerpt "misc/lib/language_tour/variables.dart (final)"?>
 {% prettify dart %}
 final name = 'Bob'; // Without a type annotation
-// name = 'Alice';  // Uncommenting this causes an error
 final String nickname = 'Bobby';
 {% endprettify %}
 
-Use `const` for variables that you want to be compile-time constants. If
+You can't change the value of a final variable:
+
+{:.fails-sa}
+<?code-excerpt "misc/lib/language_tour/variables.dart (cant-assign-to-final)"?>
+{% prettify dart %}
+name = 'Alice'; // Error: a final variable can only be set once.
+{% endprettify %}
+
+Use `const` for variables that you want to be **compile-time constants**. If
 the const variable is at the class level, mark it `static const`.
 Where you declare the variable, set the value to a compile-time constant
 such as a number or string literal, a const
@@ -282,19 +289,28 @@ Any variable can have a constant value.
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (const-vs-final)"?>
 {% prettify dart %}
-// Note: [] creates an empty list.
-// const [] creates an empty, immutable list (EIL).
-var foo = const []; // foo is currently an EIL.
-final bar = const []; // bar will always be an EIL.
-const baz = []; // baz is a compile-time constant EIL.
+var foo = const [];
+final bar = const [];
+const baz = []; // Equivalent to `const []`
+{% endprettify %}
 
-// You can change the value of a non-final, non-const variable,
-// even if it used to have a const value.
-foo = [];
+You can omit `const` from the initializing expression of a `const` declaration,
+like for `baz` above. For details, see [DON’T use const redundantly][].
 
-// You can't change the value of a final or const variable.
-// bar = []; // Unhandled exception.
-// baz = []; // Unhandled exception.
+You can change the value of a non-final, non-const variable,
+even if it used to have a const value:
+
+<?code-excerpt "misc/lib/language_tour/variables.dart (reassign-to-non-final)"?>
+{% prettify dart %}
+foo = [1, 2, 3]; // Was const []
+{% endprettify %}
+
+Being compile-time constants, you can't assign to a const variable:
+
+{:.fails-sa}
+<?code-excerpt "misc/lib/language_tour/variables.dart (cant-assign-to-const)"?>
+{% prettify dart %}
+baz = []; // Error: Constant variables can't be assigned a value.
 {% endprettify %}
 
 For more information on using `const` to create constant values, see
@@ -4115,6 +4131,7 @@ To learn more about Dart's core libraries, see
 [dart:math]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math
 [dart]: /dart-vm/tools/dart-vm
 [dartdevc]: {{site.dev-webdev}}/tools/dartdevc
+[DON’T use const redundantly]: /guides/language/effective-dart/usage#dont-use-const-redundantly
 [double]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
 [Error]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
 [Exception]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -245,8 +245,8 @@ a cat and send it after an alligator:
 
 <?code-excerpt "strong/lib/animal_bad.dart (chase-Alligator)" replace="/Alligator/[!$&!]/g"?>
 {% prettify dart %}
-Animal a = new Cat();
-a.chase(new [!Alligator!]()); // Not type safe or feline safe
+Animal a = Cat();
+a.chase([!Alligator!]()); // Not type safe or feline safe
 {% endprettify %}
 
 ### Don't use a dynamic list as a typed list
@@ -268,8 +268,8 @@ class Cat extends Animal { ... }
 class Dog extends Animal { ... }
 
 void main() {
-  List<Cat> foo = [!<dynamic>!][new Dog()]; // Error
-  List<dynamic> bar = <dynamic>[new Dog(), new Cat()]; // OK
+  List<Cat> foo = [!<dynamic>!][Dog()]; // Error
+  List<dynamic> bar = <dynamic>[Dog(), Cat()]; // OK
 }
 {% endprettify %}
 
@@ -285,7 +285,7 @@ to assign a list of Dogs to a list of Cats:
 <?code-excerpt "strong/test/strong_test.dart (runtime-checks)" replace="/cats[^;]*/[!$&!]/g"?>
 {% prettify dart %}
 void main() {
-  List<Animal> animals = [new Dog()];
+  List<Animal> animals = [Dog()];
   List<Cat> [!cats = animals!];
 }
 {% endprettify %}
@@ -431,7 +431,7 @@ a supertype of Cat.
 {:.passes-sa}
 <?code-excerpt "strong/lib/strong_analysis.dart (Animal-Cat-ok)"?>
 {% prettify dart %}
-Animal c = new Cat();
+Animal c = Cat();
 {% endprettify %}
 
 But replacing `Cat c` with `MaineCoon c` breaks type safety, because the
@@ -441,7 +441,7 @@ as Lion:
 {:.fails-sa}
 <?code-excerpt "strong/lib/strong_analysis.dart (MaineCoon-Cat-err)"?>
 {% prettify dart %}
-MaineCoon c = new Cat();
+MaineCoon c = Cat();
 {% endprettify %}
 
 In a producing position, it's safe to replace something that produces a
@@ -451,7 +451,7 @@ is allowed:
 {:.passes-sa}
 <?code-excerpt "strong/lib/strong_analysis.dart (Cat-MaineCoon-ok)"?>
 {% prettify dart %}
-Cat c = new MaineCoon();
+Cat c = MaineCoon();
 {% endprettify %}
 
 ### Generic type assignment
@@ -468,7 +468,7 @@ In the following example, you can assign a `MaineCoon` list to `myCats` because
 {:.passes-sa}
 <?code-excerpt "strong/lib/strong_analysis.dart (generic-type-assignment-MaineCoon)" replace="/MaineCoon/[!$&!]/g"?>
 {% prettify dart %}
-List<Cat> myCats = new List<[!MaineCoon!]>();
+List<Cat> myCats = List<[!MaineCoon!]>();
 {% endprettify %}
 
 {% comment %}
@@ -483,7 +483,7 @@ What about going in the other direction? Can you assign an `Animal` list to a `L
 {:.passes-sa}
 <?code-excerpt "strong/lib/strong_analysis.dart (generic-type-assignment-Animal)" replace="/Animal/[!$&!]/g"?>
 {% prettify dart %}
-List<Cat> myCats = new List<[!Animal!]>();
+List<Cat> myCats = List<[!Animal!]>();
 {% endprettify %}
 
 This assignment passes static analysis,
@@ -491,7 +491,7 @@ but it creates an implicit cast. It is equivalent to:
 
 <?code-excerpt "strong/lib/strong_analysis.dart (generic-type-assignment-implied-cast)" replace="/as.*(?=;)/[!$&!]/g"?>
 {% prettify dart %}
-List<Cat> myCats = new List<Animal>() [!as List<Cat>!];
+List<Cat> myCats = List<Animal>() [!as List<Cat>!];
 {% endprettify %}
 
 The code may fail at runtime. You can disallow implicit casts

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -144,7 +144,7 @@ argument) and accesses its `collection` member:
 {:.fails-sa}
 <?code-excerpt "strong/lib/bounded/instantiate_to_bound.dart (undefined_method)" replace="/c\..*;/[!$&!]/g"?>
 {% prettify dart %}
-var c = new C(Iterable.empty()).collection;
+var c = C(Iterable.empty()).collection;
 [!c.add(2);!]
 {% endprettify %}
 
@@ -177,7 +177,7 @@ Fix the error by providing a constructor argument of the appropriate type:
 {:.passes-sa}
 <?code-excerpt "strong/test/strong_test.dart (add-type-arg)" replace="/.List.|\[\]/[!$&!]/g"?>
 {% prettify dart %}
-var c = new C[!<List>!]([![]!]).collection;
+var c = C[!<List>!]([![]!]).collection;
 c.add(2);
 {% endprettify %}
 
@@ -190,7 +190,7 @@ If you actually meant `collection` to be an `Iterable`, then subsequent uses of
 {:.passes-sa}
 <?code-excerpt "strong/test/strong_test.dart (use-iterable)" replace="/Use.*\.\.\./[!$&!]/g"?>
 {% prettify dart %}
-var c = new C(Iterable.empty()).collection;
+var c = C(Iterable.empty()).collection;
 // [!Use c as an iterable...!]
 {% endprettify %}
 {% endcomment %}
@@ -242,7 +242,7 @@ point values are passed to an MyAdder:
 {:.runtime-fail}
 <?code-excerpt "strong/lib/common_problems_analysis.dart (unsafe-method-call)" replace="/\d[\d\.]+/[!$&!]/g"?>
 {% prettify dart %}
-NumberAdder adder = new MyAdder();
+NumberAdder adder = MyAdder();
 adder.add([!1.2!], [!3.4!]);
 {% endprettify %}
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -288,7 +288,7 @@ original String:
 {% prettify dart %}
 var greetingTemplate = 'Hello, NAME!';
 var greeting =
-    greetingTemplate.replaceAll(new RegExp('NAME'), 'Bob');
+    greetingTemplate.replaceAll(RegExp('NAME'), 'Bob');
 
 // greetingTemplate didn't change.
 assert(greeting != greetingTemplate);
@@ -303,7 +303,7 @@ lets you specify a separator—in this case, a space.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (StringBuffer)"?>
 {% prettify dart %}
-var sb = new StringBuffer();
+var sb = StringBuffer();
 sb
   ..write('Use a StringBuffer for ')
   ..writeAll(['efficient', 'string', 'creation'], ' ')
@@ -324,7 +324,7 @@ matching of strings.
 <?code-excerpt "misc/test/library_tour/core_test.dart (RegExp)"?>
 {% prettify dart %}
 // Here's a regular expression for one or more digits.
-var numbers = new RegExp(r'\d+');
+var numbers = RegExp(r'\d+');
 
 var allCharacters = 'llamas live fifteen to twenty years';
 var someDigits = 'llamas live 15 to 20 years';
@@ -343,7 +343,7 @@ provides access to a regular expression match.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (match)"?>
 {% prettify dart %}
-var numbers = new RegExp(r'\d+');
+var numbers = RegExp(r'\d+');
 var someDigits = 'llamas live 15 to 20 years';
 
 // Check whether the reg exp has a match in a string.
@@ -376,7 +376,7 @@ items to and removing items from lists.
 <?code-excerpt "misc/test/library_tour/core_test.dart (List)"?>
 {% prettify dart %}
 // Use a List constructor.
-var vegetables = new List();
+var vegetables = List();
 
 // Or simply use a list literal.
 var fruits = ['apples', 'oranges'];
@@ -434,7 +434,7 @@ should contain:
 <?code-excerpt "misc/test/library_tour/core_test.dart (ListOfString)"?>
 {% prettify dart %}
 // This list should contain only strings.
-var fruits = new List<String>();
+var fruits = List<String>();
 
 fruits.add('apples');
 var fruit = fruits[0];
@@ -459,7 +459,7 @@ is unordered, you can’t get a set’s items by index (position).
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Set)"?>
 {% prettify dart %}
-var ingredients = new Set();
+var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 assert(ingredients.length == 3);
 
@@ -477,7 +477,7 @@ objects are in a set:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (contains)"?>
 {% prettify dart %}
-var ingredients = new Set();
+var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 
 // Check whether an item is in the set.
@@ -491,11 +491,11 @@ An intersection is a set whose items are in two other sets.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (intersection)"?>
 {% prettify dart %}
-var ingredients = new Set();
+var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 
 // Create the intersection of two sets.
-var nobleGases = new Set.from(['xenon', 'argon']);
+var nobleGases = Set.from(['xenon', 'argon']);
 var intersection = ingredients.intersection(nobleGases);
 assert(intersection.length == 1);
 assert(intersection.contains('xenon'));
@@ -522,11 +522,11 @@ var hawaiianBeaches = {
 };
 
 // Maps can be built from a constructor.
-var searchTerms = new Map();
+var searchTerms = Map();
 
 // Maps are parameterized types; you can specify what
 // types the key and value should be.
-var nobleGases = new Map<int, String>();
+var nobleGases = Map<int, String>();
 {% endprettify %}
 
 You add, get, and set map items using the bracket syntax. Use `remove()`
@@ -562,7 +562,7 @@ var hawaiianBeaches = {
 var keys = hawaiianBeaches.keys;
 
 assert(keys.length == 3);
-assert(new Set.from(keys).contains('Oahu'));
+assert(Set.from(keys).contains('Oahu'));
 
 // Get all the values as an unordered collection
 // (an Iterable of Lists).
@@ -789,7 +789,7 @@ constructor:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri)"?>
 {% prettify dart %}
-var uri = new Uri(
+var uri = Uri(
     scheme: 'http',
     host: 'example.org',
     path: '/foo/bar',
@@ -809,19 +809,19 @@ You can create DateTime objects using several constructors:
 <?code-excerpt "misc/test/library_tour/core_test.dart (DateTime)"?>
 {% prettify dart %}
 // Get the current date and time.
-var now = new DateTime.now();
+var now = DateTime.now();
 
 // Create a new DateTime with the local time zone.
-var y2k = new DateTime(2000); // January 1, 2000
+var y2k = DateTime(2000); // January 1, 2000
 
 // Specify the month and day.
-y2k = new DateTime(2000, 1, 2); // January 2, 2000
+y2k = DateTime(2000, 1, 2); // January 2, 2000
 
 // Specify the date as a UTC time.
-y2k = new DateTime.utc(2000); // 1/1/2000, UTC
+y2k = DateTime.utc(2000); // 1/1/2000, UTC
 
 // Specify a date and time in ms since the Unix epoch.
-y2k = new DateTime.fromMillisecondsSinceEpoch(946684800000,
+y2k = DateTime.fromMillisecondsSinceEpoch(946684800000,
     isUtc: true);
 
 // Parse an ISO 8601 date.
@@ -834,11 +834,11 @@ milliseconds since the “Unix epoch”—January 1, 1970, UTC:
 <?code-excerpt "misc/test/library_tour/core_test.dart (millisecondsSinceEpoch)"?>
 {% prettify dart %}
 // 1/1/2000, UTC
-var y2k = new DateTime.utc(2000);
+var y2k = DateTime.utc(2000);
 assert(y2k.millisecondsSinceEpoch == 946684800000);
 
 // 1/1/1970, UTC
-var unixEpoch = new DateTime.utc(1970);
+var unixEpoch = DateTime.utc(1970);
 assert(unixEpoch.millisecondsSinceEpoch == 0);
 {% endprettify %}
 
@@ -847,7 +847,7 @@ to shift a date forward or backward:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Duration)"?>
 {% prettify dart %}
-var y2k = new DateTime.utc(2000);
+var y2k = DateTime.utc(2000);
 
 // Add one year.
 var y2001 = y2k.add(const Duration(days: 366));
@@ -949,8 +949,8 @@ class Person {
 }
 
 void main() {
-  var p1 = new Person('Bob', 'Smith');
-  var p2 = new Person('Bob', 'Smith');
+  var p1 = Person('Bob', 'Smith');
+  var p2 = Person('Bob', 'Smith');
   var p3 = 'not a person';
   assert(p1.hashCode == p2.hashCode);
   assert(p1 == p2);
@@ -982,12 +982,12 @@ class ProcessIterator implements Iterator<Process> {
 // processes. Extends a subclass of [Iterable].
 class Processes extends IterableBase<Process> {
   @override
-  final Iterator<Process> iterator = new ProcessIterator();
+  final Iterator<Process> iterator = ProcessIterator();
 }
 
 void main() {
   // Iterable objects can be used with for-in.
-  for (var process in new Processes()) {
+  for (var process in Processes()) {
     // Do something with the process.
   }
 }
@@ -1251,7 +1251,7 @@ void main(List<String> arguments) {
   // ...
   FileSystemEntity.isDirectory(searchPath).then((isDir) {
     if (isDir) {
-      final startingDir = new Directory(searchPath);
+      final startingDir = Directory(searchPath);
       startingDir
           .list(
               recursive: argResults[recursive],
@@ -1262,7 +1262,7 @@ void main(List<String> arguments) {
         }
       });
     } else {
-      searchFile(new File(searchPath), searchTerms);
+      searchFile(File(searchPath), searchTerms);
     }
   });
 }
@@ -1277,7 +1277,7 @@ looks more like synchronous code:
 Future main(List<String> arguments) async {
   // ...
   if (await FileSystemEntity.isDirectory(searchPath)) {
-    final startingDir = new Directory(searchPath);
+    final startingDir = Directory(searchPath);
     [!await for!] (var entity in startingDir.list(
         recursive: argResults[recursive],
         followLinks: argResults[followLinks])) {
@@ -1286,7 +1286,7 @@ Future main(List<String> arguments) async {
       }
     }
   } else {
-    searchFile(new File(searchPath), searchTerms);
+    searchFile(File(searchPath), searchTerms);
   }
 }
 {% endprettify %}
@@ -1347,7 +1347,7 @@ different type of data:
 {% prettify dart %}
 var lines = inputStream
     .transform(utf8.decoder)
-    .transform(new LineSplitter());
+    .transform(LineSplitter());
 {% endprettify %}
 
 This example uses two transformers. First it uses utf8.decoder to
@@ -1374,12 +1374,12 @@ goes after the asynchronous for loop.
 <?code-excerpt "misc/lib/library_tour/async/stream.dart (readFileAwaitFor)" replace="/try|catch/[!$&!]/g"?>
 {% prettify dart %}
 Future readFileAwaitFor() async {
-  var config = new File('config.txt');
+  var config = File('config.txt');
   Stream<List<int>> inputStream = config.openRead();
 
   var lines = inputStream
       .transform(utf8.decoder)
-      .transform(new LineSplitter());
+      .transform(LineSplitter());
   [!try!] {
     await for (var line in lines) {
       print('Got ${line.length} characters from stream');
@@ -1398,12 +1398,12 @@ an `onDone` listener.
 
 <?code-excerpt "misc/lib/library_tour/async/stream.dart (onDone)" replace="/onDone|onError/[!$&!]/g"?>
 {% prettify dart %}
-var config = new File('config.txt');
+var config = File('config.txt');
 Stream<List<int>> inputStream = config.openRead();
 
 inputStream
     .transform(utf8.decoder)
-    .transform(new LineSplitter())
+    .transform(LineSplitter())
     .listen((String line) {
   print('Got ${line.length} characters from stream');
 }, [!onDone!]: () {
@@ -1499,7 +1499,7 @@ optionally provide a seed to the Random constructor.
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (Random)"?>
 {% prettify dart %}
-var random = new Random();
+var random = Random();
 random.nextDouble(); // Between 0.0 and 1.0: [0, 1)
 random.nextInt(10); // Between 0 and 9.
 {% endprettify %}
@@ -1508,7 +1508,7 @@ You can even generate random booleans:
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (Random-bool)"?>
 {% prettify dart %}
-var random = new Random();
+var random = Random();
 random.nextBool(); // true or false
 {% endprettify %}
 
@@ -1616,7 +1616,7 @@ To convert a stream of UTF-8 characters into a Dart string, specify
 {% prettify dart %}
 var lines = inputStream
     .transform([!utf8.decoder!])
-    .transform(new LineSplitter());
+    .transform(LineSplitter());
 try {
   await for (var line in lines) {
     print('Got ${line.length} characters from stream');

--- a/src/_tutorials/dart-vm/httpserver.md
+++ b/src/_tutorials/dart-vm/httpserver.md
@@ -334,7 +334,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' show Random;
 
-Random intGenerator = new Random();
+Random intGenerator = Random();
 int myNumber = intGenerator.nextInt(10);
 
 Future main() async {
@@ -578,10 +578,9 @@ Map jsonData = {
 };
 
 Future main() async {
-  HttpClientRequest request =
-      await new HttpClient().[!post!](_host, 4049, path) [!/*1*/!]
-        ..[!headers!].contentType = ContentType.json [!/*2*/!]
-        ..[!write!](jsonEncode(jsonData)); [!/*3*/!]
+  HttpClientRequest request = await HttpClient().[!post!](_host, 4049, path) [!/*1*/!]
+    ..[!headers!].contentType = ContentType.json [!/*2*/!]
+    ..[!write!](jsonEncode(jsonData)); [!/*3*/!]
   HttpClientResponse response = await request.[!close!](); [!/*4*/!]
   await response.transform([!utf8.decoder!] [!/*5*/!]).forEach(print);
 }
@@ -670,7 +669,7 @@ Future main() async {
             await req.transform(utf8.decoder).join(); [!/*2*/!]
         var [!data = jsonDecode(content) as Map!]; [!/*3*/!]
         var fileName = [!req.uri.pathSegments.last;!] [!/*4*/!]
-        await new File(fileName)
+        await File(fileName)
             .writeAsString(content, mode: FileMode.write);
         req.response
           ..statusCode = HttpStatus.ok
@@ -778,7 +777,7 @@ Here's the code for mini file server:
 import 'dart:async';
 import 'dart:io';
 
-File targetFile = new File('index.html');
+File targetFile = File('index.html');
 
 Future main() async {
   var server;
@@ -842,10 +841,10 @@ import 'dart:async';
 import 'dart:io';
 import 'package:http_server/http_server.dart';
 
-File targetFile = new File('index.html');
+File targetFile = File('index.html');
 
 Future main() async {
-  VirtualDirectory staticFiles = new VirtualDirectory('.');
+  VirtualDirectory staticFiles = VirtualDirectory('.');
 
   var serverRequests =
       await HttpServer.bind(InternetAddress.loopbackIPv4, 4046);
@@ -882,11 +881,11 @@ import 'package:path/path.dart';
 Future main() async {
   var pathToBuild = join(dirname(Platform.script.toFilePath()));
 
-  var staticFiles = new VirtualDirectory(pathToBuild);
+  var staticFiles = VirtualDirectory(pathToBuild);
   staticFiles.allowDirectoryListing = true; [!/*1*/!]
   staticFiles.directoryHandler = (dir, request) [!/*2*/!] {
-    var indexUri = new Uri.file(dir.path).resolve('index.html');
-    staticFiles.serveFile(new File(indexUri.toFilePath()), request); [!/*3*/!]
+    var indexUri = Uri.file(dir.path).resolve('index.html');
+    staticFiles.serveFile(File(indexUri.toFilePath()), request); [!/*3*/!]
   };
 
   var server = await HttpServer.bind(InternetAddress.loopbackIPv4, 4048);
@@ -937,7 +936,7 @@ String certificateChain = 'server_chain.pem';
 String serverKey = 'server_key.pem';
 
 Future main() async {
-  [!var serverContext = new SecurityContext(); /*1*/!]
+  [!var serverContext = SecurityContext(); /*1*/!]
   [!serverContext.useCertificateChain(certificateChain); /*2*/!]
   [!serverContext.usePrivateKey(serverKey, password: 'dartdart'); /*3*/!]
 

--- a/src/_tutorials/language/futures.md
+++ b/src/_tutorials/language/futures.md
@@ -138,7 +138,7 @@ printBaseballScore() {
 const news = '<gathered news goes here>';
 Duration oneSecond = const Duration(seconds: 1);
 
-final newsStream = new Stream<String>.periodic(oneSecond, (_) => news);
+final newsStream = Stream<String>.periodic(oneSecond, (_) => news);
 
 // Imagine that this function is more complex and slow. :)
 Future<String> gatherNewsReports() => newsStream.first;
@@ -296,7 +296,7 @@ printBaseballScore() {
 const news = '<gathered news goes here>';
 Duration oneSecond = const Duration(seconds: 1);
 
-final newsStream = new Stream<String>.periodic(oneSecond, (_) => news);
+final newsStream = Stream<String>.periodic(oneSecond, (_) => news);
 
 // Imagine that this function is more complex and slow. :)
 Future<String> gatherNewsReports() => newsStream.first;

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -147,7 +147,7 @@ Future<int> sumStream(Stream<int> stream) async {
 Stream<int> countStream(int to) async* {
   for (int i = 1; i <= to; i++) {
     if (i == 4) {
-      throw new Exception('Intentional exception');
+      throw Exception('Intentional exception');
     } else {
       yield i;
     }
@@ -376,7 +376,7 @@ import 'dart:convert';
 import 'dart:io';
 
 Future<void> main(List<String> args) async {
-  var file = new File(args[0]);
+  var file = File(args[0]);
   var lines = file
       .openRead()
       .transform(utf8.decoder)

--- a/src/dart-vm/io-library-tour.md
+++ b/src/dart-vm/io-library-tour.md
@@ -52,7 +52,7 @@ strings.
 <?code-excerpt "misc/test/library_tour/io_test.dart (readAsString)" replace="/\btest_data\///g"?>
 {% prettify dart %}
 Future main() async {
-  var config = new File('config.txt');
+  var config = File('config.txt');
   var contents;
 
   // Put the whole file in a single string.
@@ -75,7 +75,7 @@ when it’s available.
 <?code-excerpt "misc/test/library_tour/io_test.dart (readAsBytes)" replace="/\btest_data\///g"?>
 {% prettify dart %}
 Future main() async {
-  var config = new File('config.txt');
+  var config = File('config.txt');
 
   var contents = await config.readAsBytes();
   print('The file is ${contents.length} bytes long.');
@@ -91,7 +91,7 @@ or (in an async function) use try-catch:
 <?code-excerpt "misc/test/library_tour/io_test.dart (try-catch)" replace="/does-not-exist/config/g"?>
 {% prettify dart %}
 Future main() async {
-  var config = new File('config.txt');
+  var config = File('config.txt');
   try {
     var contents = await config.readAsString();
     print(contents);
@@ -115,12 +115,12 @@ import 'dart:io';
 import 'dart:convert';
 
 Future main() async {
-  var config = new File('config.txt');
+  var config = File('config.txt');
   Stream<List<int>> inputStream = config.openRead();
 
   var lines = inputStream
       .transform(utf8.decoder)
-      .transform(new LineSplitter());
+      .transform(LineSplitter());
   try {
     await for (var line in lines) {
       print('Got ${line.length} characters from stream');
@@ -141,9 +141,9 @@ overwrites existing data in the file.
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (write-file)" replace="/\btest_data\///g"?>
 {% prettify dart %}
-var logFile = new File('log.txt');
+var logFile = File('log.txt');
 var sink = logFile.openWrite();
-sink.write('FILE ACCESSED ${new DateTime.now()}\n');
+sink.write('FILE ACCESSED ${DateTime.now()}\n');
 await sink.flush();
 await sink.close();
 {% endprettify %}
@@ -168,7 +168,7 @@ when a file or directory is encountered.
 <?code-excerpt "misc/test/library_tour/io_test.dart (list-dir)" replace="/\btest_data\b/tmp/g"?>
 {% prettify dart %}
 Future main() async {
-  var dir = new Directory('tmp');
+  var dir = Directory('tmp');
 
   try {
     var dirList = dir.list();
@@ -230,7 +230,7 @@ void processRequest(HttpRequest request) {
   final response = request.response;
   if (request.uri.path == '/dart') {
     response
-      ..headers.contentType = new ContentType(
+      ..headers.contentType = ContentType(
         'text',
         'plain',
       )
@@ -256,7 +256,7 @@ Here’s an example of using HttpClient:
 {% prettify dart %}
 Future main() async {
   var url = Uri.parse('http://localhost:8888/dart');
-  var httpClient = new HttpClient();
+  var httpClient = HttpClient();
   var request = await httpClient.getUrl(url);
   var response = await request.close();
   var data = await response.transform(utf8.decoder).toList();

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -193,10 +193,9 @@ class Spacecraft {
   void describe() {
     print('Spacecraft: $name');
     if (launchDate != null) {
-      int years = new DateTime.now()
-              .difference(launchDate)
-              .inDays ~/
-          365;
+      int years =
+          DateTime.now().difference(launchDate).inDays ~/
+              365;
       print('Launched: $launchYear ($years years ago)');
     } else {
       print('Unlaunched');
@@ -209,10 +208,10 @@ You might use the `Spacecraft` class like this:
 
 <?code-excerpt "misc/test/samples_test.dart (use class)"?>
 {% prettify dart %}
-var voyager = new Spacecraft('Voyager I', new DateTime(1977, 9, 5));
+var voyager = Spacecraft('Voyager I', DateTime(1977, 9, 5));
 voyager.describe();
 
-var voyager3 = new Spacecraft.unlaunched('Voyager III');
+var voyager3 = Spacecraft.unlaunched('Voyager III');
 voyager3.describe();
 {% endprettify %}
 
@@ -305,10 +304,10 @@ using `async` and `await`.
 
 <?code-excerpt "misc/test/samples_test.dart (async)" replace="/async/[!$&!]/g"?>
 {% prettify dart %}
-const oneSecond = const Duration(seconds: 1);
+const oneSecond = Duration(seconds: 1);
 // ···
 Future<Null> printWithDelay(String message) [!async!] {
-  await new Future.delayed(oneSecond);
+  await Future.delayed(oneSecond);
   print(message);
 }
 {% endprettify %}
@@ -318,7 +317,7 @@ The method above is equivalent to:
 <?code-excerpt "misc/test/samples_test.dart (Future.then)"?>
 {% prettify dart %}
 Future<Null> printWithDelay(String message) {
-  return new Future.delayed(oneSecond).then((_) {
+  return Future.delayed(oneSecond).then((_) {
     print(message);
   });
 }
@@ -332,7 +331,7 @@ easy to read.
 Future<Null> createDescriptions(Iterable<String> objects) async {
   for (var object in objects) {
     try {
-      var file = new File('$object.txt');
+      var file = File('$object.txt');
       if (await file.exists()) {
         var modified = await file.lastModified();
         print(
@@ -354,7 +353,7 @@ You can also use `async*`, which gives you a nice, readable way to build streams
 {% prettify dart %}
 Stream<String> report(Spacecraft craft, Iterable<String> objects) async* {
   for (var object in objects) {
-    await new Future.delayed(oneSecond);
+    await Future.delayed(oneSecond);
     yield '${craft.name} flies by $object';
   }
 }
@@ -372,7 +371,7 @@ To raise an exception, use `throw`:
 <?code-excerpt "misc/test/samples_test.dart (throw)"?>
 {% prettify dart %}
 if (astronauts == 0) {
-  throw new StateError('No astronauts.');
+  throw StateError('No astronauts.');
 }
 {% endprettify %}
 
@@ -382,7 +381,7 @@ To catch an exception, use a `try` statement with `on` or `catch` (or both):
 {% prettify dart %}
 try {
   for (var object in flybyObjects) {
-    var description = await new File('$object.txt').readAsString();
+    var description = await File('$object.txt').readAsString();
     print(description);
   }
 } on IOException catch (e) {

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -216,7 +216,7 @@ voyager3.describe();
 {% endprettify %}
 
 [Read more](/guides/language/language-tour#classes) about classes in Dart,
-including initializer lists, redirecting constructors, constant constructors,
+including initializer lists, optional `new` and `const`, redirecting constructors,
 `factory` constructors, getters, setters, and much more.
 
 


### PR DESCRIPTION
- Run dartfmt --fix on examples, ensuring to leave  excerpts illustrate bad/old syntax untouched
- In Effective Dart Usage: highlight unnecessary new/const in "bad" examples

Staged at https://dartlang-org-staging-0.firebaseapp.com. In particular see:

- https://dartlang-org-staging-0.firebaseapp.com/effective-dart/usage#dont-use-new
- https://dartlang-org-staging-0.firebaseapp.com/effective-dart/usage#dont-use-const-redundantly
- https://dartlang-org-staging-0.firebaseapp.com/guides/language/language-tour#using-constructors (mentions optional new, and const contexts).


