### PR TITLE
2.6 banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -4,6 +4,6 @@
     {% comment %} TEXT GOES HERE {% endcomment %}
     Dart 2.6 is now available, with support for compiling
     to self-contained, native executables.
-    <a href="https://medium.com/dartlang">Learn more.</a>
+    <a href="https://medium.com/dartlang/dart2native-a76c815e6baf">Learn more.</a>
   </p>
 </div>

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -2,7 +2,8 @@
 <div class="banner">
   <p class="banner__text">
     {% comment %} TEXT GOES HERE {% endcomment %}
-    Announcing <a class="no-automatic-external" href="/tools/pub/verified-publishers">verified publishers</a> for pub.dev! For more information, see the
-    <a class="no-automatic-external" href="https://medium.com/dartlang/verified-publishers-98f05466558a">announcement</a>.
+    Dart 2.6 is now available, with support for compiling
+    to self-contained, native executables.
+    <a href="https://medium.com/dartlang">Learn more.</a>
   </p>
 </div>


### PR DESCRIPTION
Staged: https://kw-staging-dartlang-2.firebaseapp.com/

We need to update the link to point to the announcement, once it's published.