### PR TITLE
Code excerpts: distribute site-global replace pattern to individual files

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3,7 +3,7 @@ title: A tour of the Dart language
 description: A tour of all of the major Dart language features.
 short-title: Language tour
 ---
-<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; / *\/\/\s+ignore:[^\n]+//g; /([A-Z]\w*)\d\b/$1/g"?>
 
 This page shows you how to use each major Dart feature, from
 variables and operators to classes and libraries, with the assumption
@@ -757,7 +757,7 @@ var list2 = [0, ...?list];
 assert(list2.length == 1);
 {% endprettify %}
 
-For more details and examples of using the spread operator, see the 
+For more details and examples of using the spread operator, see the
 [spread operator proposal.][spread proposal]
 
 <a id="collection-operators"> </a>
@@ -792,7 +792,7 @@ var listOfStrings = [
 assert(listOfStrings[1] == '#1');
 {% endprettify %}
 
-For more details and examples of using collection if and for, see the 
+For more details and examples of using collection if and for, see the
 [control flow collections proposal.][collections proposal]
 
 [collections proposal]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md

--- a/src/_guides/language/sound-dart.md
+++ b/src/_guides/language/sound-dart.md
@@ -2,7 +2,7 @@
 title: The Dart type system
 description: Why and how to write sound Dart code.
 ---
-<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g; /\b(main)\d\b/$1/g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /([A-Z]\w*)\d\b/$1/g; /\b(main)\d\b/$1/g"?>
 
 The Dart language is type safe: it uses a combination of static type checking and
 [runtime checks](#runtime-checks) to

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -3,7 +3,7 @@ title: Fixing common type problems
 description: Common type issues you may have and how to fix them.
 ---
 {% comment %}Don't show exact file names in analyzer error output.{% endcomment %}
-<?code-excerpt replace="/ at (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; / at (lib|test)\/\w+\.dart:\d+:\d+//g"?>
 <?code-excerpt plaster="none"?>
 
 If you're having problems with type checks,

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -3,6 +3,7 @@ title: A tour of the core libraries
 description: Learn about the major features in Dart's libraries.
 short-title: Library tour
 ---
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g;"?>
 <?code-excerpt plaster="none"?>
 
 This page shows you how to use the major features in Dart’s core libraries.
@@ -989,7 +990,7 @@ class FooException implements Exception {
 {% endprettify %}
 
 For more information, see
-[Exceptions](/guides/language/language-tour#exceptions) 
+[Exceptions](/guides/language/language-tour#exceptions)
 (in the language tour) and the [Exception API reference.][Exception]
 
 

--- a/tool/refresh-code-excerpts.sh
+++ b/tool/refresh-code-excerpts.sh
@@ -47,8 +47,6 @@ ARGS+='/\/\*(\s*\.\.\.\s*)\*\//$1/g;' # /*...*/ --> ...
 ARGS+='/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;' # {/*-...-*/} --> ... (removed brackets too)
 # Replace "//!analysis-issue" by, say, "Analysis issue" (although once we can use embedded DPs this won't be needed)?
 ARGS+='/\/\/!(analysis-issue|runtime-error)[^\n]*//g;' # Removed warning/error marker
-ARGS+='/\x20*\/\/\s+ignore_for_file:[^\n]+\n//g;' # Remove analyzer ignore-issue marker
-ARGS+='/\x20*\/\/\s+ignore:[^\n]+//g;' # Remove analyzer ignore-issue marker
 
 echo "Source:     $SRC"
 echo "Fragments:  $FRAG"


### PR DESCRIPTION
No site content changes.

Prep work so that we can actually show code excerpts using analyzer ignore directives.
Contributes to #1803