### PR TITLE
Call out `List.of` in the tip for `List.from`

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -376,9 +376,9 @@ numbers.removeAt(1); // Now it only contains integers.
 var ints = List<int>.from(numbers);
 {% endprettify %}
 
-If your goal is to _copy_ the iterable and preserve its original element type,
-then use `List.of()`. If you don't care about the element type, or the intent is to
-get a `List` from an `Iterable` or another collection type, then use `toList()`.
+If your goal is to copy the iterable and preserve its runtime element type, or
+you don't care about the type, then use `toList()`. If your goal is to copy the
+iterable and preseve it's static element ype, use `List.of()`.
 
 
 ### DO use `whereType()` to filter a collection by type.

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -376,8 +376,8 @@ numbers.removeAt(1); // Now it only contains integers.
 var ints = List<int>.from(numbers);
 {% endprettify %}
 
-If your goal is to _copy_ the iterable and preserve its original element type
-use `List.of()`. If you don't care about the element type, or the intent is to
+If your goal is to _copy_ the iterable and preserve its original element type,
+then use `List.of()`. If you don't care about the element type, or the intent is to
 get a `List` from an `Iterable` or another collection type, then use `toList()`.
 
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -378,7 +378,7 @@ var ints = List<int>.from(numbers);
 
 If your goal is to copy the iterable and preserve its runtime element type, or
 you don't care about the type, then use `toList()`. If your goal is to copy the
-iterable and preseve it's static element ype, use `List.of()`.
+iterable and preserve its static element type, use `List.of()`.
 
 
 ### DO use `whereType()` to filter a collection by type.

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -376,8 +376,9 @@ numbers.removeAt(1); // Now it only contains integers.
 var ints = List<int>.from(numbers);
 {% endprettify %}
 
-But if your goal is just to copy the iterable and preserve its original type, or
-you don't care about the type, then use `toList()`.
+If your goal is to _copy_ the iterable and preserve its original element type
+use `List.of()`. If you don't care about the element type, or the intent is to
+get a `List` from an `Iterable` or another collection type, then use `toList()`.
 
 
 ### DO use `whereType()` to filter a collection by type.


### PR DESCRIPTION
When copying is the main goal `List.of` better expresses the intent
than `toList()` because its a constructor call rather than something
that looks like a transformation of the original.