### PR TITLE
Tweaks codelab instructions

### DIFF
--- a/src/codelabs/dart-cheatsheet/index.md
+++ b/src/codelabs/dart-cheatsheet/index.md
@@ -32,7 +32,7 @@ and can be a handy place to return for a refresher as you grow your Dart skills.
 In addition to explanations and examples,
 the codelab includes embedded editors with partially completed code snippets.
 You can use these editors to test your knowledge by completing the code and
-clicking the **Test Code** button.
+clicking the **Run** button.
 
 
 


### PR DESCRIPTION
@leafpetersen pointed out that our DartPad2 codelab instructions no longer match the text on our buttons, which is an annoying oversight for new users.