### PR TITLE
Fix the build

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_init_to_null, empty_constructor_bodies, final_not_initialized_constructor_1, prefer_is_not_empty, sort_constructors_first, type_annotate_public_apis, type_init_formals, unnecessary_brace_in_string_interps, unnecessary_getters_setters, unused_element, unused_local_variable, prefer_equal_for_default_values, use_rethrow_when_possible, prefer_is_empty
+// ignore_for_file: avoid_init_to_null, empty_constructor_bodies, final_not_initialized_constructor_1, prefer_is_not_empty, sort_constructors_first, type_annotate_public_apis, type_init_formals, unnecessary_brace_in_string_interps, unnecessary_getters_setters, unused_element, unused_local_variable, prefer_equal_for_default_values, use_rethrow_when_possible, prefer_is_empty, prefer_iterable_wheretype
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';


### PR DESCRIPTION
The new version of pedantic includes prefer_iterable_wheretype, so it catches an intentional occurrence of that bad pattern in usage_bad.dart.