### PR TITLE
Update pub.dev site name

### DIFF
--- a/src/_articles/archive/zones.md
+++ b/src/_articles/archive/zones.md
@@ -751,7 +751,7 @@ stack_trace
   [Chain class]({{site.pub-api}}/stack_trace/latest/stack_trace/Chain-class.html)
   you can get better stack traces for asynchronously executed code.
   See the [stack_trace package]({{site.pub}}/packages/stack_trace)
-  at the Pub site for more information.
+  at the pub.dev site for more information.
 
 
 ### More examples

--- a/src/_articles/libraries/dart-io.md
+++ b/src/_articles/libraries/dart-io.md
@@ -377,7 +377,7 @@ class.
 ## Feature requests welcome
 
 The dart:io library is already capable of performing a lot of tasks.
-For example, the [Pub site]({{site.pub}}) uses dart:io.
+For example, the [pub.dev site]({{site.pub}}) uses dart:io.
 
 Please give dart:io a spin and let us know what you think.
 Feature requests are very welcome!

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -177,7 +177,7 @@ Any tools or executables that you create during development that aren't for
 public use go into the `tool` directory.
 
 Other files that are required if you publish your library to the
-Pub site, such as a README and a CHANGELOG, are
+pub.dev site, such as a README and a CHANGELOG, are
 described in [Publishing a package](/tools/pub/publishing).
 For more information on how to organize a package directory,
 see the [pub package layout conventions](/tools/pub/package-layout).
@@ -210,7 +210,7 @@ See [issue 1082.](https://github.com/dart-lang/dartdoc/issues/1082)
 ## Distributing an open source library {#distributing-a-library}
 
 If your library is open source,
-we recommend sharing it on the [Pub site.]({{site.pub}})
+we recommend sharing it on the [pub.dev site.]({{site.pub}})
 To publish or update the library,
 use [pub publish](/tools/pub/cmd/pub-lish),
 which uploads your package and creates or updates its page.
@@ -218,7 +218,7 @@ For example, see the page for the [shelf package.]({{site.pub}}/packages/shelf)
 See [Publishing a package](/tools/pub/publishing)
 for details on how to prepare your package for publishing.
 
-The pub site not only hosts your package,
+The pub.dev site not only hosts your package,
 but also generates and hosts your package's API reference docs.
 A link to the latest generated docs is in the package's **About** box;
 for example, see the shelf package's
@@ -226,7 +226,7 @@ for example, see the shelf package's
 Links to previous versions' docs are in the
 **Versions** tab of the package's page.
 
-To ensure that your package's API docs look good on the pub site,
+To ensure that your package's API docs look good on the pub.dev site,
 follow these steps:
 
 * Before publishing your package, run the [dartdoc][] tool

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -37,7 +37,7 @@ it covers only a few dart:* libraries
 and no third-party libraries.
 
 Other places to find library information are the
-[Pub site]({{site.pub}}) and the
+[pub.dev site]({{site.pub}}) and the
 [Dart web developer library guide][webdev libraries].
 You can find API documentation for all dart:* libraries in the
 [Dart API reference][Dart API] or, if you're using Flutter,

--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -7,7 +7,7 @@ This page lists some of the most popular and useful
 [packages](/guides/packages) that Dart developers have published.
 To find more packages —
 and search [core libraries](/guides/libraries), as well —
-use the [Pub site.]({{site.pub}})
+use the [pub.dev site.]({{site.pub}})
 
 Commonly used packages fall into three groups:
 
@@ -58,14 +58,14 @@ such as packages for mobile (Flutter) and web development.
 
 See [Using packages]({{site.flutter}}/docs/development/packages-and-plugins/using-packages)
 on the Flutter site.
-Or use the Pub site to [search for Flutter packages.]({{site.pub}}/flutter)
+Or use the pub.dev site to [search for Flutter packages.]({{site.pub}}/flutter)
 
 ### Web packages
 
 See [Web libraries and packages](/web/libraries).
-Or use the Pub site to [search for web packages.]({{site.pub}}/web)
+Or use the pub.dev site to [search for web packages.]({{site.pub}}/web)
 
 ### Command-line and server packages
 
 See [Command-line and server libraries and packages](/server/libraries).
-Or use the Pub site to [search for other packages.]({{site.pub}})
+Or use the pub.dev site to [search for other packages.]({{site.pub}})

--- a/src/_guides/packages.md
+++ b/src/_guides/packages.md
@@ -7,7 +7,7 @@ description: Learn more about pub, Dart's tool for managing packages.
 The Dart ecosystem uses _packages_ to manage shared software
 such as libraries and tools.
 To get Dart packages, you use the **pub package manager**.
-You can find publicly available packages on the [**Pub site**,]({{site.pub}})
+You can find publicly available packages on the [**pub.dev site**,]({{site.pub}})
 or you can load packages from the local file system or elsewhere,
 such as Git repositories.
 Wherever your packages come from, pub manages version dependencies,
@@ -43,7 +43,7 @@ name: my_app
 {% endprettify %}
 
 Here is an example of a pubspec that declares dependencies on
-two packages (`js` and `intl`) that are hosted on the Pub site:
+two packages (`js` and `intl`) that are hosted on the pub.dev site:
 
 {% prettify yaml %}
 name: my_app
@@ -71,7 +71,7 @@ This process is called _getting the dependencies_.
 The `pub get` command determines which packages your app depends on,
 and puts them in a central [system cache](/tools/pub/glossary#system-cache).
 If your app depends on a published package, pub downloads that package from the
-[Pub site.]({{site.pub}})
+[pub.dev site.]({{site.pub}})
 For a [Git dependency](/tools/pub/dependencies#git-packages),
 pub clones the Git repository.
 Transitive dependencies are included, too.

--- a/src/_tutorials/index.md
+++ b/src/_tutorials/index.md
@@ -30,7 +30,7 @@ which are fundamental to most Dart programs.
   <div class="card">
     <h3><a href="/tutorials/libraries/shared-pkgs">Install shared packages</a></h3>
     <p>Organize and share code at the
-       <a href="{{site.pub}}">Pub site.</a></p>
+       <a href="{{site.pub}}">pub.dev site.</a></p>
   </div>
 </div>
 

--- a/src/_tutorials/libraries/index.md
+++ b/src/_tutorials/libraries/index.md
@@ -9,5 +9,5 @@ be more productive. Leverage that code or put your code out in the world
 to share with others.
 
 * [Install shared packages](/tutorials/libraries/shared-pkgs).
-  Organize and share code at the [Pub site]({{site.pub}}).
+  Organize and share code at the [pub.dev site]({{site.pub}}).
 

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -8,7 +8,7 @@ description: Packages are bundles of source code, tools, and resources that help
 <div class="mini-toc" markdown="1">
   <h4>What's the point?</h4>
 
-  * The [Pub site]({{site.pub}}) is the primary public repository for Dart
+  * The [pub.dev site]({{site.pub}}) is the primary public repository for Dart
     packages.
   * Following a few conventions, such as having a valid pubspec.yaml file,
     makes your app a package.
@@ -22,14 +22,14 @@ description: Packages are bundles of source code, tools, and resources that help
 Once you can create and run a Dart app,
 you're ready to leverage code written by other programmers.
 Many interesting and useful packages of reusable Dart code
-are available at the [Pub site]({{site.pub}}) repository.
+are available at the [pub.dev site]({{site.pub}}) repository.
 
 This tutorial shows how to use `pub`&mdash;a package manager
 that comes with Dart&mdash;to
 install one of the packages in the repository,
 the vector_math package.
 You can follow these same steps to install any package hosted at
-the [Pub site]({{site.pub}});
+the [pub.dev site]({{site.pub}});
 just change the package name when you get to that step.
 This tutorial also describes some of the resources you can expect to find
 in a well-built package.
@@ -113,7 +113,7 @@ of a package that your app uses.
 
 Let's make the vector_victor app have a dependency
 on the vector_math package,
-which is available at the [Pub site]({{site.pub}}).
+which is available at the [pub.dev site]({{site.pub}}).
 
  1. Get the current installation details for the package:
 
@@ -132,7 +132,7 @@ which is available at the [Pub site]({{site.pub}}).
  2. Edit `pubspec.yaml`.
 
  3. In the dependencies section, add the string you copied from the
-    Pub site. Be careful to keep the indentation the same; YAML is
+    pub.dev site. Be careful to keep the indentation the same; YAML is
     picky! For example:
 
     ```yaml
@@ -150,7 +150,7 @@ For details of what version numbers mean
 and how you can format them,
 see [Pub versioning philosophy](/tools/pub/versioning).
 
-The [Pub site]({{site.pub}})
+The [pub.dev site]({{site.pub}})
 is the primary public repository for Dart packages.
 `pub` automatically checks that
 website when resolving package dependencies.
@@ -288,7 +288,7 @@ use the `package:` prefix.
    For inspiration, look at the
    [vector_math API
    docs]({{site.pub}}/documentation/vector_math/latest),
-   which you can find from the Pub site entry.
+   which you can find from the pub.dev site entry.
 
    <aside class="alert alert-info" markdown="1">
      **Note:** You specify a filename, not a library name,
@@ -298,7 +298,7 @@ use the `package:` prefix.
 
 ## Other resources
 
-* Dart developers share packages at the [Pub site]({{site.pub}}).
+* Dart developers share packages at the [pub.dev site]({{site.pub}}).
   Look there for packages that might be useful to you,
   or share your own Dart packages.
 * See the [pub package documentation](/guides/packages)

--- a/src/faq.md
+++ b/src/faq.md
@@ -151,7 +151,7 @@ Yes. See [Dart on the Server] for details.
 
 ### Q. How do I use third party code, or share code?
 
-You can find many packages on the [Pub site][pub] a service for hosting
+You can find many packages on the [pub.dev site][pub] a service for hosting
 packages of Dart code. Use the `pub` command to package your code and upload
 to the site.
 

--- a/src/server/libraries.md
+++ b/src/server/libraries.md
@@ -26,7 +26,7 @@ that provide low-level web APIs.
 
 ## Community packages
 
-The [Pub site]({{site.pub}}) doesn't currently support
+The [pub.dev site]({{site.pub}}) doesn't currently support
 limiting your search to packages that support command-line and server apps.
 You can, however, search for words that describe the functionality you need.
 

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -95,7 +95,7 @@ With pub you can publish packages and command-line apps.
 
 To share your Dart packages with the world, you can
 use the [`pub publish`](/tools/pub/cmd/pub-lish) command to upload the
-package to the [Pub site]({{site.pub}}). The
+package to the [pub.dev site]({{site.pub}}). The
 [`pub uploader`](/tools/pub/cmd/pub-uploader) command enables specific
 users to modify and upload new versions of your package.
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -99,7 +99,7 @@ already-acquired dependencies.
 ## The system package cache
 
 Dependencies downloaded over the internet, such as those from Git and the
-[Pub site]({{site.pub}}), are stored in a
+[pub.dev site]({{site.pub}}), are stored in a
 [system-wide cache](/tools/pub/glossary#system-cache).
 This means that if multiple packages use the same version of the
 same dependency, it only needs to be

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -1,6 +1,6 @@
 ---
 title: pub global
-description: Use pub global to run Dart scripts hosted on the Pub site from the command line.
+description: Use pub global to run Dart scripts hosted on the pub.dev site from the command line.
 ---
 
 _Global_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -36,7 +36,7 @@ pub global activate [--noexecutables] [--executable=<name>] [--overwrite] <packa
 Activate a package when you want to be able to run
 one or more of its executable files from the command line.
 You can activate packages that live on the
-[Pub site]({{site.pub}}), a Git repository,
+[pub.dev site]({{site.pub}}), a Git repository,
 or your local machine.
 Once you've activated a package, see [Running a
 script](#running-a-script) to run scripts from the package's
@@ -45,13 +45,13 @@ script](#running-a-script) to run scripts from the package's
 When you activate a package you can specify an optional version
 constraint.  See the [constraint](#options) flag for usage examples.
 
-### Activating a package on the Pub site
+### Activating a package on the pub.dev site
 
 ```terminal
 $ pub global activate <pub.dartlang package>
 ```
 
-Specify a package on the Pub site to activate it. For example:
+Specify a package on the pub.dev site to activate it. For example:
 
 ```terminal
 $ pub global activate markdown

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -1,6 +1,6 @@
 ---
 title: pub publish
-description: Use pub publish to publish your Dart package to the Pub site.
+description: Use pub publish to publish your Dart package to the pub.dev site.
 toc: false
 ---
 
@@ -11,7 +11,7 @@ $ pub publish [--dry-run] [--force] [--server <url>]
 {% endprettify %}
 
 This command publishes your package on the
-[Pub site]({{site.pub}}) for anyone to download and depend
+[pub.dev site]({{site.pub}}) for anyone to download and depend
 on. For information on how to prepare your package for publishing,
 and what files you should include or exclude,
 see [Publishing packages](/tools/pub/publishing).
@@ -41,7 +41,7 @@ either don't use `--force`, or use `--dry-run` first.
 
 If you pass `--server` followed by a URL, it attempts to publish the
 package to that server. It assumes the server supports the same HTTP API that
-the [Pub site][pubsite] uses.
+the [pub.dev site][pubsite] uses.
 
 This can be useful if you're running your own local package server for testing.
 The main pub server is itself open source and available [here][pub repo].

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -1,6 +1,6 @@
 ---
 title: pub uploader
-description: Use pub uploader to add or remove uploaders for your Dart package on the Pub site.
+description: Use pub uploader to add or remove uploaders for your Dart package on the pub.dev site.
 toc: false
 ---
 
@@ -12,7 +12,7 @@ $ pub uploader [options] {add/remove} <email>
 
 This command allows
 [uploaders](/tools/pub/glossary#uploader) of a
-package on the [Pub site]({{site.pub}}) to add or remove
+package on the [pub.dev site]({{site.pub}}) to add or remove
 other uploaders for that package. It has two sub-commands,
 `add` and `remove`, that take the email address of the person to
 add/remove as an uploader. For example:

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -32,7 +32,7 @@ dependencies:
 {% endprettify %}
 
 This creates a dependency on `transmogrify` that  allows any version, and looks
-it up using the default source, which is the [Pub site]({{site.pub}}).
+it up using the default source, which is the [pub.dev site]({{site.pub}}).
 To limit the dependency to a range of versions,
 you can provide a *version constraint*:
 
@@ -113,7 +113,7 @@ install packages that have `sdk` dependencies.
 
 ### Hosted packages
 
-A *hosted* package is one that can be downloaded from the Pub site
+A *hosted* package is one that can be downloaded from the pub.dev site
 (or another HTTP server that speaks the same API). Here's an example
 of declaring a dependency on a hosted package:
 
@@ -223,7 +223,7 @@ containing your pubspec.
 Path dependencies are useful for local development, but do not work when
 sharing code with the outside world&mdash;not everyone can get to
 your file system. Because of this, you cannot upload a package to the
-[Pub site][pubsite] if it has any path dependencies in its pubspec.
+[pub.dev site][pubsite] if it has any path dependencies in its pubspec.
 
 Instead, the typical workflow is:
 

--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -17,7 +17,7 @@ Environment variables allow you to customize pub to suit your needs.
   [The system package cache](/tools/pub/cmd/pub-get#the-system-package-cache).
 
 `PUB_HOSTED_URL`
-: Pub downloads dependencies from the [Pub site.]({{site.pub}})
+: Pub downloads dependencies from the [pub.dev site.]({{site.pub}})
   To specify the location of a particular mirror server,
   use the `PUB_HOSTED_URL` environment variable. For example:
 

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -113,7 +113,7 @@ section [in the pubspec](/tools/pub/pubspec#sdk-constraints).
 ## Source
 
 A kind of place that pub can get packages from. A source isn't a specific place
-like the Pub site or some specific Git URL. Each source describes a general
+like the pub.dev site or some specific Git URL. Each source describes a general
 procedure for accessing a package in some way. For example, _git_ is one source.
 The git source knows how to download packages given a Git URL. Several
 different [supported sources](/tools/pub/dependencies#dependency-sources) are available.

--- a/src/tools/pub/index.md
+++ b/src/tools/pub/index.md
@@ -95,7 +95,7 @@ With pub you can publish packages and command-line apps.
 
 To share your Dart packages with the world, you can
 use the [`pub publish`](/tools/pub/cmd/pub-lish) command to upload the
-package to the [Pub site]({{site.pub}}). The
+package to the [pub.dev site]({{site.pub}}). The
 [`pub uploader`](/tools/pub/cmd/pub-uploader) command enables specific
 users to modify and upload new versions of your package.
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -116,7 +116,7 @@ enchilada/
 
 One file that's very common in open source is a README file that
 describes the project. This is especially important in pub. When you upload
-to the [Pub site,]({{site.pub}}) your README is shown on
+to the [pub.dev site,]({{site.pub}}) your README is shown on
 the page for your package. This is the perfect place to introduce people to
 your code.
 
@@ -135,7 +135,7 @@ enchilada/
 To show users the latest changes to your package, you can include a changelog
 file where you can write a short note about the changes in your latest
 release. When you upload your package to the
-[Pub site,]({{site.pub}}) your package's changelog file (if any)
+[pub.dev site,]({{site.pub}}) your package's changelog file (if any)
 appears in the changelog tab.
 
 If your CHANGELOG ends in `.md`, it's parsed as
@@ -402,7 +402,7 @@ consider creating an example file with one of the following names
 * <code>example[/lib]/example.dart</code>
 
 When you publish a package that contains one or more of the above files,
-the Pub site creates an **Example** tab to display the first file it finds
+the pub.dev site creates an **Example** tab to display the first file it finds
 (searching in the order shown in the list above).
 For example, if your package has many files under its `example` directory,
 including a file named `README.md`,

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing packages
-description: Learn how to publish a Dart package to the Pub site.
+description: Learn how to publish a Dart package to the pub.dev site.
 ---
 
 [The pub package manager](/guides/packages) isn't just for using other people's packages.
@@ -10,7 +10,7 @@ command.
 
 <aside class="alert alert-info" markdown="1">
 **Note:**
-To publish to a location other than the Pub site,
+To publish to a location other than the pub.dev site,
 or to prevent publication anywhere, use the `publish_to` field,
 as defined in the [pubspec](/tools/pub/pubspec).
 </aside>
@@ -49,7 +49,7 @@ are a few additional requirements for uploading a package:
 [Google Account]: https://support.google.com/accounts/answer/27441
 
 Be aware that the email address associated with your Google account is
-displayed on the [Pub site]({{site.pub}}) along with any
+displayed on the [pub.dev site]({{site.pub}}) along with any
 packages you upload.
 
 ### Important files
@@ -63,7 +63,7 @@ affect how your package's page looks:
 * **CHANGELOG**: Your package's CHANGELOG (`CHANGELOG`, `CHANGELOG.md`,
   `CHANGELOG.mdown`, `CHANGELOG.markdown`), if found, will also be featured in a
   tab on your package's page, so that developers can read it right from
-  the Pub site.
+  the pub.dev site.
 * **The pubspec**: Your package's `pubspec.yaml` file is used to fill out
   details about your package on the right side of your package's page, like its
   description, authors, etc.
@@ -80,7 +80,7 @@ Pub will check to make sure that your package follows the
 [pubspec format](/tools/pub/pubspec) and
 [package layout conventions](/tools/pub/package-layout),
 and then upload your package to the
-[Pub site]({{site.pub}}). Pub will also show you all of
+[pub.dev site]({{site.pub}}). Pub will also show you all of
 the files it intends to publish. Here's an example of publishing a package
 named `transmogrify`:
 
@@ -108,7 +108,7 @@ $ pub publish
 {% endprettify %}
 
 After your package has been successfully uploaded to
-[Pub site]({{site.pub}}), any pub user will be able to
+[pub.dev site]({{site.pub}}), any pub user will be able to
 download it or depend on it in their projects. For example, if you just
 published version 1.0.0 of your `transmogrify` package, then another Dart
 developer can add it as a dependency in their `pubspec.yaml`:

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -23,11 +23,11 @@ A pubspec can have the following fields:
   [_Learn more._](#name)
 
 `version`
-: Required for packages that are hosted on the Pub site.
+: Required for packages that are hosted on the pub.dev site.
   [_Learn more._](#version)
 
 `description`
-: Required for packages that are hosted on the [Pub site.]({{site.pub}})
+: Required for packages that are hosted on the [pub.dev site.]({{site.pub}})
   [_Learn more._](#description)
 
 `author` or `authors`
@@ -137,13 +137,13 @@ doesn't start with digits and isn't a
 
 Try to pick a name that is clear, terse, and not already in use.
 A quick search of packages on the
-[Pub site]({{site.pub}}/packages)
+[pub.dev site]({{site.pub}}/packages)
 to make sure that nothing else is using your name is recommended.
 
 ### Version
 
 Every package has a version. A version number is required to host your package
-on the Pub site, but can be omitted for local-only packages. If you omit
+on the pub.dev site, but can be omitted for local-only packages. If you omit
 it, your package is implicitly versioned `0.0.0`.
 
 Versioning is necessary for reusing code while letting it evolve quickly. A
@@ -186,7 +186,7 @@ authors:
 {% endprettify %}
 
 The email addresses can be from any provider.
-If anyone uploads your package to the Pub site,
+If anyone uploads your package to the pub.dev site,
 then the author information (including email addresses) becomes public.
 
 ### Homepage
@@ -201,7 +201,7 @@ While providing a `homepage` is optional, *please provide* it or `repository`
 
 The optional `repository` field should contain the URL for your package's source
 code repository — for example, `https://github.com/<user>/<repository>`.
-If you publish your package to the Pub site, then your package's page
+If you publish your package to the pub.dev site, then your package's page
 displays the repository URL.
 While providing a `repository` is optional, *please provide* it or `homepage`
 (or both). It helps users understand where your package is coming from.
@@ -210,9 +210,9 @@ While providing a `repository` is optional, *please provide* it or `homepage`
 
 The optional `issue_tracker` field should contain a URL for the package's
 issue tracker, where existing bugs can be viewed and new bugs can be filed.
-The Pub site attempts to display a link to each package's issue
+The pub.dev site attempts to display a link to each package's issue
 tracker, using the value of this field. If `issue_tracker` is missing but
-`repository` is present and points to GitHub, then the Pub site uses the
+`repository` is present and points to GitHub, then the pub.dev site uses the
 default issue tracker (`https://github.com/<user>/<repository>/issues`).
 
 ### Documentation
@@ -267,7 +267,7 @@ For more information, see
 
 ### Publish_to
 
-The default uses the [Pub site.]({{site.pub}}) Specify `none` to prevent
+The default uses the [pub.dev site.]({{site.pub}}) Specify `none` to prevent
 a package from being published. This setting can be used to specify a
 [custom pub package server](https://github.com/dart-lang/pub-dev)
 to publish.

--- a/src/web/js-interop.md
+++ b/src/web/js-interop.md
@@ -12,7 +12,7 @@ also known as _package:js_.
 For help using the `js` package, see the following:
 
 * Documentation for the `js` package:
-  * [Pub site page][js]
+  * [pub.dev site page][js]
   * [API reference][js-api]
 * Packages that use the `js` package:
   * [firebase_web][] is a good example of providing a Dart-like API


### PR DESCRIPTION
Update to reflect the current branding of the pub.dev site.