### PR TITLE
chore: support use of fixed site page timestamp

### DIFF
--- a/_config_now.yml
+++ b/_config_now.yml
@@ -1,0 +1,2 @@
+# Fixed time stamp (useful when comparing generated site versions)
+now: 2018-07-01 12:34:56

--- a/scripts/serve_local.sh
+++ b/scripts/serve_local.sh
@@ -5,7 +5,17 @@ set -e -o pipefail
 # cd `dirname $0`/..
 
 if [[ "$1" == "--dev" && -e _config_dev.yml ]]; then
-  CONFIG="--config _config.yml,_config_dev.yml"
+  shift;
+  CONFIG=",_config_dev.yml$CONFIG"
+fi
+
+if [[ "$1" == "--pin-now" && -e _config_dev.yml ]]; then
+  shift;
+  CONFIG=",_config_now.yml"
+fi
+
+if [[ -n $CONFIG ]]; then
+  CONFIG="--config _config.yml$CONFIG"
 fi
 
 bundle exec jekyll build $CONFIG --incremental --watch &

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -24,7 +24,7 @@
                  href="{{site.repo | regex_replace: 'github.com','travis-ci.org'}}/jobs/{{site.data.ci.job-id}}"
                  title="Site build #{{site.data.ci.build-number}} ({{site.data.ci.build-time | date: dateFormat}})"
                  {% else %}
-                 title="Site built on {{site.time | date: dateFormat}}"
+                 title="Site built on {{site.now | default: site.time | date: dateFormat}}"
                  {% endif %}
                  class="no-automatic-external"><i class="material-icons">build</i></a>
             </li>

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -14,7 +14,7 @@ sitemap: false
     {%- if page.sitemap.lastmod -%}
       {{ page.sitemap.lastmod | date: "%Y-%m-%d" }}
     {%- else -%}
-      {{ page.date | default: site.time | date_to_xmlschema }}
+      {{ site.now | default: page.date | default: site.time | date_to_xmlschema }}
     {%- endif -%}
   </lastmod>
   <changefreq>{{ page.sitemap.changefreq | default: 'monthly' }}</changefreq>


### PR DESCRIPTION
Building the dev version of the site now uses a fixed timestamp. This makes it easier to compare generated site versions.