### PR TITLE
Adjust footer style to match Flutter's.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -205,16 +205,16 @@ img {
 }
 #page-footer {
   position: relative;
-  color: $white-base;
+  background-color: $site-color-footer;
+  color: $site-color-white;
   font-weight: 300;
-  background-color: $brand-primary;
+  font-size: $font-size-sm;
   z-index: 5;
   .brand {
     width: 120px;
   }
-  small {
-    display: block;
-    padding-right: 25px;
+  .licenses {
+    font-size: 10px;
   }
   h4 {
     color: #fff;

--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -10,7 +10,7 @@
           <style>.menu .material-icons { font-size: 14px; }</style>
           {%- assign dateFormat = '%Y/%m/%d %R %Z' -%}
           <ul class="menu">
-            <li>Site&nbsp;<a href="http://creativecommons.org/licenses/by/3.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;3.0</a></li>
+            <li class="licenses">Site&nbsp;<a href="http://creativecommons.org/licenses/by/3.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;3.0</a></li>
             <li>
               <a href="{{site.repo.this}}"
                  title="This site's source is on GitHub."


### PR DESCRIPTION
At first I wanted to use `_footer.scss` from Flutter, but neither the rules, nor the structure was close to the one on the Dart site. In the end it seemed to be better to only adjust the current one a little bit, to match the visuals of the Flutter site more closer.