### PR TITLE
Update search-all.html

### DIFF
--- a/src/search-all.html
+++ b/src/search-all.html
@@ -1,14 +1,11 @@
 ---
-title: Search all Dart documentation
-short-title: Search all Dart docs
-description: Search dart.dev, api.dart.dev, and the old www.dartlang.org site.
+title: Search more sites
+description: Search dart.dev, api.dart.dev, the old www.dartlang.org site, flutter.dev, and more.
 toc: false
 ---
 
 <p>
-Use this search when you want results from both this site
-(which may appear in search results as <em>www.dartlang.org</em>)
-and <a href="{{site.dart_api}}">{{site.dart_api}}.</a>
+Use this search when you want results from multiple Dart-related sites.
 </p>
 
 <p>


### PR DESCRIPTION
Someone had updated our main search engine to search more than dart.dev. I've changed it back (because getting flutter.dev results when I wanted dart.dev was really annoying) and added more sites to this search.