### PR TITLE
Change the recommendation for doc comments

### DIFF
--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -244,8 +244,8 @@ int weekday;
 int get checkedCount => ...
 {% endprettify %}
 
-If there's both a setter and a getter, comment only the getter. That way,
-dartdoc will treat it like a variable.
+Avoid having a doc comment on the setter and the getter, as DartDoc will only show
+one (the one on the getter.)
 
 ### PREFER starting library or type comments with noun phrases.
 


### PR DESCRIPTION
DartDoc will show setter comments as a property. It is only when there is a comment on the setter and a getter that the comment is ambiguous, and the getter is favored. Change the recommendation so that teams can comment the setter if it makes more sense for the readability of the code.