### PR TITLE
Update /guides/libraries/useful-libraries

### DIFF
--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -47,17 +47,17 @@ Dart community.  Here are some popular and useful packages,
 in alphabetical order:
 
 | **Package** | **Description** | **Commonly used APIs** |
-| [http]({{site.pub}}/packages/http) | A set of high-level functions and classes that make it easy to consume HTTP resources. | delete(), get(), post(), read() |
-| [intl]({{site.pub}}/packages/intl) | Internationalization and localization facilities, with support for plurals and genders, date and number formatting and parsing, and bidirectional text. | Bidi, DateFormat, MicroMoney, TextDirection |
-| [logging]({{site.pub}}/packages/logging) | A configurable mechanism for adding message logging to your application. | LoggerHandler, Level, LogRecord |
-| [mockito]({{site.pub}}/packages/mockito) | A popular framework for mocking objects in tests. Especially useful if you are writing tests for dependency injection. Used with the [test]({{site.pub}}/packages/test) package. | Answering, Expectation, Verification |
-| [path]({{site.pub}}/packages/path) | Common operations for manipulating different types of paths. For more information, see [Unboxing Packages: path.](https://news.dartlang.org/2016/06/unboxing-packages-path.html) | absolute(), basename(), extension(), join(), normalize(), relative(), split() |
-| [quiver]({{site.pub}}/packages/quiver) | Utilities that make using core Dart libraries more convenient. Some of the libraries where Quiver provides additional support include async, cache, collection, core, iterables, patterns, and testing. | CountdownTimer (quiver.async); MapCache (quiver.cache); MultiMap, TreeSet (quiver.collection); EnumerateIterable (quiver.iterables); center(), compareIgnoreCase(), isWhiteSpace() (quiver.strings)  |
-| [shelf]({{site.pub}}/packages/shelf) | Web server middleware for Dart. Shelf makes it easy to create and compose web servers, and parts of web servers. | Cascade, Pipeline, Request, Response, Server |
-| [stack_trace]({{site.pub}}/packages/stack_trace) | Methods for parsing, inspecting, and manipulating stack traces produced by the underlying Dart implementation. Also provides functions to produce string representations of stack traces in a more readable format than the native StackTrace implementation. For more information, see [Unboxing Packages: stack_trace.](https://news.dartlang.org/2016/01/unboxing-packages-stacktrace.html) | Trace.current(), Trace.format(), Trace.from() |
-| [stagehand]({{site.pub}}/packages/stagehand) | A Dart project generator. WebStorm and IntelliJ use Stagehand templates when you create a new application, but you can also use the templates from the command line. | Generally used through an IDE or the `stagehand` command. |
-| [test]({{site.pub}}/packages/test) | A standard way of writing and running tests in Dart. | expect(), group(), test() |
-| [yaml]({{site.pub}}/packages/yaml) | A parser for YAML. | loadYaml(), loadYamlStream() |
+| [http]({{site.pub-pkg}}/http) | A set of high-level functions and classes that make it easy to consume HTTP resources. | delete(), get(), post(), read() |
+| [intl]({{site.pub-pkg}}/intl) | Internationalization and localization facilities, with support for plurals and genders, date and number formatting and parsing, and bidirectional text. | Bidi, DateFormat, MicroMoney, TextDirection |
+| [logging]({{site.pub-pkg}}/logging) | A configurable mechanism for adding message logging to your application. | LoggerHandler, Level, LogRecord |
+| [mockito]({{site.pub-pkg}}/mockito) | A popular framework for mocking objects in tests. Especially useful if you are writing tests for dependency injection. Used with the [test]({{site.pub-pkg}}/test) package. | Answering, Expectation, Verification |
+| [path]({{site.pub-pkg}}/path) | Common operations for manipulating different types of paths. For more information, see [Unboxing Packages: path.](https://news.dartlang.org/2016/06/unboxing-packages-path.html) | absolute(), basename(), extension(), join(), normalize(), relative(), split() |
+| [quiver]({{site.pub-pkg}}/quiver) | Utilities that make using core Dart libraries more convenient. Some of the libraries where Quiver provides additional support include async, cache, collection, core, iterables, patterns, and testing. | CountdownTimer (quiver.async); MapCache (quiver.cache); MultiMap, TreeSet (quiver.collection); EnumerateIterable (quiver.iterables); center(), compareIgnoreCase(), isWhiteSpace() (quiver.strings)  |
+| [shelf]({{site.pub-pkg}}/shelf) | Web server middleware for Dart. Shelf makes it easy to create and compose web servers, and parts of web servers. | Cascade, Pipeline, Request, Response, Server |
+| [stack_trace]({{site.pub-pkg}}/stack_trace) | Methods for parsing, inspecting, and manipulating stack traces produced by the underlying Dart implementation. Also provides functions to produce string representations of stack traces in a more readable format than the native StackTrace implementation. For more information, see [Unboxing Packages: stack_trace.](https://news.dartlang.org/2016/01/unboxing-packages-stacktrace.html) | Trace.current(), Trace.format(), Trace.from() |
+| [stagehand]({{site.pub-pkg}}/stagehand) | A Dart project generator. WebStorm and IntelliJ use Stagehand templates when you create a new application, but you can also use the templates from the command line. | Generally used through an IDE or the `stagehand` command. |
+| [test]({{site.pub-pkg}}/test) | A standard way of writing and running tests in Dart. | expect(), group(), test() |
+| [yaml]({{site.pub-pkg}}/yaml) | A parser for YAML. | loadYaml(), loadYamlStream() |
 {:.table .table-striped .nowrap}
 
 To find more packages, see [pub.dartlang.org.]({{site.pub}})
@@ -68,10 +68,10 @@ Each of these "expansion pack" libraries builds upon an SDK library, adding
 additional functionality and filling in missing features:
 
 | **Package** | **Description** | **Commonly used APIs** |
-| [async]({{site.pub}}/packages/async) | Expands on dart:async, adding utility classes to work with asynchronous computations. For more information, see [Unboxing Packages: async part 1](https://news.dartlang.org/2016/03/unboxing-packages-async-part-1.html), [part 2](https://news.dartlang.org/2016/03/unboxing-packages-async-part-2.html), and [part 3.](https://news.dartlang.org/2016/04/unboxing-packages-async-part-3.html) | AsyncMemoizer, CancelableOperation, FutureGroup, LazyStream, Result, StreamCompleter, StreamGroup, StreamSplitter |
-| [collection]({{site.pub}}/packages/collection) | Expands on dart:collection, adding utility functions and classes to make working with collections easier. For more information, see [Unboxing Packages: collection.](https://news.dartlang.org/2016/01/unboxing-packages-collection.html) | Equality, CanonicalizedMap, MapKeySet, MapValueSet, PriorityQueue, QueueList |
-|[convert]({{site.pub}}/packages/convert) | Expands on dart:convert, adding encoders and decoders for converting between different data representations. One of the data representations is _percent encoding_, also known as _URL encoding_. | HexDecoder, PercentDecoder |
-|[io]({{site.pub}}/packages/io) | Contains two libraries, ansi and io, to simplify working with files, standard streams, and processes. Use the ansi library to customize terminal output. The io library has APIs for dealing with processes, stdin, and file duplication. |  copyPath(), isExecutable(), ExitCode, ProcessManager, sharedStdIn |
+| [async]({{site.pub-pkg}}/async) | Expands on dart:async, adding utility classes to work with asynchronous computations. For more information, see [Unboxing Packages: async part 1](https://news.dartlang.org/2016/03/unboxing-packages-async-part-1.html), [part 2](https://news.dartlang.org/2016/03/unboxing-packages-async-part-2.html), and [part 3.](https://news.dartlang.org/2016/04/unboxing-packages-async-part-3.html) | AsyncMemoizer, CancelableOperation, FutureGroup, LazyStream, Result, StreamCompleter, StreamGroup, StreamSplitter |
+| [collection]({{site.pub-pkg}}/collection) | Expands on dart:collection, adding utility functions and classes to make working with collections easier. For more information, see [Unboxing Packages: collection.](https://news.dartlang.org/2016/01/unboxing-packages-collection.html) | Equality, CanonicalizedMap, MapKeySet, MapValueSet, PriorityQueue, QueueList |
+|[convert]({{site.pub-pkg}}/convert) | Expands on dart:convert, adding encoders and decoders for converting between different data representations. One of the data representations is _percent encoding_, also known as _URL encoding_. | HexDecoder, PercentDecoder |
+|[io]({{site.pub-pkg}}/io) | Contains two libraries, ansi and io, to simplify working with files, standard streams, and processes. Use the ansi library to customize terminal output. The io library has APIs for dealing with processes, stdin, and file duplication. |  copyPath(), isExecutable(), ExitCode, ProcessManager, sharedStdIn |
 {:.table .table-striped .nowrap}
 {% comment %}
   update-for-dart-2
@@ -87,9 +87,9 @@ elsewhere.
 
 If you write web apps, check out AngularDart, a web application framework.
 Other available resources are the
-[js package]({{site.pub}}/packages/js)
+[js package]({{site.pub-pkg}}/js)
 for interoperability with JavaScript APIs,
-the [firebase package]({{site.pub}}/packages/firebase)
+the [firebase package]({{site.pub-pkg}}/firebase)
 for access to the Firebase JavaScript API, and the
 [dart:html library]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/dart-html-library.html)
 for low-level HTML programming.

--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -10,7 +10,7 @@ Dart libraries come from a variety of sources:
 * Core libraries&mdash;such as dart:core, dart:async, and dart:collection&mdash;are
   distributed with the SDK and documented at [api.dartlang.org]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}).
 * Libraries shared with the Dart community are distributed as library packages,
-  published at [pub.dartlang.org](https://pub.dartlang.org/).
+  published at [pub.dartlang.org.]({{site.pub}})
   The [pub](/tools/pub/) tool allows you to create, publish, and manage library packages.
 * Libraries from GitHub, a URL, or a local path can be included in your application.
   For more information, see
@@ -24,8 +24,8 @@ and tells you where to learn more about some of the most widely used Dart librar
 
 <aside class="alert alert-info" markdown="1">
 **Tip:**
-If you don't find the functionality you need on [api.dartlang.org]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}),
-check [pub.dartlang.org](https://pub.dartlang.org/).
+If you don't find the functionality you need on [api.dartlang.org,]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}})
+check [pub.dartlang.org.]({{site.pub}})
 </aside>
 
 Looking for web, server, or Flutter libraries?
@@ -47,20 +47,20 @@ Dart community.  Here are some popular and useful packages,
 in alphabetical order:
 
 | **Package** | **Description** | **Commonly used APIs** |
-| [firebase](https://pub.dartlang.org/packages/firebase) | A wrapper for [Firebase](https://firebase.google.com) that allows you to easily publish your app to the cloud. | Auth, Database, Query, Storage |
-| [http](https://pub.dartlang.org/packages/http) | A set of high-level functions and classes that make it easy to consume HTTP resources. | delete(), get(), post(), read() |
-| [intl](https://pub.dartlang.org/packages/intl) | Internationalization and localization facilities, with support for plurals and genders, date and number formatting and parsing, and bidirectional text. | Bidi, DateFormat, MicroMoney, TextDirection |
-| [logging](https://pub.dartlang.org/packages/logging) | A configurable mechanism for adding message logging to your application. | LoggerHandler, Level, LogRecord |
-| [mockito](https://pub.dartlang.org/packages/mockito) | A popular framework for mocking objects in tests. Especially useful if you are writing tests for dependency injection. Used with the [test](https://pub.dartlang.org/packages/test) package. | Answering, Expectation, Verification |
-| [path](https://pub.dartlang.org/packages/path) | Common operations for manipulating different types of paths. For more information, see [Unboxing Packages: path.](http://news.dartlang.org/2016/06/unboxing-packages-path.html) | absolute(), basename(), extension(), join(), normalize(), relative(), split() |
-| [quiver](https://pub.dartlang.org/packages/quiver) | Utilities that make using core Dart libraries more convenient. Some of the libraries where Quiver provides additional support include async, cache, collection, core, iterables, patterns, and testing. | CountdownTimer (quiver.async); MapCache (quiver.cache); MultiMap, TreeSet (quiver.collection); EnumerateIterable (quiver.iterables); center(), compareIgnoreCase(), isWhiteSpace() (quiver.strings)  |
-| [shelf](https://pub.dartlang.org/packages/shelf) | Web server middleware for Dart. Shelf makes it easy to create and compose web servers, and parts of web servers. | Cascade, Pipeline, Request, Response, Server |
-| [stack_trace](https://pub.dartlang.org/packages/stack_trace) | Methods for parsing, inspecting, and manipulating stack traces produced by the underlying Dart implementation. Also provides functions to produce string representations of stack traces in a more readable format than the native StackTrace implementation. For more information, see [Unboxing Packages: stack_trace.](http://news.dartlang.org/2016/01/unboxing-packages-stacktrace.html) | Trace.current(), Trace.format(), Trace.from() |
-| [stagehand](https://pub.dartlang.org/packages/stagehand) | A Dart project generator. WebStorm and IntelliJ use Stagehand templates when you create a new application, but you can also use the templates from the command line. | Generally used through an IDE or the [`stagehand` command](http://stagehand.pub/). |
-| [test](https://pub.dartlang.org/packages/test) | A standard way of writing and running tests in Dart. | expect(), group(), test() |
+| [http]({{site.pub}}/packages/http) | A set of high-level functions and classes that make it easy to consume HTTP resources. | delete(), get(), post(), read() |
+| [intl]({{site.pub}}/packages/intl) | Internationalization and localization facilities, with support for plurals and genders, date and number formatting and parsing, and bidirectional text. | Bidi, DateFormat, MicroMoney, TextDirection |
+| [logging]({{site.pub}}/packages/logging) | A configurable mechanism for adding message logging to your application. | LoggerHandler, Level, LogRecord |
+| [mockito]({{site.pub}}/packages/mockito) | A popular framework for mocking objects in tests. Especially useful if you are writing tests for dependency injection. Used with the [test]({{site.pub}}/packages/test) package. | Answering, Expectation, Verification |
+| [path]({{site.pub}}/packages/path) | Common operations for manipulating different types of paths. For more information, see [Unboxing Packages: path.](https://news.dartlang.org/2016/06/unboxing-packages-path.html) | absolute(), basename(), extension(), join(), normalize(), relative(), split() |
+| [quiver]({{site.pub}}/packages/quiver) | Utilities that make using core Dart libraries more convenient. Some of the libraries where Quiver provides additional support include async, cache, collection, core, iterables, patterns, and testing. | CountdownTimer (quiver.async); MapCache (quiver.cache); MultiMap, TreeSet (quiver.collection); EnumerateIterable (quiver.iterables); center(), compareIgnoreCase(), isWhiteSpace() (quiver.strings)  |
+| [shelf]({{site.pub}}/packages/shelf) | Web server middleware for Dart. Shelf makes it easy to create and compose web servers, and parts of web servers. | Cascade, Pipeline, Request, Response, Server |
+| [stack_trace]({{site.pub}}/packages/stack_trace) | Methods for parsing, inspecting, and manipulating stack traces produced by the underlying Dart implementation. Also provides functions to produce string representations of stack traces in a more readable format than the native StackTrace implementation. For more information, see [Unboxing Packages: stack_trace.](https://news.dartlang.org/2016/01/unboxing-packages-stacktrace.html) | Trace.current(), Trace.format(), Trace.from() |
+| [stagehand]({{site.pub}}/packages/stagehand) | A Dart project generator. WebStorm and IntelliJ use Stagehand templates when you create a new application, but you can also use the templates from the command line. | Generally used through an IDE or the `stagehand` command. |
+| [test]({{site.pub}}/packages/test) | A standard way of writing and running tests in Dart. | expect(), group(), test() |
+| [yaml]({{site.pub}}/packages/yaml) | A parser for YAML. | loadYaml(), loadYamlStream() |
 {:.table .table-striped .nowrap}
 
-To find more packages, see [pub.dartlang.org](https://pub.dartlang.org/).
+To find more packages, see [pub.dartlang.org.]({{site.pub}})
 
 ## Packages that correspond to SDK libraries
 
@@ -68,10 +68,15 @@ Each of these "expansion pack" libraries builds upon an SDK library, adding
 additional functionality and filling in missing features:
 
 | **Package** | **Description** | **Commonly used APIs** |
-| [async](https://www.dartdocs.org/documentation/async/latest/) | Expands on dart:async, adding utility classes to work with asynchronous computations. For more information, see [Unboxing Packages: async part 1](http://news.dartlang.org/2016/03/unboxing-packages-async-part-1.html), [part 2](http://news.dartlang.org/2016/03/unboxing-packages-async-part-2.html), and [part 3.](http://news.dartlang.org/2016/04/unboxing-packages-async-part-3.html) | AsyncMemoizer, CancelableOperation, FutureGroup, LazyStream, Result, StreamCompleter, StreamGroup, StreamSplitter |
-| [collection](https://www.dartdocs.org/documentation/collection/latest) | Expands on dart:collection, adding utility functions and classes to make working with collections easier. For more information, see [Unboxing Packages: collection.](http://news.dartlang.org/2016/01/unboxing-packages-collection.html) | Equality, CanonicalizedMap, MapKeySet, MapValueSet, PriorityQueue, QueueList |
-|[convert](https://www.dartdocs.org/documentation/convert/latest/) | Expands on dart:convert, adding encoders and decoders for converting between different data representations. One of the data representations is _percent encoding_, also known as _URL encoding_. | HexDecoder, PercentDecoder |
+| [async]({{site.pub}}/packages/async) | Expands on dart:async, adding utility classes to work with asynchronous computations. For more information, see [Unboxing Packages: async part 1](https://news.dartlang.org/2016/03/unboxing-packages-async-part-1.html), [part 2](https://news.dartlang.org/2016/03/unboxing-packages-async-part-2.html), and [part 3.](https://news.dartlang.org/2016/04/unboxing-packages-async-part-3.html) | AsyncMemoizer, CancelableOperation, FutureGroup, LazyStream, Result, StreamCompleter, StreamGroup, StreamSplitter |
+| [collection]({{site.pub}}/packages/collection) | Expands on dart:collection, adding utility functions and classes to make working with collections easier. For more information, see [Unboxing Packages: collection.](https://news.dartlang.org/2016/01/unboxing-packages-collection.html) | Equality, CanonicalizedMap, MapKeySet, MapValueSet, PriorityQueue, QueueList |
+|[convert]({{site.pub}}/packages/convert) | Expands on dart:convert, adding encoders and decoders for converting between different data representations. One of the data representations is _percent encoding_, also known as _URL encoding_. | HexDecoder, PercentDecoder |
+|[io]({{site.pub}}/packages/io) | Contains two libraries, ansi and io, to simplify working with files, standard streams, and processes. Use the ansi library to customize terminal output. The io library has APIs for dealing with processes, stdin, and file duplication. |  copyPath(), isExecutable(), ExitCode, ProcessManager, sharedStdIn |
 {:.table .table-striped .nowrap}
+{% comment %}
+  update-for-dart-2
+  TODO: Add math after it's been updated
+{% endcomment %}
 
 ## Specialized libraries
 
@@ -81,15 +86,20 @@ elsewhere.
 ### Web libraries
 
 If you write web apps, check out AngularDart, a web application framework.
-Other available resources are the js package for interoperability with
-JavaScript APIs, and the dart:html library for low-level HTML programming.
+Other available resources are the
+[js package]({{site.pub}}/packages/js)
+for interoperability with JavaScript APIs,
+the [firebase package]({{site.pub}}/packages/firebase)
+for access to the Firebase JavaScript API, and the
+[dart:html library]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/dart-html-library.html)
+for low-level HTML programming.
 
 **Learn more:** [webdev.dartlang.org]({{site.webdev}})
 
 ### Server-side libraries
 
 If you write servers or command-line applications, check out
-[dart:io](https://api.dartlang.org/stable/dart-io/dart-io-library.html)
+[dart:io]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/dart-io-library.html)
 and related libraries.
 
 **Learn more:** [server-side Dart]({{site.dart_vm}})
@@ -98,9 +108,9 @@ and related libraries.
 
 If you write mobile apps, check out Flutter.
 The core libraries distributed with the Flutter SDK are documented at
-[docs.flutter.io](http://docs.flutter.io/). To import these libraries,
+[docs.flutter.io.](https://docs.flutter.io/) To import these libraries,
 follow the instructions in [Importing libraries from
-packages](https://www.dartlang.org/tools/pub/get-started#importing-libraries-from-packages).
+packages](/tools/pub/get-started#importing-libraries-from-packages).
 
 **Learn more:** [flutter.io]({{site.flutter}})
 
@@ -127,21 +137,20 @@ Use the following resources to learn more about libraries and library packages.
 
 * [A Tour of the Dart Libraries](/guides/libraries/library-tour), which
   gives examples of many commonly used dart:* APIs.
-* [Unboxing Packages](http://news.dartlang.org/search/label/Unboxing%20Packages)
+* [Unboxing Packages](https://news.dartlang.org/search/label/Unboxing%20Packages)
   posts, written by written by Natalie Weizenbaum and published on
-  [news.dartlang.org.](http://news.dartlang.org/).
+  [news.dartlang.org.](https://news.dartlang.org/)
   This page links to some of Natalie's posts, but she covers other packages
   not mentioned here, such as stream_channel, vm_service_client, and json_rpc_2.
 
 ### Packages contributed by the community
 
-* [pub.dartlang.org](https://pub.dartlang.org)
+* [pub.dartlang.org]({{site.pub}})
 
 ### API reference documentation
 
 * [api.dartlang.org]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) contains the generated docs for dart:* libraries.
-* [dartdocs.org](https://www.dartdocs.org/) contains the generated docs for
-  packages published on pub.dartlang.org.
-* [docs.flutter.io](http://docs.flutter.io/) contains the generated docs for Flutter
+* [pub.dartlang.org]({{site.pub}}) hosts the generated docs for published packages.
+* [docs.flutter.io](https://docs.flutter.io/) contains the generated docs for Flutter
   libraries.
 


### PR DESCRIPTION
Staged: https://kw-staging-dartlang-2.firebaseapp.com/guides/libraries/useful-libraries

* Moved firebase down to the webdev list, since Flutter can't use it.
* Updated URLs, using macros where possible.
* Added the io package.

Fixes #656.