### PR TITLE
Note that only hosted dependencies are permitted.

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -36,10 +36,10 @@ are a few additional requirements for uploading a package:
   it's too large, consider splitting it into multiple packages, or cutting down
   on the number of included resources or examples.
 
-* Your package should only have hosted dependencies. Git dependencies are
-  allowed but strongly discouraged; not everyone using Dart has Git installed,
-  and Git dependencies don't support version resolution as well as hosted
-  dependencies do.
+* Your package should depend only on hosted dependencies (from the default pub
+  package server) and SDK dependencies (`sdk: flutter`). These restrictions
+  ensure that dependencies of your packages cannot become unavailable in the
+  future.
 
 Be aware that the email address associated with your Google account is
 displayed on the [Pub site]({{site.pub}}) along with any


### PR DESCRIPTION
This was announced through breaking change process in:
https://github.com/dart-lang/sdk/issues/36765

It serves to ensure that dependencies of a package cannot
become unavailable in the future. Thus, if you can `pub get`
something once, then you can `pub get` the exact same thing
if you retain the `pubspec.lock`.

Existing packages with git dependencies remain on `pub.dev`,
but new packages containing git dependencies will not be
permitted.