### PR TITLE
Ensure main nav dropdown and its divider are properly displayed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source "http://rubygems.org"
-gem 'autoprefixer-rails'
 gem 'bootstrap'
 gem 'font-awesome-sass'
 gem 'html-proofer'
 gem 'jekyll'
 gem 'jekyll-assets', group: :jekyll_plugins
 gem 'jekyll-toc'
-gem 'kramdown'
 gem 'liquid-tag-parser'
 gem 'nokogiri'
 gem 'sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,14 +125,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  autoprefixer-rails
   bootstrap
   font-awesome-sass
   html-proofer
   jekyll
   jekyll-assets
   jekyll-toc
-  kramdown
   liquid-tag-parser
   nokogiri
   sass

--- a/src/_assets/css/_icons.scss
+++ b/src/_assets/css/_icons.scss
@@ -1,6 +1,6 @@
 // Material design icons
 
-@mixin md-icon-contennt($icon-name, $width: '') {
+@mixin md-icon-content($icon-name, $width: '') {
   font-family: 'Material Icons';
   content: $icon-name;
   @if $width {
@@ -10,7 +10,7 @@
 }
 
 @mixin md-icon-before($icon-name) {
-  &:before { @include md-icon-contennt($icon-name); }
+  &:before { @include md-icon-content($icon-name); }
 }
 
 // Icons based on custom font "dart"

--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -84,6 +84,11 @@ $kbd-bg:                      #333;
 // $pre-border-color:            #ccc !default;
 // $pre-scrollable-max-height:   340px !default;
 
+//== Dropdown
+
+$dropdown-divider-bg: #bbbbbb;
+$dropdown-link-active-color: transparent;
+$dropdown-link-active-bg: transparent;
 
 //== Popovers
 

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -273,6 +273,7 @@ img {
 #mainnav {
   display: flex;
   color: $gray-base;
+  $mainnav-entry-spacing: 15px;
   ul {
     margin: auto;
     margin-right: 0;
@@ -285,7 +286,7 @@ img {
       align-items: flex-end;
     }
     li {
-      padding: 0 15px;
+      padding: 0 $mainnav-entry-spacing;
       a {
         display: inline-block;
         padding: 0;
@@ -342,6 +343,7 @@ img {
     background-color: $gray-light;
     border-top-color: transparent;
     color: $gray-base;
+    margin-left: -$mainnav-entry-spacing;
     a:hover, a:focus { background-color: transparent; }
     a.active:after {
       font-family: 'Font Awesome 5 Free';

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -515,7 +515,7 @@ img {
       &.active {
         color: $gray-dark;
         &:before {
-          @include md-icon-contennt('chevron_right'); // alt: '〉 '; // '▷ '; // '◾ '; // '▸ '; // '● ';
+          @include md-icon-content('chevron_right'); // alt: '〉 '; // '▷ '; // '◾ '; // '▸ '; // '● ';
           margin-left: -0.9rem; // We tune the margin for top-level entries below.
         }
       }
@@ -1049,7 +1049,7 @@ h3.popover-header {
         padding-left: 0; // Fix BS 4.1 padding issue: push left padding into ::before for balance
         &::before {
           padding-left: $breadcrumb-item-padding;
-          @include md-icon-contennt($breadcrumb-divider, 1rem + 2 * $breadcrumb-item-padding);
+          @include md-icon-content($breadcrumb-divider, 1rem + 2 * $breadcrumb-item-padding);
         }
       }
       &.active a {

--- a/src/_includes/_version-menu-items.html
+++ b/src/_includes/_version-menu-items.html
@@ -1,13 +1,13 @@
 {% assign dart1status = 'archive' %}
 {% assign dart2status = 'stable' %}
 {% if site.branch == '1.x' -%}
-  <li><a class="active">{{site.data.pkg-vers.SDK.vers}}&nbsp;&nbsp;({{dart1status}})</a></li>
+  <li><a class="active dropdown-item">{{site.data.pkg-vers.SDK.vers}}&nbsp;&nbsp;({{dart1status}})</a></li>
   {% if site.dev-url and site.data.pkg-vers.SDK.next-vers -%}
-    <li><a href="{{site.dev-url}}{{page.url}}" class="no-automatic-external">{{site.data.pkg-vers.SDK.next-vers}}&nbsp;&nbsp;({{dart2status}})</a></li>
+    <li><a href="{{site.dev-url}}{{page.url}}" class="dropdown-item no-automatic-external">{{site.data.pkg-vers.SDK.next-vers}}&nbsp;&nbsp;({{dart2status}})</a></li>
   {%- endif -%}
 {% else -%}
   {% if site.prev-url and site.data.pkg-vers.SDK.prev-vers -%}
-    <li><a href="{{site.prev-url}}{{page.url}}" class="no-automatic-external">{{site.data.pkg-vers.SDK.prev-vers}}&nbsp;&nbsp;({{dart1status}})</a></li>
+    <li><a href="{{site.prev-url}}{{page.url}}" class="dropdown-item no-automatic-external">{{site.data.pkg-vers.SDK.prev-vers}}&nbsp;&nbsp;({{dart1status}})</a></li>
   {%- endif -%}
-  <li><a class="active">{{site.data.pkg-vers.SDK.vers}}&nbsp;&nbsp;({{dart2status}})</a></li>
+  <li><a class="active dropdown-item">{{site.data.pkg-vers.SDK.vers}}&nbsp;&nbsp;({{dart2status}})</a></li>
 {%- endif %}

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -13,11 +13,11 @@
     <li><a href="/community">Community</a></li>
     {% else %}
     <li class="dropdown">
-      <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dart 2 <span class="caret"></span></a>
+      <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dart 2</a>
       <ul class="dropdown-menu">
         {% include _version-menu-items.html %}
-        <li role="separator" class="divider"></li>
-        <li><a href="/dart-2#migration">Migration guide</a></li>
+        <li role="separator" class="dropdown-divider"></li>
+        <li><a class="dropdown-item" href="/dart-2#migration">Migration guide</a></li>
       </ul>
     </li>
     {% endif %}


### PR DESCRIPTION
Followup to #1106. Contributes to #527.

- Divider used to be invisible. Fixed color.
- Realigned dropdown relative to "Dart 2" toggle to match Bootstrap 3 alignment.

Also:

- Cleanup gemfile dependencies
- Fix typo in Sass mixin name