### PR TITLE
Make Travis CI run on the `dash` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ deploy:
 
 # Only run Travis jobs for named branches (to avoid double builds for each PR)
 branches:
-  only: [master, /^\d\.x$/, /^\d-dev$/, /travis-build/]
+  only: [master, /^\d\.x$/, /^\d-dev$/, /travis-build/, dash]


### PR DESCRIPTION
This is kind of an ugly special case. We should remove it after `dash` is complete.