### PR TITLE
Fix page-source links for pages migrated from site-shared

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,10 +56,6 @@ defaults:
     type: tutorials
   values:
     layout: tutorial
-- scope:
-    path: tools/sdk
-  values:
-    repo: *repo-shared
 
 custom:
   downloads:
@@ -117,7 +113,6 @@ alert:
     <i class="fas fa-exclamation-triangle"></i> **Warning:**
   end: </aside>
 
-# bundler_args: --without production
 exclude: [diagrams]
 plugins: [jekyll-toc]
 source: src


### PR DESCRIPTION
Fix page-source links for pages migrated from site-shared in #1764.

Closes #2050

Staged, e.g., https://dart-dev-staging-0.firebaseapp.com/tools/sdk

cc @kwalrath @legalcodes 