### PR TITLE
Open-menu sidebar should be always full-height.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1141,6 +1141,8 @@ body.obsolete {
     #sidenav {
       display: block;
       left: 0 !important;
+      max-height: 100vh !important;
+      bottom: 0;
     }
   }
 }


### PR DESCRIPTION
This is a trade-off: either the JS code should be aware if the sidebar is always-on or visible only via menu opening, or the CSS style should prevent the JS changes to take effect. I've opted for the later, as it is much simpler than handling it in the JS.