### PR TITLE
chore: use `site.g` as generated site folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ src/site/events/2015/summit/node_modules
 .jekyll-metadata
 
 # Deployment Files
-publish
+site.g
 
 # Misc
 tmp

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once everything is installed, you need to do a full site build at least once:
 
 - `jekyll build` &nbsp;&nbsp;# full site build
 
-The generated site is placed in the `publish` folder. To serve this folder use:
+The generated site is placed in the `site.g` folder. To serve this folder use:
 
 - `superstatic --port 4000`
 

--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ source: src
 # under `src` that are symlinked to somewhere outside `src`, or it can
 # refer to the root folder of the symlinked content (like `site-shared/src`):
 symlinked-sources: [site-shared/src]
-destination: publish
+destination: site.g
 bundler_args: --without production
 
 exclude: [diagrams]

--- a/deploy/cibuild
+++ b/deploy/cibuild
@@ -2,4 +2,4 @@
 set -e # halt script on error
 
 bundle exec jekyll build --incremental
-# bundle exec htmlproofer ./publish --assume-extension --directory-index-file
+# bundle exec htmlproofer ./site.g --assume-extension --directory-index-file

--- a/deploy/urls/get_all.rb
+++ b/deploy/urls/get_all.rb
@@ -9,7 +9,7 @@ $FIREBASE_TOKEN = ENV['FIREBASE_TOKEN']
 $FIREBASE_PROJECT = ENV['FIREBASE_PROJECT'] || 'default'
 
 puts "Parsing current sitemap.xml for all current URLs"
-sitemap = File.open("publish/sitemap.xml") { |f| Nokogiri::XML(f) }
+sitemap = File.open("site.g/sitemap.xml") { |f| Nokogiri::XML(f) }
 $NEW_URLS = sitemap.xpath("//xmlns:loc").map { |node| node.content }
 $NEW_URLS.sort!
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "publish",
+    "public": "site.g",
     "cleanUrls": true,
     "trailingSlash": false,
     "headers": [{


### PR DESCRIPTION
(This will be the folder name used across all three sites. cc @kwalrath @Sfshaza @filiph)