### PR TITLE
Minor fixes in docs

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -174,7 +174,7 @@ class Dice {
 <?code-excerpt "misc/lib/effective_dart/style_bad.dart (const-names)"?>
 {% prettify dart %}
 const PI = 3.14;
-const kDefaultTimeout = 1000;
+const DefaultTimeout = 1000;
 final URL_SCHEME = RegExp('^([a-z]+):');
 
 class Dice {

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3011,7 +3011,7 @@ and the dynamic type of the receiver has an implemention of `noSuchMethod()`
 that's different from the one in class `Object`.
 
 For more information, see the informal
-[nosuchMethod forwarding specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
+[noSuchMethod forwarding specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
 
 
 <a id="enums"></a>


### PR DESCRIPTION
# Remove a letter that was probably mistyped

The section tells that we should use lowerCamelCase for constant names. Then there are some examples in other styles, one of which is `kDefaultTimeout`, which technically is lower camel case. Perhaps `DefaultTimeout` was actually meant to demonstrate UpperCamelCase.

# Correct lowerCamelCase in noSuchMethod

One of the links in that section refers to "nosuchMethod forwarding...", which is probably mistakenly capitalized. Changing it to "noSuchMethod", as everywhere else.