### PR TITLE
Re-enable publishing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,14 @@ after_script:
   # # (By default, Travis doesn't fail builds after deployment.)
   # - "./deploy/html_proof.rb || travis_terminate 1"
 
-# deploy:
-#   - provider: script
-#     script: ./tool/shared/deploy.sh --robots ok default
-#     skip_cleanup: true
-#     on:
-#       repo: dart-lang/site-www
-#       branch: master
-#       condition: $TASK == *build*
+deploy:
+  - provider: script
+    script: ./tool/shared/deploy.sh --robots ok default
+    skip_cleanup: true
+    on:
+      repo: dart-lang/site-www
+      branch: master
+      condition: $TASK == *build*
 
 # Only run Travis jobs for named branches (to avoid double builds for each PR)
 branches:


### PR DESCRIPTION
This was reverted when we brought over the `dash` branch in https://github.com/dart-lang/site-www/commit/82cb19a9761c568ae796fda3305b58788bad2669#diff-354f30a63fb0907d4ad57269548329e3