### PR TITLE
Fix dotted code: prevent the application of the link styles.

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -195,6 +195,11 @@ pre, pre.prettyprint {
     background: #fffde7;
     padding: 2px;
   }
+
+  a {
+    font-family: inherit;
+    font-weight: inherit;
+  }
 }
 code {
   background-color: transparent;


### PR DESCRIPTION
Fixes the code layout e.g. on the homepage. On the dotted lines the original `<a>` styles (non-monospaced font, different weight) was taking over, needed to counter it.