### PR TITLE
Add content to the top-level docs page

### DIFF
--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -15,4 +15,4 @@
   url: /tools/sdk
 - name: Futures & async-await
   description: How to write asynchronous Dart code that uses futures and the async and await keywords.
-  url: /guides/language/futures
+  url: /tutorials/language/futures

--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -1,0 +1,18 @@
+- name: Language samples
+  description: A brief, example-based introduction to the Dart language.
+  url: /samples
+- name: Language tour
+  description: A more thorough (yet still example-based) introduction to the Dart language.
+  url: /guides/language/language-tour
+- name: Effective Dart
+  description: Best practices for building consistent, maintainable, efficient Dart code.
+  url: /guides/language/effective-dart
+- name: Library tour
+  description: An example-based introduction to the major features in the Dart SDK's core libraries.
+  url: /guides/language/language-tour
+- name: Dart SDK
+  description: What's in the SDK, and how to install it.
+  url: /tools/sdk
+- name: Futures & async-await
+  description: How to write asynchronous Dart code that uses futures and the async and await keywords.
+  url: /guides/language/futures

--- a/src/_guides/index.md
+++ b/src/_guides/index.md
@@ -4,6 +4,57 @@ description: Learn to use the Dart language and libraries.
 toc: false
 ---
 
-[TBD: Give this page content similar to
+Welcome to the Dart documentation!
+Here are some of the most visited pages:
+
+<div class="card-grid">
+{% for card in site.data.docs_cards -%}
+  {% capture index0Modulo3 %}{{ forloop.index0 | modulo:3 }}{% endcapture %}
+  {% capture indexModulo3 %}{{ forloop.index | modulo:3 }}{% endcapture %}
+  <div class="card">
+    <h3><a href="{{card.url}}">{{card.name}}</a></h3>
+    <p>{{card.description}}</p>
+  </div>
+{% endfor -%}
+</div>
+
+{% comment %}
+[PENDING: Give this page content similar to
 [flutter.dev/docs.](https://flutter.dev/docs)]
 
+## What's new on the site
+
+**May 7, 2019**
+
+Everything. :)
+
+For a listing of new docs, see [what's new](/docs/whats-new-archive).
+
+## New to Dart?
+
+Once you've gone through [Get Started](/docs/get-started/install),
+including [Write Your First Flutter App,](/docs/get-started/codelab)
+here are some next steps.
+
+### Docs
+
+[Building layouts in Flutter](/docs/development/ui/layout)
+: Learn how to create layouts in Flutter, where everything is a widget.
+
+[Adding interactivity to your Flutter app](/docs/development/ui/interactive)
+: Learn how to add a stateful widget to your app.
+
+[A tour of the Flutter widget framework](/docs/development/ui/widgets-intro)
+: Learn more about Flutter's react-style framework.
+
+[FAQ](/docs/resources/faq)
+: Get the answers to frequently asked questions.
+
+You may also find these docs useful:
+
+* [Using packages](/docs/development/packages-and-plugins/using-packages)
+* [Adding assets and images](/docs/development/ui/assets-and-images)
+* [Navigation and routing](/docs/development/ui/navigation)
+* [State management](/docs/development/data-and-backend/state-mgmt/intro)
+* [Animations](/docs/development/ui/animations)
+{% endcomment %}

--- a/src/_tutorials/language/futures.md
+++ b/src/_tutorials/language/futures.md
@@ -1,6 +1,6 @@
 ---
-title: "Asynchronous programming: futures"
-description: A first look at futures and how to use them to make your asynchronous code better.
+title: "Asynchronous programming: futures & async-await"
+description: How to write asynchronous Dart code that uses futures and the async and await keywords.
 nextpage:
   url: /tutorials/language/streams
   title: "Asynchronous programming: streams"


### PR DESCRIPTION
Also updated site-shared to reorder the sections in the Dart SDK page.

Staged:
https://kw-www-dartlang-1.firebaseapp.com/guides
https://kw-www-dartlang-1.firebaseapp.com/tools/sdk

I still need to update the links in the SDK tool list, but I'll do that when I do a global link pass.