### PR TITLE
Top-menu nav items in the mobile view of the side-menu.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -498,6 +498,25 @@ img {
         font-weight: 400;
       }
     }
+
+    .navbar-nav {
+      display: none;
+
+      @media(max-width: 1024px) {
+        display: block;
+        margin-bottom: 1rem;
+
+        a.nav-link {
+          font-family: $site-font-family-gsans;
+          font-weight: 400;
+          font-size: 20px;
+
+          &.active {
+            color: $site-color-body
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -4,6 +4,25 @@
   </form>
 
   <div class="site-sidebar">
+    <ul class="navbar-nav">
+      <li class="nav-item">
+        <a href="/platforms" class="nav-link
+          {%- if page_url_path contains '/*/platforms/' %} active {%- endif -%}">Platforms</a>
+      </li>
+      <li class="nav-item">
+        <a href="/community" class="nav-link
+          {%- if page_url_path contains '/*/community/' %} active {%- endif -%}">Community</a>
+      </li>
+      <li class="nav-item">
+        <a href="/tbd" class="nav-link
+          {%- if page_url_path contains '/*/#dartpad' %} active {%- endif -%}">Try Dart</a>
+      </li>
+      <li class="nav-item">
+        <a href="/guides" class="nav-link
+          {%- if page_url_path contains '/*/guides/' or page_url_path contains '/*/dart-2/' or page_url_path contains '/*/codelabs/' or page_url_path contains '/*/samples/' or page_url_path contains '/*/tools/' or page_url_path contains '/*/tutorials/' or page_url_path contains '/*/server/' or page_url_path contains '/*/web/' %} active {%- endif -%}">Docs</a>
+      </li>
+    </ul>
+
     {% include shared/sidenav-level-1.html nav=site.data.side-nav %}
   </div>
 </div>


### PR DESCRIPTION
The font size follows Flutter in that these menu items are slightly larger than the otherwise top-level items (they are 20px, and the top-level items will be 16px). However, the active styling is up to discussion: should we lighten the non-active ones? Should we make the active one blue?