### PR TITLE
Fix the dev channel check-code job; break the stable channel one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       # dart: stable
   allow_failures:
     - env: TASK="./tool/check-code.sh"
-      dart: dev
+      dart: stable
   exclude:
     - env: TASK="bundle exec jekyll build"
       dart: dev

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -23,7 +23,7 @@ void miscDeclAnalyzedButNotTested() {
     return
         // #docregion string-interpolation-avoid-curly
         'Hi, ${name}!'
-        "Wear your wildest ${decade}'s outfit."
+            "Wear your wildest ${decade}'s outfit."
         // #enddocregion string-interpolation-avoid-curly
         ;
   };

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -30,8 +30,8 @@ void miscDeclAnalyzedButNotTested() {
     return
         // #docregion string-interpolation-avoid-curly
         'Hi, $name!'
-        "Wear your wildest $decade's outfit."
-        'Wear your wildest ${decade}s outfit.'
+            "Wear your wildest $decade's outfit."
+            'Wear your wildest ${decade}s outfit.'
         // #enddocregion string-interpolation-avoid-curly
         ;
   };

--- a/examples/misc/test/language_tour/built_in_types_test.dart
+++ b/examples/misc/test/language_tour/built_in_types_test.dart
@@ -50,7 +50,7 @@ void main() {
         " works even over line breaks.";
     assert(s1 ==
         'String concatenation works even over '
-        'line breaks.');
+            'line breaks.');
 
     var s2 = 'The + operator ' + 'works, as well.';
     assert(s2 == 'The + operator works, as well.');

--- a/examples/misc/test/library_tour/convert_test.dart
+++ b/examples/misc/test/library_tour/convert_test.dart
@@ -36,8 +36,8 @@ void main() {
     var jsonText = jsonEncode(scores);
     assert(jsonText ==
         '[{"score":40},{"score":80},'
-        '{"score":100,"overtime":true,'
-        '"special_guest":null}]');
+            '{"score":100,"overtime":true,'
+            '"special_guest":null}]');
     // #enddocregion json-encode
   });
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -182,15 +182,15 @@ alphanumeric text, the `{}` should be omitted.
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart %}
 'Hi, $name!'
-"Wear your wildest $decade's outfit."
-'Wear your wildest ${decade}s outfit.'
+    "Wear your wildest $decade's outfit."
+    'Wear your wildest ${decade}s outfit.'
 {% endprettify %}
 
 {:.bad-style}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart %}
 'Hi, ${name}!'
-"Wear your wildest ${decade}'s outfit."
+    "Wear your wildest ${decade}'s outfit."
 {% endprettify %}
 
 ## Collections

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -583,7 +583,7 @@ var s1 = 'String '
     " works even over line breaks.";
 assert(s1 ==
     'String concatenation works even over '
-    'line breaks.');
+        'line breaks.');
 
 var s2 = 'The + operator ' + 'works, as well.';
 assert(s2 == 'The + operator works, as well.');

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1542,8 +1542,8 @@ var scores = [
 var jsonText = jsonEncode(scores);
 assert(jsonText ==
     '[{"score":40},{"score":80},'
-    '{"score":100,"overtime":true,'
-    '"special_guest":null}]');
+        '{"score":100,"overtime":true,'
+        '"special_guest":null}]');
 {% endprettify %}
 
 Only objects of type int, double, String, bool, null, List, or Map (with


### PR DESCRIPTION
dartfmt in 2.3 treats some adjacent string literals differently from dartfmt in 2.2.
I'm going to fix our code to work with 2.3, ignoring the stable channel for now.

Related: #1445
Fixes #1446.