### PR TITLE
Fix jitter by adjusting the pre-calculated banner height

### DIFF
--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -97,9 +97,9 @@ $site-font-icon: 24px/1 $site-font-family-icon;
 
 // Layout
 $site-header-height: 50px;
-$site-header-with-banner-height: 114px; // 50 + 64
+$site-header-with-banner-height: 98px; // 50 + 48
 $site-header-with-obsolete-height: 131px; // 50 + 81
-$site-header-with-banner-obsolete-height: 195px; // 50 + 81 + 64
+$site-header-with-banner-obsolete-height: 179px; // 50 + 81 + 48
 $site-footer-md-default-height: 140px;
 $site-content-top-padding: 40px;
 $site-content-max-width: 960px;


### PR DESCRIPTION
The layout was updated by removing 8-8px from the top and bottom of the banner, decreasing the pre-calculated height by 16px.