### PR TITLE
chore: adjust to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     - TASK="bundle exec jekyll build"
 
 matrix:
-  allow_failures:
-    - env: TASK="./tool/analyze-and-test-examples.sh"
-      dart: stable
+  # allow_failures:
+    # - env: TASK="./tool/analyze-and-test-examples.sh"
+      # dart: stable
   exclude:
     - env: TASK="bundle exec jekyll build"
       dart: dev

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.1.0"
+    "vers": "2.2.0"
   }
 }


### PR DESCRIPTION
1. Re-enable stable SDK tests.
2. Update package version in Dart 2 drop-down menu.