### PR TITLE
Removed [spread operator proposal] link and line.

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -773,13 +773,6 @@ var listOfStrings = [
 assert(listOfStrings[1] == '#1');
 {% endprettify %}
 
-For more details and examples of using collection if and for, see the 
-[control flow collections proposal.][collections proposal]
-
-[collections proposal]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/control-flow-collections/feature-specification.md
-
-[spread proposal]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/spread-collections/feature-specification.md
-
 The List type has many handy methods for manipulating lists. For more
 information about lists, see [Generics](#generics) and
 [Collections](/guides/libraries/library-tour#collections).

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -741,9 +741,6 @@ var list2 = [0, ...?list];
 assert(list2.length == 1);
 {% endprettify %}
 
-For more details and examples of using the spread operator, see the 
-[spread operator proposal.][spread proposal]
-
 <a id="collection-operators"> </a>
 Dart 2.3 also introduced **collection if** and **collection for**,
 which you can use to build collections using conditionals (`if`)

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -741,6 +741,9 @@ var list2 = [0, ...?list];
 assert(list2.length == 1);
 {% endprettify %}
 
+For more details and examples of using the spread operator, see the 
+[spread operator proposal.][spread proposal]
+
 <a id="collection-operators"> </a>
 Dart 2.3 also introduced **collection if** and **collection for**,
 which you can use to build collections using conditionals (`if`)
@@ -772,6 +775,13 @@ var listOfStrings = [
 ];
 assert(listOfStrings[1] == '#1');
 {% endprettify %}
+
+For more details and examples of using collection if and for, see the 
+[control flow collections proposal.][collections proposal]
+
+[collections proposal]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
+
+[spread proposal]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
 
 The List type has many handy methods for manipulating lists. For more
 information about lists, see [Generics](#generics) and


### PR DESCRIPTION
[spread operator proposal link] was broken. I checked the source code and I found that the URL was broken due to the absence of folder which contains the file to which it was made to be directed. Deleted the whole sentence because it was meaningless without the link.