### PR TITLE
fix some mismatch example

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -230,21 +230,21 @@ ID and Mr. are still capitalized like words.)
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (acronyms and abbreviations)" replace="/,//g"?>
 {% prettify dart %}
 HttpConnectionInfo
-uiHandler
-IOStream
+UiHandler
+IoStream
 HttpRequest
 Id
-DB
+Db
 {% endprettify %}
 
 {:.bad-style}
 {% prettify dart %}
 HTTPConnection
-UiHandler
-IoStream
+UIHandler
+IOStream
 HTTPRequest
 ID
-Db
+DB
 {% endprettify %}
 
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -230,21 +230,21 @@ ID and Mr. are still capitalized like words.)
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (acronyms and abbreviations)" replace="/,//g"?>
 {% prettify dart %}
 HttpConnectionInfo
-UiHandler
-IoStream
+UIHandler
+IOStream
 HttpRequest
-Id
-Db
+ID
+DB
 {% endprettify %}
 
 {:.bad-style}
 {% prettify dart %}
 HTTPConnection
-UIHandler
-IOStream
+UiHandler
+IoStream
 HTTPRequest
-ID
-DB
+Id
+Db
 {% endprettify %}
 
 


### PR DESCRIPTION
DO capitalize acronyms and abbreviations longer than two letters like words example mismatch