### PR TITLE
Layout updates: content, banner and sidebar padding, positions

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -245,16 +245,16 @@ img {
 
   > article {
     > .content {
-      padding-left: 8%;
+      padding-left: 5%;
       padding-right: 8%;
     }
 
     @media(min-width: 1024px) {
-      margin-left: 246px;
+      margin-left: 236px;
     }
 
     @media(min-width: 1200px) {
-      margin-right: 246px;
+      margin-right: 236px;
     }
   }
 }
@@ -445,7 +445,7 @@ img {
   position: fixed;
   bottom: 0px;
   left: 0px;
-  width: 246px;
+  width: 236px;
   border-right: 1px solid #d8d8d8;
   overflow-x: hidden;
   overflow-y: auto;
@@ -453,7 +453,7 @@ img {
 
   .site-sidebar {
     // override shared/_sidebar.scss
-    padding: $content-padding 40px;
+    padding: $content-padding 40px $content-padding 30px;
 
     // override shared/_sidebar.scss
     // the first-level nav block is indented on the same level as the headers
@@ -553,7 +553,7 @@ img {
 
   position: fixed;
   bottom: 0px;
-  width: 246px;
+  width: 236px;
   right: 0px;
   overflow-x: hidden;
   overflow-y: auto;
@@ -561,7 +561,7 @@ img {
 
   // override shared/_toc.scss
   &.site-toc {
-    padding: $content-padding 40px;
+    padding: $content-padding 30px $content-padding 40px;
   }
 
   // Override BS defaults for .nav, etc.

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -245,16 +245,16 @@ img {
 
   > article {
     > .content {
-      padding-left: 10%;
-      padding-right: 10%;
+      padding-left: 8%;
+      padding-right: 8%;
     }
 
     @media(min-width: 1024px) {
-      margin-left: 266px;
+      margin-left: 246px;
     }
 
     @media(min-width: 1200px) {
-      margin-right: 266px;
+      margin-right: 246px;
     }
   }
 }
@@ -445,7 +445,7 @@ img {
   position: fixed;
   bottom: 0px;
   left: 0px;
-  width: 266px;
+  width: 246px;
   border-right: 1px solid #d8d8d8;
   overflow-x: hidden;
   overflow-y: auto;
@@ -453,7 +453,7 @@ img {
 
   .site-sidebar {
     // override shared/_sidebar.scss
-    padding: $content-padding 50px;
+    padding: $content-padding 40px;
 
     // override shared/_sidebar.scss
     // the first-level nav block is indented on the same level as the headers
@@ -553,7 +553,7 @@ img {
 
   position: fixed;
   bottom: 0px;
-  width: 266px;
+  width: 246px;
   right: 0px;
   overflow-x: hidden;
   overflow-y: auto;
@@ -561,7 +561,7 @@ img {
 
   // override shared/_toc.scss
   &.site-toc {
-    padding: $content-padding 50px;
+    padding: $content-padding 40px;
   }
 
   // Override BS defaults for .nav, etc.

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -466,6 +466,7 @@ img {
       font-weight: 300;
       color: $site-color-body;
       font-size: 13px;
+      align-items: start;
 
       // override shared/_sidebar.scss
       &.collapsable::before {
@@ -481,7 +482,7 @@ img {
         &:not(.collapsable) {
           font-family: $site-font-family-gsans;
           font-weight: 400;
-          font-size: 20px;
+          font-size: 16px;
         }
 
         &.active {
@@ -566,7 +567,7 @@ img {
   // Override BS defaults for .nav, etc.
   .site-toc__title {
     color: $site-color-body;
-    font-size: 20px;
+    font-size: 16px;
   }
   .toc-entry {
     padding-bottom: 0.5rem;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -307,7 +307,7 @@ img {
 // Banner
 .banner {
   background-color: #e7f8ff;
-  padding: 20px 0;
+  padding: 12px 0;
   text-align: center;
 }
 

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -244,24 +244,17 @@ img {
   }
 
   > article {
+    > .content {
+      padding-left: 10%;
+      padding-right: 10%;
+    }
+
     @media(min-width: 1024px) {
-      margin-left: 230px;
-      > .content {
-         padding-left: 100px;
-      }
+      margin-left: 266px;
     }
 
     @media(min-width: 1200px) {
-      margin-right: 225px;
-      > .content {
-        padding-right: 15%;
-      }
-    }
-
-    @media(min-width: 1400px) {
-      > .content {
-        padding-right: 20%;
-      }
+      margin-right: 266px;
     }
   }
 }
@@ -452,13 +445,16 @@ img {
   position: fixed;
   bottom: 0px;
   left: 0px;
-  width: 230px;
+  width: 266px;
   border-right: 1px solid #d8d8d8;
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 1;
 
   .site-sidebar {
+    // override shared/_sidebar.scss
+    padding: $content-padding 50px;
+
     // override shared/_sidebar.scss
     // the first-level nav block is indented on the same level as the headers
     > .nav > .nav-item > .nav {
@@ -556,13 +552,17 @@ img {
 
   position: fixed;
   bottom: 0px;
-  width: 225px;
+  width: 266px;
   right: 0px;
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 999;
-  padding-left: 20px;
-  padding-right: 20px;
+
+  // override shared/_toc.scss
+  &.site-toc {
+    padding: $content-padding 50px;
+  }
+
   // Override BS defaults for .nav, etc.
   .site-toc__title {
     color: $site-color-body;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -152,7 +152,7 @@ input, select {
 }
 
 pre, pre.prettyprint {
-  padding: 30px 40px;
+  padding: 30px;
   background-color: #F5F5F7;
   color: $blue;
   position: relative;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -250,11 +250,11 @@ img {
     }
 
     @media(min-width: 1024px) {
-      margin-left: 236px;
+      margin-left: 226px;
     }
 
     @media(min-width: 1200px) {
-      margin-right: 236px;
+      margin-right: 226px;
     }
   }
 }
@@ -445,7 +445,7 @@ img {
   position: fixed;
   bottom: 0px;
   left: 0px;
-  width: 236px;
+  width: 226px;
   border-right: 1px solid #d8d8d8;
   overflow-x: hidden;
   overflow-y: auto;
@@ -453,7 +453,7 @@ img {
 
   .site-sidebar {
     // override shared/_sidebar.scss
-    padding: $content-padding 40px $content-padding 30px;
+    padding: $content-padding 30px;
 
     // override shared/_sidebar.scss
     // the first-level nav block is indented on the same level as the headers
@@ -553,7 +553,7 @@ img {
 
   position: fixed;
   bottom: 0px;
-  width: 236px;
+  width: 226px;
   right: 0px;
   overflow-x: hidden;
   overflow-y: auto;
@@ -561,7 +561,7 @@ img {
 
   // override shared/_toc.scss
   &.site-toc {
-    padding: $content-padding 30px $content-padding 40px;
+    padding: $content-padding 30px;
   }
 
   // Override BS defaults for .nav, etc.


### PR DESCRIPTION
- re-done #1482 with the correct rebase
- Applied the new padding design.
- Increased sidebar and TOC width and paddings.
- Decreased sidebar and TOC first-level heading font size.
- Decreased banner top and bottom padding.
- Decreased code block left and right padding.
- Fixed the toggle button position on the leftnav (it was not always on the top).