### PR TITLE
Single quotes on raw string example in lang tour

### DIFF
--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -34,7 +34,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion raw-strings
-    var s = r"In a raw string, even \n isn't special.";
+    var s = r'In a raw string, not even \n gets special treatment.';
     // #enddocregion raw-strings
   }
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -511,7 +511,7 @@ You can create a “raw” string by prefixing it with `r`:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (raw-strings)"?>
 {% prettify dart %}
-var s = r'In a raw string, even \n isn't special.';
+var s = r'In a raw string, not even \n gets special treatment.';
 {% endprettify %}
 
 See [Runes](#runes) for details on how to express Unicode

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -511,7 +511,7 @@ You can create a “raw” string by prefixing it with `r`:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (raw-strings)"?>
 {% prettify dart %}
-var s = r"In a raw string, even \n isn't special.";
+var s = r'In a raw string, even \n isn't special.';
 {% endprettify %}
 
 See [Runes](#runes) for details on how to express Unicode


### PR DESCRIPTION
This is a tiny nit, but I just ran into trouble trying to figure out what this statement from `built_value` was doing:

      StandardJsonPlugin({this.discriminator = r'$', this.valueKey = ''});

I'd never seen the "leading r" syntax for a raw string before. I Cmd-F'ed the site for "r'" and came up empty because the example is using double quotes instead. If we generally encourage single quotes as the default (which is implied by the other examples), could we change this example to match?