### PR TITLE
Reinstate TOC second-level headings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,4 +104,4 @@ assets:
 
 toc:
   min_level: 2
-  max_level: 2 # FIXME(temporary): disable level 3 headings until we've fully fixed migrated the TOC
+  max_level: 3

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -484,6 +484,8 @@ img {
   position: fixed;
   width: 225px;
   right: 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
   z-index: 999;
   .content {
     padding-top: 20px;


### PR DESCRIPTION
We disabled inclusion of \<h3> elements in TOCs during our "essentials" migration to Bootstrap 4 (#1106). This PR reinstates their use.

Fixes #1109

Staged at https://sz-www-1.firebaseapp.com

Note that the original implementation of the TOC height adjustment has a bug (which is still visible on the v1 version of the site): make the window taller after the TOC max-height has been computed, but the TOC height isn't recomputed and so you'll get a proportional amount of blank space below the TOC (until you scroll the window context), for example:

<img width="1258" alt="screen shot 2018-09-21 at 14 39 46" src="https://user-images.githubusercontent.com/4140793/45900311-610c7b80-bdad-11e8-943c-2b5f62b511b7.png">

Under the new design, where the page structure is different, we don't have this problem. So I'll let this longstanding issue as is for now.