### PR TITLE
Adjust Platforms table style for mobile

### DIFF
--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -209,17 +209,21 @@ body.homepage .get-started-section {
 	margin-top: 20px;
 	margin-bottom: 20px;
 
-	td {
-		padding: 10px;
-		padding-left: 0;
-		padding-right: 2em;
-		border-bottom: 1px solid $gray-light;
+  td {
+    border-bottom: 1px solid $gray-light;
+    @include media-breakpoint-up(sm) {
+      padding: 10px;
+      padding-left: 0;
+      padding-right: 2em;
+    }
 	}
 
+  tr:first-child > td {
+    text-align: center !important;
+  }
+
 	td:first-child {
-		@include media-breakpoint-up(sm) {
-		  padding-right: 0;
-		}
+		@include media-breakpoint-up(sm) { padding-right: 0; }
 	}
 
   /* icon column */
@@ -232,6 +236,12 @@ body.homepage .get-started-section {
 			display: table-cell;
 		}
 	}
+
+  // Use-case column
+  td:nth-child(3) {
+    min-width: 150px;
+		@include media-breakpoint-down(sm) { padding-left: .5rem; }
+  }
 
 	td:last-child {
 		padding-left: 10px;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -993,6 +993,10 @@ h3.popover-header {
   @extend .table-bordered;
 }
 
+.table-wrapper {
+  overflow-x: auto;
+}
+
 .alert {
   padding: $content-padding;
   border: none;

--- a/src/_guides/get-started.md
+++ b/src/_guides/get-started.md
@@ -30,11 +30,13 @@ Learn about the Dart [language](/guides/language) and
 Once you have a use case in mind, go to the "get started" instructions
 for the appropriate Dart platform:
 
-| **Platform** | | **Use case** | **Get started** |
-| **Mobile** | <i class="fab fa-android" aria-hidden="true"></i> <i class="fab fa-apple" aria-hidden="true"></i> | Create an app from a single codebase that runs on both iOS and Android. | <a href="https://flutter.io/getting-started/" class="btn btn-primary no-automatic-external">Flutter</a> |
+<div class="table-wrapper" markdown="1">
+| **Platform** | | **Use case**{:.mx-auto} | **Get started** |
+| **Mobile** | <i class="fab fa-android" aria-hidden="true"></i> <i class="fab fa-apple" aria-hidden="true"></i> | Create an app from a single codebase that runs on both iOS and Android. | <a href="https://flutter.io/getting-started" class="btn btn-primary no-automatic-external">Flutter</a> |
 | **Web** | <i class="fas fa-code fa-sm" aria-hidden="true"></i> | Create an app that runs in any modern browser. | <a href="{{site.webdev}}/guides/get-started" class="btn btn-primary no-automatic-external">Dart for the web</a> |
 | **Server** | <i class="fas fa-terminal fa-sm" aria-hidden="true"></i> | Create a command-line tool or server. | <a href="/tutorials/server/get-started" class="btn btn-primary">Server-side Dart</a> |
 {:.get-started-table}
+</div>
 
 Here are some other resources:
 


### PR DESCRIPTION
AFAICT, the original change proposed by #1276 wasn't needed (at least not on iOS). In any case, this PR makes the Platforms table more compact on mobile. Other than the centering of the table heading text, here is no change for desktop appearance of the table.

Closes #1276

Staged at https://dartlang-org-staging-1.firebaseapp.com/guides/get-started

### Screenshots

Before:
<img width="432" alt="screen shot 2018-12-26 at 17 58 11" src="https://user-images.githubusercontent.com/4140793/50459815-3fd3a200-093d-11e9-9b52-e1866612cccd.png">

After:
<img width="432" alt="screen shot 2018-12-26 at 18 27 52" src="https://user-images.githubusercontent.com/4140793/50459822-495d0a00-093d-11e9-86a4-2c1a3ceaf683.png">

<img width="783" alt="screen shot 2018-12-26 at 18 29 15" src="https://user-images.githubusercontent.com/4140793/50459821-495d0a00-093d-11e9-9cfc-97b4e6fcc474.png">


