### PR TITLE
Drop reference to Jekyll conf var that doesn't exist

### DIFF
--- a/src/_includes/dart-html-tour.md
+++ b/src/_includes/dart-html-tour.md
@@ -551,7 +551,7 @@ For more information about Dart web libraries, see the
 
 [AnchorElement]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/AnchorElement-class.html
 [dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/dart-html-library.html
-[Dart Library Tour]: {{site.dartlang}}/guides/libraries/library-tour
+[Dart Library Tour]: /guides/libraries/library-tour
 [Document]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/Document-class.html
 [Element]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/Element-class.html
 [HttpRequest]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/HttpRequest-class.html

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -12,7 +12,7 @@ If you're developing only mobile apps,
 then you don't need the Dart SDK; just [install Flutter.][flutter]
 
 To learn about other tools you can use for Dart development, see
-the [Dart tools]({{site.dartlang}}/tools) page.
+the [Dart tools](/tools) page.
 To learn about what's in the SDK, see [Dart SDK overview](/tools/sdk).
 
 ## Install the Dart SDK {#install}
@@ -22,7 +22,7 @@ you can use a package manager
 to easily install and update the Dart SDK.
 Alternatively, you can
 [build the SDK from source][] or
-[download the SDK as a zip file]({{site.dartlang}}/tools/sdk/archive).
+[download the SDK as a zip file](/tools/sdk/archive).
 {% comment %}
 NOTE to editors: Keep the zip file link as the last thing in the paragraph,
 so it's easy to find (but not more tempting than package managers).
@@ -76,8 +76,8 @@ For more information, see the [Dart 2 page.][Dart 2]
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [semantic versioning]: http://semver.org/
-[Dart 2]: {{site.dartlang}}/dart-2
+[Dart 2]: /dart-2
 [build the SDK from source]: https://github.com/dart-lang/sdk/wiki/Building
-[Dart libraries]: {{site.dartlang}}/guides/libraries/library-tour
+[Dart libraries]: /guides/libraries/library-tour
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -13,7 +13,7 @@ If you're developing only mobile apps,
 then you don't need the Dart SDK; just [install Flutter.][flutter]
 
 To learn about other tools you can use for Dart development, see
-the [Dart tools]({{site.dartlang}}/tools) page.
+the [Dart tools](/tools) page.
 
 <aside class="alert alert-info" markdown="1">
   **Note:** This site's documentation and examples use
@@ -29,29 +29,29 @@ directory that has these command-line tools:
 
 <div class="row">
   <div class="col-lg-6" markdown="1">
-  [dart]({{site.dartlang}}/server)
+  [dart](/server)
   : The standalone VM
 
-  [dart2aot & dartaotruntime]({{site.dartlang}}/tools/dart2aot)
+  [dart2aot & dartaotruntime](/tools/dart2aot)
   : Tools for compiling Dart code to native x64 machine code
 
-  [dart2js]({{site.dartlang}}/tools/dart2js)
+  [dart2js](/tools/dart2js)
   : The Dart-to-JavaScript compiler (used only for web development)
 
-  [dartanalyzer]({{site.dartlang}}/tools/dartanalyzer)
+  [dartanalyzer](/tools/dartanalyzer)
   : The static analyzer
   </div><div class="col-lg-6" markdown="1">
-  [dartdevc]({{site.dartlang}}/tools/dartdevc)
+  [dartdevc](/tools/dartdevc)
   : The Dart development compiler
   (used only for web development)
 
-  [dartdoc]({{site.dartlang}}/tools/dartdoc)
+  [dartdoc](/tools/dartdoc)
   : The API documentation generator
 
-  [dartfmt]({{site.dartlang}}/tools/dartfmt)
+  [dartfmt](/tools/dartfmt)
   : The Dart code formatter
 
-  [pub]({{site.dartlang}}/tools/pub)
+  [pub](/tools/pub)
   : The Dart package manager
   </div>
 </div>
@@ -71,8 +71,8 @@ Here are some handy searches:
 * [pub issues](https://github.com/dart-lang/sdk/labels/Area-Pub)
 * [issues for the SDK as a whole](https://github.com/dart-lang/sdk/issues)
 
-[Dart 2]: {{site.dartlang}}/dart-2
+[Dart 2]: /dart-2
 [build the SDK from source]: https://github.com/dart-lang/sdk/wiki/Building
-[Dart libraries]: {{site.dartlang}}/guides/libraries/library-tour
+[Dart libraries]: /guides/libraries/library-tour
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html


### PR DESCRIPTION
The `site.dartlang` Jekyll conf variable doesn't exist. This is a vestige from the page migration of #1764.

The site generated before and after this PR are identical.