### PR TITLE
Fix obsolete banner

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -184,19 +184,14 @@ img {
 // Structure
 
 #page-header {
-  position: fixed;
-  width: 100%;
-  height: $site-header-height;
-  top: 0;
-  left: 0;
-  right: 0;
-  background-color: $gray-light;
   box-shadow: 0 3px 5px rgba(0,0,0,0.1);
-  z-index: 1030;
+
+  // override of shared/_header.scss
+  .site-header {
+    box-shadow: none;
+  }
 }
 #page-content {
-  position: relative;
-  margin-top: $site-header-height;
   min-height: calc(100vh);
   > article {
     width: calc(100vw - 525px);
@@ -279,6 +274,7 @@ img {
   z-index: 9999;
 }
 #mainnav {
+  background-color: $gray-light;
   display: flex;
   $mainnav-entry-spacing: 15px;
   ul {
@@ -1074,15 +1070,16 @@ body.hide_toc {
 body.obsolete {
   #page-header {
     .alert {
-      position: relative;
-      top: 5px;
       margin: 0;
-      h4 { margin-bottom: 0; }
+      h4 {
+        margin-bottom: 0;
+        margin-top: 0;
+      }
     }
   }
   #page-content {
-    margin-top: 120px;
     border: 10px solid $alert-warning-bg;
+    border-top: none;
   }
 }
 /* -----------------------------------------
@@ -1110,7 +1107,9 @@ body.obsolete {
   }
 
   #sidenav {
-    top: 0;
+    top: 0 !important;
+    max-height: 100vh !important;
+    bottom: 0;
     left: -100vw;
     width: calc(100vw - 60px);
     background: #fff;
@@ -1147,8 +1146,6 @@ body.obsolete {
     #sidenav {
       display: block;
       left: 0 !important;
-      max-height: 100vh !important;
-      bottom: 0;
     }
   }
 }

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -8,17 +8,16 @@
 //= require vendor/code-prettify/lang-dart
 //= require vendor/code-prettify/lang-yaml
 
-var condensedHeaderHeight = 50;
-
 function fixNav() {
   var t = $(document).scrollTop(),
     f = $("#page-footer").offset().top,
+    hh = $("#page-header").height(),
     h = window.innerHeight,
     // space between scroll position and top of the footer
     whenAtBottom = f - t,
-    mh = Math.min(h, whenAtBottom) - condensedHeaderHeight;
-  $("#sidenav").css({ maxHeight: mh });
-  $("#site-toc--side").css({ maxHeight: mh });
+    mh = Math.min(h, whenAtBottom) - hh;
+  $("#sidenav").css({ top: hh, maxHeight: mh });
+  $("#site-toc--side").css({ top: hh, maxHeight: mh });
 }
 
 // When a user scrolls to 50px add class condensed-header to body

--- a/src/_includes/page-header.html
+++ b/src/_includes/page-header.html
@@ -1,4 +1,4 @@
-<header id="page-header">
+<header id="page-header" class="site-header">
   {% include navigation-main.html %}
   {% if page.obsolete == true %}
   <div class="alert alert-warning">


### PR DESCRIPTION
The change moves the `.site-header` style to the top element of the header, and it makes it `position: sticky`. With that, the `fixed` style can be removed, and it becomes more consistent with the Flutter site.

With the fixed banner for obsolete page, the JS needs to get updated to calculate the top position, and it also needs to fix the sidebar in mobile view.