### PR TITLE
use 960px max width for all content

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -250,8 +250,9 @@ img {
 
   > article {
     > .content {
-      padding-left: 5%;
-      padding-right: 8%;
+      max-width: 960px;
+      margin-left: auto;
+      margin-right: auto;
       padding-top: $top-content-padding;
     }
 


### PR DESCRIPTION
Adding a limit to the width of content is more readable for people with larger screen resolutions. Here's a before and after:

![Screen Shot 2019-06-26 at 12 04 02 PM](https://user-images.githubusercontent.com/1145719/60207402-a95c3c80-980a-11e9-8494-f6ce027dbce5.png)

![Screen Shot 2019-06-26 at 12 03 34 PM](https://user-images.githubusercontent.com/1145719/60207422-b6792b80-980a-11e9-8c02-ba6c70dce54e.png)
