### PR TITLE
Change remaining prominent uses of "Dart VM" to "server-side Dart"

### DIFF
--- a/src/_articles/index.md
+++ b/src/_articles/index.md
@@ -11,7 +11,7 @@ Also see:
 
 * [Effective Dart](/guides/language/effective-dart)
 * [Tutorials](/tutorials)
-* [Articles about the Dart VM](/articles/dart-vm)
+* [Articles about server-side Dart](/articles/dart-vm)
 * [Articles about webdev]({{site.webdev}}/articles)
 
 {% include article_index_warning.md %}

--- a/src/_articles/language/index.md
+++ b/src/_articles/language/index.md
@@ -19,5 +19,5 @@ Read these articles for insight into the Dart language.
 Also see:
 
 * [Libraries articles](/articles/libraries)
-* [Dart VM articles](/articles/dart-vm)
+* [Server-side Dart articles](/articles/dart-vm)
 * [webdev articles]({{site.webdev}}/articles)

--- a/src/_articles/libraries/index.md
+++ b/src/_articles/libraries/index.md
@@ -19,5 +19,5 @@ Read these articles for insight into the Dart libraries and APIs.
 Also see:
 
 * [Language articles](/articles/language)
-* [Dart VM articles](/articles/dart-vm)
+* [Server-side Dart articles](/articles/dart-vm)
 * [webdev articles]({{site.webdev}}/articles)

--- a/src/_guides/get-started.md
+++ b/src/_guides/get-started.md
@@ -33,7 +33,7 @@ for the appropriate Dart platform:
 | **Platform** | | **Use case** | **Get started** |
 | **Mobile** | <i class="fab fa-android" aria-hidden="true"></i> <i class="fab fa-apple" aria-hidden="true"></i> | Create an app from a single codebase that runs on both iOS and Android. | <a href="https://flutter.io/getting-started/" class="btn btn-primary no-automatic-external">Flutter</a> |
 | **Web** | <i class="fas fa-code fa-sm" aria-hidden="true"></i> | Create an app that runs in any modern browser. | <a href="{{site.webdev}}/guides/get-started" class="btn btn-primary no-automatic-external">Dart webdev</a> |
-| **Server** | <i class="fas fa-terminal fa-sm" aria-hidden="true"></i> | Create a command-line tool or server. | <a href="/tutorials/dart-vm/get-started" class="btn btn-primary">Dart VM</a> |
+| **Server** | <i class="fas fa-terminal fa-sm" aria-hidden="true"></i> | Create a command-line tool or server. | <a href="/tutorials/dart-vm/get-started" class="btn btn-primary">Server-side Dart</a> |
 {:.get-started-table}
 
 Here are some other resources:

--- a/src/_guides/index.md
+++ b/src/_guides/index.md
@@ -11,7 +11,7 @@ Also see:
 
 * [webdev guides]({{site.webdev}}/guides)
 * [Flutter's developer guides]({{site.flutter}})
-* [Dart VM's Get Started tutorial](/tutorials/dart-vm/get-started)
+* [Server-side get started tutorial](/tutorials/dart-vm/get-started)
 
 The getting started guide helps you get up and running with Dart as quickly as possible.
 

--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -86,13 +86,13 @@ JavaScript APIs, and the dart:html library for low-level HTML programming.
 
 **Learn more:** [webdev.dartlang.org]({{site.webdev}})
 
-### Dart VM libraries
+### Server-side libraries
 
 If you write servers or command-line applications, check out
 [dart:io](https://api.dartlang.org/stable/dart-io/dart-io-library.html)
 and related libraries.
 
-**Learn more:** [Dart VM]({{site.dart_vm}})
+**Learn more:** [server-side Dart]({{site.dart_vm}})
 
 ### Flutter libraries
 

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -51,7 +51,7 @@ encounter when using Dart technologies:
 ## Generally useful libraries
 
 Although your tests partly depend on the platform your code is intended
-for&mdash;Flutter, the Dart VM, or Angular Dart, for example&mdash;the
+for&mdash;Flutter, the web, or server-side, for example&mdash;the
 following packages are useful across Dart platforms:
 
 * [package:test](https://pub.dartlang.org/packages/test)<br>

--- a/src/_tutorials/dart-vm/get-started.md
+++ b/src/_tutorials/dart-vm/get-started.md
@@ -1,12 +1,12 @@
 ---
-title: Get Started with the Dart VM
+title: Get Started with Server-Side Dart
 description: Get Dart and run a Dart app.
 nextpage:
   url: /tutorials/dart-vm/cmdline
   title: Write Command-Line Apps
 prevpage:
   url: /tutorials/dart-vm
-  title: Dart VM Tutorials
+  title: Server-Side Dart Tutorials
 ---
 
 <div class="mini-toc" markdown="1">

--- a/src/_tutorials/dart-vm/index.md
+++ b/src/_tutorials/dart-vm/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: "Dart VM Tutorials"
-description: "The Dart VM Tutorials&mdash;Your guide to building great apps."
+title: "Server-Side Dart Tutorials"
+description: "The server-side Dart tutorials show how to develop scripts and server apps for the standalone Dart VM."
 permalink: /tutorials/dart-vm
 toc: false
 

--- a/src/_tutorials/index.md
+++ b/src/_tutorials/index.md
@@ -52,7 +52,7 @@ Organize and share code at
 
 ## More tutorials
 
-* [Dart VM Tutorials](/tutorials/dart-vm)
-* [Web Tutorials]({{site.webdev}}/tutorials)
+* [Server-side Dart tutorials](/tutorials/dart-vm)
+* [Web tutorials]({{site.webdev}}/tutorials)
 * [Dart Academy](https://dart.academy)
 

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -61,13 +61,13 @@ from either Dart 1.x or an earlier version of Dart 2.
    * [Dart SDK instructions][Dart SDK install] (VM or web)
 2. **Upgrade the packages your app depends on.**
    * Flutter: [`flutter packages upgrade`][flutter package upgrade]
-   * Dart VM or web: [`pub upgrade`][pub upgrade]
+   * Server-side or web: [`pub upgrade`][pub upgrade]
 3. **Run the [dart2_fix tool.][dart2_fix]** It helps migrate some
    usages of deprecated Dart 1.x APIs to Dart 2.
 4. **Run the analyzer** to find [compile-time errors][]
    and deprecation hints.
    * Flutter: [`flutter analyze`][Flutter analyzer]
-   * Dart VM or web: [`dartanalyzer`][dartanalyzer] with
+   * Server-side or web: [`dartanalyzer`][dartanalyzer] with
      [Dart 2 semantics][enable strong mode]
 5. **Fix issues in your code and run the analyzer again**,
    repeating until your code passes static analysis.

--- a/src/dart-vm/io-library-tour.md
+++ b/src/dart-vm/io-library-tour.md
@@ -274,8 +274,8 @@ provides APIs for [processes,][Process] [sockets,][Socket] and
 [web sockets.][WebSocket]
 To find more examples of using dart:io, go to the
 [dart-samples repo.](https://github.com/dart-lang/dart-samples)
-For more information about the Dart VM, see the
-[VM overview.](/dart-vm)
+For more information about server-side and command-line app development, see the
+[server-side Dart overview.](/dart-vm)
 
 For information on other dart:* libraries, see the
 [library tour.][library tour]

--- a/src/dart-vm/tools/index.md
+++ b/src/dart-vm/tools/index.md
@@ -1,11 +1,11 @@
 ---
-title: Dart VM Tools
+title: Tools for Server-Side Development
 description: The tools that you get when you download the Dart SDK.
 toc: false
 ---
 
 When you install the [Dart SDK](/tools/sdk), you get all the command-line tools
-that you need to write Dart scripts and servers.
+that you need to write Dart servers and command-line scripts.
 
 The following tools have special support for running scripts and servers.
 

--- a/src/install.md
+++ b/src/install.md
@@ -34,10 +34,8 @@ Install the SDK for your platform.
 [DartPad]: {{site.custom.dartpad.direct-link}}
 [Dart install]: /tools/sdk#install
 [Dart logo]: {% asset_path 'shared/dart/logo/default.svg' %}
-[Dart VM]: {{site.dart_vm}}
 [Flutter]: {{site.flutter}}
 [Flutter install]: {{site.flutter}}/setup/
 [Flutter logo]: {% asset_path 'shared/flutter/logo/square.svg' %}
-[Web]: {{site.webdev}}
 [Web install]: {{site.webdev}}/tools/sdk#install {% comment %}FIXME: use site.webdev once the sites switch servers{% endcomment %}
 [Web logo]: {% asset_path 'shared/angular/icon/default.svg' %}

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -13,7 +13,7 @@ get the SDK and tools for your app type.
 |------------|-----------------------------------|--------------------------|
 | Mobile | [Install Flutter]({{site.flutter}}/setup) | [Flutter tools](https://flutter.io/using-ide/) |
 | Web    | [Install the Dart SDK]({{site.webdev}}/tools/sdk) | [Dart tools for the web]({{site.webdev}}/tools) |
-| Script or server | [Install the Dart SDK](/tools/sdk) | [Dart VM tools](/dart-vm/tools) |
+| Script or server | [Install the Dart SDK](/tools/sdk) | [Tools for server-side development](/dart-vm/tools) |
 {:.table .table-striped}
 
 The rest of this page covers general-purpose tools that


### PR DESCRIPTION
Contributes to #965.

Staged at URLs like:
https://kw-www-dartlang-1.firebaseapp.com/dart-2
https://kw-www-dartlang-1.firebaseapp.com/guides/get-started
https://kw-www-dartlang-1.firebaseapp.com/tutorials/dart-vm

No longer uses "Dart VM":
src/_articles/index.md
src/_articles/language/index.md
src/_articles/libraries/index.md
src/_guides/get-started.md
src/_guides/index.md
src/_guides/libraries/useful-libraries.md
src/_tutorials/dart-vm/get-started.md
src/_tutorials/index.md
src/dart-2.md
src/dart-vm/io-library-tour.md
src/install.md
src/tools/index.md

Still uses "Dart VM", but in an OK way:
src/tools/pub/glossary.md
src/_articles/libraries/serialization.md
src/_articles/language/mixins.md
src/_articles/dart-vm/numeric-computation.md
src/_articles/dart-vm/benchmarking.md
src/_articles/dart-vm/native-extensions.md
src/_articles/dart-vm/reflection-with-mirrors.md
src/_articles/dart-vm/io.md
src/_tutorials/dart-vm/index.md (some usages changed in this PR)
src/_tutorials/dart-vm/get-started.md
src/_tutorials/dart-vm/cmdline.md
src/_guides/language/language-tour.md
src/_guides/language/sound-dart.md
src/_guides/testing.md (some changes)
src/dart-vm/tools/index.md (some changes)
src/community/index.md