### PR TITLE
Verified publishers docs

### DIFF
--- a/src/_assets/image/verified-publisher.svg
+++ b/src/_assets/image/verified-publisher.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm-2 16l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/></svg>

--- a/src/_assets/image/verified-publisher.svg
+++ b/src/_assets/image/verified-publisher.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm-2 16l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path  d="M0 0h24v24H0z" fill="none"/><path fill="#0175c2" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm-2 16l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/></svg>

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -69,6 +69,8 @@
       permalink: /guides/libraries/useful-libraries
     - title: Creating packages
       permalink: /guides/libraries/create-library-packages
+    - title: Verified publishers
+      permalink: /tools/pub/verified-publishers
     - title: Publishing packages
       permalink: /tools/pub/publishing
     - title: Package reference

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -69,8 +69,6 @@
       permalink: /guides/libraries/useful-libraries
     - title: Creating packages
       permalink: /guides/libraries/create-library-packages
-    - title: Verified publishers
-      permalink: /tools/pub/verified-publishers
     - title: Publishing packages
       permalink: /tools/pub/publishing
     - title: Package reference
@@ -88,6 +86,8 @@
           permalink: /tools/pub/pubspec
         - title: Troubleshooting pub
           permalink: /tools/pub/troubleshoot
+        - title: Verified publishers
+          permalink: /tools/pub/verified-publishers
         - title: Versioning
           permalink: /tools/pub/versioning
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -55,35 +55,74 @@ packages you upload.
 ### Publishing as a verified publisher {#verified-publisher}
 
 Packages can be published using either your personal Google account, or under a
-pub.dev verified publisher. We recommend that you use a verified publisher when
-possible, as this enables the consumers of your package to trust that the
-publisher entity has been verified. Additionally, while packages published by a
-personal Google account will publically display the email address of the
-personal account used to upload the package, a package published by a verified
-publisher will display the publisher account, and it's associated contact
-address. Packages published by a Verified Publisher additionally display a
-verified publisher badge {% asset verified-publisher.svg alt="pub.dev verified
-publisher logo" %} {#create-verified-publisher} on both search pages, and on
-individual package pages.
+[verified publisher](/verified-publishers) account. We recommend that you use a
+verified publisher when possible, as this enables the consumers of your package
+to trust that the publisher entity has been verified. Additionally, while
+packages published by a personal Google account will publically display the
+email address of the personal account used to upload the package, a package
+published by a verified publisher will display the publisher account, and it's
+associated contact address. Packages published by a verified publisher
+additionally display a verified publisher badge {% asset verified-publisher.svg
+alt="pub.dev verified publisher logo" %} on both search pages, and on individual
+package pages.
 
-### Creating a new pub.dev Verified Publisher account {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %} {#create-verified-publisher}
+### Creating a new {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %} verified publisher account  {#create-verified-publisher}
 
 Verified publisher accounts on pub.dev are created using the following steps.
 Note that verified publisher accounts are based on an associated domain for
 indetity, and that during creation of the account, the verification relies on
 DNS (domain name system) configuration of the associated domain.
 
-1. Open the [pub.dev site]{{site.pub}} in a web browser.
-1. Log in to the site using a Google account
-1. Click the user menu in the top-right corner
-1. Select **Create Publisher**
-1. Enter the domain name you wish to use for your publisher account (e.g. `dart.dev`), and click **create publisher**
-1. Select **OK** in the confirmation dialog
-1. If prompted, complete the verification flow. This will open the Google Search
-   Console. Note that when adding DNS records, it may take a few hours before
-   the Search Console is able to see the changes.
+1. Open the [pub.dev site]({{site.pub}}).
+
+1. Log in to the site using a Google account.
+
+1. Click the user menu in the top-right corner.
+
+1. Select **Create Publisher**.
+
+1. Enter the domain name you wish to use for your publisher account (e.g.
+   `dart.dev`), and click **create publisher**.
+
+1. Select **OK** in the confirmation dialog.
+
+1. If prompted, complete the verification flow. This will open the (Google
+   Search Console)[https://search.google.com/search-console/about]. Note that
+   when adding DNS records, it may take a few hours before the Search Console is
+   able to see the changes.
+
 1. Once the DNS flow has completed, re-initiate the creation step by clicking
-   **create publisher**
+   **create publisher**.
+
+You are now ready to publish packages for your publisher.
+
+<aside class="alert alert-info" markdown="1">
+**Note:**
+The pub client currently doesn't support publishing a new package directly to a
+publisher account. As a temporary workaround you need to publish it to a user
+account, and then transfer the package to a publisher (see below).´
+
+Once a package has been transferred to a publisher account, you can publish new
+versions using `pub publish`.
+</aside>
+
+### Transferring an existing package to a verified publisher account
+
+Packages already published to {{site.pub}} under a user account can be
+transferred to a verified publisher account using the following steps. Note that
+this process is not reversible.
+
+1. Login to {{site.pub}} with a user that is listed as an [uploader](#uploader)
+   of the package
+
+1. Go to the package details page for the package (e.g.
+   https://pub.dev/packages/http)
+
+1. Select the **Admin** tab (you will only see this if you are an uploader)
+
+1. Enter the name of the publisher, and click **transfer to publisher**. You
+   will only be able to complete this step if you are an admin in the verified
+   publisher account.
 
 ### Important files
 
@@ -171,7 +210,7 @@ Be sure to delete any files you don't want to include (or add them to
 before uploading your package,
 so examine the list carefully before completing your upload.
 
-## Authors versus uploaders
+## Uploaders {#uploaders}
 
 The package authors as listed in the `pubspec.yaml` file
 are different from the list of people authorized to publish that package.

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -52,6 +52,34 @@ Be aware that the email address associated with your Google account is
 displayed on the [Pub site]({{site.pub}}) along with any
 packages you upload.
 
+### Publishing as a pub.dev Verified Publisher
+
+Packages can be published using either your personal Google account, or under a
+pub.dev Verified Publisher. We recommend that you use a pub.dev Verified
+Publisher when possible, as this enables the consumers of your package to trust
+that the publisher entity has been verified. Additionally, while packages
+published by a personal Google account will publically display the email address
+of the personal account used to upload the package, a package published by a
+Verified Publisher will display the publisher account, and it's associated
+contact address. Packages published by a Verified Publisher additionally display
+a Verified Publisher badge visible both on search pages, and on an individual
+package page.
+
+TODO mit@: Create screenshot showing the badge for a Verified Publisher.
+
+### Creating a new pub.dev Verified Publisher account
+
+Verified Publisher accounts on pub.dev are created using the following steps.
+Note that Verified Publisher accounts are based on an associated domain for
+indetity, and that during creation of the account, the verification relies on
+DNS (domain name system) configuration of the associated domain.
+
+1. Open the [pub.dev site]{{site.pub}} in a web browser.
+1. Log in to the site using a Google account
+1. Click the user menu in the top-right corner
+1. Select **Create Publisher**
+1. TODO
+
 ### Important files
 
 Pub uses the contents of a few files to create a page for your
@@ -146,6 +174,10 @@ Whoever publishes the first version of some package automatically becomes
 the first and only person authorized to upload additional versions of the package.
 To allow or disallow other people to upload versions,
 use the [`pub uploader`](cmd/pub-uploader) command.
+
+Note that for packages published with a pub.dev Verified Publisher, the package
+details page will display the Verified Publisher account, rather than the author
+field.
 
 ## Publishing prereleases
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -52,25 +52,24 @@ Be aware that the email address associated with your Google account is
 displayed on the [Pub site]({{site.pub}}) along with any
 packages you upload.
 
-### Publishing as a pub.dev Verified Publisher
+### Publishing as a verified publisher {#verified-publisher}
 
 Packages can be published using either your personal Google account, or under a
-pub.dev Verified Publisher. We recommend that you use a pub.dev Verified
-Publisher when possible, as this enables the consumers of your package to trust
-that the publisher entity has been verified. Additionally, while packages
-published by a personal Google account will publically display the email address
-of the personal account used to upload the package, a package published by a
-Verified Publisher will display the publisher account, and it's associated
-contact address. Packages published by a Verified Publisher additionally display
-a Verified Publisher badge visible both on search pages, and on an individual
-package page.
+pub.dev verified publisher. We recommend that you use a verified publisher when
+possible, as this enables the consumers of your package to trust that the
+publisher entity has been verified. Additionally, while packages published by a
+personal Google account will publically display the email address of the
+personal account used to upload the package, a package published by a verified
+publisher will display the publisher account, and it's associated contact
+address. Packages published by a Verified Publisher additionally display a
+verified publisher badge {% asset verified-publisher.svg alt="pub.dev verified
+publisher logo" %} {#create-verified-publisher} on both search pages, and on
+individual package pages.
 
-TODO mit@: Create screenshot showing the badge for a Verified Publisher.
+### Creating a new pub.dev Verified Publisher account {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %} {#create-verified-publisher}
 
-### Creating a new pub.dev Verified Publisher account
-
-Verified Publisher accounts on pub.dev are created using the following steps.
-Note that Verified Publisher accounts are based on an associated domain for
+Verified publisher accounts on pub.dev are created using the following steps.
+Note that verified publisher accounts are based on an associated domain for
 indetity, and that during creation of the account, the verification relies on
 DNS (domain name system) configuration of the associated domain.
 
@@ -78,7 +77,13 @@ DNS (domain name system) configuration of the associated domain.
 1. Log in to the site using a Google account
 1. Click the user menu in the top-right corner
 1. Select **Create Publisher**
-1. TODO
+1. Enter the domain name you wish to use for your publisher account (e.g. `dart.dev`), and click **create publisher**
+1. Select **OK** in the confirmation dialog
+1. If prompted, complete the verification flow. This will open the Google Search
+   Console. Note that when adding DNS records, it may take a few hours before
+   the Search Console is able to see the changes.
+1. Once the DNS flow has completed, re-initiate the creation step by clicking
+   **create publisher**
 
 ### Important files
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing packages
-description: Learn how to publish a Dart package to the Pub site.
+description: Learn how to publish a Dart package to pub.dev.
 ---
 
 [The pub package manager](/guides/packages) isn't just for using other people's packages.
@@ -10,7 +10,7 @@ command.
 
 <aside class="alert alert-info" markdown="1">
 **Note:**
-To publish to a location other than the Pub site,
+To publish to a location other than pub.dev,
 or to prevent publication anywhere, use the `publish_to` field,
 as defined in the [pubspec](/tools/pub/pubspec).
 </aside>
@@ -48,81 +48,10 @@ are a few additional requirements for uploading a package:
 
 [Google Account]: https://support.google.com/accounts/answer/27441
 
-Be aware that the email address associated with your Google account is
-displayed on the [Pub site]({{site.pub}}) along with any
-packages you upload.
-
-### Publishing as a verified publisher {#verified-publisher}
-
-Packages can be published using either your personal Google account, or under a
-[verified publisher](/verified-publishers) account. We recommend that you use a
-verified publisher when possible, as this enables the consumers of your package
-to trust that the publisher entity has been verified. Additionally, while
-packages published by a personal Google account will publically display the
-email address of the personal account used to upload the package, a package
-published by a verified publisher will display the publisher account, and it's
-associated contact address. Packages published by a verified publisher
-additionally display a verified publisher badge {% asset verified-publisher.svg
-alt="pub.dev verified publisher logo" %} on both search pages, and on individual
-package pages.
-
-### Creating a new {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %} verified publisher account  {#create-verified-publisher}
-
-Verified publisher accounts on pub.dev are created using the following steps.
-Note that verified publisher accounts are based on an associated domain for
-indetity, and that during creation of the account, the verification relies on
-DNS (domain name system) configuration of the associated domain.
-
-1. Open the [pub.dev site]({{site.pub}}).
-
-1. Log in to the site using a Google account.
-
-1. Click the user menu in the top-right corner.
-
-1. Select **Create Publisher**.
-
-1. Enter the domain name you wish to use for your publisher account (e.g.
-   `dart.dev`), and click **create publisher**.
-
-1. Select **OK** in the confirmation dialog.
-
-1. If prompted, complete the verification flow. This will open the (Google
-   Search Console)[https://search.google.com/search-console/about]. Note that
-   when adding DNS records, it may take a few hours before the Search Console is
-   able to see the changes.
-
-1. Once the DNS flow has completed, re-initiate the creation step by clicking
-   **create publisher**.
-
-You are now ready to publish packages for your publisher.
-
-<aside class="alert alert-info" markdown="1">
-**Note:**
-The pub client currently doesn't support publishing a new package directly to a
-publisher account. As a temporary workaround you need to publish it to a user
-account, and then transfer the package to a publisher (see below).´
-
-Once a package has been transferred to a publisher account, you can publish new
-versions using `pub publish`.
-</aside>
-
-### Transferring an existing package to a verified publisher account
-
-Packages already published to {{site.pub}} under a user account can be
-transferred to a verified publisher account using the following steps. Note that
-this process is not reversible.
-
-1. Login to {{site.pub}} with a user that is listed as an [uploader](#uploader)
-   of the package
-
-1. Go to the package details page for the package (e.g.
-   https://pub.dev/packages/http)
-
-1. Select the **Admin** tab (you will only see this if you are an uploader)
-
-1. Enter the name of the publisher, and click **transfer to publisher**. You
-   will only be able to complete this step if you are an admin in the verified
-   publisher account.
+{{ site.alert.note }}
+Unless you publish using a [verified publisher](#verified-publisher),
+**pub.dev displays the email address associated with your Google Account.**
+{{ site.alert.end }}
 
 ### Important files
 
@@ -133,26 +62,68 @@ affect how your package's page looks:
 * **README**: The README file (`README`, `README.md`, `README.mdown`,
   `README.markdown`) is the main content featured in your package's page.
 * **CHANGELOG**: Your package's CHANGELOG (`CHANGELOG`, `CHANGELOG.md`,
-  `CHANGELOG.mdown`, `CHANGELOG.markdown`), if found, will also be featured in a
+  `CHANGELOG.mdown`, `CHANGELOG.markdown`), if found, is also featured in a
   tab on your package's page, so that developers can read it right from
-  the Pub site.
+  pub.dev.
 * **The pubspec**: Your package's `pubspec.yaml` file is used to fill out
   details about your package on the right side of your package's page, like its
   description, authors, etc.
 
+
+### Advantages of using a verified publisher {#verified-publisher}
+
+You can publish packages using either a verified publisher (recommended)
+or an independent Google Account.
+Using a verified publisher has the following advantages:
+
+* The consumers of your package know that the publisher domain has been verified.
+* You can avoid having pub.dev display your personal email address.
+  Instead, pub.dev displays displays the publisher domain and contact address. 
+* A verified publisher badge {% asset verified-publisher.svg
+  alt="pub.dev verified publisher logo" %} is displayed next to your package name
+  on both search pages and individual package pages.
+
+
+### Creating a verified publisher {#create-verified-publisher}
+
+To create a verified publisher, follow these steps:
+
+1. Go to [pub.dev.]({{site.pub}})
+
+1. Log in to pub.dev using a Google Account.
+
+1. In the user menu in the top-right corner, select **Create Publisher**.
+
+1. Enter the domain name that you want to associate with your publisher (for example,
+   `dart.dev`), and click **Create Publisher**.
+
+1. In the confirmation dialog, select **OK**.
+
+1. If prompted, complete the verification flow, which opens the [Google
+   Search Console.](https://search.google.com/search-console/about)
+   * When adding DNS records, it may take a few hours before the Search Console
+   reflects the changes. 
+   * When the verification flow is complete, return to step 4.
+
+
 ## Publishing your package
 
-For your first time around, you can perform a dry run:
+Use the [`pub publish`][] command to publish your package for the first time,
+or to update it to a new version.
+
+
+### Performing a dry run
+
+To test how `pub publish` will work, you can perform a dry run:
 
 {% prettify none %}
 $ pub publish --dry-run
 {% endprettify %}
 
-Pub will check to make sure that your package follows the
+Pub makes sure that your package follows the
 [pubspec format](/tools/pub/pubspec) and
 [package layout conventions](/tools/pub/package-layout),
-and then upload your package to the
-[Pub site]({{site.pub}}). Pub will also show you all of
+and then uploads your package to pub.dev]. Pub also shows you all of
 the files it intends to publish. Here's an example of publishing a package
 named `transmogrify`:
 
@@ -173,14 +144,25 @@ Publishing transmogrify 1.0.0
 Package has 0 warnings.
 {% endprettify %}
 
+### Publishing
+
 When you're ready to publish your package, remove the `--dry-run` argument:
 
 {% prettify none %}
 $ pub publish
 {% endprettify %}
 
-After your package has been successfully uploaded to
-[Pub site]({{site.pub}}), any pub user will be able to
+{{ site.alert.note }}
+  The `pub` command currently doesn't support publishing a new package directly to a
+  verified publisher. As a temporary workaround, publish new packages to a Google Account,
+  and then [transfer the package to a publisher](#transferring-a-package-to-a-verified-publisher).
+
+  Once a package has been transferred to a publisher,
+  you can update the package using `pub publish`.
+{{ site.alert.end }}
+
+
+After your package has been successfully uploaded to pub.dev, any pub user can
 download it or depend on it in their projects. For example, if you just
 published version 1.0.0 of your `transmogrify` package, then another Dart
 developer can add it as a dependency in their `pubspec.yaml`:
@@ -189,6 +171,27 @@ developer can add it as a dependency in their `pubspec.yaml`:
 dependencies:
   transmogrify: ^1.0.0
 {% endprettify %}
+
+### Transferring a package to a verified publisher
+
+To transfer a package to a verified publisher,
+you must be an [uploader](#uploader) for the package
+and an admin for the verified publisher. 
+
+{{ site.alert.note }}
+  This process isn't reversible. Once you transfer a package to a publisher,
+  you can't transfer it back to an individual account.
+{{ site.alert.end }}
+
+Here's how to transfer a package to a verified publisher:
+
+1. Log in to [pub.dev]({{site.pub}}) with a Google Account that's listed as
+   an uploader of the package.
+1. Go to the package details page (for example,
+   `{{site.pub-pkg}}/http`).
+1. Select the **Admin** tab.
+1. Enter the name of the publisher, and click **Transfer to Publisher**. 
+
 
 ## What files are published?
 
@@ -217,11 +220,13 @@ are different from the list of people authorized to publish that package.
 Whoever publishes the first version of some package automatically becomes
 the first and only person authorized to upload additional versions of the package.
 To allow or disallow other people to upload versions,
-use the [`pub uploader`](cmd/pub-uploader) command.
+use the [`pub uploader`][] command.
 
-Note that for packages published with a pub.dev Verified Publisher, the package
-details page will display the Verified Publisher account, rather than the author
-field.
+{{ site.alert.note }}
+  For packages published using a verified publisher,
+  the package details page displays the verified publisher domain,
+  rather than the author field.
+{{ site.alert.end }}
 
 ## Publishing prereleases
 
@@ -248,7 +253,7 @@ instead of `^2.0.0` or `^2.1.0` they might specify `^2.1.0-dev.1`.
   then pub chooses that prerelease instead of a stable release.
 </aside>
 
-When a prerelease is published to [pub.dev](https://pub.dev),
+When a prerelease is published to pub.dev,
 the package page displays links to both the prerelease and the stable release.
 The prerelease doesn't affect the analysis score, show up in search results,
 or replace the package README and documentation. 
@@ -258,7 +263,7 @@ or replace the package README and documentation.
 ## Publishing is forever
 
 Keep in mind that publishing is forever. As soon as you publish your package,
-users will be able to depend on it. Once they start doing that, removing
+users can depend on it. Once they start doing that, removing
 the package would break theirs. To avoid that, pub strongly discourages
 deleting packages. You can always upload new versions of your package, but
 old ones will continue to be available for users that aren't ready to
@@ -266,7 +271,10 @@ upgrade yet.
 
 ## Resources
 
-For more information, see the reference pages for:
+For more information, see the reference pages for the `pub` commands:
 
-* [`pub publish`](/tools/pub/cmd/pub-lish)
-* [`pub uploader`](/tools/pub/cmd/pub-uploader)
+* [`pub publish`][]
+* [`pub uploader`][]
+
+[`pub publish`]: /tools/pub/cmd/pub-lish
+[`pub uploader`]: /tools/pub/cmd/pub-uploader

--- a/src/tools/pub/verified-publishers.md
+++ b/src/tools/pub/verified-publishers.md
@@ -1,37 +1,45 @@
 ---
-description: Learn what verified publishers are, and how they are verified.
+title: Verified publishers
+description: Learn what verified publishers are, and they're verified.
 ---
 
-# Verified publishers {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %}
+The pub.dev verified publisher badge {% asset verified-publisher.svg
+alt="pub.dev verified publisher logo" %} lets you know that a package
+was published by a publisher whose identity has been verified.
+For example, [dart.dev](https://pub.dev/publishers/dart.dev/)
+is the verified publisher for packages that are supported by
+Google's Dart team.
 
-The pub.dev verified publisher logo {% asset verified-publisher.svg alt="pub.dev
-verified publisher logo" %} let's you know that a package was published by a
-publisher who's identity has been verified.
+The badge appears in several places on pub.dev,
+next to packages published by verified publishers:
 
-The badge appears next to packages published by verified publishers in several
-places:
+  * Package search results
+  * Package detail pages
+  * Publisher profile pages
+  * The pub.dev front page
 
-  * On the pub.dev landing page
-  * In package search results
-  * On a package detail page
-  * On a publisher profile page
-
-If you wish to see additional details (such as the contact email) for a
-publisher (e.g. [dart.dev](https://pub.dev/publishers/dart.dev/)), or
-see a list of all packages published by the publisher, click the publisher
-identity link (e.g. `dart.dev`) next to the badge.
+Each publisher has a page with a list of
+all packages belonging to that publisher,
+plus additional details such as the publisher's contact email.
+To visit the publisher page, click the publisher identity link
+(for example, `dart.dev`) next to the verified publisher badge {% asset
+verified-publisher.svg alt="pub.dev verified publisher logo" %}.
 
 ## Verification process
 
-To ensure that verified publishers are trustworthy, low cost, available to
-anyone interested in being a verified publisher, pub.dev relies on DNS (domain
-name system) domains as an identification token. We chose DNS because we believe
-that most package publishers already have a domain/homepage. During the
-publisher creation process (see below), pub.dev verifies that the user creating
-the verified publisher has admin access to the associated domain, based on
-existing logic in the (Google Search Console)[https://search.google.com/search-console/about].
+To ensure that creating verified publishers is low cost and available to anyone,
+pub.dev relies on DNS (domain name system) domains as an identification token.
+We chose DNS because we believe that most package publishers
+already have a domain and a homepage for that domain.
+During the [publisher creation process][publishing page],
+pub.dev verifies that the user creating the verified publisher has
+admin access to the associated domain, based on existing logic in the
+[Google Search Console.][]
 
 ## Creating a verified publisher account
 
-If you are a publisher and wish to create a new verified publisher,
-please see the [publishing page](/tools/pub/publishing#create-verified-publisher).
+If you publish packages and want to create a new verified publisher,
+see the instructions on the [publishing page][].
+
+[publishing page]: /tools/pub/publishing#create-verified-publisher
+[Google Search Console.]: https://search.google.com/search-console/about

--- a/src/tools/pub/verified-publishers.md
+++ b/src/tools/pub/verified-publishers.md
@@ -1,0 +1,39 @@
+---
+description: Learn what verified publishers are, and how they are verified.
+---
+
+# Verified publishers {% asset verified-publisher.svg alt="pub.dev verified publisher logo" %}
+
+The pub.dev verified publisher logo {% asset verified-publisher.svg alt="pub.dev
+verified publisher logo" %} let's you know that a package was published by a
+publisher who's identity has been verified.
+
+The badge appears next to packages published by verified publishers in several
+places:
+
+  * On the pub.dev landing page
+  * In package search results
+  * On a package detail page
+  * On a publisher profile page
+
+If you wish to see additional details (such as the contact email) for a
+publisher (e.g. [dart.dev](https://pub.dev/publishers/dart.dev/packages)), or
+see a list of all packages published by the publisher, click the pubisher
+identity link (e.g. `dart.dev`) next to the badge.
+
+## Verification process
+
+To ensure anyone who wishes to create a publisher account is able to do so
+themselves, and to ensure there are no high verification costs, pub.dev relies
+on DNS (domain name system) domains as an identification token. This was
+selected as we believe most organizations who with to publish content already
+have a domain/home-page. During the publisher creation process (see below),
+pub.dev verifies that the user creating the verified publisher account has admin
+access to the associated domain based on existing logic available in the (Google
+Search Console)[https://search.google.com/search-console/about].
+
+
+## Creating a verified publisher account
+
+If you are a publisher and wish to create a new verified publisher account,
+please see the [publishing page](/tools/pub/publishing#create-verified-publisher).

--- a/src/tools/pub/verified-publishers.md
+++ b/src/tools/pub/verified-publishers.md
@@ -17,23 +17,21 @@ places:
   * On a publisher profile page
 
 If you wish to see additional details (such as the contact email) for a
-publisher (e.g. [dart.dev](https://pub.dev/publishers/dart.dev/packages)), or
-see a list of all packages published by the publisher, click the pubisher
+publisher (e.g. [dart.dev](https://pub.dev/publishers/dart.dev/)), or
+see a list of all packages published by the publisher, click the publisher
 identity link (e.g. `dart.dev`) next to the badge.
 
 ## Verification process
 
-To ensure anyone who wishes to create a publisher account is able to do so
-themselves, and to ensure there are no high verification costs, pub.dev relies
-on DNS (domain name system) domains as an identification token. This was
-selected as we believe most organizations who with to publish content already
-have a domain/home-page. During the publisher creation process (see below),
-pub.dev verifies that the user creating the verified publisher account has admin
-access to the associated domain based on existing logic available in the (Google
-Search Console)[https://search.google.com/search-console/about].
-
+To ensure that verified publishers are trustworthy, low cost, available to
+anyone interested in being a verified publisher, pub.dev relies on DNS (domain
+name system) domains as an identification token. We chose DNS because we believe
+that most package publishers already have a domain/homepage. During the
+publisher creation process (see below), pub.dev verifies that the user creating
+the verified publisher has admin access to the associated domain, based on
+existing logic in the (Google Search Console)[https://search.google.com/search-console/about].
 
 ## Creating a verified publisher account
 
-If you are a publisher and wish to create a new verified publisher account,
+If you are a publisher and wish to create a new verified publisher,
 please see the [publishing page](/tools/pub/publishing#create-verified-publisher).


### PR DESCRIPTION
Initial publisher docs for pub.dev Verified Publishers.

TODO:
  - [x] Complete steps for creating
  - [x] Link to a sample publisher
  - [x] Add docs for consumers of packages

Staged:
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/publishing
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/verified-publishers