### PR TITLE
Add `environment` field to sdk constraint section

### DIFF
--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -119,11 +119,12 @@ Once your package passes Dart 2 analysis, update the upper constraint
 to declare that the package is compatible with Dart 2:
 
 ```yaml
-# Works in Dart 1 (starting with 1.20.1), and works in Dart 2
-sdk: '>=1.20.1 <3.0.0'
+environment:
+  # Works in Dart 1 (starting with 1.20.1), and works in Dart 2
+  sdk: '>=1.20.1 <3.0.0'
 
-# Works in Dart 2 only, starting with Dart 2 dev build 61
-sdk: '>=2.0.0-dev.61.0 <3.0.0'
+  # Works in Dart 2 only, starting with Dart 2 dev build 61
+  sdk: '>=2.0.0-dev.61.0 <3.0.0'
 ```
 
 <aside class="alert alert-warning" markdown="1">


### PR DESCRIPTION
In the sdk constraint section of the Dart 2 page it previously showed only the `sdk` field, which must be nested under the `environment` field to work. It also didn't have the proper indentation so it looked like a top level key.

This adds the `environment` key with proper indentation for the `sdk` field, which should help clarify how to set up sdk constraints.

This caused some confusion in the gitter channel today for a user trying to get their sdk constraints updated to allow Dart 2.