### PR TITLE
Books page: fix ToC links, drop image external-link icon, make page mobile friendly

### DIFF
--- a/src/_assets/css/_books.scss
+++ b/src/_assets/css/_books.scss
@@ -1,15 +1,13 @@
 .item-with-pic {
-  display: flex;
-  align-items: flex-start;
-  margin-bottom: 20px;
+  margin-bottom: 1.5rem;
   img {
-    margin:0;
-    max-width: none;
+    @include media-breakpoint-down(sm) { max-width: 200px; }
+    width: 100%;
   }
   .details {
-    margin-left: 20px;
     .title {
-      margin: 0;
+      @include media-breakpoint-up(sm) { margin-top: 0; }
+      margin-bottom: 0;
     }
     .authors {
       color: $site-color-body; // TODO: drop once heading class styles (like .h4) are fixed.

--- a/src/_assets/css/_books.scss
+++ b/src/_assets/css/_books.scss
@@ -12,8 +12,7 @@
       margin: 0;
     }
     .authors {
-      margin: 0;
-      margin-bottom: 5px;
+      color: $site-color-body; // TODO: drop once heading class styles (like .h4) are fixed.
     }
   }
 }

--- a/src/_assets/css/_books.scss
+++ b/src/_assets/css/_books.scss
@@ -1,4 +1,4 @@
-.item-with-pic {
+.book-img-with-details {
   margin-bottom: 1.5rem;
   img {
     @include media-breakpoint-down(sm) { max-width: 200px; }

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -25,6 +25,16 @@ $dropdown-divider-bg: #bbbbbb;
 $dropdown-link-active-color: transparent;
 $dropdown-link-active-bg: transparent;
 
+//== Headings
+
+// The following are needed only because _bootstrap_config_shared is not imported in the right order:
+// https://github.com/dart-lang/site-www/issues/2007
+$headings-font-family: $site-font-family-gsans;
+$headings-font-weight: 400;
+
+// Move to _bootstrap_config_shared once #2007 is fixed:
+$headings-color: $site-color-body;
+
 //== Popovers
 
 $popover-font-size: $font-size-base;

--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -20,7 +20,7 @@ For information on converting Dart 1.x code to Dart 2, see the
 The following books cover Dart 1.x.
 
 {% for book in site.data.books %}
-<div class="item-with-pic row">
+<div class="book-img-with-details row">
 <a href="{{book.link}}" title="{{book.title}}" class="col-sm-3 no-automatic-external">
   <img src="{% asset 'cover/{{book.cover}}' @path %}" alt="{{book.title}}"/>
 </a>

--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -21,13 +21,17 @@ The following books cover Dart 1.x.
 
 {% for book in site.data.books %}
 <div class="item-with-pic">
-  <a href="{{ book.link }}" title="{{ book.title }}">
-    <img src="{% asset 'cover/{{ book.cover }}' @path %}" alt="Cover: {{ book.title }}"/>
-  </a>
-  <div class="details">
-    <h3 class="title"><a href="{{ book.link }}" title="{{ book.title }}">{{ book.title }}</a></h3>
-    <h4 class="authors">by {{ book.authors | array_to_sentence_string }}</h4>
-    <p>{{ book.desc }}</p>
-  </div>
+<a href="{{book.link}}" title="{{book.title}}" class="no-automatic-external">
+  <img src="{% asset 'cover/{{book.cover}}' @path %}" alt="{{book.title}}"/>
+</a>
+<div class="details" markdown="1">
+### [{{book.title}}]({{book.link}})
+{:.title}
+
+by {{book.authors | array_to_sentence_string}}
+{:.authors.h4}
+
+{{book.desc}}
+</div>
 </div>
 {% endfor %}

--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -20,11 +20,11 @@ For information on converting Dart 1.x code to Dart 2, see the
 The following books cover Dart 1.x.
 
 {% for book in site.data.books %}
-<div class="item-with-pic">
-<a href="{{book.link}}" title="{{book.title}}" class="no-automatic-external">
+<div class="item-with-pic row">
+<a href="{{book.link}}" title="{{book.title}}" class="col-sm-3 no-automatic-external">
   <img src="{% asset 'cover/{{book.cover}}' @path %}" alt="{{book.title}}"/>
 </a>
-<div class="details" markdown="1">
+<div class="details col-sm-9" markdown="1">
 ### [{{book.title}}]({{book.link}})
 {:.title}
 


### PR DESCRIPTION
Closes #2060: fix ToC links, remove external-link icon from image, make page mobile friendly.
Contributes to #2061

Staged at: https://dart-dev-staging-0.firebaseapp.com/resources/books
Master at: https://dart.dev/resources/books

---

## Screenshots

#### Mobile friendliness

Before:
> <img src="https://user-images.githubusercontent.com/4140793/68044154-26ae2700-fcad-11e9-9b3d-35578b45ac8a.png" width="250">

After:
> <img src="https://user-images.githubusercontent.com/4140793/68046966-a17a4080-fcb3-11e9-8a3f-6af683c6a174.png" width="250">

### General display

> ![image](https://user-images.githubusercontent.com/4140793/68047064-df776480-fcb3-11e9-9407-31d46b810424.png)
