### PR TITLE
Change dartpad.dartlang.org to dartpad.dev

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,8 @@ pub: https://pub.dev
 pub-api: https://pub.dev/documentation
 pub-pkg: https://pub.dev/packages
 lints: https://dart-lang.github.io/linter/lints
-dartpad: https://dartpad.dartlang.org
-dartpadx: https://dartpad.dartlang.org/experimental/embed-new-dart.html
+dartpad: https://dartpad.dev
+dartpadx: https://dartpad.dev/experimental/embed-new-dart.html
 news: https://news.dartlang.org
 group: https://groups.google.com/a/dartlang.org
 
@@ -63,10 +63,10 @@ defaults:
 
 custom:
   dartpad:
-    embed-dart-prefix: https://dartpad.dartlang.org/embed-dart.html
-    embed-html-prefix: https://dartpad.dartlang.org/embed-html.html
-    embed-inline-prefix: https://dartpad.dartlang.org/embed-inline.html
-    direct-link: https://dartpad.dartlang.org
+    embed-dart-prefix: https://dartpad.dev/embed-dart.html
+    embed-html-prefix: https://dartpad.dev/embed-html.html
+    embed-inline-prefix: https://dartpad.dev/embed-inline.html
+    direct-link: https://dartpad.dev
   downloads:
     dartarchive-be-url-prefix: https://storage.googleapis.com/dart-archive/channels/be/raw
     dartarchive-dev-url-prefix: https://storage.googleapis.com/dart-archive/channels/dev/release

--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,6 @@ custom:
     embed-dart-prefix: https://dartpad.dev/embed-dart.html
     embed-html-prefix: https://dartpad.dev/embed-html.html
     embed-inline-prefix: https://dartpad.dev/embed-inline.html
-    direct-link: https://dartpad.dev
   downloads:
     dartarchive-be-url-prefix: https://storage.googleapis.com/dart-archive/channels/be/raw
     dartarchive-dev-url-prefix: https://storage.googleapis.com/dart-archive/channels/dev/release

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -231,7 +231,7 @@
     - title: Blog
       permalink: https://medium.com/dartlang
     - title: DartPad (online editor)
-      permalink: https://dartpad.dartlang.org
+      permalink: https://dartpad.dev
     - title: Flutter
       permalink: https://flutter.dev
     - title: Package site

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -19,7 +19,7 @@ consult the [Dart language specification][].
 You can play with most of Dart's language features using DartPad
 ([learn more](/tools/dartpad)).
 
-**<a href="{{ site.custom.dartpad.direct-link }}" target="_blank">Open DartPad</a>**
+**<a href="{{ site.dartpad }}" target="_blank">Open DartPad</a>**
 </div>
 
 

--- a/src/_includes/dartpad.html
+++ b/src/_includes/dartpad.html
@@ -1,5 +1,5 @@
 {% comment %}
-https://dartpad.dartlang.org/a6907e26b96678b75303
+https://dartpad.dev/a6907e26b96678b75303
 https://gist.github.com/a6907e26b96678b75303
 verticalRatio set to a value that makes output have no scrollbar.
 {% endcomment %}

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -19,7 +19,7 @@
         {%- if page_url_path contains '/*/community/' %} active {%- endif -%}">Community</a>
     </li>
     <li>
-      <a href="https://dartpad.dartlang.org/" target="_blank" class="nav-link no-automatic-external 
+      <a href="https://dartpad.dev" target="_blank" class="nav-link no-automatic-external 
         {%- if page_url_path contains '/*/#dartpad' %} active {%- endif -%}">Try Dart</a>
     </li>
     <li>

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -14,7 +14,7 @@
           {%- if page_url_path contains '/*/community/' %} active {%- endif -%}">Community</a>
       </li>
       <li class="nav-item">
-        <a href="https://dartpad.dartlang.org" class="nav-link
+        <a href="https://dartpad.dev" class="nav-link
           {%- if page_url_path contains '/*/#dartpad' %} active {%- endif -%}">Try Dart</a>
       </li>
       <li class="nav-item">

--- a/src/_tutorials/language/futures.md
+++ b/src/_tutorials/language/futures.md
@@ -126,7 +126,7 @@ The following app simulates reading the news by using `async` and `await`
 to read the contents of a file on this site.
 Click run {% asset red-run.png alt="" %} to start the app.
 Or open a
-[DartPad window containing the app,]({{site.custom.dartpad.direct-link}}/477fb799d21401f46f8c04462fd249c4){: target="_blank"}
+[DartPad window containing the app,]({{site.dartpad}}/477fb799d21401f46f8c04462fd249c4){: target="_blank"}
 run the app, and click CONSOLE to see the app's output.
 
 {% comment %}
@@ -301,7 +301,7 @@ The following app simulates reading the news by using the `Future` API to read
 the contents of a file on this site.
 Click run {% asset red-run.png %} to start the app.
 Or open a
-[DartPad window containing the app,]({{site.custom.dartpad.direct-link}}/5ceabe371903b6672026bd3fb30cdf5b){: target="_blank"}
+[DartPad window containing the app,]({{site.dartpad}}/5ceabe371903b6672026bd3fb30cdf5b){: target="_blank"}
 run the app, and click CONSOLE to see the app's output.
 
 {% comment %}

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -27,7 +27,7 @@ the console output appears beneath the code.
 Try editing the source code—perhaps you'd like to change the greeting
 to use another language. To get the full DartPad experience,
 <a href="{{site.dartpad}}/27e044ec9e2957d9c5c7062871ce8bf3"
-   target="_blank">open the example at dartpad.dartlang.org.</a>
+   target="_blank">open the example at dartpad.dev.</a>
 
 <iframe
     src="{{site.custom.dartpad.embed-inline-prefix}}?id=27e044ec9e2957d9c5c7062871ce8bf3&verticalRatio=70"

--- a/src/_tutorials/web/fetch-data.md
+++ b/src/_tutorials/web/fetch-data.md
@@ -45,7 +45,7 @@ Click run ( {% asset red-run.png %} ) to start the app.
 Then change the values of the input elements,
 and check out the JSON format for each data type.
 You might prefer to
-[open the app in DartPad]({{site.custom.dartpad.direct-link}}/1d42e4eadb75bcc1ffbc079e299b862e){: target="_blank" rel="noopener"}
+[open the app in DartPad]({{site.dartpad}}/1d42e4eadb75bcc1ffbc079e299b862e){: target="_blank" rel="noopener"}
 to have more space for the app's code and UI.
 
 {% comment %}
@@ -397,7 +397,7 @@ and loads the file.
 <aside class="alert alert-info" markdown="1">
   **Implementation note:**
   The original portmanteaux example loaded the co-located file `portmanteaux.json`.
-  When we moved the example into [**DartPad**]({{site.custom.dartpad.direct-link}}),
+  When we moved the example into [**DartPad**]({{site.dartpad}}),
   we couldn't co-locate the JSON file because DartPad
   supports at most 3 files: one Dart file, one HTML file,
   and one CSS file.

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -21,7 +21,7 @@ Try editing the source code—perhaps you'd like to add "horses"
 to the list of pets. To get the full DartPad experience,
 which includes the web UI that the app produces,
 <a href="{{site.dartpad}}/2a24f3f042f1c86cf91621c30adce771"
-   target="_blank">open the example at dartpad.dartlang.org.</a>
+   target="_blank">open the example at dartpad.dev.</a>
 
 <iframe
     src="{{site.custom.dartpad.embed-inline-prefix}}?id=2a24f3f042f1c86cf91621c30adce771&verticalRatio=70"

--- a/src/_tutorials/web/low-level-html/add-elements.md
+++ b/src/_tutorials/web/low-level-html/add-elements.md
@@ -347,7 +347,7 @@ The Anagram app shows how to move an element within the DOM.
 Click run ( {% asset red-run.png %} ) to start the web app.
 Then form a word by clicking the app's letter tiles.
 You might prefer to
-<a href="{{site.custom.dartpad.direct-link}}/0532bfcb70bf5e4a900c" target="_blank" rel="noopener">open
+<a href="{{site.dartpad}}/0532bfcb70bf5e4a900c" target="_blank" rel="noopener">open
 the app in DartPad</a>
 to have more space for the app's code and UI.
 

--- a/src/_tutorials/web/low-level-html/connect-dart-html.md
+++ b/src/_tutorials/web/low-level-html/connect-dart-html.md
@@ -65,7 +65,7 @@ for more interesting and useful web apps.
 ## About the Dart, HTML, and CSS triumvirate {#source-files}
 
 If you've used
-<a href="{{site.custom.dartpad.direct-link}}" target="_blank" rel="noopener">DartPad,</a>
+<a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad,</a>
 you've already seen the DART, HTML, and CSS tabs
 that let you write the code for a web app.
 Each of these three languages
@@ -164,7 +164,7 @@ or even insert an entire subtree of nodes.
 
 ## Create a new Dart app {#create-dart-app}
 
-1. Go to <a href="{{site.custom.dartpad.direct-link}}" target="_blank" rel="noopener">DartPad.</a>
+1. Go to <a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad.</a>
 2. Click the **New Pad** button to undo any changes you might have made
    the last time you visited DartPad.
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -192,7 +192,7 @@ Inside or outside of Google, every Flutter app uses Dart.
 [Who Uses Dart]: /community/who-uses-dart
 [spec]: http://www.ecma-international.org/publications/standards/Ecma-408.htm
 [DEP]: https://github.com/dart-lang/dart_enhancement_proposals
-[DartPad]: {{site.custom.dartpad.direct-link}}
+[DartPad]: {{site.dartpad}}
 [Flutter]: {{site.flutter}}
 [DDC]: https://github.com/dart-lang/sdk/tree/master/pkg/dev_compiler#dev_compiler
 [strong mode]: /guides/language/sound-dart

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -3,7 +3,7 @@ title: DartPad
 description: The tool that lets you interactively play with Dart in a browser.
 ---
 
-<a href="{{site.custom.dartpad.direct-link}}"
+<a href="{{site.dartpad}}"
 target="_blank">DartPad (dartpad.dev)</a>
 is an open-source tool that
 lets you play with the Dart language in any modern browser.
@@ -36,7 +36,7 @@ try running some samples and then creating a simple command-line app.
 
 <ol markdown="1">
   <li markdown="1">
-  Go to <a href="{{site.custom.dartpad.direct-link}}" target="_blank">DartPad.</a>
+  Go to <a href="{{site.dartpad}}" target="_blank">DartPad.</a>
 
   A sample appears on the left and the output appears on the right.
   If you've played with DartPad before,

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -4,7 +4,7 @@ description: The tool that lets you interactively play with Dart in a browser.
 ---
 
 <a href="{{site.custom.dartpad.direct-link}}"
-target="_blank">DartPad (dartpad.dartlang.org)</a>
+target="_blank">DartPad (dartpad.dev)</a>
 is an open-source tool that
 lets you play with the Dart language in any modern browser.
 Here's what DartPad looks like:

--- a/src/web/libraries.md
+++ b/src/web/libraries.md
@@ -25,7 +25,7 @@ that provide low-level web APIs.
   how to include a Dart script in an HTML page and
   how to add and remove elements from a web page.
   These tutorials feature interactive examples in
-  [DartPad.]({{site.custom.dartpad.direct-link}})
+  [DartPad.]({{site.dartpad}})
 
 [The dart:html section](/guides/libraries/library-tour) of the library tour
 : An example-driven tour of using the dart:html library.


### PR DESCRIPTION
I might do a little cleanup of the config file (and the files that use the dartpad variables) in another commit.

Fixes #1741.