### PR TITLE
Change factory constructor sample

### DIFF
--- a/examples/misc/lib/language_tour/classes/logger.dart
+++ b/examples/misc/lib/language_tour/classes/logger.dart
@@ -10,13 +10,8 @@ class Logger {
       <String, Logger>{};
 
   factory Logger(String name) {
-    if (_cache.containsKey(name)) {
-      return _cache[name];
-    } else {
-      final logger = Logger._internal(name);
-      _cache[name] = logger;
-      return logger;
-    }
+    return _cache.putIfAbsent(
+        name, () => Logger._internal(name));
   }
 
   Logger._internal(this.name);

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2993,14 +2993,8 @@ class Logger {
   static final Map<String, Logger> _cache =
       <String, Logger>{};
 
-  factory Logger(String name) {
-    if (_cache.containsKey(name)) {
-      return _cache[name];
-    } else {
-      final logger = Logger._internal(name);
-      _cache[name] = logger;
-      return logger;
-    }
+  factory Logger(String name) {    
+    return _cache.putIfAbsent(name, () => Logger._internal(name));
   }
 
   Logger._internal(this.name);

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2993,8 +2993,9 @@ class Logger {
   static final Map<String, Logger> _cache =
       <String, Logger>{};
 
-  factory Logger(String name) {    
-    return _cache.putIfAbsent(name, () => Logger._internal(name));
+  factory Logger(String name) {
+    return _cache.putIfAbsent(
+        name, () => Logger._internal(name));
   }
 
   Logger._internal(this.name);


### PR DESCRIPTION
This change rewrites the factory constructor example to use putIfAbsent to implement a cache.

It can well be that we want to keep the existing code, instead of rewriting the cache example.
The existing code is easy to understand for beginners.
The Map.putIfAbsent is a more complex concept than the explicit code (doing the same thing) that
is used now in the code.  But putIfAbsent is the more idiomatic way of writing it.