### PR TITLE
Reinstate DartPad example now that it uses SDK 2-dev.69.5

### DIFF
--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -26,16 +26,6 @@ For a full introduction to the Dart language, including types, see the
 One benefit of static type checking is the ability to find bugs
 at compile time using Dart's [static analyzer.][analyzer]
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  The dart2js compiler and tools that depend on it
-  (such as DartPad)
-  don't yet have full support for runtime checks.
-{% comment %}
-update-for-dart-2
-{% endcomment %}
-</aside>
-
 You can fix most static analysis errors by adding type annotations to generic
 classes. The most common generic classes are the collection types
 `List<T>` and `Map<K,V>`.
@@ -90,16 +80,12 @@ void main() {
 }
 {% endprettify %}
 
-{% comment %} update-for-dart-2
-Note: Can't use embedded DP because DartPad
+{% comment %}
+  Note: DartPad does not yet support no-implicit-casts, but it does
+  report a runtime type error.
+{% endcomment -%}
 
-- Does not support no-implicit-casts
-- Runtime doesn't implement strong mode checks
-
-https://github.com/dart-lang/dart-services/issues/334
-
-[Try it in DartPad](https://dartpad.dartlang.org/3c7c95683f0c06be8326a2fd3975cd19).
-{% endcomment %}
+[Try it in DartPad](https://dartpad.dartlang.org/f64e963cb5f894e2146c2b28d5efa4ed).
 
 ## What is soundness?
 

--- a/src/tools/dartpad.md
+++ b/src/tools/dartpad.md
@@ -15,20 +15,13 @@ Here's what DartPad looks like:
 ## Library support
 
 DartPad supports
-[dart:* libraries]({{site.dart_api}})
+[dart:* libraries]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}})
 that work with web apps; it doesn't support
-[dart:io]({{site.dart_api}}/stable/dart-io) or
+[dart:io]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io) or
 libraries from [packages.]({{site.pub}})
 If you want to use dart:io, use the [Dart SDK](/tools/sdk) instead.
 If you want to use a package, get the SDK for a
 [platform](/guides/platforms) that the package supports.
-
-{% comment %}
-update-for-dart-2
-Once DartPad is based on Dart 2, change all occurrences of
-{{site.dart_api}}/... to be
-{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/....
-{% endcomment %}
 
 ## Getting started
 

--- a/src/tools/pub/cmd/pub-run.md
+++ b/src/tools/pub/cmd/pub-run.md
@@ -7,6 +7,12 @@ permalink: /tools/pub/cmd/pub-run
 _Run_ is one of the commands of the _pub_ tool.
 [Learn more about pub](/tools/pub).
 
+{% comment %}
+update-for-dart-2
+https://github.com/dart-lang/pub/issues/1922 to track
+replacement of -c, --[no-]checked
+{% endcomment %}
+
 {% prettify nocode %}
 $ pub run [--mode=<mode>] [--checked] <executable> [args...]
 {% endprettify %}
@@ -59,11 +65,6 @@ All other directories are private.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
-
-{% comment %}
-update-for-dart-2
-TODO: Add any run-specific options here.
-{% endcomment %}
 
 <aside class="alert alert-info" markdown="1">
   *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).


### PR DESCRIPTION
cc @kevmoo 