### PR TITLE
Add deprecation hints & new/const removal to /dart-2

### DIFF
--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -76,9 +76,8 @@ from either Dart 1.x or an earlier version of Dart 2.
    * Do manual testing, and look for console errors.
    Consider adding automated tests to catch issues that you find.
 7. **Fix issues until your code works.**
-8. _Optional:_ Remove `new` and unnecessary `const`.
-   * Flutter: [PENDING]
-   * Dart VM or web: `dartfmt --fix`
+8. _Optional:_ **Remove `new` and unnecessary `const`.** You can do this
+   by hand or use a tool such as `dartfmt --fix`.
 
 Each time the SDK has a significant release, repeat the process.
 

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -64,7 +64,8 @@ from either Dart 1.x or an earlier version of Dart 2.
    * Dart VM or web: [`pub upgrade`][pub upgrade]
 3. **Run the [dart2_fix tool.][dart2_fix]** It helps migrate some
    usages of deprecated Dart 1.x APIs to Dart 2.
-4. **Run the analyzer** to find [compile-time errors][].
+4. **Run the analyzer** to find [compile-time errors][]
+   and deprecation hints.
    * Flutter: [`flutter analyze`][Flutter analyzer]
    * Dart VM or web: [`dartanalyzer`][dartanalyzer] with
      [Dart 2 semantics][enable strong mode]
@@ -75,6 +76,9 @@ from either Dart 1.x or an earlier version of Dart 2.
    * Do manual testing, and look for console errors.
    Consider adding automated tests to catch issues that you find.
 7. **Fix issues until your code works.**
+8. _Optional:_ Remove `new` and unnecessary `const`.
+   * Flutter: [PENDING]
+   * Dart VM or web: `dartfmt --fix`
 
 Each time the SDK has a significant release, repeat the process.
 

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -314,7 +314,7 @@ to process it. For example:
 
 {% prettify yaml %}
 environment:
-  sdk: '>=1.8.3 <2.0.0'
+  sdk: '>=1.8.3 <3.0.0'
 {% endprettify %}
 
 ## Dev dependencies


### PR DESCRIPTION
Also remove the last unnecessary use of <2.0.0 for an SDK constraint.

Staged:
https://kw-staging-dartlang-2.firebaseapp.com/dart-2#general-process
https://kw-staging-dartlang-2.firebaseapp.com/tools/pub/dependencies#caret-syntax

Fixes #1001.