### PR TITLE
Add Smartherd videos to community page

### DIFF
--- a/src/_articles/libraries/zones.md
+++ b/src/_articles/libraries/zones.md
@@ -753,7 +753,7 @@ Zone-related API documentation
 
 stack_trace
 : With the stack_trace library's
-  [Chain class](https://www.dartdocs.org/documentation/stack_trace/1.6.5/stack_trace/Chain-class.html)
+  [Chain class]({{site.pub-api}}/stack_trace/latest/stack_trace/Chain-class.html)
   you can get better stack traces for asynchronously executed code.
   See the [stack_trace package]({{site.pub}}/packages/stack_trace)
   at the Pub site for more information.

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1640,7 +1640,6 @@ To learn more about the Dart language, see the
 
 [language tour]: /guides/language/language-tour
 [docs.flutter]: {{site.flutter_api}}
-[dartdocs.org]: https://www.dartdocs.org/
 [pub.dartlang]: {{site.pub}}
 [DartPad]: {{site.dartpad}}
 [Assert]: /guides/language/language-tour#assert

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -180,8 +180,8 @@ The args library contains two classes:
 
 | Library | Description |
 |---|---|
-| <a href="https://www.dartdocs.org/documentation/args/latest/args/ArgParser-class.html" target="_blank">ArgParser</a> | A class that parses command-line arguments |
-| <a href="https://www.dartdocs.org/documentation/args/latest/args/ArgResults-class.html" target="_blank">ArgResults</a> | The result of parsing command-line arguments using ArgParser. |
+| <a href="{{site.pub-api}}/args/latest/args/ArgParser-class.html" target="_blank">ArgParser</a> | A class that parses command-line arguments |
+| <a href="{{site.pub-api}}/args/latest/args/ArgResults-class.html" target="_blank">ArgResults</a> | The result of parsing command-line arguments using ArgParser. |
 {: .table }
 
 Let's take a look at the `dcat` sample,
@@ -239,7 +239,7 @@ void main(<a tabindex="0" role="button" class="highlight" data-toggle="popover" 
 </pre>
 
 The
-<a href="https://www.dartdocs.org/documentation/args/latest/index.html" target="_blank">API docs</a>
+<a href="{{site.pub-api}}/args/latest/index.html" target="_blank">API docs</a>
 for the args library
 provide detailed information
 to help you use ArgsParser and ArgResults classes.
@@ -595,8 +595,8 @@ In addition, this tutorial covers two classes that help with command-line argume
 
 | Class | Description |
 |---|---|
-| <a href="https://www.dartdocs.org/documentation/args/latest/args/ArgParser-class.html" target="_blank">ArgParser</a> | A class that transforms a list of raw arguments and into a set of options, flags, and remaining values. |
-| <a href="https://www.dartdocs.org/documentation/args/latest/args/ArgResults-class.html" target="_blank">ArgResults</a> | The result of parsing raw command line arguments using ArgParser. |
+| <a href="{{site.pub-api}}/args/latest/args/ArgParser-class.html" target="_blank">ArgParser</a> | A class that transforms a list of raw arguments and into a set of options, flags, and remaining values. |
+| <a href="{{site.pub-api}}/args/latest/args/ArgResults-class.html" target="_blank">ArgResults</a> | The result of parsing raw command line arguments using ArgParser. |
 {: .table }
 
 ## Other resources
@@ -609,7 +609,7 @@ Refer to the API docs for
 <a href="{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/dart-async-library.html" target="_blank">dart:async</a>,
 <a href="{{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html" target="_blank">dart:convert</a>,
 and the
-<a href="https://www.dartdocs.org/documentation/args/latest/index.html" target="_blank">args</a>
+<a href="{{site.pub-api}}/args/latest/index.html" target="_blank">args</a>
 package for more classes, functions, and properties.
 
 ## What next?

--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -1014,4 +1014,4 @@ for further details about the classes and libraries discussed in this tutorial.
 [SecurityContext]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/SecurityContext-class.html
 [Stream]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Stream-class.html
 [Uri]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Uri-class.html
-[VirtualDirectory]: https://www.dartdocs.org/documentation/http_server/latest/http_server/VirtualDirectory-class.html
+[VirtualDirectory]: {{site.pub-api}}/http_server/latest/http_server/VirtualDirectory-class.html

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -64,9 +64,9 @@ Dart is open source. Learn how to
 
 Our wonderful community has provided these resources.
 
-* [dartdocs.org](http://www.dartdocs.org) - Documentation for pub packages
 * [Dart Academy](https://dart.academy/) - Tutorials
   and articles written by the Dart community
+* [Smartherd videos](https://www.youtube.com/watch?v=5rtujDjt50I&list=PLlxmoA0rQ-LyHW9voBdNo4gEEIh0SjG-q) - A series of tutorial videos about the Dart language
 * [Chinese version of this site (此网站的中文版)](http://www.dartdoc.cn)
 
 Also see [Community and Support]({{site.webdev}}/community) on Dart webdev.

--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -137,12 +137,6 @@ Google internal sales tool
 [Anionu](http://sourcey.com/anionu/)
 : Cloud surveillance and security platform using Dart and native WebRTC.
 
-[dartdocs.org](http://www.dartdocs.org)
-: Automated documentation generation for Pub packages.
-
-Google internal customer support tool
-: Built with polymer.dart.
-
 [Quire](https://quire.io/)
 : A simple, collaborative, multi-level task management tool with both the
   client and server written in Dart.


### PR DESCRIPTION
Fixes #1353.
Related: #1356.

Removed some lingering occurrences of dartdocs.org, while I was in there.