### PR TITLE
Reclaim 'good' and 'bad' style names

### DIFF
--- a/src/_articles/libraries/creating-streams.md
+++ b/src/_articles/libraries/creating-streams.md
@@ -235,7 +235,7 @@ This code creates a stream to return,
 and then feeds data into it based on timer events,
 which are neither futures nor stream events.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (flawed stream)"?>
 {% prettify dart %}
 // NOTE: This implementation is FLAWED!

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1003,9 +1003,8 @@ li.card {
   }
 }
 
-// TODO: reclaim and use the class names good and bad (rather than good-style and bad-style):
-@include dart-style-for(good-style, $alert-success-bg, $alert-success-fg, 'good');
-@include dart-style-for(bad-style, $alert-danger-bg, $alert-danger-fg, 'bad');
+@include dart-style-for(good, $alert-success-bg, $alert-success-fg, 'good');
+@include dart-style-for(bad, $alert-danger-bg, $alert-danger-fg, 'bad');
 
 @include dart-style-for(passes-sa, $alert-success-bg, $alert-success-fg, '\2714  static analysis: success');
 @include dart-style-for(fails-sa, $alert-danger-bg, $alert-danger-fg, '\2717  static analysis: error/warning');

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -21,7 +21,7 @@ Use the same name for the same thing, throughout your code. If a precedent
 already exists outside your API that users are likely to know, follow that
 precedent.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 pageCount         // A field.
 updatePageCount() // Consistent with pageCount.
@@ -30,7 +30,7 @@ asSomething()     // Consistent with List's asMap().
 Point             // A familiar concept.
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 renumberPages()      // Confusingly different from pageCount.
 convertToSomething() // Inconsistent with toX() precedent.
@@ -52,7 +52,7 @@ abbreviate. If you do abbreviate, [capitalize it correctly][caps].
 
 [caps]: /guides/language/effective-dart/style#identifiers
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 pageCount
 buildRectangles
@@ -60,7 +60,7 @@ IOStream
 HttpRequest
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 numPages    // "num" is an abbreviation of number(of)
 buildRects
@@ -74,7 +74,7 @@ HypertextTransferProtocolRequest
 The last word should be the most descriptive of what the thing is. You can
 prefix it with other words, such as adjectives, to further describe the thing.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 pageCount             // A count (of pages).
 ConversionSink        // A sink for doing conversions.
@@ -82,7 +82,7 @@ ChunkedConversionSink // A ConversionSink that's chunked.
 CssFontFaceRule       // A rule for font faces in CSS.
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 numPages                  // Not a collection of pages.
 CanvasRenderingContext2D  // Not a "2D".
@@ -95,7 +95,7 @@ RuleFontFaceCss           // Not a CSS.
 When in doubt about naming, write some code that uses your API, and try to read
 it like a sentence.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (code-like-prose)"?>
 {% prettify dart %}
 // "If errors is empty..."
@@ -108,7 +108,7 @@ subscription.cancel();
 monsters.where((monster) => monster.hasClaws);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose)" replace="/ as bool//g"?>
 {% prettify dart %}
 // Telling errors to empty itself, or asking if it is?
@@ -125,7 +125,7 @@ It's helpful to try out your API and see how it "reads" when used in code, but
 you can go too far. It's not helpful to add articles and other parts of speech
 to force your names to *literally* read like a grammatically correct sentence.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose-overdone)"?>
 {% prettify dart %}
 if (theCollectionOfErrors.isEmpty) ...
@@ -140,14 +140,14 @@ The reader's focus is on *what* the property is. If the user cares more about
 *how* a property is determined, then it should probably be a method with a
 verb phrase name.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 list.length
 context.lineWidth
 quest.rampagingSwampBeast
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 list.deleteItems
 {% endprettify %}
@@ -186,7 +186,7 @@ object to do something, because accessing a property doesn't change the object.
 (If the property *does* modify the object in a meaningful way, it should be a
 method.)
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 isEmpty
 hasElements
@@ -196,7 +196,7 @@ canShowPopup
 hasShownPopup
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 empty         // Adjective or verb?
 withElements  // Sounds like it might hold elements.
@@ -219,7 +219,7 @@ This refines the previous rule. For named parameters that are boolean, the name
 is often just as clear without the verb, and the code reads better at the call
 site.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
 {% prettify dart %}
 Isolate.spawn(entryPoint, message, paused: false);
@@ -243,7 +243,7 @@ including negation operators. If your property itself reads like a negation,
 it's harder for the reader to mentally perform the double negation and
 understand what the code means.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (positive)"?>
 {% prettify dart %}
 if (socket.isConnected && database.hasData) {
@@ -251,7 +251,7 @@ if (socket.isConnected && database.hasData) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (positive)"?>
 {% prettify dart %}
 if (!socket.isDisconnected && !database.isEmpty) {
@@ -280,7 +280,7 @@ produce some output, or talk to the outside world.
 Those kinds of members should be named using an imperative verb phrase that
 clarifies the work the member performs.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-side-effect)"?>
 {% prettify dart %}
 list.add("element");
@@ -303,7 +303,7 @@ This means the member is *syntactically* a method, but *conceptually* it is a
 property, and should be named as such using a phrase that describes *what* the
 member returns.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (noun-for-func-returning-value)"?>
 {% prettify dart %}
 var element = list.elementAt(3);
@@ -326,7 +326,7 @@ file I/O. In cases like this, where you want the caller to think about the work
 the member is doing, give the member a verb phrase name that describes that
 work.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-work)"?>
 {% prettify dart %}
 var table = database.downloadData();
@@ -373,7 +373,7 @@ named starting with `to` followed by the kind of result.
 
 If you define a conversion method, it's helpful to follow that convention.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (to___)"?>
 {% prettify dart %}
 list.toSet();
@@ -393,7 +393,7 @@ original. Later changes to the original object are reflected in the view.
 
 The core library convention for you to follow is `as___()`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (as___)"?>
 {% prettify dart %}
 var map = table.asMap();
@@ -407,14 +407,14 @@ var future = subscription.asFuture();
 The user will see the argument at the callsite, so it usually doesn't help
 readability to also refer to it in the name itself.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-desc-param-in-func)"?>
 {% prettify dart %}
 list.add(element);
 map.remove(key);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 list.addElement(element)
 map.removeKey(key)
@@ -423,7 +423,7 @@ map.removeKey(key)
 However, it can be useful to mention a parameter to disambiguate it from other
 similarly-named methods that take different types:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (desc-param-in-func-ok)"?>
 {% prettify dart %}
 map.containsKey(key);
@@ -439,7 +439,7 @@ The conventions are:
 
 *   `E` for the **element** type in a collection:
 
-    {:.good-style}
+    {:.good}
     <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
     {% prettify dart %}
     class IterableBase<E> {}
@@ -451,7 +451,7 @@ The conventions are:
 *   `K` and `V` for the **key** and **value** types in an associative
     collection:
 
-    {:.good-style}
+    {:.good}
     <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
     {% prettify dart %}
     class Map<K, V> {}
@@ -463,7 +463,7 @@ The conventions are:
     methods. This isn't common, but appears in typedefs sometimes and in classes
     that implement the visitor pattern:
 
-    {:.good-style}
+    {:.good}
     <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-r)"?>
     {% prettify dart %}
     abstract class ExpressionVisitor<R> {
@@ -478,7 +478,7 @@ The conventions are:
     are multiple letters here to allow nesting without shadowing a surrounding
     name. For example:
 
-    {:.good-style}
+    {:.good}
     <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-t)"?>
     {% prettify dart %}
     class Future<T> {
@@ -492,7 +492,7 @@ The conventions are:
 If none of the above cases are a good fit, then either another single-letter
 mnemonic name or a descriptive name is fine:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-graph)"?>
 {% prettify dart %}
 class Graph<N, E> {
@@ -563,13 +563,13 @@ function. If you're defining a class and it only has a single abstract member
 with a meaningless name like `call` or `invoke`, there is a good chance you
 just want a function.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (one-member-abstract-class)"?>
 {% prettify dart %}
 typedef Predicate<E> = bool Function(E element);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (one-member-abstract-class)"?>
 {% prettify dart %}
 abstract class Predicate<E> {
@@ -597,7 +597,7 @@ If a function or variable isn't logically tied to a class, put it at the top
 level. If you're worried about name collisions, give it a more precise name or
 move it to a separate library that can be imported with a prefix.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (class-only-static)"?>
 {% prettify dart %}
 DateTime mostRecent(List<DateTime> dates) {
@@ -607,7 +607,7 @@ DateTime mostRecent(List<DateTime> dates) {
 const _favoriteMammal = 'weasel';
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static)"?>
 {% prettify dart %}
 class DateUtils {
@@ -627,7 +627,7 @@ instantiated is a code smell.
 However, this isn't a hard rule. With constants and enum-like types, it may be
 natural to group them in a class.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static-exception)"?>
 {% prettify dart %}
 class Color {
@@ -705,7 +705,7 @@ created using that can *only* be used as mixins, and the language also ensures
 that your mixin stays within the restrictions. When defining a new type that you
 intend to be used as a mixin, use this syntax.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (mixin)"?>
 {% prettify dart %}
 mixin ClickableMixin implements Control {
@@ -814,7 +814,7 @@ as the caller knows. That implies:
     of work, you may want to draw their attention to that by making it a method
     whose name is a verb describing what it does.
 
-    {:.bad-style}
+    {:.bad}
     {% prettify dart %}
     connection.nextIncomingMessage; // Does network I/O.
     expression.normalForm; // Could be exponential to calculate.
@@ -830,7 +830,7 @@ as the caller knows. That implies:
     store their result, write to a cache, log stuff, etc. As long as the caller
     doesn't *care* about the side effect, it's probably fine.
 
-    {:.bad-style}
+    {:.bad}
     {% prettify dart %}
     stdout.newline; // Produces output.
     list.clear; // Modifies object.
@@ -852,7 +852,7 @@ as the caller knows. That implies:
     In other words, the result value should be the same *in the aspects that the
     caller cares about.*
 
-    {:.bad-style}
+    {:.bad}
     {% prettify dart %}
     DateTime.now; // New result each time.
     {% endprettify %}
@@ -870,7 +870,7 @@ like few members would survive that gauntlet, but surprisingly many do. Many
 operations just do some computation on some state and most of those can and
 should be getters.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 rectangle.area;
 collection.isEmpty;
@@ -899,7 +899,7 @@ For a setter, "field-like" means:
     That's fine. But from the caller's perspective, it appears that the second
     call does nothing.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 rectangle.width = 3;
 button.visible = false;
@@ -950,7 +950,7 @@ clearly, including the conditions under which `null` will be returned.
 
 Method cascades are a better solution for chaining method calls.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (cascades)"?>
 {% prettify dart %}
 var buffer = StringBuffer()
@@ -959,7 +959,7 @@ var buffer = StringBuffer()
   ..write('three');
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (cascades)"?>
 {% prettify dart %}
 var buffer = StringBuffer()
@@ -1078,7 +1078,7 @@ Type annotations are important documentation for how a library should be used.
 They form boundaries between regions of a program to isolate the source of a
 type error. Consider:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (type_annotate_public_apis)"?>
 {% prettify dart %}
 install(id, destination) => ...
@@ -1087,7 +1087,7 @@ install(id, destination) => ...
 Here, it's unclear what `id` is. A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous? This is clearer:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (type_annotate_public_apis)"?>
 {% prettify dart %}
 Future<bool> install(PackageId id, String destination) => ...
@@ -1095,7 +1095,7 @@ Future<bool> install(PackageId id, String destination) => ...
 
 In some cases, though, the type is so obvious that writing it is pointless:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred)"?>
 {% prettify dart %}
 const screenWidth = 640; // Inferred as int.
@@ -1141,7 +1141,7 @@ Local variables, especially in modern code where functions tend to be small,
 have very little scope. Omitting the type focuses the reader's attention on the
 more important *name* of the variable and its initialized value.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-types-on-locals)"?>
 {% prettify dart %}
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
@@ -1156,7 +1156,7 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (omit-types-on-locals)"?>
 {% prettify dart %}
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
@@ -1175,7 +1175,7 @@ If the local variable doesn't have an initializer, then its type can't be
 inferred. In that case, it *is* a good idea to annotate. Otherwise, you get
 `dynamic` and lose the benefits of static type checking.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (uninitialized-local)"?>
 {% prettify dart %}
 List<AstNode> parameters;
@@ -1199,13 +1199,13 @@ For example, when you pass a function expression to `Iterable.map()`, your
 function's parameter type is inferred based on the type of callback that `map()`
 expects:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (func-expr-no-param-type)"?>
 {% prettify dart %}
 var names = people.map((person) => person.name);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (func-expr-no-param-type)"?>
 {% prettify dart %}
 var names = people.map((Person person) => person.name);
@@ -1222,13 +1222,13 @@ A type argument is redundant if inference would fill in the same type. If the
 invocation is the initializer for a type-annotated variable, or is an argument
 to a function, then inference usually fills in the type for you:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (redundant)"?>
 {% prettify dart %}
 Set<String> things = Set();
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (redundant)"?>
 {% prettify dart %}
 Set<String> things = Set<String>();
@@ -1240,13 +1240,13 @@ constructor call in the initializer.
 In other contexts, there isn't enough information to infer the type and then you
 should write the type argument:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (explicit)"?>
 {% prettify dart %}
 var things = Set<String>();
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (explicit)"?>
 {% prettify dart %}
 var things = Set();
@@ -1263,7 +1263,7 @@ Sometimes, Dart infers a type, but not the type you want. For example, you may
 want a variable's type to be a supertype of the initializer's type so that you
 can later assign some other sibling type to the variable:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred-wrong)"?>
 {% prettify dart %}
 num highScore(List<num> scores) {
@@ -1275,7 +1275,7 @@ num highScore(List<num> scores) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (inferred-wrong)" replace="/ +\/\/ ignore: .*?\n//g"?>
 {% prettify dart %}
 num highScore(List<num> scores) {
@@ -1307,13 +1307,13 @@ annotation.
 When `dynamic` is the type you want, writing it explicitly makes your intent
 clear.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (prefer-dynamic)"?>
 {% prettify dart %}
 dynamic mergeJson(dynamic original, dynamic changes) => ...
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (prefer-dynamic)"?>
 {% prettify dart %}
 mergeJson(original, changes) => ...
@@ -1342,13 +1342,13 @@ function.
 
 [Function]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart %}
 bool isValid(String value, [!bool Function(String)!] test) => ...
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
 {% prettify dart %}
 bool isValid(String value, [!Function!] test) => ...
@@ -1362,7 +1362,7 @@ parameter or a function that takes two. Since we don't have union types, there's
 no way to precisely type that and you'd normally have to use `dynamic`.
 `Function` is at least a little more helpful than that:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (function-arity)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart %}
 void handleError([!void Function()!] operation, [!Function!] errorHandler) {
@@ -1387,13 +1387,13 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
 
 Setters always return `void` in Dart. Writing the word is pointless.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid_return_types_on_setters)"?>
 {% prettify dart %}
 void set foo(Foo value) { ... }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid_return_types_on_setters)"?>
 {% prettify dart %}
 set foo(Foo value) { ... }
@@ -1407,7 +1407,7 @@ set foo(Foo value) { ... }
 Dart has two notations for defining a named typedef for a function type. The
 original syntax looks like:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (old-typedef)"?>
 {% prettify dart %}
 typedef int Comparison<T>(T a, T b);
@@ -1424,7 +1424,7 @@ That syntax has a couple of problems:
 *   A single identifier in a parameter is interpreted as the parameter's *name*,
     not its *type*. Given:
 
-    {:.bad-style}
+    {:.bad}
     <?code-excerpt "misc/lib/effective_dart/design_bad.dart (typedef-param)"?>
     {% prettify dart %}
     typedef bool TestNumber(num);
@@ -1438,7 +1438,7 @@ That syntax has a couple of problems:
 
 The new syntax looks like this:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef)"?>
 {% prettify dart %}
 typedef Comparison<T> = int Function(T, T);
@@ -1446,7 +1446,7 @@ typedef Comparison<T> = int Function(T, T);
 
 If you want to include a parameter's name, you can do that too:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef-param-name)"?>
 {% prettify dart %}
 typedef Comparison<T> = int Function(T a, T b);
@@ -1470,7 +1470,7 @@ In Dart 1, if you wanted to use a function type for a field, variable, or
 generic type argument, you had to first define a typedef for it. Dart 2 supports
 a function type syntax that can be used anywhere a type annotation is allowed:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
 {% prettify dart %}
 class FilteredObservable {
@@ -1517,7 +1517,7 @@ parameter a function type without defining a typedef. Now that Dart has a
 general notation for function types, you can use it for function-typed
 parameters as well:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type-param)"?>
 {% prettify dart %}
 Iterable<T> where(bool Function(T) predicate) => ...
@@ -1541,7 +1541,7 @@ that the values are coming from interop or otherwise outside of the purview of
 the static type system, or that you explicitly want runtime dynamism at that
 point in the program.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (Object-vs-dynamic)"?>
 {% prettify dart %}
 void log(Object object) {
@@ -1591,13 +1591,13 @@ the value, effectively always treating it as a `Future`.) Just return a
 is either always asynchronous or always synchronous, but a function that can be
 either is hard to use correctly.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or)"?>
 {% prettify dart %}
 Future<int> triple(FutureOr<int> value) async => (await value) * 3;
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (future-or)"?>
 {% prettify dart %}
 FutureOr<int> triple(FutureOr<int> value) {
@@ -1615,7 +1615,7 @@ means it's OK for a *callback's* type to return `FutureOr<T>`:
 
 [contravariant]: https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or-contra)" replace="/FutureOr.S./[!$&!]/g"?>
 {% prettify dart %}
 Stream<S> asyncMap<T, S>(
@@ -1641,7 +1641,7 @@ numbers are usually wrapped in named constants, but we usually just pass around
 `true` and `false` directly. That can make callsites unreadable if it isn't
 clear what the boolean represents:
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 new Task(true);
 new Task(false);
@@ -1652,7 +1652,7 @@ new Button(false);
 Instead, consider using named arguments, named constructors, or named constants
 to clarify what the call is doing.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-positional-bool-param)"?>
 {% prettify dart %}
 Task.oneShot();
@@ -1664,7 +1664,7 @@ Button(ButtonState.enabled);
 Note that this doesn't apply to setters, where the name makes it clear what the
 value represents:
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 listBox.canScroll = true;
 button.isEnabled = false;
@@ -1678,7 +1678,7 @@ earlier parameters are passed more often than later ones. Users should almost
 never need to explicitly pass a "hole" to omit an earlier positional argument to
 pass later one. You're better off using named arguments for that.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-optional-positional)"?>
 {% prettify dart %}
 String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
@@ -1712,13 +1712,13 @@ Omitting the parameter is more terse and helps prevent bugs where a sentinel
 value like `null` is accidentally passed when the user thought they were
 providing a real value.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-mandatory-param)"?>
 {% prettify dart %}
 var rest = string.substring(start);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-mandatory-param)"?>
 {% prettify dart %}
 var rest = string.substring(start, null);
@@ -1734,7 +1734,7 @@ than the index of the last item.
 
 This is consistent with core libraries that do the same thing.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/test/effective_dart_test.dart (param-range)" replace="/expect\(//g; /, \/\*\*\// \/\//g; /\);//g"?>
 {% prettify dart %}
 [0, 1, 2, 3].sublist(1, 3) // [1, 2]
@@ -1798,7 +1798,7 @@ true.
 The language specifies that this check is done automatically and your `==`
 method is called only if the right-hand side is not `null`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/design_good.dart (eq-dont-check-for-null)" replace="/operator ==/[!$&!]/g" plaster?>
 {% prettify dart %}
 class Person {
@@ -1810,7 +1810,7 @@ class Person {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/design_bad.dart (eq-dont-check-for-null)" replace="/\w+ != null/[!$&!]/g" plaster?>
 {% prettify dart %}
 class Person {

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -27,7 +27,7 @@ generated documentation.
 
 ### DO format comments like sentences.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (comments-like-sentences)"?>
 {% prettify dart %}
 // Not if there is nothing before it.
@@ -40,7 +40,7 @@ inline stuff, even TODOs. Even if it's a sentence fragment.
 
 ### DON'T use block comments for documentation.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (block-comments)"?>
 {% prettify dart %}
 greet(name) {
@@ -49,7 +49,7 @@ greet(name) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (block-comments)"?>
 {% prettify dart %}
 greet(name) {
@@ -77,14 +77,14 @@ before a declaration and uses the special `///` syntax that dartdoc looks for.
 Using a doc comment instead of a regular comment enables [dartdoc][] to find it
 and generate documentation for it.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)"?>
 {% prettify dart %}
 /// The number of characters in this chunk when unsplit.
 int get length => ...
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)" replace="/^\///g"?>
 {% prettify dart %}
 // The number of characters in this chunk when unsplit.
@@ -138,7 +138,7 @@ period. A sentence fragment is often sufficient. Provide just enough context for
 the reader to orient themselves and decide if they should keep reading or look
 elsewhere for the solution to their problem.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence)"?>
 {% prettify dart %}
 /// Deletes the file at [path] from the file system.
@@ -147,7 +147,7 @@ void delete(String path) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence)"?>
 {% prettify dart %}
 /// Depending on the state of the file system and the user's permissions,
@@ -169,7 +169,7 @@ This helps you write a tight first sentence that summarizes the documentation.
 Also, tools like Dartdoc use the first paragraph as a short summary in places
 like lists of classes and members.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence-a-paragraph)"?>
 {% prettify dart %}
 /// Deletes the file at [path].
@@ -181,7 +181,7 @@ void delete(String path) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence-a-paragraph)"?>
 {% prettify dart %}
 /// Deletes the file at [path]. Throws an [IOError] if the file could not
@@ -200,7 +200,7 @@ right there, and the enclosing class is obvious. None of that needs to be
 spelled out in the doc comment. Instead, focus on explaining what the reader
 *doesn't* already know.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (redundant)"?>
 {% prettify dart %}
 class RadioButtonWidget extends Widget {
@@ -212,7 +212,7 @@ class RadioButtonWidget extends Widget {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (redundant)"?>
 {% prettify dart %}
 class RadioButtonWidget extends Widget {
@@ -229,7 +229,7 @@ class RadioButtonWidget extends Widget {
 
 The doc comment should focus on what the code *does*.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (third-person)"?>
 {% prettify dart %}
 /// Returns `true` if every element satisfies the [predicate].
@@ -247,7 +247,7 @@ The doc comment should stress what the property *is*. This is true even for
 getters which may do calculation or other work. What the caller cares about is
 the *result* of that work, not the work itself.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-var-etc)"?>
 {% prettify dart %}
 /// The current day of the week, where `0` is Sunday.
@@ -267,7 +267,7 @@ program. They describe the type's invariants, establish the terminology it uses,
 and provide context to the other doc comments for the class's members. A little
 extra effort here can make all of the other members simpler to document.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-type-or-lib)"?>
 {% prettify dart %}
 /// A chunk of non-breaking output text terminated by a hard or soft newline.
@@ -278,7 +278,7 @@ class Chunk { ... }
 
 ### CONSIDER including code samples in doc comments.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (code-sample)"?>
 {% prettify dart %}
 /// Returns the lesser of two numbers.
@@ -301,7 +301,7 @@ then dartdoc looks up the name and links to the relevant API docs. Parentheses
 are optional, but can make it clearer when you're referring to a method or
 constructor.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (identifiers)"?>
 {% prettify dart %}
 /// Throws a [StateError] if ...
@@ -311,7 +311,7 @@ constructor.
 To link to a member of a specific class, use the class name and member name,
 separated by a dot:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (member)"?>
 {% prettify dart %}
 /// Similar to [Duration.inDays], but handles fractional days.
@@ -320,7 +320,7 @@ separated by a dot:
 The dot syntax can also be used to refer to named constructors. For the unnamed
 constructor, put parentheses after the class name:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (ctor)"?>
 {% prettify dart %}
 /// To create a point, call [Point()] or use [Point.polar()] to ...
@@ -331,7 +331,7 @@ constructor, put parentheses after the class name:
 Other languages use verbose tags and sections to describe what the parameters
 and returns of a method are.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (no-annotations)"?>
 {% prettify dart %}
 /// Defines a flag with the given name and abbreviation.
@@ -347,7 +347,7 @@ Flag addFlag(String name, String abbr) => ...
 The convention in Dart is to integrate that into the description of the method
 and highlight parameters using square brackets.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (no-annotations)"?>
 {% prettify dart %}
 /// Defines a flag.
@@ -359,7 +359,7 @@ Flag addFlag(String name, String abbr) => ...
 
 ### DO put doc comments before metadata annotations.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (doc-before-meta)"?>
 {% prettify dart %}
 /// A button that can be flipped on and off.
@@ -367,7 +367,7 @@ Flag addFlag(String name, String abbr) => ...
 class ToggleComponent {}
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/docs_bad.dart (doc-before-meta)" replace="/\n\n/\n/g"?>
 {% prettify dart %}
 @Component(selector: 'toggle')
@@ -464,7 +464,7 @@ indented code.
 The backtick syntax avoids those indentation woes, lets you indicate the code's
 language, and is consistent with using backticks for inline code.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 /// You can use [CodeBlockExample] like this:
 ///
@@ -474,7 +474,7 @@ language, and is consistent with using backticks for inline code.
 /// ```
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 /// You can use [CodeBlockExample] like this:
 ///
@@ -508,7 +508,7 @@ think.
 When documenting a member for a class, you often need to refer back to the
 object the member is being called on. Using "the" can be ambiguous.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/docs_good.dart (this)"?>
 {% prettify dart %}
 class Box {

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -38,7 +38,7 @@ Identifiers come in three flavors in Dart.
 Classes, enums, typedefs, and type parameters should capitalize the first letter
 of each word (including the first word), and use no separators.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (type-names)"?>
 {% prettify dart %}
 class SliderMenu { ... }
@@ -50,7 +50,7 @@ typedef Predicate<T> = bool Function(T value);
 
 This even includes classes intended to be used in metadata annotations.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-type-names)"?>
 {% prettify dart %}
 class Foo {
@@ -67,7 +67,7 @@ class B { ... }
 If the annotation class's constructor takes no parameters, you might want to
 create a separate `lowerCamelCase` constant for it.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-const)"?>
 {% prettify dart %}
 const foo = Foo();
@@ -92,7 +92,7 @@ in that form. Using underscores as the separator ensures that the name is still
 a valid Dart identifier, which may be helpful if the language later supports
 symbolic imports.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g"?>
 {% prettify dart %}
 library peg_parser.source_scanner;
@@ -101,7 +101,7 @@ import 'file_system.dart';
 import 'slider_menu.dart';
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g;/file./file-/g;/slider_menu/SliderMenu/g;/source_scanner/SourceScanner/g;/peg_parser/pegparser/g"?>
 {% prettify dart %}
 library pegparser.SourceScanner;
@@ -120,7 +120,7 @@ import 'SliderMenu.dart';
 
 {% include linter-rule.html rule="library_prefixes" %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
 {% prettify dart %}
 import 'dart:math' as math;
@@ -129,7 +129,7 @@ import 'package:angular_components/angular_components'
 import 'package:js/js.dart' as js;
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g;/as angular_components/as angularComponents/g;/ math/ Math/g;/as js/as JS/g"?>
 {% prettify dart %}
 import 'dart:math' as Math;
@@ -147,7 +147,7 @@ Class members, top-level definitions, variables, parameters, and named
 parameters should capitalize the first letter of each word *except* the first
 word, and use no separators.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (misc-names)"?>
 {% prettify dart %}
 var item;
@@ -166,7 +166,7 @@ void align(bool clearItems) {
 
 In new code, use `lowerCamelCase` for constant variables, including enum values.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (const-names)"?>
 {% prettify dart %}
 const pi = 3.14;
@@ -178,7 +178,7 @@ class Dice {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_bad.dart (const-names)"?>
 {% prettify dart %}
 const PI = 3.14;
@@ -223,7 +223,7 @@ To avoid this, acronyms and abbreviations are capitalized like regular words,
 except for two-letter acronyms. (Two-letter *abbreviations* like
 ID and Mr. are still capitalized like words.)
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (acronyms and abbreviations)" replace="/,//g"?>
 {% prettify dart %}
 HttpConnectionInfo
@@ -234,7 +234,7 @@ Id
 DB
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 HTTPConnection
 UiHandler
@@ -270,12 +270,12 @@ help you understand your code. Because Dart can tell you the type, scope,
 mutability, and other properties of your declarations, there's no reason to
 encode those properties in identifier names.
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 defaultTimeout
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 kDefaultTimeout
 {% endprettify %}
@@ -294,7 +294,7 @@ A single linter rule handles all the ordering guidelines:
 
 {% include linter-rule.html rule="directives_ordering" %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart %}
 import 'dart:async';
@@ -309,7 +309,7 @@ import 'package:foo/foo.dart';
 
 {% include linter-rule.html rule="directives_ordering" %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
 {% prettify dart %}
 import 'package:bar/bar.dart';
@@ -326,7 +326,7 @@ import 'util.dart';
 If you have a number of "package:" imports for your own package along with other
 external packages, place yours in a separate section after the external ones.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (third-party)" replace="/\w+\/effective_dart\///g;/(package):foo(.dart)/$1:my_package\/util$2/g"?>
 {% prettify dart %}
 import 'package:bar/bar.dart';
@@ -340,7 +340,7 @@ import 'package:my_package/util.dart';
 
 {% include linter-rule.html rule="directives_ordering" %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (export)"?>
 {% prettify dart %}
 import 'src/error.dart';
@@ -349,7 +349,7 @@ import 'src/foo_bar.dart';
 export 'src/error.dart';
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (export)"?>
 {% prettify dart %}
 import 'src/error.dart';
@@ -362,7 +362,7 @@ import 'src/foo_bar.dart';
 
 {% include linter-rule.html rule="directives_ordering" %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart %}
 import 'package:bar/bar.dart';
@@ -372,7 +372,7 @@ import 'foo.dart';
 import 'foo/foo.dart';
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart %}
 import 'package:foo/foo.dart';
@@ -453,7 +453,7 @@ Doing so avoids the [dangling else][] problem.
 
 [dangling else]: http://en.wikipedia.org/wiki/Dangling_else
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (curly-braces)"?>
 {% prettify dart %}
 if (isWeekDay) {
@@ -466,7 +466,7 @@ if (isWeekDay) {
 **Exception:** When you have an `if` statement with no `else` clause and the
 whole `if` statement fits on one line, you can omit the braces if you prefer:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if)"?>
 {% prettify dart %}
 if (arg == null) return defaultValue;
@@ -474,7 +474,7 @@ if (arg == null) return defaultValue;
 
 If the body wraps to the next line, though, use braces:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if-wrap)"?>
 {% prettify dart %}
 if (overflowChars != other.overflowChars) {
@@ -482,7 +482,7 @@ if (overflowChars != other.overflowChars) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/style_bad.dart (one-line-if-wrap)"?>
 {% prettify dart %}
 if (overflowChars != other.overflowChars)

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -43,7 +43,7 @@ part "some/other/file.dart";
 
 Then the part file should look like:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/some/other/file.dart"?>
 {% prettify dart %}
 part of "../../my_library.dart";
@@ -51,7 +51,7 @@ part of "../../my_library.dart";
 
 And not:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/some/other/file_2.dart"?>
 {% prettify dart %}
 part of my_library;
@@ -90,14 +90,14 @@ my_package
 
 If `api.dart` wants to import `utils.dart`, it should do so using:
 
-{:.good-style}
+{:.good}
 {% prettify dart %}
 import 'src/utils.dart';
 {% endprettify %}
 
 And not:
 
-{:.bad-style}
+{:.bad}
 {% prettify dart %}
 import 'package:my_package/src/utils.dart';
 {% endprettify %}
@@ -127,7 +127,7 @@ This rule applies when an expression can evaluate `true`, `false`, or `null`,
 and you need to pass the result to something that doesn't accept `null`. A
 common case is the result of a null-aware method call being used as a condition:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (null-aware-condition)"?>
 {% prettify dart %}
 if (optionalThing?.isEnabled) {
@@ -139,7 +139,7 @@ This code throws an exception if `optionalThing` is `null`. To fix this, you
 need to "convert" the `null` value to either `true` or `false`. Although you
 could do this using `==`, we recommend using `??`:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (convert-null-aware)"?>
 {% prettify dart %}
 // If you want null to be false:
@@ -149,7 +149,7 @@ optionalThing?.isEnabled ?? false;
 optionalThing?.isEnabled ?? true;
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (convert-null-equals)"?>
 {% prettify dart %}
 // If you want null to be false:
@@ -186,7 +186,7 @@ form&mdash;you do not need to use `+` to concatenate them. Just like in C and
 C++, simply placing them next to each other does it. This is a good way to make
 a single long string that doesn't fit on one line.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (adjacent-strings-literals)"?>
 {% prettify dart %}
 raiseAlarm(
@@ -194,7 +194,7 @@ raiseAlarm(
     'parts are overrun by martians. Unclear which are which.');
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (adjacent-strings-literals)"?>
 {% prettify dart %}
 raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
@@ -209,13 +209,13 @@ If you're coming from other languages, you're used to using long chains of `+`
 to build a string out of literals and other values. That does work in Dart, but
 it's almost always cleaner and shorter to use interpolation:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation)"?>
 {% prettify dart %}
 'Hello, $name! You are ${year - birth} years old.';
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation)"?>
 {% prettify dart %}
 'Hello, ' + name + '! You are ' + (year - birth).toString() + ' y...';
@@ -228,7 +228,7 @@ it's almost always cleaner and shorter to use interpolation:
 If you're interpolating a simple identifier not immediately followed by more
 alphanumeric text, the `{}` should be omitted.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart %}
 'Hi, $name!'
@@ -236,7 +236,7 @@ alphanumeric text, the `{}` should be omitted.
     'Wear your wildest ${decade}s outfit.'
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart %}
 'Hi, ${name}!'
@@ -261,14 +261,14 @@ then, by all means, use a constructor. Otherwise, use the nice literal syntax.
 The core library exposes those constructors to ease adoption, but idiomatic Dart
 code does not use them.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (collection-literals)"?>
 {% prettify dart %}
 var points = [];
 var addresses = {};
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (collection-literals)"?>
 {% prettify dart %}
 var points = List();
@@ -277,14 +277,14 @@ var addresses = Map();
 
 You can even provide a type argument for them if that matters.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (generic-collection-literals)"?>
 {% prettify dart %}
 var points = <Point>[];
 var addresses = <String, Address>{};
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (generic-collection-literals)"?>
 {% prettify dart %}
 var points = List<Point>();
@@ -307,14 +307,14 @@ collection contains *anything* can be painfully slow.
 Instead, there are faster and more readable getters: `.isEmpty` and
 `.isNotEmpty`. Use the one that doesn't require you to negate the result.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-use-length)"?>
 {% prettify dart %}
 if (lunchBox.isEmpty) return 'so hungry...';
 if (words.isNotEmpty) return words.join(' ');
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-use-length)"?>
 {% prettify dart %}
 if (lunchBox.length == 0) return 'so hungry...';
@@ -330,7 +330,7 @@ other handy methods on `Iterable`.
 Using those instead of an imperative `for` loop makes it clear that your intent
 is to produce a new sequence and not to produce side effects.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-higher-order-func)"?>
 {% prettify dart %}
 var aquaticNames = animals
@@ -350,7 +350,7 @@ code.
 `for-in` loop doesn't do what you usually want. In Dart, if you want to iterate
 over a sequence, the idiomatic way to do that is using a loop.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-forEach)"?>
 {% prettify dart %}
 for (var person in people) {
@@ -358,7 +358,7 @@ for (var person in people) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-forEach)"?>
 {% prettify dart %}
 people.forEach((person) {
@@ -369,7 +369,7 @@ people.forEach((person) {
 Note that this guideline specifically says "function *literal*". If you want to
 invoke some *already existing* function on each element, `forEach()` is fine.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (forEach-over-func)"?>
 {% prettify dart %}
 people.forEach(print);
@@ -393,7 +393,7 @@ The obvious difference is that the first one is shorter. The *important*
 difference is that the first one preserves the type argument of the original
 object:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/test/effective_dart_test.dart (list-from-good)"?>
 {% prettify dart %}
 // Creates a List<int>:
@@ -403,7 +403,7 @@ var iterable = [1, 2, 3];
 print(iterable.toList().runtimeType);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/test/effective_dart_test.dart (list-from-bad)"?>
 {% prettify dart %}
 // Creates a List<int>:
@@ -415,7 +415,7 @@ print(List.from(iterable).runtimeType);
 
 If you *want* to change the type, then calling `List.from()` is useful:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/test/effective_dart_test.dart (list-from-3)"?>
 {% prettify dart %}
 var numbers = [1, 2.3, 4]; // List<num>.
@@ -434,7 +434,7 @@ you don't care about the type, then use `toList()`.
 Let's say you have a list containing a mixture of objects, and you want to get
 just the integers out of it. You could use `where()` like this:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type)"?>
 {% prettify dart %}
 var objects = [1, "a", 2, "b", 3];
@@ -447,7 +447,7 @@ you likely want an `Iterable<int>` since that's the type you're filtering it to.
 
 Sometimes you see code that "corrects" the above error by adding `cast()`:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type-2)"?>
 {% prettify dart %}
 var objects = [1, "a", 2, "b", 3];
@@ -460,7 +460,7 @@ the [`whereType()`][where-type] method for this exact use case:
 
 [where-type]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/whereType.html
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/test/effective_dart_test.dart (whereType)"?>
 {% prettify dart %}
 var objects = [1, "a", 2, "b", 3];
@@ -483,14 +483,14 @@ If you're already calling `toList()`, replace that with a call to
 
 [list-from]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List/List.from.html
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-list)"?>
 {% prettify dart %}
 var stuff = <dynamic>[1, 2];
 var ints = List<int>.from(stuff);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-list)"?>
 {% prettify dart %}
 var stuff = <dynamic>[1, 2];
@@ -502,14 +502,14 @@ produces an iterable of the desired type. Type inference often picks the correct
 type for you based on the function you pass to `map()`, but sometimes you need
 to be explicit.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 {% prettify dart %}
 var stuff = <dynamic>[1, 2];
 var reciprocals = stuff.map<double>((n) => 1 / n);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 {% prettify dart %}
 var stuff = <dynamic>[1, 2];
@@ -542,7 +542,7 @@ Prefer any of these options instead:
 
 Here is an example of **creating it with the right type:**
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-at-create)"?>
 {% prettify dart %}
 List<int> singletonList(int value) {
@@ -552,7 +552,7 @@ List<int> singletonList(int value) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-at-create)"?>
 {% prettify dart %}
 List<int> singletonList(int value) {
@@ -564,7 +564,7 @@ List<int> singletonList(int value) {
 
 Here is **casting each element on access:**
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
 {% prettify dart %}
 void printEvens(List<Object> objects) {
@@ -575,7 +575,7 @@ void printEvens(List<Object> objects) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-iterate)"?>
 {% prettify dart %}
 void printEvens(List<Object> objects) {
@@ -588,7 +588,7 @@ void printEvens(List<Object> objects) {
 
 Here is **casting eagerly using `List.from()`:**
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-from)"?>
 {% prettify dart %}
 int median(List<Object> objects) {
@@ -599,7 +599,7 @@ int median(List<Object> objects) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-from)"?>
 {% prettify dart %}
 int median(List<Object> objects) {
@@ -633,7 +633,7 @@ function expression is great for that.
 But, if you do need to give it a name, use a function declaration statement
 instead of binding a lambda to a variable.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (func-decl)"?>
 {% prettify dart %}
 void main() {
@@ -643,7 +643,7 @@ void main() {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (func-decl)"?>
 {% prettify dart %}
 void main() {
@@ -664,13 +664,13 @@ invokes it when you call it.
 If you have a function that invokes a method with the same arguments as are
 passed to it, you don't need to manually wrap the call in a lambda.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-tear-off)"?>
 {% prettify dart %}
 names.forEach(print);
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (use-tear-off)"?>
 {% prettify dart %}
 names.forEach((name) {
@@ -689,13 +689,13 @@ For legacy reasons, Dart allows both `:` and `=` as the default value separator
 for named parameters. For consistency with optional positional parameters, use
 `=`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-separator)"?>
 {% prettify dart %}
 void insert(Object item, {int at = 0}) { ... }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-separator)"?>
 {% prettify dart %}
 void insert(Object item, {int at: 0}) { ... }
@@ -709,7 +709,7 @@ void insert(Object item, {int at: 0}) { ... }
 If you make a parameter optional but don't give it a default value, the language
 implicitly uses `null` as the default, so there's no need to write it.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-value-null)"?>
 {% prettify dart %}
 void error([String message]) {
@@ -717,7 +717,7 @@ void error([String message]) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-value-null)"?>
 {% prettify dart %}
 void error([String message = null]) {
@@ -736,7 +736,7 @@ gets initialized to `null`. This is reliably specified by the language. There's
 no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and
 unneeded.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-null-init)"?>
 {% prettify dart %}
 int _nextId;
@@ -753,7 +753,7 @@ class LazyId {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-null-init)"?>
 {% prettify dart %}
 int _nextId = null;
@@ -777,7 +777,7 @@ When designing a class, you often want to expose multiple views into the same
 underlying state. Often you see code that calculates all of those views in the
 constructor and then stores them:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store1)"?>
 {% prettify dart %}
 class Circle {
@@ -805,7 +805,7 @@ the `area` and `circumference` will retain their previous, now incorrect values.
 
 To correctly handle cache invalidation, we need to do this:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store2)"?>
 {% prettify dart %}
 class Circle {
@@ -836,7 +836,7 @@ class Circle {
 That's an awful lot of code to write, maintain, debug, and read. Instead, your
 first implementation should be:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (cacl-vs-store)"?>
 {% prettify dart %}
 class Circle {
@@ -878,7 +878,7 @@ Dart doesn't have this limitation. Fields and getters/setters are completely
 indistinguishable. You can expose a field in a class and later wrap it in a
 getter and setter without having to touch any code that uses that field.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-wrap-field)"?>
 {% prettify dart %}
 class Box {
@@ -886,7 +886,7 @@ class Box {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-wrap-field)"?>
 {% prettify dart %}
 class Box {
@@ -906,7 +906,7 @@ class Box {
 If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (final)"?>
 {% prettify dart %}
 class Box {
@@ -914,7 +914,7 @@ class Box {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (final)"?>
 {% prettify dart %}
 class Box {
@@ -936,7 +936,7 @@ In addition to using `=>` for function expressions, Dart also lets you define
 members with it. That style is a good fit for simple members that just calculate
 and return a value.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-arrow)"?>
 {% prettify dart %}
 double get area => (right - left) * (bottom - top);
@@ -953,7 +953,7 @@ lines or contains deeply nested expressions&mdash;cascades and conditional
 operators are common offenders&mdash;do yourself and everyone who has to read
 your code a favor and use a block body and some statements.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-long)"?>
 {% prettify dart %}
 Treasure openChest(Chest chest, Point where) {
@@ -966,7 +966,7 @@ Treasure openChest(Chest chest, Point where) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (arrow-long)"?>
 {% prettify dart %}
 Treasure openChest(Chest chest, Point where) =>
@@ -977,7 +977,7 @@ Treasure openChest(Chest chest, Point where) =>
 You can also use `=>` on members that don't return a value. This is idiomatic
 when a setter is small and has a corresponding getter that uses `=>`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-setter)"?>
 {% prettify dart %}
 num get x => center.x;
@@ -996,7 +996,7 @@ C#&mdash;doesn't have that limitation.
 There are only two times you need to use `this.`. One is when a local variable
 with the same name shadows the member you want to access:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot)"?>
 {% prettify dart %}
 class Box {
@@ -1012,7 +1012,7 @@ class Box {
 }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot)"?>
 {% prettify dart %}
 class Box {
@@ -1030,7 +1030,7 @@ class Box {
 
 The other time to use `this.` is when redirecting to a named constructor:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot-constructor)"?>
 {% prettify dart %}
 class ShadeOfGray {
@@ -1045,7 +1045,7 @@ class ShadeOfGray {
 }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot-constructor)"?>
 {% prettify dart %}
 class ShadeOfGray {
@@ -1063,7 +1063,7 @@ class ShadeOfGray {
 Note that constructor parameters never shadow fields in constructor
 initialization lists:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (param-dont-shadow-field-ctr-init)"?>
 {% prettify dart %}
 class Box extends BaseBox {
@@ -1085,7 +1085,7 @@ If a field doesn't depend on any constructor parameters, it can and should be
 initialized at its declaration. It takes less code and makes sure you won't
 forget to initialize it if the class has multiple constructors.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-at-decl)"?>
 {% prettify dart %}
 class Folder {
@@ -1097,7 +1097,7 @@ class Folder {
 }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-at-decl)"?>
 {% prettify dart %}
 class Folder {
@@ -1123,7 +1123,7 @@ The following best practices apply to declaring constructors for a class.
 
 Many fields are initialized directly from a constructor parameter, like:
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-as-param)"?>
 {% prettify dart %}
 class Point {
@@ -1137,7 +1137,7 @@ class Point {
 
 We've got to type `x` _four_ times here to define a field. We can do better:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-as-param)"?>
 {% prettify dart %}
 class Point {
@@ -1158,7 +1158,7 @@ initializing. But when you *can* use initializing formals, you *should*.
 If a constructor parameter is using `this.` to initialize a field, then the type
 of the parameter is understood to be the same type as the field.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-type-init-formals)"?>
 {% prettify dart %}
 class Point {
@@ -1167,7 +1167,7 @@ class Point {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-type-init-formals)"?>
 {% prettify dart %}
 class Point {
@@ -1184,7 +1184,7 @@ class Point {
 In Dart, a constructor with an empty body can be terminated with just a
 semicolon. (In fact, it's required for const constructors.)
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (semicolon-for-empty-body)"?>
 {% prettify dart %}
 class Point {
@@ -1193,7 +1193,7 @@ class Point {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (semicolon-for-empty-body)"?>
 {% prettify dart %}
 class Point {
@@ -1213,7 +1213,7 @@ actually return a new object.
 The language still permits `new` in order to make migration less painful, but
 consider it deprecated and remove it from your code.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)"?>
 {% prettify dart %}
 Widget build(BuildContext context) {
@@ -1228,7 +1228,7 @@ Widget build(BuildContext context) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
 {% prettify dart %}
 Widget build(BuildContext context) {
@@ -1265,7 +1265,7 @@ may support non-const default values.)
 Basically, any place where it would be an error to write `new` instead of
 `const`, Dart 2 allows you to omit the `const`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-const)"?>
 {% prettify dart %}
 const primaryColors = [
@@ -1275,7 +1275,7 @@ const primaryColors = [
 ];
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
 {% prettify dart %}
 const primaryColors = [!const!] [
@@ -1355,7 +1355,7 @@ instead of throwing the same exception object using `throw`.
 `rethrow` preserves the original stack trace of the exception. `throw` on the
 other hand resets the stack trace to the last thrown position.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (rethrow)"?>
 {% prettify dart %}
 try {
@@ -1366,7 +1366,7 @@ try {
 }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (rethrow)" replace="/rethrow/[!$&!]/g"?>
 {% prettify dart %}
 try {
@@ -1389,7 +1389,7 @@ Asynchronous code is notoriously hard to read and debug, even when using a nice
 abstraction like futures. The `async`/`await` syntax improves readability and
 lets you use all of the Dart control flow structures within your async code.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (async-await)" replace="/async|await/[!$&!]/g"?>
 {% prettify dart %}
 Future<int> countActivePlayers(String teamName) [!async!] {
@@ -1406,7 +1406,7 @@ Future<int> countActivePlayers(String teamName) [!async!] {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (async-await)"?>
 {% prettify dart %}
 Future<int> countActivePlayers(String teamName) {
@@ -1429,7 +1429,7 @@ It's easy to get in the habit of using `async` on any function that does
 anything related to asynchrony. But in some cases, it's extraneous. If you can
 omit the `async` without changing the behavior of the function, do so.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (unnecessary-async)"?>
 {% prettify dart %}
 Future afterTwoThings(Future first, Future second) {
@@ -1437,7 +1437,7 @@ Future afterTwoThings(Future first, Future second) {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (unnecessary-async)"?>
 {% prettify dart %}
 Future afterTwoThings(Future first, Future second) async {
@@ -1455,7 +1455,7 @@ Cases where `async` *is* useful include:
 * You are returning a value and you want it implicitly wrapped in a future.
   `async` is shorter than `Future.value(...)`.
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (async)"?>
 {% prettify dart %}
 Future usesAwait(Future later) async {
@@ -1481,7 +1481,7 @@ Many people new to asynchronous programming want to write code that produces a
 future. The constructors in Future don't seem to fit their need so they
 eventually find the Completer class and use that.
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-completer)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) {
@@ -1502,7 +1502,7 @@ they're clearer and make error handling easier.
 
 [then]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future/then.html
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) {
@@ -1512,7 +1512,7 @@ Future<bool> fileContainsBear(String path) {
 }
 {% endprettify %}
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer-alt)"?>
 {% prettify dart %}
 Future<bool> fileContainsBear(String path) async {
@@ -1536,7 +1536,7 @@ itself implements `Object`, so `is Object` or `is T` where `T` is some type
 parameter that could be instantiated with `Object` returns true even when the
 object is a future. Instead, explicitly test for the `Future` case:
 
-{:.good-style}
+{:.good}
 <?code-excerpt "misc/lib/effective_dart/usage_good.dart (test-future-or)"?>
 {% prettify dart %}
 Future<T> logValue<T>(FutureOr<T> value) async {
@@ -1551,7 +1551,7 @@ Future<T> logValue<T>(FutureOr<T> value) async {
 }
 {% endprettify %}
 
-{:.bad-style}
+{:.bad}
 <?code-excerpt "misc/lib/effective_dart/usage_bad.dart (test-future-or)"?>
 {% prettify dart %}
 Future<T> logValue<T>(FutureOr<T> value) async {


### PR DESCRIPTION
No net change in the site appearance.

This is cleanup following #2037, which dropped old and unused style names "good" and "bad".
This completes the TODO item in `main.scss`: reclaim and use the class names "good" and "bad", rather than "good-style" and "bad-style". (The "-style" suffix was only added while we were transitioning away from the old "good" and "bad".)
