### PR TITLE
Apply new sidebar style settings.

### DIFF
--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -82,8 +82,10 @@ $live-content-width:      1280px;
 $content-padding:         20px;
 
 // Fonts
-$site-font-family-base: 'Roboto', sans-serif;
-$site-font-family-alt: 'Google Sans', 'Roboto', sans-serif;
+$site-font-family-roboto: 'Roboto', sans-serif;
+$site-font-family-gsans: 'Google Sans', 'Roboto', sans-serif;
+$site-font-family-base: $site-font-family-roboto;
+$site-font-family-alt: $site-font-family-gsans;
 $site-font-family-icon: 'Material Icons';
 $site-font-family-monospace: 'Roboto Mono', monospace;
 $site-font-icon: 24px/1 $site-font-family-icon;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -362,7 +362,7 @@ img {
     .nav-link {
       font-family: $site-font-family-roboto;
       font-weight: 300;
-      color: #4a4a4a;
+      color: $site-color-body;
       font-size: 13px;
 
       &[data-toggle] {

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -360,18 +360,16 @@ img {
 
   .site-sidebar {
     .nav-link {
-      font-family: $site-font-family-base;
-      font-weight: light;
+      font-family: $site-font-family-roboto;
+      font-weight: 300;
       color: #4a4a4a;
       font-size: 13px;
-      line-height: 26px;
 
       &[data-toggle] {
         &:not(.collapsable) {
-          font-family: $site-font-family-alt;
-          font-weight: regular;
+          font-family: $site-font-family-gsans;
+          font-weight: 400;
           font-size: 20px;
-          line-height: 25px;
         }
 
         &.active {

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -357,6 +357,33 @@ img {
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 1;
+
+  .site-sidebar {
+    .nav-link {
+      font-family: $site-font-family-base;
+      font-weight: light;
+      color: #4a4a4a;
+      font-size: 13px;
+      line-height: 26px;
+
+      &[data-toggle] {
+        &:not(.collapsable) {
+          font-family: $site-font-family-alt;
+          font-weight: regular;
+          font-size: 20px;
+          line-height: 25px;
+        }
+
+        &.active {
+          color: inherit;
+        }
+      }
+
+      &.active {
+        color: #1389fd;
+      }
+    }
+  }
 }
 
 // The table-of-content section on the right side of the screen.


### PR DESCRIPTION
The `[data-toggle]` + `:not(.collapsable)` rule got a bit complex, but it was still simpler than updating the templates to emit new styles for the different part of the tree.