### PR TITLE
Use absolute font-weight setting.

### DIFF
--- a/src/_assets/css/_bootstrap_adjust.scss
+++ b/src/_assets/css/_bootstrap_adjust.scss
@@ -1,3 +1,7 @@
 @mixin pre-defaults {
   padding: 2px 3px; // bs-spacer(3) bs-spacer(4);
 }
+
+b, strong {
+  font-weight: bold;
+}


### PR DESCRIPTION
The bootstrap defaults set the `<strong>` boldness to `bolder`, which is a relative weight: it may be `400` or `700`, depending on the base font weight. Setting this to `700` (bold) to make sure it is always distinctive.