### PR TITLE
Update vers to 2.5

### DIFF
--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.4.0"
+    "vers": "2.5.0"
   }
 }


### PR DESCRIPTION
Visible in https://dart.dev/tools/sdk.
Process documented in https://github.com/dart-lang/site-www/wiki/Updating-to-new-SDK-releases.