### PR TITLE
Full-sized search box in sidenav's mobile view.

### DIFF
--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -20,17 +20,6 @@ a code {
 	color: #fff;
 }
 
-// SIDE NAV
-
-.sidenav__search {
-	margin-bottom: 20px;
-	display: block;
-
-	@include media-breakpoint-up(sm) {
-		display: none;
-	}
-}
-
 // FRONT-PAGE RELATED
 
 @mixin front-page-first-section-height {

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -477,9 +477,21 @@ img {
     // Override of _header.scss
     border: 0;
   }
+
+  #sidenav & {
+    display: none;
+    border-bottom: 1px solid $site-color-light-grey;
+    flex-shrink: 0;
+    margin: 0;
+    padding: 0 $site-nav-mobile-side-padding;
+    order: -1;
+  }
 }
 
 .site-header__searchfield {
+  border: 0;
+  box-shadow: none;
+
   #mainnav & {
     // Override of _header.scss
     @include media-breakpoint-down(sm) {
@@ -489,6 +501,20 @@ img {
       width: 24px !important;
       &:focus {
         width: 220px !important;
+      }
+    }
+  }
+
+  #sidenav & {
+    font-size: $font-size-lg;
+    height: 66px;
+    width: 100%;
+
+    // Override of _header.scss
+    @include media-breakpoint-up(md) {
+      width: 100% !important;
+      &:focus {
+        width: 100% !important;
       }
     }
   }
@@ -1107,13 +1133,15 @@ body.obsolete {
 
   #sidenav {
     top: 0;
-    left: -300px;
+    left: -100vw;
+    width: calc(100vw - 60px);
     background: #fff;
     z-index: 9999;
     box-shadow: 0 0 4px rgba(0,0,0,.14),0 4px 8px rgba(0,0,0,.28);
     @include transition(left, .5s);
-    .brand {
-      display: block;
+
+    .site-header__search {
+      display: flex;
     }
   }
 

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -373,16 +373,6 @@ img {
   border-right: 1px solid #d8d8d8;
   overflow-x: hidden;
   overflow-y: auto;
-  .brand {
-    display: none;
-    border-bottom: 1px solid $gray-light;
-    margin-top: -5px;
-    margin-bottom: 20px;
-    img {
-      width: 100px;
-      margin-bottom: 10px;
-    }
-  }
 }
 
 // The table-of-content section on the right side of the screen.

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -1,15 +1,9 @@
 <div id="sidenav" class="">
+  <form action="/search/" class="site-header__search form-inline">
+    <input class="site-header__searchfield form-control" type="search" name="q" id="q" autocomplete="off" placeholder="Search" aria-label="Search">
+  </form>
+
   <div class="site-sidebar">
-    <a href="/" class="brand" title="{{ site.title }}">
-      <img src="{% asset shared/dart/logo+text/horizontal/default.svg @path %}" alt="{{ site.title }}">
-    </a>
-
-    <div class="sidenav__search">
-      <p>
-        <a href="/search">Search <i class="icon icon-search"></i></a>
-      </p>
-    </div>
-
     {% include shared/sidenav-level-1.html nav=site.data.side-nav %}
   </div>
 </div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -3,8 +3,8 @@
   {% include head.html %}
   <body class="{{ page.layout }}{% if page.toc == false %} hide_toc{% endif %}{% if page.obsolete == true %} obsolete{% endif %}">
     {% include page-header.html %}
+    {% include navigation-side.html %}
     <main id="page-content">
-      {% include navigation-side.html %}
       {% include navigation-toc.html id='site-toc--side' %}
       <article>
         <div class="content">


### PR DESCRIPTION
- Moving `#sidenav` outside of `#page-content`, because otherwise clicking on the search field automatically closed it.
- Made the `#sidenav` wider, same as Flutter site, but the trigger when it is enabled for mobile view still differs (TBD in a subsequent PR).
- Removed branding logo from sidenav's mobile view (Flutter has none either).
- Removed search page link from sidebar, instead using the same full-sized search field as Flutter site.
- Added extra styles to remove the search field's outline.
- Added styles to compensate the differences of the to-be-shared `_header.scss`.
