### PR TITLE
Ensure links to GitHub work for site-shared pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,9 @@ title: Dart
 description: Dart is a platform for building structured apps. It includes a language, a VM, libraries, tools, and compilers to many targets, including JavaScript.
 url: https://www.dartlang.org
 dev-url: https://dartlang-org-dev.firebaseapp.com
-repo: https://github.com/dart-lang/site-www
+repo:
+  this: https://github.com/dart-lang/site-www
+  shared: &repo-shared https://github.com/dart-lang/site-shared
 branch: master
 port: 4000
 
@@ -50,6 +52,10 @@ defaults:
     path: tools
   values:
     show_breadcrumbs: true
+- scope:
+    path: tools/sdk
+  values:
+    repo: *repo-shared
 
 custom:
   dartpad:

--- a/src/_guides/language/effective-dart/index.md
+++ b/src/_guides/language/effective-dart/index.md
@@ -66,8 +66,8 @@ For links to all the guidelines, see the
   **Have feedback on the guides?** <br>
   Please create a [new issue][] or comment on one of our [existing issues][].
 
-  [new issue]: {{site.repo}}/issues/new
-  [existing issues]: {{site.repo}}/issues?q=is%3Aopen+is%3Aissue+label%3AEffectiveDart
+  [new issue]: {{site.repo.this}}/issues/new
+  [existing issues]: {{site.repo.this}}/issues?q=is%3Aopen+is%3Aissue+label%3AEffectiveDart
 </aside>
 {% endcomment %}
 

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -12,16 +12,16 @@
           <ul class="menu">
             <li>Site&nbsp;<a href="http://creativecommons.org/licenses/by/3.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;3.0</a></li>
             <li>
-              <a href="{{site.repo}}"
+              <a href="{{site.repo.this}}"
                  title="This site's source is on GitHub."
                  class="no-automatic-external"><i class="fab fa-github fa-sm"></i></a>
               &nbsp;
-              <a href="{{site.repo}}/issues"
+              <a href="{{site.repo.this}}/issues"
                  title="File an issue about this site."
                  class="no-automatic-external"><i class="fas fa-bug fa-sm"></i></a>
               &nbsp;
               <a {% if site.data.ci.job-id %}
-                 href="{{site.repo | regex_replace: 'github.com','travis-ci.org'}}/jobs/{{site.data.ci.job-id}}"
+                 href="{{site.repo.this | regex_replace: 'github.com','travis-ci.org'}}/jobs/{{site.data.ci.job-id}}"
                  title="Site build #{{site.data.ci.build-number}} ({{site.data.ci.build-time | date: dateFormat}})"
                  {% else %}
                  title="Site built on {{site.now | default: site.time | date: dateFormat}}"

--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -1,7 +1,8 @@
 {% if page.long-title or page.title -%}
+{% assign repo = page.repo | default: site.repo.this -%}
 <ul class="page-github-links-menu" role="group">
   <li>
-    <a href="{{site.repo}}/tree/{{site.branch}}/{{site.source}}/{{page.path}}"
+    <a href="{{repo}}/tree/{{site.branch}}/{{site.source}}/{{page.path}}"
       class="no-automatic-external"
       title="View page source"
       target="_blank" rel="noopener">
@@ -9,7 +10,7 @@
     </a>
   </li>
   <li>
-    <a href="{{site.repo}}/issues/new?title='{{page.title}}' page issue&body=From URL: {{site.url}}{{page.url}}"
+    <a href="{{repo}}/issues/new?title='{{page.title}}' page issue&body=From URL: {{site.url}}{{page.url}}"
       class="no-automatic-external"
       title="Report a bug on this page" target="_blank" rel="noopener">
       <i class="fas fa-bug fa-sm"></i>

--- a/src/resources/synonyms/index.md
+++ b/src/resources/synonyms/index.md
@@ -13,5 +13,5 @@ you're welcome to use our source code!
 Here are links to the old files for Synonyms:
 
 * [Synonyms (archived)]({{site.prev-url}}/resources/synonyms)
-* [Source code for Synonyms]({{site.repo}}/tree/1.x/src/resources/synonyms)
-  ([LICENSE]({{site.repo}}/blob/master/LICENSE))
+* [Source code for Synonyms]({{site.repo.this}}/tree/1.x/src/resources/synonyms)
+  ([LICENSE]({{site.repo.this}}/blob/master/LICENSE))


### PR DESCRIPTION
Fixes #1122

- Jekyll config: refactor site.repo -> site.repo.this
- Set page repo for site-shared pages under tool/sdk.

Staged, see:
- https://sz-www-1.firebaseapp.com/tools/sdk
- https://sz-www-1.firebaseapp.com/tools/sdk/archive