### PR TITLE
Slightly subdue the analyzer error formatting

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -11,6 +11,8 @@ li.L5, li.L6, li.L7, li.L8, li.L9 {
 }
 pre.prettyprint.analyzer .highlight {
     border-bottom: 2px red dashed;
+    background: inherit;
+    padding-bottom: 1px;
 }
 </style>
 


### PR DESCRIPTION
I found myself expecting a mouseover or click to do something.
This change removes the yellow background and moves up the
dashed line a bit to compensate.

Before:
![image](https://user-images.githubusercontent.com/2164483/66173563-a80a8f00-e605-11e9-9aaa-acd142ba9fc9.png)

After:
![image](https://user-images.githubusercontent.com/2164483/66173556-9d4ffa00-e605-11e9-8c4a-5678231b579e.png)
