### PR TITLE
Tweak deferred loading warning

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3558,11 +3558,11 @@ Keep in mind the following when you use deferred loading:
 
 <aside class="alert alert-warning" markdown="1">
 **Dart VM difference:**
-Due to [issue #33118](https://github.com/dart-lang/sdk/issues/33118),
-the Dart VM allows access to members of deferred libraries
+The Dart VM allows access to members of deferred libraries
 even before the call to `loadLibrary()`.
-We expect this bug to be fixed soon, so
+This behavior might change, so
 **don't depend on the current VM behavior.**
+For details, see [issue #33118.](https://github.com/dart-lang/sdk/issues/33118)
 </aside>
 
 ### Implementing libraries


### PR DESCRIPTION
This PR changes the warning at the end of the deferred loading section (https://www.dartlang.org/guides/language/language-tour#deferred-loading) to this:

![image](https://user-images.githubusercontent.com/2164483/45058136-8f1f5b00-b04c-11e8-81e5-ff3db4cf68ce.png)

Related issue: dart-lang/sdk#33118