### PR TITLE
followup on banner work

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,15 +1,8 @@
-{% if site.url == site.www %}
 {% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
 <div class="banner alert alert-info">
   <p class="banner__text">
-    <a href="https://medium.com/dartlang/dart-2-stable-and-the-dart-web-platform-3775d5f8eac7" target="_blank">Dart 2.0 is now stable!</a>
+    <a href="https://medium.com/dartlang/dart-2-stable-and-the-dart-web-platform-3775d5f8eac7" rel="noopener"><b>Dart 2</b> is now stable!</a>
     <a href="/dart-2#migration">Migrate your code</a> or
     <a href="/install">install Dart</a>.
-    {% comment %}
-    Still using Dart 1.x? See the
-    <a href="{{site.prev-url}}" class="no-automatic-external" target="_blank" rel="noopener">archived site</a>
-    or the <a href="/dart-2#migration">migration guide</a>.
-    {% endcomment %}
   </p>
 </div>
-{% endif %}


### PR DESCRIPTION
Staged at https://kw-www-dartlang-1.firebaseapp.com. The only visible change is that "Dart 2" is now bold, and I dropped the ".0".

