### PR TITLE
Remove the banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ pub: https://pub.dartlang.org
 pub-api: https://pub.dartlang.org/documentation
 pub-pkg: https://pub.dartlang.org/packages
 
-show_banner: true
+show_banner: false
 
 collections:
   articles:


### PR DESCRIPTION
It's been a couple of months now since we published 2.1. Time to pull the banner, I think.

/cc @mit-mit 