### PR TITLE
Get-started server tutorial: analyze/test code excerpts

### DIFF
--- a/examples/misc/test/tutorial/get_started.dart
+++ b/examples/misc/test/tutorial/get_started.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+// #docregion calculate
+int calculate() {
+  return 6 * 7 ~/ 2;
+}
+// #enddocregion calculate
+
+void main() {
+  test('calculate update', () {
+    expect(calculate(), 21);
+  });
+}

--- a/examples/misc/test/tutorial/get_started.dart
+++ b/examples/misc/test/tutorial/get_started.dart
@@ -7,7 +7,7 @@ int calculate() {
 // #enddocregion calculate
 
 void main() {
-  test('calculate update', () {
+  test('updated calculate function', () {
     expect(calculate(), 21);
   });
 }

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -1,9 +1,6 @@
 Once you’re ready to move beyond DartPad and develop real apps,
 you need the Dart SDK.
 
-As you install, **note the path to the SDK.**
-You'll need it in the next step.
-
 <ul class="tabs__top-bar">
   <li class="tab-link current" data-tab="tab-sdk-install-windows">Windows</li>
   <li class="tab-link" data-tab="tab-sdk-install-linux">Linux</li>
@@ -23,15 +20,15 @@ You'll need it in the next step.
 
    1. Perform the following one-time setup:
       ```terminal
-      > sudo apt-get update
-      > sudo apt-get install apt-transport-https
-      > sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      > sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+      $ sudo apt-get update
+      $ sudo apt-get install apt-transport-https
+      $ sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+      $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
       ```
    2. Install the Dart SDK:
       ```terminal
-      > sudo apt-get update
-      > sudo apt-get install dart
+      $ sudo apt-get update
+      $ sudo apt-get install dart
       ```
 </div>
 
@@ -40,9 +37,12 @@ You'll need it in the next step.
   installing Dart is easy.
 
   ```terminal
-  > brew tap dart-lang/dart
-  > brew install dart
+  $ brew tap dart-lang/dart
+  $ brew install dart
   ```
 </div>
 
-More information: [Get the Dart SDK](/get-dart)
+{{site.alert.important}}
+  For more information, including how to **adjust your `PATH`**, see
+  [Get the Dart SDK](/get-dart).
+{{site.alert.end}}

--- a/src/_includes/mac-path.md
+++ b/src/_includes/mac-path.md
@@ -1,0 +1,5 @@
+{{site.alert.important}}
+  Ensure that the **Homebrew `bin` directory is in your `PATH`** if you'd like
+  direct command-line access to Dart commands such as the Dart VM (`dart`). For
+  details, consult the [Homebrew FAQ](https://docs.brew.sh/FAQ).
+{{site.alert.end}}

--- a/src/_includes/mac-path.md
+++ b/src/_includes/mac-path.md
@@ -1,5 +1,0 @@
-{{site.alert.important}}
-  Ensure that the **Homebrew `bin` directory is in your `PATH`** if you'd like
-  direct command-line access to Dart commands such as the Dart VM (`dart`). For
-  details, consult the [Homebrew FAQ](https://docs.brew.sh/FAQ).
-{{site.alert.end}}

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -60,14 +60,14 @@ Install or update Stagehand using
 [pub global activate](/tools/pub/cmd/pub-global):
 
 ```terminal
-> pub global activate stagehand
+$ pub global activate stagehand
 ```
 
 Now run the `stagehand` command to see what kinds of template files
 it can generate:
 
 ```terminal
-> stagehand
+$ stagehand
 ```
 
 You'll see a list of generators, including various web and server-side apps.
@@ -77,9 +77,9 @@ In a new directory named `vector_victor`,
 use Stagehand to generate a command-line app:
 
 ```terminal
-> mkdir vector_victor
-> cd vector_victor
-> stagehand console-full
+$ mkdir vector_victor
+$ cd vector_victor
+$ stagehand console-full
 ```
 
 The pubspec.yaml file contains the package specification written in YAML.
@@ -167,7 +167,7 @@ If not, do it yourself by running
 [pub get](/tools/pub/cmd/pub-get):
 
 ```terminal
-> pub get
+$ pub get
 Resolving dependencies...
 + vector_math 2.0.7
 Changed 1 dependency!

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -105,7 +105,7 @@ Hello world: 42!
 Let's customize the app you just created.
 
  1. Edit `lib/cli.dart` to calculate a different result. For example, divide the
-    previous value by two (see [Arithmetic operators][] for operator details):
+    previous value by two (operator details, see [Arithmetic operators][]):
 
     <?code-excerpt "misc/test/tutorial/get_started.dart (calculate)" replace="/~\/ 2/[!$&!]/g"?>
     {% prettify dart %}

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -44,23 +44,17 @@ More information:
 
 {% include get-sdk.md %}
 
-<!-- PENDING: the following instructions assume you have set the PATH.
-     We should update the included instructions to refer to that. -->
-
 ## 3. Get more command-line developer tools
 
 Install [`stagehand`,][stagehand] which gives you templates for creating Dart apps:
 
 ```terminal
-> pub global activate stagehand
+$ pub global activate stagehand
 ```
-
 
 Note that although these instructions feature the command line,
 many IDEs support Dart development.
 Those IDEs use Stagehand behind the scenes when you create new Dart projects.
-
-<!-- PENDING: the following instructions assume you have the bin directory for the system cache in your path. -->
 
 More information:
 
@@ -72,9 +66,9 @@ More information:
 Create a command-line app:
 
 ```terminal
-> mkdir cli
-> cd cli
-> stagehand console-full
+$ mkdir cli
+$ cd cli
+$ stagehand console-full
 ```
 
 These commands create a small Dart app that has the following:
@@ -93,7 +87,7 @@ Use the [`pub`](/tools/pub/cmd) command to get the packages
 that the app depends on:
 
 ```terminal
-> pub get
+$ pub get
 ```
 
 ## 6. Run the app
@@ -102,7 +96,7 @@ To run the app from the command line, use the Dart VM by running the
 [`dart`](/tools/dart-vm) command:
 
 ```terminal
-> dart bin/main.dart
+$ dart bin/main.dart
 Hello world: 42!
 ```
 
@@ -110,20 +104,23 @@ Hello world: 42!
 
 Let's customize the app you just created.
 
- 1. Edit `lib/cli.dart` to return a different result:
+ 1. Edit `lib/cli.dart` to calculate a different result. For example, divide the
+    previous value by two (see [Arithmetic operators][] for operator details):
 
-    ```dart
+    <?code-excerpt "misc/test/tutorial/get_started.dart (calculate)" replace="/~\/ 2/[!$&!]/g"?>
+    {% prettify dart %}
     int calculate() {
-      return -1;
+      return 6 * 7 [!~/ 2!];
     }
-    ```
+    {% endprettify %}
+
  1. Save your changes.
 
  1. Rerun the main entrypoint of your app:
 
     ```terminal
-    > dart bin/main.dart
-    Hello world: -1
+    $ dart bin/main.dart
+    Hello world: 21!
     ```
 
 More information:
@@ -139,21 +136,25 @@ Dart code to optimized native machine code.
 Use the `dart2aot` tool to AOT compile the program to machine code:
 
 ```terminal
-> dart2aot bin/main.dart bin/main.dart.aot
+$ dart2aot bin/main.dart bin/main.dart.aot
 ```
 
 To run the compiled program, use the Dart runtime (`dartaotruntime`):
 
 ```terminal
-> dartaotruntime bin/main.dart.aot
+$ dartaotruntime bin/main.dart.aot
+Hello world: 21!
 ```
 
 Notice how the compiled program starts instantly, completing quickly:
 
 ```terminal
-> time dartaotruntime bin/main.dart.aot
+$ time dartaotruntime bin/main.dart.aot
+Hello world: 21!
 
-real	0m0.032s
+real	0m0.016s
+user	0m0.008s
+sys	0m0.006s
 ```
 
 ## What next?
@@ -175,6 +176,7 @@ Check out these resources:
 
 If you get stuck, find help at [Community and support.](/community)
 
+[Arithmetic operators]: /guides/language/language-tour#arithmetic-operators
 [stagehand]: {{site.pub-pkg}}/stagehand
 [DartPad documentation]: /tools/dartpad
 [Dart language tour]: /guides/language/language-tour

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -105,7 +105,7 @@ Hello world: 42!
 Let's customize the app you just created.
 
  1. Edit `lib/cli.dart` to calculate a different result. For example, divide the
-    previous value by two (operator details, see [Arithmetic operators][]):
+    previous value by two (for details about `~/`, see [Arithmetic operators][]):
 
     <?code-excerpt "misc/test/tutorial/get_started.dart (calculate)" replace="/~\/ 2/[!$&!]/g"?>
     {% prettify dart %}
@@ -143,7 +143,6 @@ To run the compiled program, use the Dart runtime (`dartaotruntime`):
 
 ```terminal
 $ dartaotruntime bin/main.dart.aot
-Hello world: 21!
 ```
 
 Notice how the compiled program starts instantly, completing quickly:

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -48,8 +48,8 @@ If you like to use the command line, install [webdev][]
 and [stagehand:][stagehand]
 
 ```terminal
-> pub global activate webdev
-> pub global activate stagehand
+$ pub global activate webdev
+$ pub global activate stagehand
 ```
 
 <i class="material-icons">web</i>
@@ -65,10 +65,10 @@ For a list of available IDEs, see the
 To create a web app from the command line, use these commands:
 
 ```terminal
-> mkdir quickstart
-> cd quickstart
-> stagehand web-simple
-> pub get
+$ mkdir quickstart
+$ cd quickstart
+$ stagehand web-simple
+$ pub get
 ```
 
 <i class="material-icons">web</i>
@@ -82,7 +82,7 @@ create a project using the template named **Bare-bones Web App**.
 To run the app from the command line, use [webdev][] to build and serve the app:
 
 ```terminal
-> webdev serve
+$ webdev serve
 ```
 
 <i class="material-icons">web</i>

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -28,9 +28,9 @@ NOTE to editors: Keep the zip file link as the last thing in the paragraph,
 so it's easy to find (but not more tempting than package managers).
 {% endcomment %}
 
-<aside class="alert alert-warning" markdown="1">
+{{site.alert.warn}}
   {% include_relative tools/sdk/archive/_sdk-terms.md %}
-</aside>
+{{site.alert.end}}
 
 <ul class="tabs__top-bar">
   <li class="tab-link current" data-tab="tab-sdk-install-windows">Windows</li>
@@ -57,12 +57,10 @@ The Dart SDK has two release channels:
 * **dev** channel: **pre-releases**, usually updated 1/week;
   currently `[calculating]`{:.editor-build-rev-dev}.
 
-<aside class="alert alert-warning" markdown="1">
-  **Warning:**
+{{site.alert.warning}}
   To give you early access to new features and fixes,
   dev channel releases are not as heavily tested as the stable release.
-</aside>
-
+{{site.alert.end}}
 
 **Stable** channel releases of the Dart SDK have version strings like `1.24.3` and `2.1.0`.
 They consist of dot-separated integers, with no hyphens or letters.

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -101,10 +101,10 @@ you can also use `pub global run`.
 
 ### Running a script from your PATH
 
-To run a script directly from the command line, add the `bin` file
-for the [system cache](/tools/pub/glossary#system-cache) to your path.
+To run a script directly from the command line, add the [system cache][] `bin`
+directory to your `PATH` environment variable.
 
-For example, say you've activated the Stagehand script,
+For example, say you've activated the Stagehand package,
 but you still can't run the command:
 
 ```terminal
@@ -114,14 +114,14 @@ $ stagehand
 ```
 
 Verify that the `bin` directory for the system cache is in your path.
-The following path, on macOS, includes the system cache.
+The following `PATH` variable, on macOS, includes the system cache:
 
 {% prettify none %}
 $ echo $PATH
 [!/Users/<user>/.pub-cache/bin!]:/Users/<user>/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 {% endprettify %}
 
-If this directory is missing from your path,
+If this directory is missing from your `PATH`,
 locate the file for your platform and add it.
 
 |-------------------+---------------------------|
@@ -256,3 +256,5 @@ For options that apply to all pub commands, see
 <aside class="alert alert-info" markdown="1">
   *Problems?* See [Troubleshooting pub](/tools/pub/troubleshoot).
 </aside>
+
+[system cache]: /tools/pub/glossary#system-cache

--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -8,28 +8,30 @@ description: "Common gotchas you might run into when using pub."
 
 You receive the following error when running `pub publish`:
 
-{% prettify none %}
+```terminal
+$ pub publish ...
 HTTP error 403: Forbidden
 ...
 You aren't an uploader for package '<foo>'
-{% endprettify %}
+```
 
 This problem can occur if one of your accounts was granted permission to
 publish a package, but the pub client registers you with another account.
 
 You can reset pub's authentication process by removing the credentials file:
 
-{% prettify sh %}
-rm ~/.pub-cache/credentials.json
-{% endprettify %}
+```terminal
+$ rm ~/.pub-cache/credentials.json
+```
 
 ## Getting an "UnauthorizedAccess" error when publishing a package {#pub-publish-unauthorized}
 
 You receive the following error when running `pub publish`:
 
-{% prettify none %}
-UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versions to package '<foo>'..
-{% endprettify %}
+```terminal
+$ pub publish ...
+UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versions to package '<foo>'.
+```
 
 You will see this message if you are not on the list of people
 authorized to publish new versions of a package.
@@ -40,12 +42,13 @@ See [Authors versus uploaders](publishing#authors-versus-uploaders).
 You receive an HttpException error similar to the following when
 running `pub build`:
 
-{% prettify none %}
+```terminal
+$ pub build ...
 Pub build failed, [1] IsolateSpawnException: 'HttpException: Connection closed while receiving data,
 ...
 library handler failed
 ...
-{% endprettify %}
+```
 
 This can happen as a result of some antivirus software, such as the
 AVG 2013 Internet security suite. Check the manual for your security
@@ -61,39 +64,39 @@ You can set the proxy server environment variable as follows.
 
 On Linux/macOS:
 
-{% prettify sh %}
+```terminal
 $ export https_proxy=hostname:port
-{% endprettify %}
+```
 
 On Windows Command Prompt:
 
-{% prettify sh %}
-> set https_proxy=hostname:port
-{% endprettify %}
+```terminal
+$ set https_proxy=hostname:port
+```
 
 On Windows PowerShell:
 
-{% prettify sh %}
-> $Env:https_proxy="hostname:port"
-{% endprettify %}
+```terminal
+$ $Env:https_proxy="hostname:port"
+```
 
 If the proxy requires credentials, you can set them as follows.
 
 On Linux/macOS:
 
-{% prettify sh %}
+```terminal
 $ export https_proxy=username:password@hostname:port
-{% endprettify %}
+```
 
 On Windows Command Prompt:
 
-{% prettify sh %}
-> set https_proxy=username:password@hostname:port
-{% endprettify %}
+```terminal
+$ set https_proxy=username:password@hostname:port
+```
 
 On Windows PowerShell:
 
-{% prettify sh %}
-> $Env:https_proxy="username:password@hostname:port"
-{% endprettify %}
+```terminal
+$ $Env:https_proxy="username:password@hostname:port"
+```
 

--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -8,8 +8,8 @@ description: "Common gotchas you might run into when using pub."
 
 You receive the following error when running `pub publish`:
 
-```terminal
-$ pub publish ...
+{:.console-output}
+```nocode
 HTTP error 403: Forbidden
 ...
 You aren't an uploader for package '<foo>'
@@ -28,8 +28,8 @@ $ rm ~/.pub-cache/credentials.json
 
 You receive the following error when running `pub publish`:
 
-```terminal
-$ pub publish ...
+{:.console-output}
+```nocode
 UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versions to package '<foo>'.
 ```
 
@@ -42,8 +42,8 @@ See [Authors versus uploaders](publishing#authors-versus-uploaders).
 You receive an HttpException error similar to the following when
 running `pub build`:
 
-```terminal
-$ pub build ...
+{:.console-output}
+```nocode
 Pub build failed, [1] IsolateSpawnException: 'HttpException: Connection closed while receiving data,
 ...
 library handler failed

--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -71,8 +71,8 @@ Alternatively, download Dart SDK as Debian package in the `.deb` package format.
 
 #### Modify PATH for access to all Dart binaries
 
-After installing the SDK, **add its bin directory to your PATH**. For example,
-use the following command to change PATH in your active terminal session:
+After installing the SDK, **add its `bin` directory to your `PATH`**. For example,
+use the following command to change `PATH` in your active terminal session:
 
 ```terminal
 $ export PATH="$PATH:/usr/lib/dart/bin"

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -1,4 +1,4 @@
-[Install homebrew](http://brew.sh/), and then run:
+[Install Homebrew](http://brew.sh), and then run:
 
 {% if site.data.pkg-vers.SDK.channel == 'dev' %}
 ```terminal
@@ -6,8 +6,7 @@ $ brew tap dart-lang/dart
 $ brew install dart -- --devel
 ```
 
-To install a **stable channel** release,
-don't use `--devel`:
+To install a **stable channel** release, don't use `--devel`:
 
 ```terminal
 $ brew install dart
@@ -26,6 +25,7 @@ $ brew install dart -- --devel
 ```
 {% endif %}
 
+{% include mac-path.md %}
 
 ### Upgrade
 

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -25,7 +25,12 @@ $ brew install dart -- --devel
 ```
 {% endif %}
 
-{% include mac-path.md %}
+{{site.alert.important}}
+  Make sure the **Homebrew `bin` directory is in your `PATH`**. Setting up the
+  path correctly makes it easier to use Dart SDK commands such as `dart` and
+  `dartfmt`. For help setting up your path, consult the [Homebrew
+  FAQ.](https://docs.brew.sh/FAQ)
+{{site.alert.end}}
 
 ### Upgrade
 

--- a/src/web/debugging.md
+++ b/src/web/debugging.md
@@ -85,11 +85,11 @@ but you'll need to adjust the instructions to match your app.
      using [Stagehand:][stagehand]
 
      ```terminal
-> mkdir test_app
-> cd test_app
-> stagehand web-angular
-> pub get
-```
+     $ mkdir test_app
+     $ cd test_app
+     $ stagehand web-angular
+     $ pub get
+     ```
 
    * If you're using a Dart IDE or editor,
     create an **AngularDart web app** and name it `test_app`.
@@ -99,7 +99,7 @@ but you'll need to adjust the instructions to match your app.
    using either your IDE or `webdev` at the command line.
 
    ```terminal
-   > webdev serve
+   $ webdev serve
    ```
 
    <aside class="alert alert-info" markdown="1">
@@ -255,15 +255,15 @@ you also need the [stagehand tool.][stagehand]
 Use pub to get these tools:
 
 ```terminal
-> pub global activate webdev
-> pub global activate stagehand
+$ pub global activate webdev
+$ pub global activate stagehand
 ```
 
 If your PATH environment variable is set up correctly,
 you can now use these tools at the command line:
 
 ```terminal
-> webdev --help
+$ webdev --help
 A tool to develop Dart web projects.
 ...
 ```
@@ -276,8 +276,8 @@ want to get the latest Stagehand templates,
 update the tools by activating them again:
 
 ```terminal
-> pub global activate webdev     # update webdev
-> pub global activate stagehand  # update stagehand
+$ pub global activate webdev     # update webdev
+$ pub global activate stagehand  # update stagehand
 ```
 
 [Chrome DevTools]: https://developers.google.com/web/tools/chrome-devtools


### PR DESCRIPTION
- Resolves 3rd item of #1803, for the `tutorials/server/get-started` page.
  - Note that I've chosen not to do anything with the opening Dartpad hello-world example. It doesn't really make sense to do anything with that example (since the Gist is created manually) until #1919 is addressed.
- I've also consistently applied the recommendation of using `$` as the default command-line prompt (see "Command prompt" in [Documenting command-line syntax](https://developers.google.com/style/code-syntax)). The copyediting for this is in a separate commit.

Staged at https://dart-dev-staging-1.firebaseapp.com/tutorials/server/get-started
Original https://dart.dev/tutorials/server/get-started

Possible followup issue: #1919.

---

I've checked external links: 

```console
$ blc -fgi http://localhost:4000/tutorials/server/get-started
Getting links from: http://localhost:4000/tutorials/server/get-started
├───OK─── https://dartpad.dev/
├───OK─── https://chocolatey.org/
├───OK─── http://www.google.com/intl/en/policies/privacy/
├───OK─── https://pub.dev/
├───OK─── http://creativecommons.org/licenses/by/3.0/
├───OK─── http://brew.sh/
├───OK─── https://dartpad.dev/27e044ec9e2957d9c5c7062871ce8bf3
├───OK─── https://flutter.dev/
├───OK─── https://pub.dev/packages/stagehand
├───OK─── https://dartpad.dev/experimental/embed-new-inline.html?id=27e044ec9e2957d9c5c7062871ce8bf3
├───OK─── https://api.dart.dev/
├───OK─── https://github.com/dart-lang/site-www/tree/master/src/_tutorials/server/get-started.md
├───OK─── https://github.com/dart-lang/site-www/issues/new?...
├───OK─── https://medium.com/dartlang/announcing-dart-2-5-super-charged-development-328822024970
├───OK─── https://medium.com/dartlang
├───OK─── https://github.com/dart-lang/site-www
```