### PR TITLE
Markdown cleanup: no need for spaces in Jekyll directives

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -16,14 +16,14 @@ To learn more about Dart's core libraries, see the
 Whenever you want more details about a language feature,
 consult the [Dart language specification][].
 
-{{ site.alert.note }}
+{{site.alert.note}}
   You can play with most of Dart's language features using DartPad
   ([learn more](/tools/dartpad)).
   **<a href="{{ site.dartpad }}" target="_blank">Open DartPad</a>**
 
   This page uses embedded DartPads to display some of the examples.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## A basic Dart program

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -12,7 +12,7 @@ _FFI_ stands for [_foreign function interface._][FFI]
 Other terms for similar functionality include _native interface_
 and _language bindings._
 
-{{ site.alert.warning }}
+{{site.alert.warning}}
 The dart:ffi library is [in active development][ffi issue]
 and isn't complete yet.
 The API is likely to have breaking changes
@@ -22,7 +22,7 @@ If you're developing a Flutter app, use the Flutter dev channel,
 as described in the [Flutter dart:ffi page.][binding]
 Otherwise, use the
 [Dart dev channel](/get-dart#about-release-channels-and-version-strings).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 API documentation is available from the dev channel:
 [dart:ffi API reference.]({{site.dart_api}}/dev/dart-ffi/dart-ffi-library.html)
@@ -58,7 +58,7 @@ The hello_world example has the following files:
 {% comment %}
 [PENDING: say something about setup.sh? It doesn't seem necessary for this example, but maybe it's needed by other examples?]
 
-<!-- 
+<!--
   | [setup.sh]({{ page.hw}}/setup.sh) | A macOS-specific script that sets an environment variable. [PENDING: Omit from this list? Why is it necessary? I didn't seem to need it.] |
 -->
 {% endcomment %}
@@ -81,7 +81,7 @@ gcc -dynamiclib -undefined suppress -flat_namespace hello.o -o ../hello_world.dy
 $ cd ..
 $ dart hello.dart
 Hello World
-$ 
+$
 ```
 
 ### Using dart:ffi

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -56,10 +56,10 @@ when using the **await for** loop.
 The following example tests the previous code by
 generating a simple stream of integers using an `async*` function:
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This page uses embedded DartPads to display runnable examples.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 {% comment %}
 https://gist.github.com/Sfshaza/15d5ef986238c97dbc14

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -27,9 +27,9 @@ change the greeting to use another language. To get the full DartPad experience,
 <a href="{{site.dartpad}}/27e044ec9e2957d9c5c7062871ce8bf3" target="_blank">open
 the example at dartpad.dev.</a>
 
-{{ site.alert.note }}
+{{site.alert.note}}
   {% include dartpad-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 <iframe
     src="{{site.dartpad-embed-inline}}?id=27e044ec9e2957d9c5c7062871ce8bf3"

--- a/src/_tutorials/web/fetch-data.md
+++ b/src/_tutorials/web/fetch-data.md
@@ -30,10 +30,10 @@ For web apps,
 HTTP requests are served by the browser in which the app is running,
 and thus are subject to the browser's security restrictions.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This page uses embedded DartPads to display runnable examples.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## About JSON

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -23,9 +23,9 @@ which includes the web UI that the app produces,
 <a href="{{site.dartpad}}/2a24f3f042f1c86cf91621c30adce771"
    target="_blank">open the example at dartpad.dev.</a>
 
-{{ site.alert.note }}
+{{site.alert.note}}
   {% include dartpad-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 <iframe
     src="{{site.dartpad-embed-html}}?id=2a24f3f042f1c86cf91621c30adce771"

--- a/src/_tutorials/web/low-level-html/add-elements.md
+++ b/src/_tutorials/web/low-level-html/add-elements.md
@@ -22,10 +22,10 @@ prevpage:
 
 </div>
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This page uses embedded DartPads to display runnable examples.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 As you learned in the previous tutorial,
 the DOM represents the structure

--- a/src/_tutorials/web/low-level-html/remove-elements.md
+++ b/src/_tutorials/web/low-level-html/remove-elements.md
@@ -79,9 +79,9 @@ Click it and it disappears from the list.
 Use the **Delete All** button
 to remove all of the items in the list at once.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   {% include dartpad-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 <iframe
 src="{{site.dartpad-embed-html}}?id=582b9a8d36786566ba08"

--- a/src/codelabs/async-await/index.md
+++ b/src/codelabs/async-await/index.md
@@ -20,10 +20,10 @@ in `async` functions.
 
 Estimated time to complete this codelab: 40-60 minutes.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This page uses embedded DartPads to display examples and exercises.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ## Why asynchronous code matters
 
@@ -71,7 +71,7 @@ In the next sections you'll learn the about futures, `async`, and `await`
 so that you'll be able to write the code necessary to make `getUserOrder()`
 print the desired value ("Large Latte") to the console.
 
- {{ site.alert.secondary }}
+ {{site.alert.secondary}}
  **Key terms:**
 * **synchronous operation**: A synchronous operation blocks other operations
 from executing until it completes.
@@ -81,7 +81,7 @@ operations.
 other operations to execute before it completes.
 * **asynchronous function**: An asynchronous function performs at least one
 asynchronous operation and can also perform _synchronous_ operations.
- {{ site.alert.end }}
+ {{site.alert.end}}
 
 
 ## What is a future?
@@ -89,10 +89,10 @@ A future (lower case "f") is an instance of the [Future][future class]
 (capitalized "F") class. A future represents the result of an asynchronous
 operation, and can have two states: uncompleted or completed.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   _Uncompleted_ is a Dart term referring to the state of a future
   before it has produced a value.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### Uncompleted
 
@@ -157,7 +157,7 @@ You've learned about futures and how they complete, but how do you use the
 results of asynchronous functions? In the next section you'll learn how to get
 results with the `async` and `await` keywords.
 
-{{ site.alert.secondary }}
+{{site.alert.secondary}}
   **Quick review:**
   * A [Future\<T\>][future class] instance produces a value of type `T`.
   * If a future doesn't produce a usable value, then the future's type is
@@ -172,7 +172,7 @@ results with the `async` and `await` keywords.
 * **Future**: the Dart [Future][future class] class.
 
 * **future**: an instance of the Dart Future class.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ## Working with futures: async and await
 
@@ -190,14 +190,14 @@ First, add the `async` keyword before the function body:
     main() [!async!] {
 {% endprettify %}
 
-{{ site.alert.info }}
+{{site.alert.info}}
   You might have noticed that some functions (like `main()`, above)
   don't have return types.
   That's because Dart can [infer the return type][infer] for you.
   Omitting return types is fine when you're prototyping,
   but when you write production code,
   we recommend that you specify the return type.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [infer]: https://dart.dev/guides/language/sound-dart#type-inference
 
@@ -291,7 +291,7 @@ The asynchronous example is different in three ways:
   * The **`await`** keyword appears before calling the asynchronous functions
   `getUserOrder()` and `createOrderMessage()`.
 
-{{ site.alert.secondary }}
+{{site.alert.secondary}}
   **Key terms:**
 * **async**: You can use the `async` keyword before a function's body to mark it as
 asynchronous.
@@ -299,7 +299,7 @@ asynchronous.
 keyword.
 * **await**: You can use the `await` keyword to get the completed result of an
 asynchronous expression. The `await` keyword only works within an `async` function.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### Execution flow with async and await
 
@@ -307,10 +307,10 @@ An `async` function runs synchronously until the first
 `await` keyword. This means that within an `async` function body, all
 synchronous code before the first `await` keyword executes immediately.
 
-{{ site.alert.note }}
+{{site.alert.note}}
 Before Dart 2.0, an `async` function returned immediately,
 without executing any code within the `async` function body.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### Example: Execution within async functions
 Run the following example to see how execution proceeds within an `async`
@@ -381,9 +381,9 @@ Implement an `async` function `reportLogins()` so that it does the following:
   width="100%">
 </iframe>
 
-  {{ site.alert.info }}
+  {{site.alert.info}}
     If your code passes the tests, you can ignore [info-level messages.](/guides/language/analysis-options#customizing-analysis-rules)
-  {{ site.alert.end }}
+  {{site.alert.end}}
 
 ## Handling errors
 To handle errors in an `async` function, use try-catch:

--- a/src/codelabs/dart-cheatsheet/index.md
+++ b/src/codelabs/dart-cheatsheet/index.md
@@ -18,7 +18,7 @@ description: Interactively learn (or relearn) some of Dart's unique features.
 The Dart language is designed to be easy to learn for
 coders coming from other languages,
 but it has a few unique features.
-This codelab — which is based on a 
+This codelab — which is based on a
 [Dart language cheatsheet](/guides/language/cheatsheet)
 written by and for Google engineers —
 walks you through the most important of these language features.
@@ -31,10 +31,10 @@ To run the code formatter ([dartfmt](/tools/dartfmt)), click **Format**.
 The **Reset** button erases your work and
 restores the editor to its original state.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This page uses embedded DartPads to display runnable examples.
   {% include dartpads-embedded-troubleshooting.md %}
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ## String interpolation
 
@@ -697,7 +697,7 @@ making it do the following:
 * If the list has **three** values,
   create an `IntegerTriple` with the values in order.
 * Otherwise, return null.
-    
+
 {% comment %}
 TODO: Fix the comment to not say "named".
 ISSUE: The hint acts like you don't already have the signature for the constructor.

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -11,12 +11,12 @@ To get a DartPad as big as your browser window, go to the
 <a href="{{site.dartpad}}"
 target="_blank">DartPad site (dartpad.dev).</a>
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   If you're in China, try [dartpad.cn.](https://dartpad.cn)
-  
+
   If you have issues using DartPad, see the [DartPad troubleshooting
   tips](/tools/dartpad/troubleshoot).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 Here's what DartPad looks like:
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -48,10 +48,10 @@ are a few additional requirements for uploading a package:
 
 [Google Account]: https://support.google.com/accounts/answer/27441
 
-{{ site.alert.note }}
+{{site.alert.note}}
 Unless you publish using a [verified publisher](#verified-publisher),
 **pub.dev displays the email address associated with your Google Account.**
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### Important files
 
@@ -78,7 +78,7 @@ Using a verified publisher has the following advantages:
 
 * The consumers of your package know that the publisher domain has been verified.
 * You can avoid having pub.dev display your personal email address.
-  Instead, pub.dev displays displays the publisher domain and contact address. 
+  Instead, pub.dev displays displays the publisher domain and contact address.
 * A verified publisher badge {% asset verified-publisher.svg
   alt="pub.dev verified publisher logo" %} is displayed next to your package name
   on both search pages and individual package pages.
@@ -102,7 +102,7 @@ To create a verified publisher, follow these steps:
 1. If prompted, complete the verification flow, which opens the [Google
    Search Console.](https://search.google.com/search-console/about)
    * When adding DNS records, it may take a few hours before the Search Console
-   reflects the changes. 
+   reflects the changes.
    * When the verification flow is complete, return to step 4.
 
 
@@ -152,14 +152,14 @@ When you're ready to publish your package, remove the `--dry-run` argument:
 $ pub publish
 {% endprettify %}
 
-{{ site.alert.note }}
+{{site.alert.note}}
   The `pub` command currently doesn't support publishing a new package directly to a
   verified publisher. As a temporary workaround, publish new packages to a Google Account,
   and then [transfer the package to a publisher](#transferring-a-package-to-a-verified-publisher).
 
   Once a package has been transferred to a publisher,
   you can update the package using `pub publish`.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 After your package has been successfully uploaded to pub.dev, any pub user can
 download it or depend on it in their projects. For example, if you just
@@ -175,12 +175,12 @@ dependencies:
 
 To transfer a package to a verified publisher,
 you must be an [uploader](#uploader) for the package
-and an admin for the verified publisher. 
+and an admin for the verified publisher.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   This process isn't reversible. Once you transfer a package to a publisher,
   you can't transfer it back to an individual account.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 Here's how to transfer a package to a verified publisher:
 
@@ -189,7 +189,7 @@ Here's how to transfer a package to a verified publisher:
 1. Go to the package details page (for example,
    `{{site.pub-pkg}}/http`).
 1. Select the **Admin** tab.
-1. Enter the name of the publisher, and click **Transfer to Publisher**. 
+1. Enter the name of the publisher, and click **Transfer to Publisher**.
 
 
 ## What files are published?
@@ -221,11 +221,11 @@ the first and only person authorized to upload additional versions of the packag
 To allow or disallow other people to upload versions,
 use the [`pub uploader`][] command.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   For packages published using a verified publisher,
   the package details page displays the verified publisher domain,
   rather than the author field.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ## Publishing prereleases
 
@@ -255,7 +255,7 @@ instead of `^2.0.0` or `^2.1.0` they might specify `^2.1.0-dev.1`.
 When a prerelease is published to pub.dev,
 the package page displays links to both the prerelease and the stable release.
 The prerelease doesn't affect the analysis score, show up in search results,
-or replace the package README and documentation. 
+or replace the package README and documentation.
 
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html
 


### PR DESCRIPTION
Broad search-and-replace. No changes to the generated site.