### PR TITLE
Fix sliding menu: click, top-nav search.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -626,6 +626,10 @@ img {
   #mainnav & {
     // Override of _header.scss
     border: 0;
+
+    .open_menu & {
+      visibility: hidden;
+    }
   }
 
   #sidenav & {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -115,11 +115,15 @@ $(function () {
     $("body").toggleClass('open_menu');
   });
 
-  $("#page-content").on('click', function () {
-    if ($('body').hasClass('open_menu')) {
-      $('body').removeClass("open_menu");
-    }
-  });
+  var topLevelMenuTogglers = ['#page-header', '.banner', '#page-content', '#page-footer'];
+  for (var i = 0; i < topLevelMenuTogglers.length; i++) {
+    $(topLevelMenuTogglers[i]).on('click', function (e) {
+      if ($('body').hasClass('open_menu')) {
+        e.preventDefault();
+        $('body').removeClass("open_menu");
+      }
+    });
+  }
 
   $(window).smartresize(fixNav());
 


### PR DESCRIPTION
Prior to this, click events on the right-side darkened part of the page were actually accepted and acted upon, instead of just closing the sliding menu.