### PR TITLE
Removed dartosphere from community resources

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -67,7 +67,6 @@ Our wonderful community has provided these resources.
 * [dartdocs.org](http://www.dartdocs.org) - Documentation for pub packages
 * [Dart Academy](https://dart.academy/) - Tutorials
   and articles written by the Dart community
-* [Dartosphere blog aggregator](http://www.dartosphere.org)
 * [Chinese version of this site（此网站的中文版）](http://dart.goodev.org/)
 
 Also see [Community and Support]({{site.webdev}}/community) on Dart webdev.


### PR DESCRIPTION
It has been shut down by its creator due GDPR regulations, as announced on twitter, since May 15. It's safe to remove now I reckon.

Looks a little sloppy to users.