### PR TITLE
Update language-tour.md to add a note for overriding operators.

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2990,9 +2990,9 @@ Vector class, you might define a `+` method to add two vectors.
 {:.table}
 
 <div class="alert alert-info" markdown="1">
-**Note** You may have noticed that `!=` is not an overridable operator. 
-This is because `!=` is not an operator in its own right, the expression `e1 != e2` 
-is just syntactic sugar for `!(e1 == e2)`.
+  **Note:** You may have noticed that `!=` is not an overridable operator.
+  This is because `!=` is not an operator in its own right; the expression `e1 != e2`
+  is just syntactic sugar for `!(e1 == e2)`.
 </div>
 
 Here’s an example of a class that overrides the `+` and `-` operators:

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2989,6 +2989,12 @@ Vector class, you might define a `+` method to add two vectors.
 `–`  | `%`  | `>>`
 {:.table}
 
+<div class="alert alert-info" markdown="1">
+**Note** You may have noticed that `!=` is not an overridable operator. 
+This is because `!=` is not an operator in its own right, the expression `e1 != e2` 
+is just syntactic sugar for `!(e1 == e2)`.
+</div>
+
 Here’s an example of a class that overrides the `+` and `-` operators:
 
 <?code-excerpt "misc/lib/language_tour/classes/vector.dart"?>


### PR DESCRIPTION
This is to address issue #1081 by providing a note to the documentation indicating that `!=` is not an overriding operator but a syntactic sugar shortcut for evaluating an expression like `!(e1 == e2)`.