### PR TITLE
Update js interop docs

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -134,7 +134,7 @@
             permalink: /tutorials/web/low-level-html/add-elements 
           - title: Remove DOM elements
             permalink: /tutorials/web/low-level-html/remove-elements
-        - title: JS/TS interop
+        - title: JS interop
           permalink: /web/js-interop
         - title: Deployment
           permalink: /web/deployment

--- a/src/_guides/libraries/index.md
+++ b/src/_guides/libraries/index.md
@@ -26,8 +26,8 @@ Each library works on at least one [platform](/platforms).
 | [`dart:indexed_db`][dart-indexed_db]    <br> Client-side key-value store with support for indexes. | Web |
 | [`dart:io`][dart-io]                    <br> File, socket, HTTP, and other I/O support for non-web applications. | JIT<br>AOT |
 | [`dart:isolate`][dart-isolate]          <br> Concurrent programming using isolates: independent workers similar to threads. | JIT<br>AOT |
-| [`dart:js`][dart-js]                    <br> Interoperability with JavaScript. [PENDING: obsolete? use package:js instead?] | Web |
-| [`dart:js_util`][dart-js_util]          <br> Utility methods to efficiently manipulate typed JSInterop objects. | Web |
+| [`dart:js`][dart-js]                    <br> _Don't use._ Instead, use the `js` package, as described in [JavaScript interoperability][]. | Web |
+| [`dart:js_util`][dart-js_util]                    <br> _Don't use._ Instead, use the `js` package, as described in [JavaScript interoperability][]. | Web |
 | [`dart:math`][dart-math]                <br> Mathematical constants and functions, plus a random number generator. | All
 | [`dart:mirrors`][dart-mirrors]          <br> Basic reflection with support for introspection and dynamic invocation. | JIT (experimental, _not_&nbsp;Flutter) |
 | [`dart:typed_data`][dart-typed_data]    <br> Lists that efficiently handle fixed sized data (for example, unsigned 8-byte integers) and SIMD numeric types. | All |
@@ -57,3 +57,4 @@ Each library works on at least one [platform](/platforms).
 [dart-web_audio]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-web_audio/dart-web_audio-library.html
 [dart-web_gl]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-web_gl/dart-web_gl-library.html
 [dart-web_sql]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-web_sql/dart-web_sql-library.html
+[JavaScript interoperability]: /web/js-interop

--- a/src/web/js-interop.md
+++ b/src/web/js-interop.md
@@ -1,23 +1,27 @@
 ---
-title: "JavaScript and TypeScript interop"
-short-title: JS/TS interop
-description: "Use package:js to integrate JavaScript or TypeScript code into your Dart web app."
+title: JavaScript interoperability
+short-title: JS interop
+description: "Use package:js to integrate JavaScript code into your Dart web app."
 toc: false
 ---
 
 The [Dart web platform](/platforms/) supports calling
-JavaScript (JS) and TypeScript (TS) using the [`js`
-package,]({{site.pub-pkg}}/js) also known as _`package:js`_.
+JavaScript using the `js` package,
+also known as _package:js_.
 
 For help using the `js` package, see the following:
 
-[js_facade_gen](https://github.com/dart-lang/js_facade_gen)
-: A tool that generates Dart code from JavaScript libraries that have
-  [TypeScript type definitions.](http://definitelytyped.org/)
+* Documentation for the `js` package:
+  * [Pub site page][js]
+  * [API reference][js-api]
+* Packages that use the `js` package:
+  * [firebase_web][] is a good example of providing a Dart-like API
+    to a JavaScript library.
+  * [sass][] is an example of a more unusual use case: providing a
+    way for JavaScript code to call Dart code.
 
-[dart_js_interop](https://github.com/matanlurey/dart_js_interop)
-: Examples of using the `js` package,
-  with comparisons to old code that uses the dart:js library.
+[js]: {{site.pub-pkg}}/js
+[js-api]: {{site.pub-api}}/js
+[firebase_web]: {{site.pub-pkg}}/firebase_web
+[sass]: {{site.pub-pkg}}/sass
 
-[Packages that depend on `js`]({{site.pub}}?q=dependency%3Ajs)
-: Published packages that have `js` in their pubspec.

--- a/src/web/libraries.md
+++ b/src/web/libraries.md
@@ -44,12 +44,15 @@ are a few:
 |-----------------+---------------------------------+--------------------------|
 | Library         | Packages                        | Notes                    |
 |-----------------|---------------------------------|--------------------------|
-| AngularDart     | angular*                        | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation]({{site.angulardart}}), [AngularDart Components]({{site.angulardart}}/components) | 
+| AngularDart     | angular*                        | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation,]({{site.angulardart}}) [AngularDart Components]({{site.angulardart}}/components) | 
+| JavaScript interop | [js][] | Support for calling JavaScript libraries from Dart code. More info: [JavaScript interoperability][] |
 | Material Design | [md_core,][] [m4d_components][] | Basic Material Design components. |
 | React           | [react][]                       | Bindings for the ReactJS library. |
 | Vue             | [vue][]                         | Bindings for the Vue.js library. |
 {:.table .table-striped}
 
+[js]: {{site.pub-pkg}}/js
+[JavaScript interoperability]: /web/js-interop
 [md_core,]: {{site.pub-pkg}}/m4d_core
 [m4d_components]: {{site.pub-pkg}}/m4d_components
 [vue]: {{site.pub-pkg}}/vue


### PR DESCRIPTION
Contributes to #1835. We should flesh out the JS interop page, but this is a start.

Staged:
https://kw-www-dartlang-1.firebaseapp.com/guides/libraries
https://kw-www-dartlang-1.firebaseapp.com/web/libraries#web-packages
https://kw-www-dartlang-1.firebaseapp.com/web/js-interop

/cc @vsmenon 