### PR TITLE
pub/troubleshooting: fix link

### DIFF
--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -35,7 +35,7 @@ UnauthorizedAccess: Unauthorized user: <username> is not allowed to upload versi
 
 You will see this message if you are not on the list of people
 authorized to publish new versions of a package.
-See [Authors versus uploaders](publishing#authors-versus-uploaders).
+See [Uploaders](publishing#uploaders).
 
 ## Pub build fails with HttpException error {#pub-get-fails}
 


### PR DESCRIPTION
[This Travis job](https://travis-ci.org/dart-lang/site-www/jobs/599326331) reports an invalid anchor name in the pub/troubleshoot page:

```console
$ pub run linkcheck --skip-file ./tool/config/linkcheck-skip-list.txt :4000 (logging to /home/travis/tmp/linkcheck-log.txt)
Crawling...
http://localhost:4000/tools/pub/troubleshoot
- (635:4) 'Authors ..' => http://localhost:4000/tools/pub/publishing#authors-versus-uploaders (HTTP 200 but missing anchor)
```

This PR adjusts the link text and fixes the link.