### PR TITLE
Small fixes

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -62,6 +62,12 @@ h6, .h6 { font-size: $font-size-h6;}
 
 p {}
 
+dt {
+  a {
+    font-weight: $font-weight-bold
+  }
+}
+
 a, button {
  text-decoration: none;
  color: $brand-primary;

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -1,6 +1,6 @@
 ---
 title: Get the Dart SDK
-description: Get the Dart SDK
+description: Get the libraries and command-line tools that you need to develop Dart web, command-line, and server apps.
 js:
 - url: /tools/sdk/archive/assets/install.js
   defer: true


### PR DESCRIPTION
Fix a couple of things I happened to notice:

* The social sharing text for /get-dart. It had been the same as the page name, which looked bad.
* Styling in definition lists. If you had a definition list where the terms were links, they weren't bold. Now they are. I don't think this is used anywhere, but I discovered this when I was prototyping the video page (#1808).