### PR TITLE
use a 1330px max-width for header

### DIFF
--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -6,6 +6,7 @@ $dash-dark-black: #4a4a4a;
 $dash-highlight: #1967d2;
 $dash-off-black: #12202f;
 $dark-darker-black: #0d1520;
+$dash-header-bg: #17212f;
 
 .dash-header-callout {
   font-family: "Google Sans", "Roboto", sans-serif;
@@ -159,8 +160,16 @@ $dark-darker-black: #0d1520;
   }
 }
 
+.dash-header {
+  background-color: $dash-header-bg;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .dash-header video {
   width: 100%;
+  max-width: 1330px;
   margin-bottom: -10px;
 }
 


### PR DESCRIPTION
This is for users with large screens... we don't want to make the video too big 

before:

![Screen Shot 2019-05-03 at 12 40 57 PM](https://user-images.githubusercontent.com/1145719/57161601-cf340a80-6da0-11e9-98bf-d25956b07031.png)

after:

![Screen Shot 2019-05-03 at 12 40 38 PM](https://user-images.githubusercontent.com/1145719/57161608-d22efb00-6da0-11e9-9c47-0891647c29ee.png)
