### PR TITLE
Restore a basic /community/who-uses-dart page

### DIFF
--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -4,8 +4,9 @@ description: Mobile apps and Google web apps are two of the most common uses for
 toc: false
 ---
 
-Many Dart developers write mobile apps for Android, iOS, or both,
-using the [Flutter toolkit.][Flutter]
+The popular [Flutter toolkit][Flutter] relies on the Dart language,
+so developers writing Flutter apps —
+for Android, iOS, or other targets — use Dart.
 To find a list of Flutter apps, visit the [Flutter showcase.][showcase]
 
 [Flutter]: {{site.flutter}}
@@ -15,8 +16,11 @@ Google engineers use Dart to create many apps,
 including some that are essential to Google's business.
 For example, if you use the [Google Ads][] web or mobile app,
 you're using a Dart app that supports much of Google's revenue.
+Also, the Assistant team at Google uses Dart for features in Smart Displays,
+as described in [this announcement.][flutter-io19]
 
 [Google Ads]: https://ads.google.com/getstarted
+[flutter-io19]: https://developers.googleblog.com/2019/05/Flutter-io19.html
 
 {% comment %}
 [IDEAS FOR IMPROVEMENT: https://github.com/dart-lang/site-www/issues/679]

--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -1,0 +1,23 @@
+---
+title: Who uses Dart
+description: Mobile apps and Google web apps are two of the most common uses for the Dart language.
+toc: false
+---
+
+Many Dart developers write mobile apps for Android, iOS, or both,
+using the [Flutter toolkit.][Flutter]
+To find a list of Flutter apps, visit the [Flutter showcase.][showcase]
+
+[Flutter]: https://flutter.dev
+[showcase]: {{site.flutter}}/showcase
+
+Google engineers use Dart to create many apps,
+including some that are essential to Google's business.
+For example, if you use the [Google Ads][] web or mobile app,
+you're using a Dart app that supports much of Google's revenue.
+
+[Google Ads]: https://ads.google.com/getstarted
+
+{% comment %}
+[IDEAS FOR IMPROVEMENT: https://github.com/dart-lang/site-www/issues/679]
+{% endcomment %}

--- a/src/community/who-uses-dart.md
+++ b/src/community/who-uses-dart.md
@@ -8,7 +8,7 @@ Many Dart developers write mobile apps for Android, iOS, or both,
 using the [Flutter toolkit.][Flutter]
 To find a list of Flutter apps, visit the [Flutter showcase.][showcase]
 
-[Flutter]: https://flutter.dev
+[Flutter]: {{site.flutter}}
 [showcase]: {{site.flutter}}/showcase
 
 Google engineers use Dart to create many apps,


### PR DESCRIPTION
We get lots of 404s for this page, but we don't have much to point people to. (Not that there aren't lots of people using Dart, but we don't have a system for showing off the non-Flutter uses.) I'm adding this page to avoid the 404s, but I'm not (yet) linking to it from anywhere.

/cc @messi01 