### PR TITLE
Add a link to LSP readme on tools page

### DIFF
--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -82,9 +82,11 @@ thanks to the Dart community.
 </li>
 </ul>
 
-A [Language Server Protocol implementation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md)
-is also available for [LSP-capable editors](https://microsoft.github.io/language-server-protocol/implementors/tools/)
-that do not have specific Dart extensions.
+A [Language Server Protocol implementation][LSP] is also available for
+[LSP-capable editors][] that don't have specific Dart extensions.
+
+[LSP]: https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md
+[LSP-capable editors]: https://microsoft.github.io/language-server-protocol/implementors/tools/
 
 ### Command-line tools {#cli}
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -82,6 +82,9 @@ thanks to the Dart community.
 </li>
 </ul>
 
+A [Language Server Protocol implementation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md)
+is also available for LSP-capable editors that do not have specific Dart extensions.
+
 ### Command-line tools {#cli}
 
 The Dart SDK includes the following general-purpose tools:

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -83,7 +83,8 @@ thanks to the Dart community.
 </ul>
 
 A [Language Server Protocol implementation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md)
-is also available for LSP-capable editors that do not have specific Dart extensions.
+is also available for [LSP-capable editors](https://microsoft.github.io/language-server-protocol/implementors/tools/)
+that do not have specific Dart extensions.
 
 ### Command-line tools {#cli}
 


### PR DESCRIPTION
This adds a note to the tools page about the LSP server, for anyone using an LSP-capable editor that doesn't have a specific Dart plugin.