### PR TITLE
change address of example links

### DIFF
--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -6,7 +6,7 @@ prevpage:
   title: "Write command-line apps"
 ---
 {% capture gh-path -%}
-  https://github.com/dart-lang/dart-tutorials-samples/blob/master/httpserver
+  https://github.com/dart-lang/site-www/blob/master/examples/httpserver
 {%- endcapture -%}
 
 <div class="mini-toc" markdown="1">


### PR DESCRIPTION
all samples in " Write HTTP clients & servers " section of tutorials are linked to examples from dart-lang project but provided codes are from examples of site-www.

related to this issue #1978 