### PR TITLE
Update text on "pub cache repair"

### DIFF
--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -45,8 +45,8 @@ versions.</dd>
 
 <dt><code>repair</code></dt>
 <dd>It's possible for packages in your pub cache to change or break.
-For example, if you follow a symlink in the <code>packages</code> directory
-and modify a package, this affects the canonical copy of that package in
+For example, if your editor follows the reference in the <code>.packages</code> file
+and you modify a file in a package, this affects the canonical copy of that package in
 the system cache. The <code>pub cache repair</code> command performs a clean
 reinstall of all hosted and git packages in the system cache.</dd>
 

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -45,10 +45,10 @@ versions.</dd>
 
 <dt><code>repair</code></dt>
 <dd>It's possible for packages in your pub cache to change or break.
-For example, if your editor follows the reference in the <code>.packages</code> file
-and you modify a file in a package, this affects the canonical copy of that package in
-the system cache. The <code>pub cache repair</code> command performs a clean
-reinstall of all hosted and git packages in the system cache.</dd>
+For example, some editors make it easy to find implementation files for
+packages in the pub cache, and you might accidentally edit one of those files.
+The <code>pub cache repair</code> command performs a clean reinstall of all
+hosted and git packages in the system cache.</dd>
 
 <aside class="alert alert-info" markdown="1">
   *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).


### PR DESCRIPTION
 * Avoid talking about the `packages/` folder as something that contains symlinks.
 * Mention `.packages` and how your editor might follow references in this file.