### PR TITLE
Added entry to who uses dart

### DIFF
--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -63,6 +63,9 @@ Google internal sales tool
 [drone.io](http://drone.io)
 : Continuous integration with support for testing Dart apps.
 
+[eurovision.app](https://eurovision.app)
+: Unofficial Eurovision Song Contest PWA built with AngularDart using a Firebase backend.
+
 [Soundtrap](https://www.soundtrap.com/)
 : Collaboratively record music with your browser, built with Dart and WebRTC.
 


### PR DESCRIPTION
There appears to be no order to this list and it's rather large. It may be worth categorising these in to Tooling, Products & services? You could feature the high-profile projects like flutter & adwords and then order the smaller projects alphabetically? Shall I implement and send a PR?