### PR TITLE
Add mobile apps

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -135,7 +135,6 @@
       { "source": "/logos", "destination": "https://github.com/dart-lang/logos", "type": 301 },
       { "source": "/linter/lints/:lint*", "destination": "http://dart-lang.github.io/linter/lints/:lints*", "type": 301 },
       { "source": "/mailing-list", "destination": "https://groups.google.com/a/dartlang.org/forum/#!forum/misc", "type": 301 },
-      { "source": "/mobile", "destination": "/guides/platforms", "type": 301 },
       { "source": "/news{,/**}", "destination": "https://news.dartlang.org/", "type": 301 },
       { "source": "/observatory{,/**}", "destination": "https://dart-lang.github.io/observatory", "type": 301 },
       { "source": "/performance", "destination": "/articles/server/benchmarking", "type": 301 },

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -76,7 +76,9 @@
       permalink: /guides/json
     - title: Streams
       permalink: /tutorials/language/streams
-    - title: Command line & server
+    - title: Mobile apps
+      permalink: /mobile
+    - title: Command-line & server apps
       children:
         - title: Get started
           permalink: /tutorials/server/get-started
@@ -88,7 +90,7 @@
           permalink: /articles/server/native-extensions
         - title: AOT and JIT compilation [TBD]
           permalink: /tbd
-    - title: Web
+    - title: Web apps
       children:
         - title: Overview
           urlExactMatch: true

--- a/src/mobile.md
+++ b/src/mobile.md
@@ -1,0 +1,22 @@
+---
+title: Dart mobile apps
+description: Dart mobile apps can be written using the Flutter framework.
+toc: false
+---
+
+## Dart mobile apps using the Flutter framework
+
+Mobile apps can be written in Dart using the Flutter framework. The Flutter
+framework is powered by the [Dart platform](/platforms), using the [Dart
+VM](/platforms) for it's instant 'hot reload' developer cycle, and the [Dart
+AOT](/platforms) native code compiler for creating fast production code.
+
+<p class="text-center"> 
+  <a href="{{site.flutter}}">
+    <img src="{% asset shared/flutter/logo+text/horizontal/default.svg @path %}" width="400px" alt="Flutter logo"/>
+  </a>
+</p>
+
+<p class="text-center"> 
+  <a href="{{site.flutter}}/get-started" class="btn btn-primary btn-lg">Get started</a>
+</p>

--- a/src/mobile.md
+++ b/src/mobile.md
@@ -1,22 +1,20 @@
 ---
-title: Dart mobile apps
-description: Dart mobile apps can be written using the Flutter framework.
+title: Mobile app development
+short-title: Mobile
+description: Use the Flutter framework to build beautiful native apps on iOS and Android from a single codebase.
 toc: false
 ---
 
-## Dart mobile apps using the Flutter framework
-
-Mobile apps can be written in Dart using the Flutter framework. The Flutter
-framework is powered by the [Dart platform](/platforms), using the [Dart
-VM](/platforms) for it's instant 'hot reload' developer cycle, and the [Dart
+We recommend the [Flutter framework][] for developing mobile apps.
+It's powered by the [Dart platform](/platforms), using the [Dart
+VM](/platforms) for its instant _hot reload_ developer cycle and the [Dart
 AOT](/platforms) native code compiler for creating fast production code.
 
 <p class="text-center"> 
-  <a href="{{site.flutter}}">
-    <img src="{% asset shared/flutter/logo+text/horizontal/default.svg @path %}" width="400px" alt="Flutter logo"/>
+  <a href="{{site.flutter}}/get-started" class="btn btn-primary btn-lg no-automatic-external">
+    <img src="{% asset shared/flutter/icon/64.png @path %}" width="32px" alt=""/>
+    Get started
   </a>
 </p>
 
-<p class="text-center"> 
-  <a href="{{site.flutter}}/get-started" class="btn btn-primary btn-lg">Get started</a>
-</p>
+[Flutter framework]: {{site.flutter}}

--- a/src/web/index.md
+++ b/src/web/index.md
@@ -1,5 +1,6 @@
 ---
-title: Web development with Dart
+title: Web app development
+short-title: Web
 description: Resources for developing Dart web apps.
 toc: false
 ---


### PR DESCRIPTION
Now that we don't have https://www.dartlang.org/guides/platforms anymore, and to make sure Development represents all types of apps you can create with Dart