### PR TITLE
Update highlight in design.md

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1322,7 +1322,7 @@ function.
 {:.good-style}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart %}
-bool isValid(String value, bool [!Function(String)!] test) => ...
+bool isValid(String value, [!bool Function(String)!] test) => ...
 {% endprettify %}
 
 {:.bad-style}

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1320,7 +1320,7 @@ function.
 [Function]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 
 {:.good-style}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart %}
 bool isValid(String value, [!bool Function(String)!] test) => ...
 {% endprettify %}


### PR DESCRIPTION
Updates the highlight in the "good" example given for "PREFER signatures in function type annotations." Previously, the good example did not highlight the return type in the function signature which is an important part of the change from the "bad" example.