### PR TITLE
Add prefix item to Effective Dart

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -228,6 +228,24 @@ Db
 {% endprettify %}
 
 
+### DON’T use prefix letters to indicate type, mutability, or scope.
+
+The type system can tell you all about these for any identifier,
+so there's no need to use
+[Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation)
+or any other prefix scheme to encode this information.
+
+{:.good-style}
+{% prettify dart %}
+defaultTimeout
+{% endprettify %}
+
+{:.bad-style}
+{% prettify dart %}
+kDefaultTimeout
+{% endprettify %}
+
+
 ## Ordering
 
 To keep the preamble of your file tidy, we have a prescribed order that

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -228,12 +228,13 @@ Db
 {% endprettify %}
 
 
-### DON’T use prefix letters to indicate type, mutability, or scope.
+### DON’T use prefix letters
 
-The type system can tell you all about these for any identifier,
-so there's no need to use
-[Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation)
-or any other prefix scheme to encode this information.
+[Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation) and
+other schemes arose in the time of BCPL, when the compiler didn't do much to
+help you understand your code. Because Dart can tell you the type, scope,
+mutability, and other properties of your declarations, there's no reason to
+encode those properties in identifier names.
 
 {:.good-style}
 {% prettify dart %}

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -20,7 +20,7 @@
 * <a href='/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase'>DO name other identifiers using <code>lowerCamelCase</code>.</a>
 * <a href='/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names'>PREFER using <code>lowerCamelCase</code> for constant names.</a>
 * <a href='/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words'>DO capitalize acronyms and abbreviations longer than two letters like words.</a>
-* <a href='/guides/language/effective-dart/style#dont-use-prefix-letters-to-indicate-type-mutability-or-scope'>DON’T use prefix letters to indicate type, mutability, or scope.</a>
+* <a href='/guides/language/effective-dart/style#dont-use-prefix-letters'>DON’T use prefix letters.</a>
 
 **Ordering**
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -20,6 +20,7 @@
 * <a href='/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase'>DO name other identifiers using <code>lowerCamelCase</code>.</a>
 * <a href='/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names'>PREFER using <code>lowerCamelCase</code> for constant names.</a>
 * <a href='/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words'>DO capitalize acronyms and abbreviations longer than two letters like words.</a>
+* <a href='/guides/language/effective-dart/style#dont-use-prefix-letters-to-indicate-type-mutability-or-scope'>DON’T use prefix letters to indicate type, mutability, or scope.</a>
 
 **Ordering**
 


### PR DESCRIPTION
Followup to #990

I changed the wording, so please make sure it says when you meant to say. Should we add more examples? 

Staged:
https://kw-www-dartlang-1.firebaseapp.com/guides/language/effective-dart/style#dont-use-prefix-letters-to-indicate-type-mutability-or-scope
https://kw-www-dartlang-1.firebaseapp.com/guides/language/effective-dart#style