### PR TITLE
Use site-shared code styles, which fixes terminal styling issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,12 @@ custom:
 
 # Build settings
 
+assets:
+  source_maps: false
+  sources:
+    - _shared/_assets
+    - _shared/_assets/css
+
 future: true # In support of https://github.com/dart-lang/site-www/issues/1111
 
 # bundler_args: --without production
@@ -100,9 +106,6 @@ symlinked-sources: [site-shared/src]
 # when you update any og:image file. (Also increment the corresponding number
 # in the `firebase.json` redirect rule.)
 og_image_vers: "?2"
-
-assets:
-  source_maps: false
 
 toc:
   min_level: 2

--- a/src/_assets/css/_bootstrap_adjust.scss
+++ b/src/_assets/css/_bootstrap_adjust.scss
@@ -1,0 +1,3 @@
+@mixin pre-defaults {
+  padding: 2px 3px; // bs-spacer(3) bs-spacer(4);
+}

--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -1,3 +1,6 @@
+// TODO: most of the content of this file is in _shared/_assets/css/_code_pre.scss,
+// except for things like the media-print declarations. Move the media-print to the shared styles file.
+
 .prettyprint {
   background: #eee;
   // font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1,21 +1,22 @@
 //= require vendor/code-prettify/prettify.css
 
-@import '_variables';
-@import '_colors';
+@import 'variables';
+@import 'colors';
 @import 'bootstrap';
+@import 'bootstrap_adjust';
 
-@import "font-awesome-sprockets";
-@import "font-awesome";
+@import 'font-awesome-sprockets';
+@import 'font-awesome';
 
-@import '_mixins';
+@import 'mixins';
 
-@import '_icons';
-@import '_code';
-@import '_animations';
+@import 'icons';
+@import 'code_pre';
+@import 'animations';
 
-@import '_dartvm';
-@import '_books';
-@import '_os-tabs';
+@import 'dartvm';
+@import 'books';
+@import 'os-tabs';
 
 // Extra variables (defined in terms of bootstrap and other defaults)
 $font-color: $body-color;


### PR DESCRIPTION
Context: https://github.com/dart-lang/site-shared/pull/38#issuecomment-432446941

Staged, e.g., see https://sz-www-1.firebaseapp.com/tools/sdk#install

---

## Screenshots

Old appearance:

<img width="594" alt="screen shot 2018-10-24 at 14 23 36" src="https://user-images.githubusercontent.com/4140793/47452529-7d2e7e80-d798-11e8-96c5-9ee6265cb2cc.png">

New appearance:

<img width="595" alt="screen shot 2018-10-24 at 14 23 51" src="https://user-images.githubusercontent.com/4140793/47452532-815a9c00-d798-11e8-86ed-fc3c4fbd3e6e.png">

cc @sfshaza2 