### PR TITLE
Fix default pub cache location

### DIFF
--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -8,7 +8,7 @@ Environment variables allow you to customize pub to suit your needs.
 
 `PUB_CACHE`
 : Some of pub's dependencies are downloaded to the pub cache.
-  By default, this directory is located under `.pub_cache`
+  By default, this directory is located under `.pub-cache`
   in your home directory (on Mac and Linux),
   or in `%APPDATA%\Pub\Cache` (on Windows). (The precise location of the
   cache may vary depending on the Windows version.)


### PR DESCRIPTION
The folder is named `. pub-cache` not `.pub_cache`. It's correct in another page on the site, but wrong here.