### PR TITLE
Add search page for all Dart documentation.

### DIFF
--- a/src/search-all.html
+++ b/src/search-all.html
@@ -4,7 +4,15 @@ description: Search dart.dev, api.dartlang.org, and the old www.dartlang.org sit
 toc: false
 ---
 
+<p>
+Use this search when you want results from both this site
+(which may appear in search results as <em>www.dartlang.org</em>)
+and <a href="{{site.dart_api}}">{{site.dart_api}}.</a>
+</p>
+
+<p>
 Want only results from dart.dev? <a href="search.html">Search dart.dev.</a>
+</p>
 
 <div class="d-flex">
   <script>

--- a/src/search-all.html
+++ b/src/search-all.html
@@ -1,15 +1,15 @@
 ---
-title: Search dart.dev
-description: The search page for dart.dev.
+title: Search all Dart documentation
+description: Search dart.dev, api.dartlang.org, and the old www.dartlang.org site.
 toc: false
 ---
 
-Want results from the API docs, too? <a href="search-all.html">Search all Dart documentation.</a>
+Want only results from dart.dev? <a href="search.html">Search dart.dev.</a>
 
 <div class="d-flex">
   <script>
     (function() {
-      var cx = '011220921317074318178:ufsd-ukx1ii';
+      var cx = '011220921317074318178:_yy-tmb5t_i';
       var gcse = document.createElement('script');
       gcse.type = 'text/javascript';
       gcse.async = true;

--- a/src/search-all.html
+++ b/src/search-all.html
@@ -1,5 +1,6 @@
 ---
 title: Search all Dart documentation
+short-title: Search all Dart docs
 description: Search dart.dev, api.dartlang.org, and the old www.dartlang.org site.
 toc: false
 ---

--- a/src/search.html
+++ b/src/search.html
@@ -1,10 +1,11 @@
 ---
 title: Search dart.dev
+short-title: Search
 description: The search page for dart.dev.
 toc: false
 ---
 
-Want results from the API docs, too? <a href="search-all.html">Search all Dart documentation.</a>
+Want results from the API reference, too? <a href="search-all.html">Search all Dart documentation.</a>
 
 <div class="d-flex">
   <script>


### PR DESCRIPTION
Because some people were confused by dartlang.org search returning results for other sites, as well, I implemented dart.dev search to include only results from dart.dev.

But it turns out that some people really like being able to search at least api.dartlang.org, as well. I've created a new page for searching dart.dev and api.dartlang.org (as well as www.dartlang.org, for now, since that has better SEO and the results would otherwise be dominated by api.dartlang.org).

Staged: 
https://kw-staging-dartlang-2.firebaseapp.com (use the search field at the top of this or any other page)
https://kw-staging-dartlang-2.firebaseapp.com/search.html (default search)
https://kw-staging-dartlang-2.firebaseapp.com/search-all.html (alternate search)

Known issues:
* The search query should be plugged into the new page.
* The search field starts out narrow, growing as you type into it.

/cc @jamesderlin 