### PR TITLE
Remove top-bar blue bottom border.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -189,6 +189,15 @@ img {
   // override of shared/_header.scss
   .site-header {
     box-shadow: none;
+    .navbar {
+      .nav-link {
+        &.active {
+          &:after {
+            display: none;
+          }
+        }
+      }
+    }
   }
 }
 #page-content {


### PR DESCRIPTION
The `/guides/language/effective-dart/style` has a blue bottom border under the "Language" top menu item. This will remove it (parent style is in the shared `_header.scss`).