### PR TITLE
Point to pub.dev rather than arbitrary package site.

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -48,7 +48,7 @@ packages you upload.
 ### Important files
 
 Pub uses the contents of a few files to create a page for your
-package at `<package site>/packages/<your_package>`. Here are the files that
+package at `pub.dev/packages/<your_package>`. Here are the files that
 affect how your package's page looks:
 
 * **README**: The README file (`README`, `README.md`, `README.mdown`,


### PR DESCRIPTION
I'm not entirely sure about this. I'm thinking that
3rd party pub sites may or may not have package pages at all.
I'm not aware of any specification that requires 3rd party pub servers to host a package page.

Regardless, we should probably update this with more information about other files that'll be read.

Note. if you'd prefer to keep this generic and refer to `<package-site>` that's fine too.