### PR TITLE
Update sidenav's line heights

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -478,7 +478,10 @@ img {
       font-weight: 300;
       color: $site-color-body;
       font-size: 13px;
-      line-height: 45px;
+
+      .open_menu & {
+        padding-bottom: 21px;
+      }
 
       // center text and arrow button
       display: flex;


### PR DESCRIPTION
- Using `padding-bottom` instead of `line-height`, so that multiline text doesn't get separated.
- Using the `open_menu` style to set it only when the hamburger menu triggers the mobile sidebar display. This does not yet detects "true mobile" displays, but it preserves the compact view for most desktop clients.