### PR TITLE
Fix 404s for /tutorials/dart-vm

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -182,6 +182,7 @@
       { "source": "/server/tls-ssl?(.html)", "destination": "https://dart-lang.github.io/server/tls-ssl.html", "type": 301 },
       { "source": "/dart-vm", "destination": "/server", "type": 301 },
       { "source": "/dart-vm/:page*", "destination": "/server/:page*", "type": 301 },
+      { "source": "/tutorials/dart-vm", "destination": "/tutorials/server", "type": 301 },
       { "source": "/tutorials/dart-vm/:page*", "destination": "/tutorials/server/:page*", "type": 301 },
       { "source": "/stable{,/**}", "destination": "https://api.dartlang.org/stable", "type": 301 },
       { "source": "/support/faq?(.html)", "destination": "/faq", "type": 301 },


### PR DESCRIPTION
#1285 fixed lots of these dart-vm -> server 404s, but this one remained.

I've confirmed that the site builds and URLs like http://localhost:4000/tutorials/dart-vm/httpserver still work.