### PR TITLE
 Use 2.3.1 SDK and pedantic package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: dart
-# dart: [stable, dev]
-dart: [stable/raw/2.3.0, dev]
+dart: [stable, dev]
 
 cache:
   timeout: 300

--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -10,6 +10,7 @@ analyzer:
 
 linter:
   rules:
+    avoid_shadowing_type_parameters: false # TODO: reinstate?
     - annotate_overrides
     - await_only_futures
     - camel_case_types

--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -1,6 +1,8 @@
 # Supported lint rules and documentation:
 #   http://dart-lang.github.io/linter/lints/
 
+include: package:pedantic/analysis_options.yaml
+
 analyzer:
   exclude: [build/**]
   strong-mode:
@@ -8,15 +10,7 @@ analyzer:
 
 linter:
   rules:
-    #- always_declare_return_types
-    #- always_specify_types
     - annotate_overrides
-    #- avoid_as
-    - avoid_empty_else
-    - avoid_init_to_null
-    - avoid_relative_lib_imports
-    - avoid_return_types_on_setters
-    - avoid_types_as_parameter_names
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions
@@ -24,16 +18,11 @@ linter:
     - comment_references
     - constant_identifier_names
     - control_flow_in_finally
-    - empty_catches
-    - empty_constructor_bodies
     - empty_statements
     - hash_and_equals
     - implementation_imports
     - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
     - list_remove_unrelated_type
-    - no_duplicate_case_values
     - non_constant_identifier_names
     - one_member_abstracts
     - only_throw_errors
@@ -41,24 +30,12 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_is_not_empty
-    #- public_member_api_docs
-    - recursive_getters
-    - slash_for_doc_comments
     #- sort_constructors_first # TODO: reinstate after https://github.com/dart-lang/site-www/issues/1196 is resolved?
     - sort_unnamed_constructors_first
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - type_annotate_public_apis
-    - type_init_formals
-    #- unawaited_futures
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_getters_setters
     - unnecessary_new
-    - unrelated_type_equality_checks
-    - use_rethrow_when_possible
-    - valid_regexps

--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -31,7 +31,7 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
-    #- sort_constructors_first # TODO: reinstate after https://github.com/dart-lang/site-www/issues/1196 is resolved?
+    - sort_constructors_first
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/examples/httpserver/pubspec.yaml
+++ b/examples/httpserver/pubspec.yaml
@@ -3,10 +3,11 @@ description: Sample HTTP clients and servers
 homepage: https://www.dartlang.org/docs/tutorials/httpserver/
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.3.1 <3.0.0'
 
 dependencies:
   http_server: ^0.9.6
 
 dev_dependencies:
   test: ^1.0.0
+  pedantic: ^1.0.0

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,9 +2,10 @@ name: examples
 description: dartlang.org example code.
 
 environment:
-  sdk: '>=2.3.0-dev.0.5 <3.0.0'
+  sdk: '>=2.3.1 <3.0.0'
 
 dev_dependencies:
   test: ^1.0.0
+  pedantic: ^1.0.0
   dartlang_examples_util:
     path: ../util

--- a/examples/strong/pubspec.yaml
+++ b/examples/strong/pubspec.yaml
@@ -2,9 +2,10 @@ name: dartlang_strong
 description: dartlang.org strong mode examples
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.3.1 <3.0.0'
 
 dependencies:
   test: ^1.0.0
+  pedantic: ^1.0.0
   dartlang_examples_util:
     path: ../util

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -3,7 +3,8 @@ description: dartlang.org example utilities.
 version: 0.0.2
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.3.1 <3.0.0'
 
 dependencies:
   test: ^1.0.0
+  pedantic: ^1.0.0


### PR DESCRIPTION
Contributes to #1651.

In a subsequent PR, we should update the code samples to work with avoid_shadowing_type_parameters (if possible) and add lints such as prefer_collection_literals, which will help us fix #1365.