### PR TITLE
Move top navigation closer to the structure Flutter has.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -280,7 +280,6 @@ img {
 }
 #mainnav {
   display: flex;
-  color: $gray-base;
   $mainnav-entry-spacing: 15px;
   ul {
     margin: auto;
@@ -300,26 +299,14 @@ img {
         padding: 0;
         font-size: 16px;
         line-height: 50px;
-        color: $gray-dark;
         &:hover {
           color: $brand-primary;
-        }
-      }
-      &.active {
-        a {
-          color: darken($gray-light, 15%);
-          cursor: default;
-          &:hover {
-            color: darken($gray-light, 15%);
-          }
         }
       }
     }
   }
   .dropdown-menu {
-    background-color: $gray-light;
     border-top-color: transparent;
-    color: $gray-base;
     margin-left: -$mainnav-entry-spacing;
     a:hover, a:focus { background-color: transparent; }
     a.active:after {

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -1,16 +1,33 @@
-<nav id="mainnav">
+{% assign page_url_path = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' | prepend: '/*' | append: '/' -%}
+
+<nav id="mainnav" class="site-header">
   <div id="menu-toggle"><i class="icon icon-menu"></i></div>
   <a href="/" class="brand" title="{{ site.title }}">
     <img src="{% asset shared/dart/logo+text/horizontal/default.svg @path %}" alt="{{ site.title }}">
   </a>
-  <ul>
-    <li class="mainnav__get-started"><a href="/guides/get-started"><span>Get Started</span></a></li>
-    <li><a href="/guides/language">Language</a></li>
-    <li><a href="/guides/libraries">Libraries</a></li>
-    <li><a href="/tools">Tools</a></li>
+  <ul class="navbar">
+    <li class="mainnav__get-started">
+      <a href="/guides/get-started" class="nav-link
+        {%- if page_url_path contains '/*/guides/get-started/' %} active {%- endif -%}"><span>Get Started</span></a>
+    </li>
+    <li>
+      <a href="/guides/language" class="nav-link
+        {%- if page_url_path contains '/*/guides/language/' %} active {%- endif -%}">Language</a>
+    </li>
+    <li>
+      <a href="/guides/libraries" class="nav-link
+        {%- if page_url_path contains '/*/guides/libraries/' %} active {%- endif -%}">Libraries</a>
+    </li>
+    <li>
+      <a href="/tools" class="nav-link
+        {%- if page_url_path contains '/*/tools/' %} active {%- endif -%}">Tools</a>
+    </li>
     {% comment %}Temporarily make room for the version dropdown by omitting Community{% endcomment %}
     {% if site.url != site.www %}
-    <li><a href="/community">Community</a></li>
+    <li>
+      <a href="/community" class="nav-link
+        {%- if page_url_path contains '/*/community/' %} active {%- endif -%}">Community</a>
+    </li>
     {% else %}
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dart 2</a>


### PR DESCRIPTION
`page_url_path` is slightly different than in the Flutter templates: instead of `doing url == 'x' or url contains 'x/'`, I'm prepending and appending the url string, making the checks simpler (and more reliable).

I haven't replicated the exact structure as the Flutter site has, because we still have dropdowns, and it would be easier to replicate the remaining structure and styles after those are removed.
