### PR TITLE
Examples: drop unnecessary `const`

### DIFF
--- a/examples/misc/test/language_tour/browser_test.dart
+++ b/examples/misc/test/language_tour/browser_test.dart
@@ -1,4 +1,4 @@
-@Tags(const ['browser']) // ignore: unnecessary_const
+@Tags(['browser']) // ignore: unnecessary_const
 @TestOn('browser')
 // #docregion dart-html-import
 import 'dart:html';

--- a/examples/misc/test/pi_test.dart
+++ b/examples/misc/test/pi_test.dart
@@ -1,4 +1,4 @@
-@Tags(const ['browser']) // ignore: unnecessary_const
+@Tags(['browser']) // ignore: unnecessary_const
 @TestOn('browser')
 import 'dart:html';
 import 'package:test/test.dart';


### PR DESCRIPTION
Closes #1028. cc @kwalrath 