### PR TITLE
Recover CSS prettify-filename style

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1531,5 +1531,15 @@ body.obsolete {
   }
 }
 
+// FIXME: move into _code.scss once #2008 is merged
+.prettify-filename {
+  position: relative;
+  text-align: right;
+  margin-right: $font-size-base;
+  margin-top: -$font-size-base * 2.5;
+  margin-bottom: $font-size-base;
+  opacity: 0.5;
+}
+
 @import '_overwrites';
 @import '_dash';


### PR DESCRIPTION
The style was indeed lost during the migration, #1572. It used to be in `src/_assets/css/_code.scss`, see https://github.com/dart-lang/site-www/pull/1572/files?file-filters%5B%5D=.scss#diff-62d01b154a949752cf4f6d782e1c569f.

I've temporarily added it back to `main.scss`. (It should be moved to `_code.scss` after #2008 is merged.)

Staged, e.g., see https://dart-dev-staging-0.firebaseapp.com/tutorials/server/httpserver

Screenshot:
> ![image](https://user-images.githubusercontent.com/4140793/67317690-69ffdd00-f4d8-11e9-9112-18f5b1a43aea.png)
