### PR TITLE
Temporarily allow dev check-code to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
   # allow_failures:
     # - env: TASK="./tool/analyze-and-test-examples.sh"
       # dart: stable
+  allow_failures:
+    - env: TASK="./tool/check-code.sh"
+      dart: dev
   exclude:
     - env: TASK="bundle exec jekyll build"
       dart: dev


### PR DESCRIPTION
Due to recent changes in indentation for adjacent strings, the build has been failing. (See https://github.com/dart-lang/dart_style/issues/799.)

I plan to temporarily allow the dev build to fail until I know whether the indentation is really changing.