### PR TITLE
Collapsible table of contents.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -431,6 +431,46 @@ img {
   }
 }
 
+.site-toc--button__toggle {
+  display: none;
+}
+
+#site-toc--inline {
+  &.toc-collapsible {
+    border-left: 3px solid $gray-light;
+    padding-left: 12px;
+    margin-bottom: 1rem;
+
+    > .section-nav {
+      background: white;
+      margin-bottom: 0;
+      opacity: 1.0;
+      transition: opacity .5s ease-in-out, background .5s ease-in-out;
+    }
+
+    .toc-toggle-down {
+      display: none;
+    }
+
+    &.toc-collapsed {
+      .section-nav {
+        background: $gray-light;
+        max-height: 80px;
+        opacity: 0.5;
+        overflow: hidden;
+      }
+
+      .toc-toggle-up {
+        display: none;
+      }
+
+      .toc-toggle-down {
+        display: inline-block;
+      }
+    }
+  }
+}
+
 // The table-of-content section on the right side of the screen.
 #site-toc--side {
   position: fixed;

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -126,4 +126,9 @@ $(function () {
   // Add external link indicators
   $('a[href^="http"], a[target="_blank"]').not('.no-automatic-external').addClass('external');
 
+  // Collapsible inline TOC expand/collapse
+  $(".site-toc--inline__toggle").on('click', function () {
+    var root = $("#site-toc--inline");
+    root.toggleClass('toc-collapsed');
+  });
 });

--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -1,16 +1,29 @@
 {% unless page.toc == false or page.layout == 'homepage' %}
 {% assign toc = content | toc_only %}
+{% assign itemCount = toc | split: 'class="toc-entry' | size %}
+{% assign collapsible = include.collapsible and itemCount > 10 %}
+{% if collapsible %}
+  {% assign topStyle = 'toc-collapsible toc-collapsed' %}
+{% endif %}
 {% if include.extendToc -%}
   {% assign toc = toc | replace: '<ul>', '<ul class="nav">' %}
   {% assign toc = toc | replace: '<ul class="section-nav">', '<ul class="section-nav nav">' %}
   {% assign toc = toc | replace: 'class="toc-entry', 'class="toc-entry nav-item' %}
   {% assign toc = toc | replace: '<a href="#', '<a class="nav-link" href="#' %}
 {% endif -%}
-<div id="{{include.id}}" class="site-toc">
+<div id="{{include.id}}" class="site-toc {{topStyle}}">
   <header class="site-toc__title">
     Contents
     <button type="button" class="btn site-toc--button__page-top" aria-label="Page top"></button>
+    {% if collapsible %}
+      <span class="{{include.id}}__toggle toc-toggle-down"><i class="fas fa-chevron-down fa-m"></i></span>
+      <span class="{{include.id}}__toggle toc-toggle-up"><i class="fas fa-chevron-up fa-m"></i></span>
+    {% endif %}
   </header>
   {{ toc }}
+  {% if collapsible %}
+  <span class="{{include.id}}__toggle toc-toggle-down"><i class="fas fa-chevron-down fa-m"></i></span>
+  <span class="{{include.id}}__toggle toc-toggle-up"><i class="fas fa-chevron-up fa-m"></i></span>
+  {% endif %}
 </div>
 {% endunless %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -16,7 +16,7 @@
             {% include shared/page-github-links.html %}
             <h1>{{ page.title }}</h1>
           </div>
-          {% include navigation-toc.html id='site-toc--inline' %}
+          {% include navigation-toc.html id='site-toc--inline' collapsible=true %}
           {{ content | inject_anchors }}
           {% include navigation-sub.html %}
         </div>


### PR DESCRIPTION
I wanted to have the max-height transitioned and the content being unrolled, but it seems it can't be done with sanity. We could probably do a JS-based animated expand and collapse, but I would postpone that for now.

I also added some extra styles (opacity and background) in order to mark the area different from the body content. I'm not sure what looked better, nor about the icons, so let's iterate on it :)