### PR TITLE
[DO NOT COMMIT] Fix highlights in the diagnostics page

### DIFF
--- a/src/_guides/diagnostics.md
+++ b/src/_guides/diagnostics.md
@@ -44,7 +44,7 @@ The following code produces this diagnostic:
 
 ```dart
 union(Map<String, String> a, List<String> b, Map<String, String> c) =>
-    {...a, ...b, ...c};
+    [!{...a, ...b, ...c}!];
 ```
 
 The list `b` can only be spread into a set, and the maps `a` and `c` can
@@ -95,7 +95,7 @@ literal or a set literal.
 The following code produces this diagnostic:
 
 ```dart
-union(a, b) => !{...a, ...b}!;
+union(a, b) => [!{...a, ...b}!];
 ```
 
 The problem occurs because there are no type arguments, and there is no
@@ -161,7 +161,7 @@ the following code produces this diagnostic:
 
 ```dart
 void f(C c) {
-  c.!m!();
+  c.[!m!]();
 }
 ```
 
@@ -184,7 +184,7 @@ expression, rather than a map entry, in what appears to be a map literal.
 The following code generates this diagnostic:
 
 ```dart
-var map = <String, int>{'a': 0, 'b': 1, !'c'!};
+var map = <String, int>{'a': 0, 'b': 1, [!'c'!]};
 ```
 
 #### Common fix
@@ -211,7 +211,7 @@ to a const constructor.
 The following code produces this diagnostic:
 
 ```dart
-!@literal!
+[!@literal!]
 var x;
 ```
 
@@ -239,7 +239,7 @@ The following code generates this diagnostic:
 
 ```dart
 var m = <String, int>{'a': 0, 'b': 1};
-var s = <String>{...m};
+var s = <String>{...[!m!]};
 ```
 
 #### Common fix
@@ -277,7 +277,7 @@ environment:
 The following code generates this diagnostic:
 
 ```dart
-var s = !<int>{}!;
+var s = [!<int>{}!];
 ```
 
 #### Common fixes

--- a/src/_guides/diagnostics.md
+++ b/src/_guides/diagnostics.md
@@ -42,10 +42,10 @@ literal or a set literal.
 
 The following code produces this diagnostic:
 
-```dart
+{% prettify dart %}
 union(Map<String, String> a, List<String> b, Map<String, String> c) =>
     [!{...a, ...b, ...c}!];
-```
+{% endprettify %}
 
 The list `b` can only be spread into a set, and the maps `a` and `c` can
 only be spread into a map, and the literal can't be both.
@@ -94,9 +94,9 @@ literal or a set literal.
 
 The following code produces this diagnostic:
 
-```dart
+{% prettify dart %}
 union(a, b) => [!{...a, ...b}!];
-```
+{% endprettify %}
 
 The problem occurs because there are no type arguments, and there is no
 information about the type of either `a` or `b`.
@@ -159,11 +159,11 @@ member is used in a different package.
 If the method `m` in the class `C` is annotated with `@deprecated`, then
 the following code produces this diagnostic:
 
-```dart
+{% prettify dart %}
 void f(C c) {
   c.[!m!]();
 }
-```
+{% endprettify %}
 
 #### Common fixes
 
@@ -183,9 +183,9 @@ expression, rather than a map entry, in what appears to be a map literal.
 
 The following code generates this diagnostic:
 
-```dart
+{% prettify dart %}
 var map = <String, int>{'a': 0, 'b': 1, [!'c'!]};
-```
+{% endprettify %}
 
 #### Common fix
 
@@ -210,10 +210,10 @@ to a const constructor.
 
 The following code produces this diagnostic:
 
-```dart
+{% prettify dart %}
 [!@literal!]
 var x;
-```
+{% endprettify %}
 
 #### Common fixes
 
@@ -237,10 +237,10 @@ set literal doesn't implement the type `Iterable`.
 
 The following code generates this diagnostic:
 
-```dart
+{% prettify dart %}
 var m = <String, int>{'a': 0, 'b': 1};
 var s = <String>{...[!m!]};
-```
+{% endprettify %}
 
 #### Common fix
 
@@ -276,9 +276,9 @@ environment:
 
 The following code generates this diagnostic:
 
-```dart
+{% prettify dart %}
 var s = [!<int>{}!];
-```
+{% endprettify %}
 
 #### Common fixes
 


### PR DESCRIPTION
The good news: I got the highlights working, and you can see them at https://kw-www-dartlang-1.firebaseapp.com/guides/diagnostics.

The bad news: to get the highlights working, I [had to change](https://github.com/dart-lang/site-www/commit/6afcc3891a415556d4c1cc1aa7f9e77cf5144d01) ```dart to `{% prettify dart %}`. Yuck. This is a known problem, and I’ve created #1744 to track it.

Other issues to ponder:
* We might want to use a different URL.
* The right-hand TOC is too narrow, so the entries for ambiguous_set_or_map_literal_both &
ambiguous_set_or_map_literal_either look the same.

/cc @domesticmouse @legalcodes @bwilkerson @johnpryan 