### PR TITLE
Apply text colors

### DIFF
--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -5,11 +5,6 @@ dd {
 	margin-bottom: 15px;
 }
 
-/* Make code font more noticeable (without being obnoxious). */
-code {
-	color: #008f83
-}
-
 /* Make code-font links look like links. Should also change the hover color. */
 a code {
     color: $default-link

--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -46,8 +46,7 @@ $teal:                      #1FBAAC;
 $blue:                      #1b87c9;
 $blue-light:                #e2f4fd;
 
-$brand-primary-dark:        #02569B; // 700
-$brand-primary:             #0175C2; // 600
+$brand-primary:             #0171B7;
 $brand-secondary:           #13B9FD; // 400
 $brand-highlight:           #FFC108; // 700
 
@@ -67,7 +66,7 @@ $site-color-primary: $brand-primary;
 
 $font-size-base:            0.875rem; // 14px
 $font-family-base:          Roboto, sans-serif;
-$font-family-monospace:     Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+$font-family-monospace:     "Roboto Mono", Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
 $google-font-family:        "Product Sans", $font-family-base;
 
 // TODO: use / override BS defaults named $hX-font-size.

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -139,11 +139,22 @@ input, select {
 
 pre, pre.prettyprint {
   padding: $content-padding;
-  background-color: $gray-light;
+  background-color: #F5F5F7;
   color: $blue;
   position: relative;
   border: none;
   border-radius: 0;
+
+  .kwd {
+    color: #BC0056;
+  }
+  .pln {
+    color: #7500A0;
+  }
+  .lit, .str {
+    color: #00677A;
+  }
+
   &.dartpad {
     // &:after {
     //   content: 'Run';
@@ -169,8 +180,9 @@ pre, pre.prettyprint {
 }
 code {
   background-color: transparent;
+  color: #006666;
+  font-size: 100%;
   padding: 0;
-  color: darken($brand-primary, 20%);
 }
 img {
   max-width: 100%;


### PR DESCRIPTION
- `$brand-primary-dark` is no longer used.
- Added `Roboto Mono` to `$font-family-monospace`.
- Applied font colors. I think on my monitor the `code`'s `006666` is a bit different color than it was on the screenshot, but going with it, as it was specified in the pdf.