### PR TITLE
Dartpad prose updates

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -44,43 +44,8 @@ You can find API documentation for all dart:* libraries in the
 the [Flutter API reference.][docs.flutter.io]
 
 <aside class="alert alert-info" markdown="1">
-**DartPad tip:**
-You can play with the code in this page
-by copying it into a [DartPad.][DartPad]
-Note, however, that [assert][] statements are no-ops in DartPad
-because DartPad executes in production mode, not checked mode.
-An easy workaround: **change `assert` to `print`.**
-<br>
-<br>
-
-{% comment %}
-update-for-dart-2
-[TODO: fix styling instead of using the <br><br> hack.]
-
-https://gist.github.com/2edc7174867be377021813ba4119ab8c
-https://dartpad.dartlang.org/2edc7174867be377021813ba4119ab8c
-
-{% prettify dart %}
-void main() {
-  assert(int.parse('42') == 42); // in checked mode: continues
-  print(int.parse('42') == 42); // true
-
-  assert(int.parse('43') == 42); // in checked mode: exception
-  print(int.parse('43') == 42); // false
-}
-{% endprettify %}
-{% endcomment %}
-
-<iframe
-src="{{site.custom.dartpad.embed-dart-prefix}}?id=2edc7174867be377021813ba4119ab8c&horizontalRatio=99&verticalRatio=70"
-    width="100%"
-    height="255px"
-    style="border: 1px solid #ccc;">
-</iframe>
-
-{% comment %}
-https://github.com/dart-lang/dart-pad/issues/310
-{% endcomment %}
+  **DartPad tip:** You can play with the code in this page by copying it into a
+  [DartPad.][DartPad]
 </aside>
 
 

--- a/src/tools/dartpad.md
+++ b/src/tools/dartpad.md
@@ -168,30 +168,8 @@ To create a simple web app, start with the Hello World HTML sample.
   </li>
 </ol>
 
-### Checking Dart version info
+## Checking Dart version info
 
-DartPad's various language features and APIs depend on the
-<b>Dart SDK version</b> that DartPad is based on,
-to view the version number firstly go to the Dart editor.
-
-<ol>
-  <li>
-    Click the <b>DartPad</b> title,
-    which is at the upper left of your DartPad editor.
-  </li>
-  <li>
-     At the bottom of the dialog that appears,
-     you can see the <b>Dart SDK</b> version number.
-  </li>
-</ol>
-
-{% comment %}
-update-for-dart-2
-{% endcomment %}
-
-For example, if DartPad is based on Dart SDK 1.25.0,
-then DartPad partially supports type safety but doesn't support many other Dart 2 features.
-
-
-
-
+DartPad's various language features and APIs depend on the **Dart SDK version**
+that DartPad is based on. You can find the SDK version in the DartPad editor
+footer.


### PR DESCRIPTION
(Dart 2.0 prep)

As of at least a couple of months ago:

- Assertion checking is enabled by default in DartPad (https://github.com/dart-lang/dart-pad/issues/310); drop warning to the contrary.
- SDK version is shown directly in DartPad editor footer

cc @kevmoo @kwalrath @Sfshaza 