### PR TITLE
Fix function & method names missing `()`

### DIFF
--- a/src/_articles/archive/converters-and-codecs.md
+++ b/src/_articles/archive/converters-and-codecs.md
@@ -434,7 +434,7 @@ advanced method (for example `addModifiableSlice()`) would take range arguments
 (`from`, `to`) and an `isLast` boolean as arguments.
 
 This new method is not yet used by transformers, but we can already use it when
-invoking `startChunkedConversion` explicitly.
+invoking `startChunkedConversion()` explicitly.
 
 {% prettify dart %}
 

--- a/src/_articles/archive/converters-and-codecs.md
+++ b/src/_articles/archive/converters-and-codecs.md
@@ -61,7 +61,7 @@ abstract class Codec<S, T> {
 
 As can be seen, codecs provide convenience methods such as `encode()` and
 `decode()` that are expressed in terms of the encoder and decoder. The `fuse()`
-method and `inverted` getter allow you to fuse converters and
+method and `inverted()` getter allow you to fuse converters and
 change the direction of a codec, respectively.
 The base implementation of
 [Codec]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/Codec-class.html)

--- a/src/_articles/archive/converters-and-codecs.md
+++ b/src/_articles/archive/converters-and-codecs.md
@@ -61,7 +61,7 @@ abstract class Codec<S, T> {
 
 As can be seen, codecs provide convenience methods such as `encode()` and
 `decode()` that are expressed in terms of the encoder and decoder. The `fuse()`
-method and `inverted()` getter allow you to fuse converters and
+method and `inverted` getter allow you to fuse converters and
 change the direction of a codec, respectively.
 The base implementation of
 [Codec]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/Codec-class.html)

--- a/src/_articles/libraries/creating-streams.md
+++ b/src/_articles/libraries/creating-streams.md
@@ -326,7 +326,7 @@ as shown in the next section.
 ### Honoring the pause state
 
 Avoid producing events when the listener has requested a pause.
-An async* function automatically pauses at a `yield` statement
+An `async*` function automatically pauses at a `yield` statement
 while the stream subscription is paused.
 A `StreamController`, on the other hand, buffers events during the pause.
 If the code providing the events doesn't respect the pause,

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -110,7 +110,7 @@ Let's customize the app you just created.
  1. Copy the `thingsTodo()` function from the DartPad above
     to the `web/main.dart` file.
 
- 2. In the `main()` method, initialize the `output` element using
+ 2. In the `main()` function, initialize the `output` element using
     `thingsTodo()`:
 
     {% prettify dart %}

--- a/src/codelabs/dart-cheatsheet/index.md
+++ b/src/codelabs/dart-cheatsheet/index.md
@@ -306,7 +306,7 @@ Imagine you have a shopping cart class that keeps a private `List<double>`
 of prices.
 Add the following:
 
-* A getter called `total()` that returns the sum of the prices
+* A getter called `total` that returns the sum of the prices
 * A setter that replaces the list with a new one,
   as long as the new list doesn't contain any negative prices
   (in which case the setter should throw an `InvalidPriceException`).

--- a/src/codelabs/dart-cheatsheet/index.md
+++ b/src/codelabs/dart-cheatsheet/index.md
@@ -121,7 +121,7 @@ You can chain multiple uses of `?.` together in a single expression:
 myObject?.someProperty?.someMethod()
 {% endprettify %}
 
-The preceding code returns null (and never calls `someMethod`) if either
+The preceding code returns null (and never calls `someMethod()`) if either
 `myObject` or `myObject.someProperty` is
 null.
 
@@ -219,8 +219,8 @@ We've all seen an expression like this:
 myObject.someMethod()
 {% endprettify %}
 
-It invokes `someMethod` on `myObject`, and the result of
-the expression is the return value of `someMethod`.
+It invokes `someMethod()` on `myObject`, and the result of
+the expression is the return value of `someMethod()`.
 
 Here's the same expression with a cascade:
 
@@ -228,7 +228,7 @@ Here's the same expression with a cascade:
 myObject..someMethod()
 {% endprettify %}
 
-Although it still invokes `someMethod` on `myObject`, the result
+Although it still invokes `someMethod()` on `myObject`, the result
 of the expression **isn't** the return value — it's a reference to `myObject`!
 Using cascades, you can chain together operations that
 would otherwise require separate statements.
@@ -306,7 +306,7 @@ Imagine you have a shopping cart class that keeps a private `List<double>`
 of prices.
 Add the following:
 
-* A getter called `total` that returns the sum of the prices
+* A getter called `total()` that returns the sum of the prices
 * A setter that replaces the list with a new one,
   as long as the new list doesn't contain any negative prices
   (in which case the setter should throw an `InvalidPriceException`).

--- a/src/codelabs/dart-cheatsheet/index.md
+++ b/src/codelabs/dart-cheatsheet/index.md
@@ -181,7 +181,7 @@ This arrow syntax is a way to define a function that executes the
 expression to its right and returns its value.
 
 For example, consider this call to the `List` class's
-`any` method:
+`any()` method:
 
 {% prettify dart %}
 bool hasEmpty = aListOfStrings.any((s) {
@@ -358,7 +358,7 @@ print(newTotal); // <-- prints 15
 
 ### Code example
 
-Implement a function called `joinWithCommas` that accepts one to
+Implement a function called `joinWithCommas()` that accepts one to
 five integers, then returns a string of those numbers separated by commas.
 Here are some examples of function calls and returned values:
 
@@ -401,14 +401,14 @@ A function can't have both optional positional and optional named parameters.
 
 ### Code example
 
-Add a `copyWith` instance method to the `MyDataObject`
+Add a `copyWith()` instance method to the `MyDataObject`
 class. It should take three named parameters:
 
 * `int newInt`
 * `String newString`
 * `double newDouble`
 
-When called, `copyWith` should return a new `MyDataObject`
+When called, `copyWith()` should return a new `MyDataObject`
 based on the current instance,
 with data from the preceding parameters (if any)
 copied into the object's properties.
@@ -481,16 +481,16 @@ try {
 
 ### Code example
 
-Implement `tryFunction` below. It should execute an untrustworthy method and
+Implement `tryFunction()` below. It should execute an untrustworthy method and
 then do the following:
 
-* If `untrustworthy` throws an `ExceptionWithMessage`,
+* If `untrustworthy()` throws an `ExceptionWithMessage`,
   call `logger.logException` with the exception type and message
   (try using `on` and `catch`).
-* If `untrustworthy` throws an `Exception`,
+* If `untrustworthy()` throws an `Exception`,
   call `logger.logException` with the exception type
   (try using `on` for this one).
-* If `untrustworthy` throws any other object, don't catch the exception.
+* If `untrustworthy()` throws any other object, don't catch the exception.
 * After everything's caught and handled, call `logger.doneLogging`
   (try using `finally`).
 

--- a/src/tools/dartdevc/faq.md
+++ b/src/tools/dartdevc/faq.md
@@ -155,7 +155,7 @@ determines which modules the webdev command creates:
   and can be imported by other packages.
 
 * One module for each Dart file that’s not under `lib` and
-  that contains a top-level `main` function. <br>
+  that contains a top-level `main()` function. <br>
   For example, `web/main.dart` gets its own module.
 
 * One module for each Dart file that’s not imported by one of the above.

--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -291,7 +291,7 @@ member is used in a different package.
 
 #### Example
 
-If the method `m()` in the class `C` is annotated with `@deprecated`, then
+If the method `m` in the class `C` is annotated with `@deprecated`, then
 the following code produces this diagnostic:
 
 {% prettify dart %}

--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -291,7 +291,7 @@ member is used in a different package.
 
 #### Example
 
-If the method `m` in the class `C` is annotated with `@deprecated`, then
+If the method `m()` in the class `C` is annotated with `@deprecated`, then
 the following code produces this diagnostic:
 
 {% prettify dart %}

--- a/src/tools/pub/versioning.md
+++ b/src/tools/pub/versioning.md
@@ -294,18 +294,18 @@ dependencies:
 {% endprettify %}
 
 The `collection` package is then updated to 2.5.0.
-The 2.5.0 version of `collection` includes a new method called `sortBackwards`.
-`bookshelf` may call `sortBackwards`,
+The 2.5.0 version of `collection` includes a new method called `sortBackwards()`.
+`bookshelf` may call `sortBackwards()`,
 because it's part of the API exposed by `widgets`,
 despite `bookshelf` having only a transitive dependency on `collection`.
 
 Because `widgets` has an API that is not reflected in its version number,
-the app that uses the `bookshelf` package and calls `sortBackwards` may crash.
+the app that uses the `bookshelf` package and calls `sortBackwards()` may crash.
 
 Exporting an API causes that API to be treated as if it is
 defined in the package itself, but it can't increase the version number when
 the API adds features. This means that `bookshelf` has no way of declaring
-that it needs a version of `widgets` that supports `sortBackwards`.
+that it needs a version of `widgets` that supports `sortBackwards()`.
 
 For this reason, when dealing with exported packages,
 it's recommended that the package's author keeps a tighter


### PR DESCRIPTION
Other cases to consider:
- "getter methods" (See https://github.com/dart-lang/site-www/blob/master/src/_guides/language/sound-dart.md)
- callbacks (See https://github.com/dart-lang/site-www/blob/master/src/_guides/libraries/futures-error-handling.md)