### PR TITLE
fix: language-tour.md spelling mistake

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -745,7 +745,7 @@ expressing 32-bit Unicode values within a string requires
 special syntax.
 
 The usual way to express a Unicode code point is
-`\uXXXX`, where XXXX is a 4-digit hexidecimal value.
+`\uXXXX`, where XXXX is a 4-digit hexadecimal value.
 For example, the heart character (♥) is `\u2665`.
 To specify more or less than 4 hex digits,
 place the value in curly brackets.


### PR DESCRIPTION
# fix language-tour.md spelling mistake
`hexidecimal` => `hexadecimal`