### PR TITLE
Move sidebar outside of #page-content in all templates.

### DIFF
--- a/src/_layouts/error.html
+++ b/src/_layouts/error.html
@@ -3,8 +3,8 @@
   {% include head.html %}
   <body class="{{ page.layout }} hide_toc">
     {% include page-header.html %}
+    {% include navigation-side.html %}
     <main id="page-content">
-      {% include navigation-side.html %}
       <div class="content">
         {{ content }}
       </div>

--- a/src/_layouts/homepage.html
+++ b/src/_layouts/homepage.html
@@ -3,8 +3,8 @@
   {% include head.html %}
   <body class="homepage">
     {% include page-header.html %}
+    {% include navigation-side.html %}
     <main id="page-content">
-      {% include navigation-side.html %}
       {{ content }}
     </main>
     {% include page-footer.html %}


### PR DESCRIPTION
The logic that hides the sidebar in mobile mode checks whether a click is inside the header, content or footer. The `_default` template had it moved outside the `#page-content` element, but the rest did not. Moving this outside fixes the issue where the links were not working.