### PR TITLE
Clarify that a Google account is required to authenticate with pub server

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -41,9 +41,12 @@ are a few additional requirements for uploading a package:
   and Git dependencies don't support version resolution as well as hosted
   dependencies do.
 
-* Once you run `pub publish` you will be required to authenticate with a "Google Account". This can be a Gmail account, but you can use any Google account, including one registered with your own email address.
+* You must have a [Google Account,][Google Account]
+  which pub uses to manage package upload permissions.
+  Your Google Account can be associated with a Gmail address or
+  with any other email address.
 
-This allows us to leverage all the security and account recovery features associated with Google Accounts.
+[Google Account]: https://support.google.com/accounts/answer/27441
 
 Be aware that the email address associated with your Google account is
 displayed on the [Pub site]({{site.pub}}) along with any

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -41,6 +41,10 @@ are a few additional requirements for uploading a package:
   and Git dependencies don't support version resolution as well as hosted
   dependencies do.
 
+* Once you run `pub publish` you will be required to authenticate with a "Google Account". This can be a Gmail account, but you can use any Google account, including one registered with your own email address.
+
+This allows us to leverage all the security and account recovery features associated with Google Accounts.
+
 Be aware that the email address associated with your Google account is
 displayed on the [Pub site]({{site.pub}}) along with any
 packages you upload.

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -184,7 +184,9 @@ authors:
 - Bob Nystrom <rnystrom@google.com>
 {% endprettify %}
 
-If anyone uploads your package to the Pub site, your email address is public. The email can be from any email provider as long as it being listed publicly is okay.
+The email addresses can be from any provider.
+If anyone uploads your package to the Pub site,
+then the author information (including email addresses) becomes public.
 
 ### Homepage
 

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -184,8 +184,7 @@ authors:
 - Bob Nystrom <rnystrom@google.com>
 {% endprettify %}
 
-If anyone uploads your package to the Pub site, your email address is
-public.
+In order to authenticate with the pub server your `email` **must** be a Google or Gmail email address. If anyone uploads your package to the Pub site, your email address is public.
 
 ### Homepage
 

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -184,7 +184,7 @@ authors:
 - Bob Nystrom <rnystrom@google.com>
 {% endprettify %}
 
-In order to authenticate with the pub server your `email` **must** be a Google or Gmail email address. If anyone uploads your package to the Pub site, your email address is public.
+If anyone uploads your package to the Pub site, your email address is public. The email can be from any email provider as long as it being listed publicly is okay.
 
 ### Homepage
 


### PR DESCRIPTION
After reading an article and then confirming the information on Gitter, I realized that one needs a Google account in order to publish to pub.dev

Since pub.dev links to dart.dev, I am updating the relevant page. I don't know if there are any other pages where it may be warranted to include the information.

The requirements for publishing a package are spread between [the pubspec file](https://dart.dev/tools/pub/pubspec), [package layout conventions](https://dart.dev/tools/pub/package-layout), and the [publishing packages](https://dart.dev/tools/pub/publishing) pages.

In the `Publishing your package` section of Publishing Packages, it talks about what happens when you `pub publish`, but it makes no reference to validating the email is a Google account. So what happens if that fails, should that section be updated as well?

Unfortunately, I haven't published a package and I don't know if I ever will because of the Google account requirement. I just hope the documentation can be clarified to make it clear before someone spends time on a package. Cause they might not put the work into it if they don't want to abide by that or any other requirement for publishing,