### PR TITLE
Fix build and update strong problems page

### DIFF
--- a/examples/httpserver/test/httpserver_test.dart
+++ b/examples/httpserver/test/httpserver_test.dart
@@ -100,9 +100,9 @@ void main() {
 
       expect(
         () async => Future.any([
-              server,
-              _test(),
-            ]),
+          server,
+          _test(),
+        ]),
         prints(''),
       );
     });
@@ -120,9 +120,9 @@ void main() {
 
       expect(
         () async => Future.any([
-              server,
-              _test(),
-            ]),
+          server,
+          _test(),
+        ]),
         prints('Wrote data for Han Solo.\n'),
       );
     });

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -8,6 +8,7 @@ void miscDeclAnalyzedButNotTested() {
     // Not if there is nothing before it.
     if (_chunks.isEmpty) return false;
     // #enddocregion comments-like-sentences
+    return true;
   };
 
   // #docregion block-comments

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -47,6 +47,7 @@ void miscDeclAnalyzedButNotTested() {
     if (lunchBox.length == 0) return 'so hungry...';
     if (!words.isEmpty) return words.join(' ');
     // #enddocregion dont-use-length
+    return 'foo';
   };
 
   (Iterable people) {

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -55,6 +55,7 @@ void miscDeclAnalyzedButNotTested() {
     if (lunchBox.isEmpty) return 'so hungry...';
     if (words.isNotEmpty) return words.join(' ');
     // #enddocregion dont-use-length
+    return 'foo';
   };
 
   {

--- a/examples/strong/analyzer-2-results.txt
+++ b/examples/strong/analyzer-2-results.txt
@@ -1,6 +1,6 @@
 Analyzing lib, test...
-  error • 'HoneyBadger.parent' ('() → Root') isn't a valid override of 'Animal.parent' ('() → Animal') at lib/animal_bad.dart:15:3 • invalid_override
-  error • 'Cat.chase' ('(Mouse) → void') isn't a valid override of 'Animal.chase' ('(Animal) → void') at lib/animal_bad.dart:26:3 • invalid_override
+  error • 'HoneyBadger.parent' ('Root Function()') isn't a valid override of 'Animal.parent' ('Animal Function()') at lib/animal_bad.dart:15:3 • invalid_override
+  error • 'Cat.chase' ('void Function(Mouse)') isn't a valid override of 'Animal.chase' ('void Function(Animal)') at lib/animal_bad.dart:26:3 • invalid_override
   error • A value of type 'List' can't be assigned to a variable of type 'List<Cat>' at lib/animal_bad.dart:49:19 • invalid_assignment
   error • The method 'add' isn't defined for the class 'Iterable' at lib/bounded/instantiate_to_bound.dart:7:5 • undefined_method
   error • A value of type 'Element' can't be assigned to a variable of type 'CanvasElement' at lib/common_fixes_analysis.dart:21:28 • invalid_assignment
@@ -8,11 +8,11 @@ Analyzing lib, test...
   error • The getter 'context2D' isn't defined for the class 'Element' at lib/common_problems_analysis.dart:23:12 • undefined_getter
   error • A value of type 'double' can't be assigned to a variable of type 'int' at lib/common_problems_analysis.dart:38:16 • invalid_assignment
   error • A value of type 'List<int>' can't be assigned to a variable of type 'List<String>' at lib/common_problems_analysis.dart:46:27 • invalid_assignment
-  error • 'MyAdder.add' ('(int, int) → int') isn't a valid override of 'NumberAdder.add' ('(num, num) → num') at lib/common_problems_analysis.dart:61:3 • invalid_override
-  error • 'Subclass.method' ('(int) → void') isn't a valid override of 'Superclass.method' ('(dynamic) → void') at lib/common_problems_analysis.dart:74:3 • invalid_override
+  error • 'MyAdder.add' ('int Function(int, int)') isn't a valid override of 'NumberAdder.add' ('num Function(num, num)') at lib/common_problems_analysis.dart:61:3 • invalid_override
+  error • 'Subclass.method' ('void Function(int)') isn't a valid override of 'Superclass.method' ('void Function(dynamic)') at lib/common_problems_analysis.dart:74:3 • invalid_override
   error • super call must be last in an initializer list (see https://goo.gl/EY6hDP): 'super(food)' at lib/common_problems_analysis.dart:92:9 • strong_mode_invalid_super_invocation
-  error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' at lib/common_problems_analysis.dart:102:17 • invalid_assignment
-  error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) at lib/common_problems_analysis.dart:102:17 • strong_mode_invalid_cast_function_expr
+  error • A value of type 'bool Function(String)' can't be assigned to a variable of type 'bool Function(dynamic)' at lib/common_problems_analysis.dart:102:17 • invalid_assignment
+  error • The function expression type 'bool Function(String)' isn't of type 'bool Function(dynamic)'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) at lib/common_problems_analysis.dart:102:17 • strong_mode_invalid_cast_function_expr
   error • The argument type 'List' can't be assigned to the parameter type 'List<int>' at lib/strong_analysis.dart:27:17 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:38:15 • argument_type_not_assignable
   error • The argument type 'int' can't be assigned to the parameter type 'String' at lib/strong_analysis.dart:54:15 • argument_type_not_assignable

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -233,7 +233,7 @@ class MyAdder extends NumberAdder {
 {:.console-output}
 <?code-excerpt "strong/analyzer-2-results.txt" retain="/isn't a valid override of.*num.*common_problems/"?>
 ```nocode
-error • 'MyAdder.add' ('(int, int) → int') isn't a valid override of 'NumberAdder.add' ('(num, num) → num') • invalid_override
+error • 'MyAdder.add' ('int Function(int, int)') isn't a valid override of 'NumberAdder.add' ('num Function(num, num)') • invalid_override
 ```
 
 Consider the following scenario where floating
@@ -304,7 +304,7 @@ class Subclass extends Superclass {
 {:.console-output}
 <?code-excerpt "strong/analyzer-2-results.txt" retain="/isn't a valid override of.*dynamic.*common_problems/"?>
 ```nocode
-error • 'Subclass.method' ('(int) → void') isn't a valid override of 'Superclass.method' ('(dynamic) → void') • invalid_override
+error • 'Subclass.method' ('void Function(int)') isn't a valid override of 'Superclass.method' ('void Function(dynamic)') • invalid_override
 ```
 
 #### Fix: Specify type arguments for the generic subclass
@@ -422,9 +422,9 @@ HoneyBadger(Eats food, String name)
 <hr>
 
 <a name="uses-dynamic-as-bottom"></a>
-### A function of type ... can't be assigned
+### The function expression type ... isn't of type ...
 
-<?code-excerpt "strong/analyzer-2-results.txt" retain="/The function expression type.*common_problems/" replace="/'\S+ → \S+'/'...'/g"?>
+<?code-excerpt "strong/analyzer-2-results.txt" retain="/The function expression type.*common_problems/" replace="/'bool.*?\)'/'...'/g"?>
 ```nocode
 error • The function expression type '...' isn't of type '...'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
 ```
@@ -449,10 +449,9 @@ Filter filter = ([!String!] x) => x.contains('Hello');
 {% endprettify %}
 
 {:.console-output}
-<?code-excerpt "strong/analyzer-2-results.txt" retain="/type '\(String\) → bool'.*common_problems/"?>
+<?code-excerpt "strong/analyzer-2-results.txt" retain="/The function expression type.*common_problems/"?>
 ```nocode
-error • A value of type '(String) → bool' can't be assigned to a variable of type '(dynamic) → bool' • invalid_assignment
-error • The function expression type '(String) → bool' isn't of type '(dynamic) → bool'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
+error • The function expression type 'bool Function(String)' isn't of type 'bool Function(dynamic)'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s) • strong_mode_invalid_cast_function_expr
 ```
 
 #### Fix: Add type parameters _or_ cast from dynamic explicitly


### PR DESCRIPTION
Fixed some problems that broke the build when we released 2.4:

* Update analyzer messages for 2.4. This affects the strong problems page, which I’ve staged at https://kw-www-dartlang-1.firebaseapp.com/guides/language/sound-problems#the-function-expression-type--isnt-of-type-.
* Add return statements to a few examples, to avoid new hints.
* Update a source file to make 2.4 dartfmt happy.