### PR TITLE
Remove "Dart VM" from sidenav

### DIFF
--- a/src/_articles/dart-vm/index.md
+++ b/src/_articles/dart-vm/index.md
@@ -1,12 +1,13 @@
 ---
 layout: default
-title: "Articles: Dart VM"
-description: "Articles pertaining to the Dart Virtual Machine (VM), such as benchmarking, native extensions, and numeric computation"
+title: "Articles: Server-Side Dart"
+description: "Articles pertaining to command-line and server-side Dart apps, covering topics such as benchmarking, native extensions, and numeric computation."
 permalink: /articles/dart-vm
 toc: false
 ---
 
-Read these articles for insight into the Dart VM.
+Read these articles for information that's relevant to
+Dart apps that run on the command line or as servers.
 
 Also see: [Articles about the Dart language and libraries](/articles)
 

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -33,7 +33,7 @@
       permalink: https://webdev.dartlang.org
     - title: Mobile (Flutter)
       permalink: https://flutter.io
-    - title: Dart VM
+    - title: Server
       permalink: /dart-vm
 
 - title: Testing

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -29,10 +29,10 @@
   permalink: /guides/platforms
   urlExactMatch: true
   children:
-    - title: Web
-      permalink: https://webdev.dartlang.org
     - title: Mobile (Flutter)
       permalink: https://flutter.io
+    - title: Web
+      permalink: https://webdev.dartlang.org
     - title: Server
       permalink: /dart-vm
 

--- a/src/_includes/article_index_warning.md
+++ b/src/_includes/article_index_warning.md
@@ -1,6 +1,6 @@
 <aside class="alert alert-danger" markdown="1">
 **Obsolete content:**
-These articles haven't been updated to reflect the latest release.
+Most of these articles haven't been updated to reflect the latest release.
 To find newer articles, look in
 [Medium's dartlang channel.](https://medium.com/dartlang)
 </aside>

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -37,8 +37,7 @@
           <ul>
             <li><a href="{{site.flutter}}">Flutter</a></li>
             <li><a href="{{site.webdev}}">Dart for the web</a></li>
-            <li><a href="{{site.webdev}}/angular">AngularDart</a></li>
-            <li><a href="{{site.dart_vm}}">Dart VM</a></li>
+            <li><a href="{{site.dart_vm}}">Server-side Dart</a></li>
             <li><a href="https://dart-lang.github.io/observatory/">Observatory</a></li>
             <li><a href="/guides/libraries">Dart libraries</a></li>
             <li><a href="/guides/language">Dart programming language</a></li>

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -35,7 +35,7 @@
         <div class="content">
           <h4>Technologies</h4>
           <ul>
-            <li><a href="{{site.flutter}}">Flutter</a></li>
+            <li><a href="{{site.flutter}}">Mobile (Flutter)</a></li>
             <li><a href="{{site.webdev}}">Dart for the web</a></li>
             <li><a href="{{site.dart_vm}}">Server-side Dart</a></li>
             <li><a href="https://dart-lang.github.io/observatory/">Observatory</a></li>

--- a/src/dart-vm/index.md
+++ b/src/dart-vm/index.md
@@ -5,8 +5,7 @@ toc: false
 ---
 
 This page points to tools and documentation
-that can help you develop command-line and server-side apps
-for the Dart VM.
+that can help you develop command-line and server-side apps.
 
 ## Tools
 
@@ -21,7 +20,7 @@ for the Dart VM.
 
 [Dart SDK](/tools/sdk)
 : [Install the Dart SDK](/tools/sdk#install) to get the core Dart
-  libraries and [Dart VM tools](/dart-vm/tools).
+  libraries and [tools](/dart-vm/tools).
 
 More tools
 : The Dart [Tools](/tools) page links to generally useful tools,

--- a/src/dart-vm/index.md
+++ b/src/dart-vm/index.md
@@ -1,12 +1,12 @@
 ---
-title: Dart VM
-description: The landing page for all things relating to the Dart virtual machine (Dart VM).
+title: Server-Side Dart
+description: All things relating to command-line and server-side apps.
 toc: false
 ---
 
 This page points to tools and documentation
-that can help you develop scripts and server apps
-for the standalone Dart VM.
+that can help you develop command-line and server-side apps
+for the Dart VM.
 
 ## Tools
 
@@ -21,7 +21,7 @@ for the standalone Dart VM.
 
 [Dart SDK](/tools/sdk)
 : [Install the Dart SDK](/tools/sdk#install) to get the core Dart
-  libraries and [Dart VM Tools](/dart-vm/tools).
+  libraries and [Dart VM tools](/dart-vm/tools).
 
 More tools
 : The Dart [Tools](/tools) page links to generally useful tools,
@@ -54,7 +54,7 @@ You might find the following tutorials helpful.
 : Code that performs common I/O tasks, featuring APIs from
   dart:io, dart:convert, the path package, and more.
 
-[Articles: Dart VM](/articles/dart-vm)
+[Articles: Server-Side Dart](/articles/dart-vm)
 : A collection of articles covering topics such as benchmarking,
   numeric computation, and SIMD.
 


### PR DESCRIPTION
...and the footer and some pages they point to.

Staged at URLs like https://kw-www-dartlang-1.firebaseapp.com/dart-vm.

Contributes to #965.