### PR TITLE
Add linter rules to Effective Dart

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ flutter_api: https://docs.flutter.io
 pub: https://pub.dartlang.org
 pub-api: https://pub.dartlang.org/documentation
 pub-pkg: https://pub.dartlang.org/packages
+lints: https://dart-lang.github.io/linter/lints
 
 show_banner: false
 

--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -322,3 +322,9 @@ body.homepage .get-started-section {
 pre code {
   white-space: pre;
 }
+
+/* Effective Dart linter rules */
+.linter-rule {
+  font-size: smaller;
+  font-style: italic;
+}

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -369,6 +369,8 @@ previous guidelines state, either:
 
 ### PREFER naming a method `to___()` if it copies the object's state to a new object.
 
+{% include linter-rule.html rule="use_to_and_as_if_applicable" %}
+
 A *conversion* method is one that returns a new object containing a copy of
 almost all of the state of the receiver but usually in some different form or
 representation. The core libraries have a convention that these methods are
@@ -386,6 +388,8 @@ dateTime.toLocal();
 
 
 ### PREFER naming a method `as___()` if it returns a different representation backed by the original object.
+
+{% include linter-rule.html rule="use_to_and_as_if_applicable" %}
 
 Conversion methods are "snapshots". The resulting object has its own copy of the
 original object's state. There are other conversion-like methods that return
@@ -556,6 +560,8 @@ you can in a procedural or functional language.
 
 ### AVOID defining a one-member abstract class when a simple function will do.
 
+{% include linter-rule.html rule="one_member_abstracts" %}
+
 Unlike Java, Dart has first-class functions, closures, and a nice light syntax
 for using them. If all you need is something like a callback, just use a
 function. If you're defining a class and it only has a single abstract member
@@ -578,6 +584,8 @@ abstract class Predicate<E> {
 
 
 ### AVOID defining a class that contains only static members.
+
+{% include linter-rule.html rule="avoid_classes_with_only_static_members" %}
 
 In Java and C#, every definition *must* be inside a class, so it's common to see
 "classes" that exist only as a place to stuff static members. Other classes are
@@ -740,6 +748,8 @@ A member belongs to an object and can be either methods or instance variables.
 
 ### PREFER making fields and top-level variables `final`.
 
+{% include linter-rule.html rule="prefer_final_fields" %}
+
 State that is not *mutable*&mdash;that does not change over time&mdash;is
 easier for programmers to reason about. Classes and libraries that minimize the
 amount of mutable state they work with tend to be easier to maintain.
@@ -849,6 +859,8 @@ dataSet.minimumValue;
 
 ### DO use setters for operations that conceptually change properties.
 
+{% include linter-rule.html rule="use_setters_to_change_properties" %}
+
 Deciding between a setter versus a method is similar to deciding between a
 getter versus a method. In both cases, the operation should be "field-like".
 
@@ -874,6 +886,8 @@ button.visible = false;
 
 ### DON'T define a setter without a corresponding getter.
 
+{% include linter-rule.html rule="avoid_setters_without_getters" %}
+
 Users think of getters and setters as visible properties of an object. A
 "dropbox" property that can be written to but not seen is confusing and
 confounds their intuition about how properties work. For example, a setter
@@ -896,6 +910,8 @@ getter.)
 
 ### AVOID returning `null` from members whose return type is `bool`, `double`, `int`, or `num`.
 
+{% include linter-rule.html rule="avoid_returning_null" %}
+
 Even though all types are nullable in Dart, users assume those types almost
 never contain `null`, and the lowercase names encourage a "Java primitive"
 mindset.
@@ -909,6 +925,8 @@ clearly, including the conditions under which `null` will be returned.
 
 
 ### AVOID returning `this` from methods just to enable a fluent interface.
+
+{% include linter-rule.html rule="avoid_returning_this" %}
 
 Method cascades are a better solution for chaining method calls.
 
@@ -1034,6 +1052,8 @@ The remaining guidelines cover other more specific questions around types.
 
 ### PREFER type annotating public fields and top-level variables if the type isn't obvious.
 
+{% include linter-rule.html rule="prefer_typing_uninitialized_variables" %}
+
 Type annotations are important documentation for how a library should be used.
 They form boundaries between regions of a program to isolate the source of a
 type error. Consider:
@@ -1079,6 +1099,8 @@ type of your own API without you realizing.
 
 ### CONSIDER type annotating private fields and top-level variables if the type isn't obvious.
 
+{% include linter-rule.html rule="prefer_typing_uninitialized_variables" %}
+
 Type annotations on your public declarations help *users* of your code. Types on
 private members help *maintainers*. The scope of a private declaration is
 smaller and those who need to know the type of that declaration are also more
@@ -1092,6 +1114,8 @@ annotating helps make the code clearer, then add one.
 
 
 ### AVOID type annotating initialized local variables.
+
+{% include linter-rule.html rule="omit_local_variable_types" %}
 
 Local variables, especially in modern code where functions tend to be small,
 have very little scope. Omitting the type focuses the reader's attention on the
@@ -1339,6 +1363,8 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
 
 ### DON'T specify a return type for a setter.
 
+{% include linter-rule.html rule="avoid_return_types_on_setters" %}
+
 Setters always return `void` in Dart. Writing the word is pointless.
 
 {:.bad-style}
@@ -1355,6 +1381,8 @@ set foo(Foo value) { ... }
 
 
 ### DON'T use the legacy typedef syntax.
+
+{% include linter-rule.html rule="prefer_generic_function_type_aliases" %}
 
 Dart has two notations for defining a named typedef for a function type. The
 original syntax looks like:
@@ -1416,6 +1444,8 @@ it's deprecated.
 
 ### PREFER inline function types over typedefs.
 
+{% include linter-rule.html rule="avoid_private_typedef_functions" %}
+
 In Dart 1, if you wanted to use a function type for a field, variable, or
 generic type argument, you had to first define a typedef for it. Dart 2 supports
 a function type syntax that can be used anywhere a type annotation is allowed:
@@ -1450,6 +1480,8 @@ that clarity.
 
 
 ### CONSIDER using function type syntax for parameters.
+
+{% include linter-rule.html rule="use_function_type_syntax_for_parameters" %}
 
 Dart has a special syntax when defining a parameter whose type is a function.
 Sort of like in C, you surround the parameter's name with the function's return
@@ -1582,6 +1614,8 @@ In Dart, optional parameters can be either positional or named, but not both.
 
 ### AVOID positional boolean parameters.
 
+{% include linter-rule.html rule="avoid_positional_boolean_parameters" %}
+
 Unlike other types, booleans are usually used in literal form. Things like
 numbers are usually wrapped in named constants, but we usually just pass around
 `true` and `false` directly. That can make callsites unreadable if it isn't
@@ -1701,6 +1735,8 @@ elements to follow.
 
 ### DO override `hashCode` if you override `==`.
 
+{% include linter-rule.html rule="hash_and_equals" %}
+
 The default hash code implementation provides an *identity* hash&mdash;two
 objects generally only have the same hash code if they are the exact same
 object. Likewise, the default behavior for `==` is identity.
@@ -1736,6 +1772,8 @@ hash code will be the same forever and may behave unpredictably if that isn't
 true.
 
 ### DON'T check for `null` in custom `==` operators.
+
+{% include linter-rule.html rule="avoid_null_checks_in_equality_operators" %}
 
 The language specifies that this check is done automatically and your `==`
 method is called only if the right-hand side is not `null`.

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -75,6 +75,8 @@ before a declaration and uses the special `///` syntax that dartdoc looks for.
 
 ### DO use `///` doc comments to document members and types.
 
+{% include linter-rule.html rule="slash_for_doc_comments" %}
+
 Using a doc comment instead of a regular comment enables [dartdoc][] to find it
 and generate documentation for it.
 
@@ -102,6 +104,8 @@ If you stumble onto code that still uses the JavaDoc style, consider cleaning it
 up.
 
 ### PREFER writing doc comments for public APIs.
+
+{% include linter-rule.html rule1="package_api_docs" rule2="public_member_api_docs"%}
 
 You don't have to document every single library, top-level variable, type, and
 member, but you should document most of them.
@@ -293,6 +297,8 @@ makes an API easier to learn.
 
 ### DO use square brackets in doc comments to refer to in-scope identifiers.
 
+{% include linter-rule.html rule="comment_references" %}
+
 If you surround things like variable, method, or type names in square brackets,
 then dartdoc looks up the name and links to the relevant API docs. Parentheses
 are optional, but can make it clearer when you're referring to a method or
@@ -376,10 +382,10 @@ class ToggleComponent {}
 ## Markdown
 
 You are allowed to use most [markdown][] formatting in your doc comments and
-dartdoc will process it accordingly using the [markdown package][].
+dartdoc will process it accordingly using the [markdown package.][]
 
 [markdown]: https://daringfireball.net/projects/markdown/
-[markdown package]: https://pub.dartlang.org/packages/markdown
+[markdown package.]: https://pub.dartlang.org/packages/markdown
 
 There are tons of guides out there already to introduce you to Markdown. Its
 universal popularity is why we chose it. Here's just a quick example to give you

--- a/src/_guides/language/effective-dart/index.md
+++ b/src/_guides/language/effective-dart/index.md
@@ -34,6 +34,18 @@ write consistent, robust, fast code too. There are two overarching themes:
 
 [code golf]: https://en.wikipedia.org/wiki/Code_golf
 
+The Dart analyzer has a linter to help you write good, consistent code.
+If a linter rule exists that can help you follow a guideline,
+then the guideline links to that rule. Here's an example:
+
+{% include linter-rule.html rule="prefer_collection_literals" %}
+
+For help on
+[enabling linter rules](/guides/language/analysis-options#enabling-linter-rules),
+see the documentation for
+[customizing static analysis](/guides/language/analysis-options).
+
+
 ## The guides
 
 We split the guidelines into a few separate pages for easy digestion:

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -36,6 +36,8 @@ Identifiers come in three flavors in Dart.
 
 ### DO name types using `UpperCamelCase`.
 
+{% include linter-rule.html rule="camel_case_types" %}
+
 Classes, enums, typedefs, and type parameters should capitalize the first letter
 of each word (including the first word), and use no separators.
 
@@ -77,8 +79,12 @@ const foo = Foo();
 class C { ... }
 {% endprettify %}
 
+[camel_case_types]: http://dart-lang.github.io/linter/lints/camel_case_types.html
+[Linter rule]: /guides/language/analysis-options#the-analysis-options-file
 
 ### DO name libraries and source files using `lowercase_with_underscores`.
+
+{% include linter-rule.html rule1="library_names" rule2="file_names" %}
 
 Some file systems are not case-sensitive, so many projects require filenames to
 be all lowercase. Using a separating character allows names to still be readable
@@ -112,6 +118,8 @@ import 'SliderMenu.dart';
 
 ### DO name import prefixes using `lowercase_with_underscores`.
 
+{% include linter-rule.html rule="library_prefixes" %}
+
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
 {% prettify dart %}
@@ -133,6 +141,8 @@ import 'package:js/js.dart' as JS;
 
 ### DO name other identifiers using `lowerCamelCase`.
 
+{% include linter-rule.html rule="non_constant_identifier_names" %}
+
 Class members, top-level definitions, variables, parameters, and named
 parameters should capitalize the first letter of each word *except* the first
 word, and use no separators.
@@ -151,6 +161,8 @@ void align(bool clearItems) {
 
 
 ### PREFER using `lowerCamelCase` for constant names.
+
+{% include linter-rule.html rule="constant_identifier_names" %}
 
 In new code, use `lowerCamelCase` for constant variables, including enum values.
 In existing code that uses `SCREAMING_CAPS`, you may continue to use all caps to
@@ -250,8 +262,13 @@ kDefaultTimeout
 To keep the preamble of your file tidy, we have a prescribed order that
 directives should appear in. Each "section" should be separated by a blank line.
 
+A single linter rule handles all the ordering guidelines:
+[directives_ordering.]({{ site.lints }}/directives_ordering.html)
+
 
 ### DO place "dart:" imports before other imports.
+
+{% include linter-rule.html rule="directives_ordering" %}
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
@@ -266,6 +283,8 @@ import 'package:foo/foo.dart';
 
 ### DO place "package:" imports before relative imports.
 
+{% include linter-rule.html rule="directives_ordering" %}
+
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
 {% prettify dart %}
@@ -277,6 +296,8 @@ import 'util.dart';
 
 
 ### PREFER placing external "package:" imports before other imports. {#prefer-placing-third-party-package-imports-before-other-imports}
+
+{% include linter-rule.html rule="directives_ordering" %}
 
 If you have a number of "package:" imports for your own package along with other
 external packages, place yours in a separate section after the external ones.
@@ -292,6 +313,8 @@ import 'package:my_package/util.dart';
 
 
 ### DO specify exports in a separate section after all imports.
+
+{% include linter-rule.html rule="directives_ordering" %}
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (export)"?>
@@ -312,6 +335,8 @@ import 'src/foo_bar.dart';
 
 
 ### DO sort sections alphabetically.
+
+{% include linter-rule.html rule="directives_ordering" %}
 
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
@@ -372,6 +397,8 @@ produce beautiful code.
 
 ### AVOID lines longer than 80 characters.
 
+{% include linter-rule.html rule="lines_longer_than_80_chars" %}
+
 Readability studies show that long lines of text are harder to read because your
 eye has to travel farther when moving to the beginning of the next line. This is
 why newspapers and magazines use multiple columns of text.
@@ -393,6 +420,8 @@ a given path.
 
 
 ### DO use curly braces for all flow control structures.
+
+{% include linter-rule.html rule="curly_braces_in_flow_control_structures" %}
 
 Doing so avoids the [dangling else][] problem.
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -76,6 +76,8 @@ theoretically non-breaking point release of that package could break your code.
 
 ### PREFER relative paths when importing libraries within your own package's `lib` directory.
 
+{% include linter-rule.html rule="avoid_relative_lib_imports" %}
+
 When referencing a library inside your package's `lib` directory from another
 library in that same package, either a relative URI or an explicit `package:`
 will work.
@@ -127,6 +129,8 @@ Here are some best practices to keep in mind when composing strings in Dart.
 
 ### DO use adjacent strings to concatenate string literals.
 
+{% include linter-rule.html rule="prefer_adjacent_string_concatenation" %}
+
 If you have two string literals&mdash;not values, but the actual quoted literal
 form&mdash;you do not need to use `+` to concatenate them. Just like in C and
 C++, simply placing them next to each other does it. This is a good way to make
@@ -149,6 +153,8 @@ raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
 
 ### PREFER using interpolation to compose strings and values.
 
+{% include linter-rule.html rule="prefer_interpolation_to_compose_strings" %}
+
 If you're coming from other languages, you're used to using long chains of `+`
 to build a string out of literals and other values. That does work in Dart, but
 it's almost always cleaner and shorter to use interpolation:
@@ -166,6 +172,8 @@ it's almost always cleaner and shorter to use interpolation:
 {% endprettify %}
 
 ### AVOID using curly braces in interpolation when not needed.
+
+{% include linter-rule.html rule="unnecessary_brace_in_string_interps" %}
 
 If you're interpolating a simple identifier not immediately followed by more
 alphanumeric text, the `{}` should be omitted.
@@ -191,6 +199,8 @@ Out of the box, Dart supports four collection types: lists, maps, queues, and se
 The following best practices apply to collections.
 
 ### DO use collection literals when possible.
+
+{% include linter-rule.html rule="prefer_collection_literals" %}
 
 There are two ways to make an empty growable list: `[]` and `List()`.
 Likewise, there are three ways to make an empty linked hash map: `{}`,
@@ -284,6 +294,8 @@ code.
 
 ### AVOID using `Iterable.forEach()` with a function literal.
 
+{% include linter-rule.html rule="avoid_function_literals_in_foreach_calls" %}
+
 `forEach()` functions are widely used in JavaScript because the built in
 `for-in` loop doesn't do what you usually want. In Dart, if you want to iterate
 over a sequence, the idiomatic way to do that is using a loop.
@@ -363,6 +375,8 @@ you don't care about the type, then use `toList()`.
 
 
 ### DO use `whereType()` to filter a collection by type.
+
+{% include linter-rule.html rule="prefer_iterable_whereType" %}
 
 Let's say you have a list containing a mixture of objects, and you want to get
 just the integers out of it. You could use `where()` like this:
@@ -556,6 +570,8 @@ involving functions.
 
 ### DO use a function declaration to bind a function to a name.
 
+{% include linter-rule.html rule="prefer_function_declarations_over_variables" %}
+
 Modern languages have realized how useful local nested functions and closures
 are. It's common to have a function defined inside another one. In many cases,
 this function is used as a callback immediately and doesn't need a name. A
@@ -586,6 +602,8 @@ void main() {
 
 ### DON'T create a lambda when a tear-off will do.
 
+{% include linter-rule.html rule="unnecessary_lambdas" %}
+
 If you refer to a method on an object but omit the parentheses, Dart gives you
 a "tear-off"&mdash;a closure that takes the same parameters as the method and
 invokes it when you call it.
@@ -612,6 +630,8 @@ names.forEach((name) {
 
 ### DO use `=` to separate a named parameter from its default value.
 
+{% include linter-rule.html rule="prefer_equal_for_default_values" %}
+
 For legacy reasons, Dart allows both `:` and `=` as the default value separator
 for named parameters. For consistency with optional positional parameters, use
 `=`.
@@ -630,6 +650,8 @@ void insert(Object item, {int at: 0}) { ... }
 
 
 ### DON'T use an explicit default value of `null`.
+
+{% include linter-rule.html rule="avoid_init_to_null" %}
 
 If you make a parameter optional but don't give it a default value, the language
 implicitly uses `null` as the default, so there's no need to write it.
@@ -790,6 +812,8 @@ variables). The following best practices apply to an object's members.
 
 ### DON'T wrap a field in a getter and setter unnecessarily.
 
+{% include linter-rule.html rule="unnecessary_getters_setters" %}
+
 In Java and C#, it's common to hide all fields behind getters and setters (or
 properties in C#), even if the implementation just forwards to the field. That
 way, if you ever need to do more work in those members, you can without needing
@@ -824,6 +848,8 @@ class Box {
 
 ### PREFER using a `final` field to make a read-only property.
 
+{% include linter-rule.html rule="unnecessary_getters" %}
+
 If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.
 
@@ -850,6 +876,8 @@ don't reach for that until you need to.
 
 
 ### CONSIDER using `=>` for simple members.
+
+{% include linter-rule.html rule="prefer_expression_function_bodies" %}
 
 In addition to using `=>` for function expressions, Dart also lets you define
 members with it. That style is a good fit for simple members that just calculate
@@ -905,6 +933,8 @@ set x(num value) => center = Point(value, center.y);
 
 
 ### DON'T use `this.` when not needed to avoid shadowing.
+
+{% include linter-rule.html rule="unnecessary_this" %}
 
 JavaScript requires an explicit `this.` to refer to members on the object whose
 method is currently being executed, but Dart&mdash;like C++, Java, and
@@ -1004,6 +1034,8 @@ The following best practices apply to declaring constructors for a class.
 
 ### DO use initializing formals when possible.
 
+{% include linter-rule.html rule="prefer_initializing_formals" %}
+
 Many fields are initialized directly from a constructor parameter, like:
 
 {:.bad-style}
@@ -1037,6 +1069,8 @@ should.
 
 ### DON'T type annotate initializing formals.
 
+{% include linter-rule.html rule="type_init_formals" %}
+
 If a constructor parameter is using `this.` to initialize a field, then the type
 of the parameter is understood to be the same type as the field.
 
@@ -1061,6 +1095,8 @@ class Point {
 
 ### DO use `;` instead of `{}` for empty constructor bodies.
 
+{% include linter-rule.html rule="empty_constructor_bodies" %}
+
 In Dart, a constructor with an empty body can be terminated with just a
 semicolon. (In fact, it's required for const constructors.)
 
@@ -1083,6 +1119,8 @@ class Point {
 {% endprettify %}
 
 ### DON'T use `new`.
+
+{% include linter-rule.html rule="unnecessary_new" %}
 
 Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
 clear because factory constructors mean a `new` invocation may still not
@@ -1123,6 +1161,8 @@ Widget build(BuildContext context) {
 
 
 ### DON'T use `const` redundantly.
+
+{% include linter-rule.html rule="unnecessary_const" %}
 
 In contexts where an expression *must* be constant, the `const` keyword is
 implicit, doesn't need to be written, and shouldn't. Those contexts are any
@@ -1167,6 +1207,8 @@ Dart uses exceptions when an error occurs in your program. The following
 best practices apply to catching and throwing exceptions.
 
 ### AVOID catches without `on` clauses.
+
+{% include linter-rule.html rule="avoid_catches_without_on_clauses" %}
 
 A catch clause with no `on` qualifier catches *anything* thrown by the code in
 the try block. [Pokémon exception handling][pokemon] is very likely not what you
@@ -1221,6 +1263,8 @@ and fix the code that is causing it to be thrown in the first place.
 
 
 ### DO use `rethrow` to rethrow a caught exception.
+
+{% include linter-rule.html rule="use_rethrow_when_possible" %}
 
 If you decide to rethrow an exception, prefer using the `rethrow` statement
 instead of throwing the same exception object using `throw`.

--- a/src/_includes/linter-rule.html
+++ b/src/_includes/linter-rule.html
@@ -1,0 +1,6 @@
+{:.linter-rule}
+{% if include.rule %}
+Linter rule: <a href="{{ site.lints }}/{{ include.rule }}.html">{{ include.rule }}</a>
+{% else %}
+Linter rules: <a href="{{ site.lints }}/{{ include.rule1 }}.html">{{ include.rule1 }},</a> <a href="{{ site.lints }}/{{ include.rule2 }}.html">{{ include.rule2 }}</a>
+{% endif %}


### PR DESCRIPTION
Fixes #921.

Staged: https://kw-staging-dartlang-2.firebaseapp.com/guides/language/effective-dart

I should probably use a different example lint in the overview (since the description of prefer_collection_literals lacks types), but first I want to get your feedback on the words and format.

Work for the another time:
* automate and test the association between linter rules and guideline text/URLs
* update descriptions in linter rule docs.

/cc @munificent 