### PR TITLE
Apply new style rules on github-links.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1009,6 +1009,7 @@ ul.nav-list {
 #page-github-links {
   float: right;
   .btn {
+    color: $site-color-body;
     $padding-x: $btn-padding-x / 2;
     padding-left: $padding-x;
     padding-right: $padding-x;


### PR DESCRIPTION
This does not yet changes the label, only repositions the icons.