### PR TITLE
Samples: change `Future<Null>` to `Future<void>`

### DIFF
--- a/examples/misc/test/samples_test.dart
+++ b/examples/misc/test/samples_test.dart
@@ -152,7 +152,7 @@ void main() {
 
   test('async', () {
     // #docregion async
-    Future<Null> printWithDelay(String message) async {
+    Future<void> printWithDelay(String message) async {
       await Future.delayed(oneSecond);
       print(message);
     }
@@ -163,7 +163,7 @@ void main() {
 
   test('Future.then', () {
     // #docregion Future-then
-    Future<Null> printWithDelay(String message) {
+    Future<void> printWithDelay(String message) {
       return Future.delayed(oneSecond).then((_) {
         print(message);
       });
@@ -186,7 +186,7 @@ void main() {
 
     test('await', () {
       // #docregion await
-      Future<Null> createDescriptions(Iterable<String> objects) async {
+      Future<void> createDescriptions(Iterable<String> objects) async {
         for (var object in objects) {
           try {
             var file = File('$object.txt');

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -306,7 +306,7 @@ using `async` and `await`.
 {% prettify dart %}
 const oneSecond = Duration(seconds: 1);
 // ···
-Future<Null> printWithDelay(String message) [!async!] {
+Future<void> printWithDelay(String message) [!async!] {
   await Future.delayed(oneSecond);
   print(message);
 }
@@ -316,7 +316,7 @@ The method above is equivalent to:
 
 <?code-excerpt "misc/test/samples_test.dart (Future.then)"?>
 {% prettify dart %}
-Future<Null> printWithDelay(String message) {
+Future<void> printWithDelay(String message) {
   return Future.delayed(oneSecond).then((_) {
     print(message);
   });
@@ -328,7 +328,7 @@ easy to read.
 
 <?code-excerpt "misc/test/samples_test.dart (await)"?>
 {% prettify dart %}
-Future<Null> createDescriptions(Iterable<String> objects) async {
+Future<void> createDescriptions(Iterable<String> objects) async {
   for (var object in objects) {
     try {
       var file = File('$object.txt');


### PR DESCRIPTION
Contributes to #655 by changing all occurences (across all example code) of `Future<Null>` to `Future<void>`.