### PR TITLE
align navigation arrows with text

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -480,11 +480,16 @@ img {
       font-size: 13px;
       line-height: 45px;
 
+      // center text and arrow button
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
       // copy of shared/_sidebar.scss
       // @mixin collapsable() is not reachable from here, this is a copy of that
       &.collapsable {
         display: flex;
-        align-items: start;
+        align-items: center;
         justify-content: space-between;
 
         &::after {


### PR DESCRIPTION
this aligns the arrows and text towards the vertical center:

![Screen Shot 2019-04-30 at 2 25 19 PM](https://user-images.githubusercontent.com/1145719/56994401-cf8b9600-6b53-11e9-9c12-5c87250afff0.png)
