### PR TITLE
Fix some of the external link icons

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -84,10 +84,16 @@ a, button {
     color: inherit;
     opacity: 0.5;
   }
-  i.fa-external-link-alt {
+ }
+}
+// Disable template-generated external links.
+i.fa-external-link-alt {
+  a.external & {
     display: none;
   }
- }
+  #sidenav & {
+    display: none;
+  }
 }
 
 form {

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -4,6 +4,6 @@
     {% comment %} TEXT GOES HERE {% endcomment %}
     Dart 2.2 is now available,
     with faster native code and support for set literals. 
-    <a href="https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-support-for-set-literals-7e2ab19cc86d">Learn more.</a>
+    <a class="external" href="https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-support-for-set-literals-7e2ab19cc86d">Learn more.</a>
   </p>
 </div>


### PR DESCRIPTION
Addresses the [initially large icons](https://github.com/dart-lang/site-www/issues/1453#issuecomment-482305030) on the sidebar, and also the shifting position of the banner's text. Unfortunately I couldn't find a good way to replace the JS code that extends links with the `external` style, but luckily, updating the banner template solves the most prominent of them.