### PR TITLE
Update analysis-options.md

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -402,4 +402,4 @@ Use the following resources to learn more about static analysis in Dart:
 [linter rules]: http://dart-lang.github.io/linter/lints/
 [sound-dart]: /guides/language/sound-dart
 [todo]: {{site.pub-api}}/analyzer/latest/analyzer/TodoCode/TODO-constant.html
-[use a specific version]: /tools/pub/dependencies#version-constraints
+[use a specific version]: https://github.com/dart-lang/pedantic/blob/master/README.md#using-the-lints


### PR DESCRIPTION
The way to pin analysis options versions using `package:pedantic` has changed; the package now contains old analysis options files so you can just point to those. I think the best way to convey this in the doc is to link to the pedantic package README file instead of to the doc on pub versioning.

Please take a look :)