### PR TITLE
Use HTTPS in links when possible

### DIFF
--- a/src/_articles/archive/numeric-computation.md
+++ b/src/_articles/archive/numeric-computation.md
@@ -105,7 +105,7 @@ graduates from smi to mint to bigint:
 ### Floating-point numbers
 
 The VM has a single representation for floating-point numbers, the
-[IEEE-754 double-precision floating-point number](http://en.wikipedia.org/wiki/Double_precision_floating-point_format).
+[IEEE-754 double-precision floating-point number](https://en.wikipedia.org/wiki/Double_precision_floating-point_format).
 
 ### Boxed and unboxed numbers
 

--- a/src/_articles/libraries/dart-io.md
+++ b/src/_articles/libraries/dart-io.md
@@ -30,9 +30,9 @@ the application makes no progress before that operation completes.
 For scalability it is therefore crucial that no I/O operations block.
 Instead of blocking on I/O operations,
 dart:io uses an asynchronous programming model inspired by
-[node.js,](http://nodejs.org)
+[node.js,](https://nodejs.org)
 [EventMachine,](https://github.com/eventmachine/eventmachine/wiki) and
-[Twisted.](http://twistedmatrix.com/trac/)
+[Twisted.](https://twistedmatrix.com/trac/)
 
 ## The Dart VM and the event loop
 
@@ -382,6 +382,6 @@ For example, the [pub.dev site]({{site.pub}}) uses dart:io.
 Please give dart:io a spin and let us know what you think.
 Feature requests are very welcome!
 When you file a bug or feature request,
-use [dartbug.com.](http://dartbug.com)
+use [dartbug.com.](https://dartbug.com)
 To find reported issues, search for the
 [library-io label.](https://github.com/dart-lang/sdk/issues?q=label%3Alibrary-io)

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -452,7 +452,7 @@ Use the following resources to learn more about static analysis in Dart:
 [analyzer error codes]: https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/lib/error/error.dart
 [change the severity of rules]: #changing-the-severity-of-rules
 [invalid_assignment]: {{site.pub-api}}/analyzer/latest/analyzer/StaticTypeWarningCode/INVALID_ASSIGNMENT-constant.html
-[linter rules]: http://dart-lang.github.io/linter/lints/
+[linter rules]: https://dart-lang.github.io/linter/lints/
 [sound-dart]: /guides/language/sound-dart
 [todo]: {{site.pub-api}}/analyzer/latest/analyzer/TodoCode/TODO-constant.html
 [in the pedantic README]: {{site.pub-pkg}}/pedantic#using-the-lints

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -427,11 +427,11 @@ a flavor of what's supported:
 ///
 /// Links can be:
 ///
-/// * http://www.just-a-bare-url.com
-/// * [with the URL inline](http://google.com)
+/// * https://www.just-a-bare-url.com
+/// * [with the URL inline](https://google.com)
 /// * [or separated out][ref link]
 ///
-/// [ref link]: http://google.com
+/// [ref link]: https://google.com
 ///
 /// # A Header
 ///

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -76,7 +76,7 @@ const foo = Foo();
 class C { ... }
 {% endprettify %}
 
-[camel_case_types]: http://dart-lang.github.io/linter/lints/camel_case_types.html
+[camel_case_types]: https://dart-lang.github.io/linter/lints/camel_case_types.html
 [Linter rule]: /guides/language/analysis-options#the-analysis-options-file
 
 ### DO name libraries, packages, directories, and source files using `lowercase_with_underscores`. {#do-name-libraries-and-source-files-using-lowercase_with_underscores}
@@ -451,7 +451,7 @@ shorter ones can alter the program.
 
 Doing so avoids the [dangling else][] problem.
 
-[dangling else]: http://en.wikipedia.org/wiki/Dangling_else
+[dangling else]: https://en.wikipedia.org/wiki/Dangling_else
 
 {:.good}
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (curly-braces)"?>

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1037,7 +1037,7 @@ units, and 32-bit code points. Click **Run** to see runes in action.
 {% comment %}
 https://gist.github.com/589bc5c95318696cefe5
 {{site.dartpad}}/589bc5c95318696cefe5
-Unicode emoji: http://unicode.org/emoji/charts/full-emoji-list.html
+Unicode emoji: https://unicode.org/emoji/charts/full-emoji-list.html
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (runes)"?>
 {% prettify dart %}
@@ -1067,7 +1067,7 @@ Be careful when manipulating runes using list operations.
 This approach can easily break down,
 depending on the particular language, character set, and operation.
 For more information, see
-[How do I reverse a String in Dart?](http://stackoverflow.com/questions/21521729/how-do-i-reverse-a-string-in-dart) on Stack Overflow.
+[How do I reverse a String in Dart?](https://stackoverflow.com/questions/21521729/how-do-i-reverse-a-string-in-dart) on Stack Overflow.
 </div>
 
 ### Symbols

--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -33,5 +33,5 @@ New language features are typically described using informal language feature sp
 The formal Dart 1.x language specification is available from
 the Ecma International website:
 
-* <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-408.pdf"
+* <a href="https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-408.pdf"
    target="_blank" rel="noopener">Dart Programming Language Specification, 4<sup>th</sup> Edition</a>

--- a/src/_guides/libraries/dart-html-tour.md
+++ b/src/_guides/libraries/dart-html-tour.md
@@ -61,7 +61,7 @@ You can get this object using a query.
 Find one or more elements using the top-level functions
 `querySelector()` and `querySelectorAll()`. You can query by ID, class, tag, name, or
 any combination of these. The [CSS Selector Specification
-guide](http://www.w3.org/TR/css3-selectors/) defines the formats of the
+guide](https://www.w3.org/TR/css3-selectors/) defines the formats of the
 selectors such as using a \# prefix to specify IDs and a period (.) for
 classes.
 
@@ -115,7 +115,7 @@ AnchorElement’s `href` property:
 {% comment %}code-excerpt "test/html_test.dart (href)"{% endcomment %}
 ```dart
 var anchor = querySelector('#example') as AnchorElement;
-anchor.href = 'http://dart.dev';
+anchor.href = 'https://dart.dev';
 ```
 
 Often you need to set properties on multiple elements. For example, the
@@ -285,7 +285,7 @@ To respond to external events such as clicks, changes of focus, and
 selections, add an event listener. You can add an event listener to any
 element on the page. Event dispatch and propagation is a complicated
 subject; [research the
-details](http://www.w3.org/TR/DOM-Level-3-Events/#dom-event-architecture)
+details](https://www.w3.org/TR/DOM-Level-3-Events/#dom-event-architecture)
 if you’re new to web programming.
 
 Add an event handler using

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -33,7 +33,7 @@ you need the Dart SDK.
 </div>
 
 <div id="tab-sdk-install-mac" class="tabs__content" markdown="1">
-  With [Homebrew,](http://brew.sh/)
+  With [Homebrew,](https://brew.sh/)
   installing Dart is easy.
 
   ```terminal

--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -725,7 +725,7 @@ void addCorsHeaders(HttpResponse response) {
 <div class="prettify-filename">note_server.dart</div>
 
 For more information, refer to Wikipedia's article
-[Cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
+[Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
 
 ## Using the http_server package {#using-http-server-package}
 
@@ -909,7 +909,7 @@ using HTTPS (Hyper Text Transfer Protocol with Secure Sockets Layer).
 To use the bindSecure() method, you need a certificate,
 which is provided by a Certificate Authority (CA).
 For more information about certificates refer to
-[What is SSL and what are Certificates?](http://www.tldp.org/HOWTO/SSL-Certificates-HOWTO/x64.html)
+[What is SSL and what are Certificates?](https://www.tldp.org/HOWTO/SSL-Certificates-HOWTO/x64.html)
 
 For illustrative purposes only,
 the following server, `hello_world_server_secure.dart`,

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -190,7 +190,7 @@ If you get stuck, find help at [Community and Support.](/community)
 [Dart library tour]: /guides/libraries/library-tour
 [Dart tools]: /tools
 [Debugging Dart Web Apps]: /web/debugging
-[Homebrew,]: http://brew.sh/
+[Homebrew,]: https://brew.sh/
 [Install the SDK]: /get-dart
 [low-level HTML tutorial for Dart]: /tutorials/web/low-level-html
 [Overview of Dart web libraries]: /web/web-programming

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -24,7 +24,7 @@ Get answers and connect with Dart developers.
 
 #### Communities
 
-* [StackOverflow](http://stackoverflow.com/tags/dart) -
+* [StackOverflow](https://stackoverflow.com/tags/dart) -
   The best place for how-to questions.
 * [Gitter](https://gitter.im/dart-lang/home) -
   Chat with Dart team and community members.
@@ -54,7 +54,7 @@ Our wonderful community has provided these resources.
 
 * [Dart Academy](https://dart.academy/) - Tutorials
   and articles written by the Dart community
-* [Chinese version of this site (此网站的中文版)](http://www.dartdoc.cn)
+* [Chinese version of this site (此网站的中文版)](https://www.dartdoc.cn)
 
 Also see the [Flutter community page.]({{site.flutter}}/community)
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -181,7 +181,7 @@ Inside or outside of Google, every Flutter app uses Dart.
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language process]: https://github.com/dart-lang/language/blob/master/doc/life_of_a_language_feature.md
 [pub]: {{site.pub}}
-[announcement]: http://blog.chromium.org/2013/11/dart-10-stable-sdk-for-structured-web.html
+[announcement]: https://blog.chromium.org/2013/11/dart-10-stable-sdk-for-structured-web.html
 [lang]: /guides/language/language-tour
 [libs]: /guides/libraries/library-tour
 [JSON]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/JsonCodec-class.html
@@ -190,7 +190,7 @@ Inside or outside of Google, every Flutter app uses Dart.
 [Dart tools]: /tools/
 [Dart and Google Cloud Platform]: https://dart-lang.github.io/server/google-cloud-platform/
 [Who Uses Dart]: /community/who-uses-dart
-[spec]: http://www.ecma-international.org/publications/standards/Ecma-408.htm
+[spec]: https://www.ecma-international.org/publications/standards/Ecma-408.htm
 [DEP]: https://github.com/dart-lang/dart_enhancement_proposals
 [DartPad]: {{site.dartpad}}
 [Flutter]: {{site.flutter}}
@@ -447,7 +447,7 @@ noticeably slower than the well-tuned garbage collectors of
 modern JavaScript VMs.
 
 
-[ppwsize]: http://work.j832.com/2012/11/excited-to-see-dart2js-minified-output.html
+[ppwsize]: https://work.j832.com/2012/11/excited-to-see-dart2js-minified-output.html
 [sourcemaps]: http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
 [package:js]: {{site.pub-pkg}}/js
 [AngularDart]: {{site.angulardart}}
@@ -457,7 +457,7 @@ modern JavaScript VMs.
 [dartanalyzer]: /tools/dartanalyzer
 [dartdevc]: /tools/dartdevc
 [chrome.dart]: https://github.com/dart-gde/chrome.dart
-[fixallthethings]: http://hyperboleandahalf.blogspot.com/2010/06/this-is-why-ill-never-be-adult.html
+[fixallthethings]: https://hyperboleandahalf.blogspot.com/2010/06/this-is-why-ill-never-be-adult.html
 [typescript]: {{site.news}}/2012/10/the-dart-team-welcomes-typescript.html
 [webdev]: /tools/webdev
 [fwebannounce]: https://medium.com/flutter-io/bringing-flutter-to-the-web-904de05f0df0

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -75,7 +75,6 @@ the [instructions above](#install), or you can
 [download the SDK as a zip file](/tools/sdk/archive).
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
-[semantic versioning]: http://semver.org/
 [Dart 2]: /dart-2
 [build the SDK from source]: https://github.com/dart-lang/sdk/wiki/Building
 [Dart libraries]: /guides/libraries/library-tour

--- a/src/security.md
+++ b/src/security.md
@@ -10,7 +10,7 @@ the risk of introducing a vulnerability.
 ## Reporting vulnerabilities
 
 In the rare event that you find a vulnerability in Dart itself,
-contact us at [http://goo.gl/vulnz](http://goo.gl/vulnz).
+contact us at [https://goo.gl/vulnz](https://goo.gl/vulnz).
 For more information about how Google handles security issues, see
 [Google’s security philosophy.](https://www.google.com/about/appsecurity/)
 

--- a/src/tools/dart2js.md
+++ b/src/tools/dart2js.md
@@ -144,7 +144,7 @@ The following options control the analysis that dart2js performs on Dart code:
 `--csp`
 : Disables dynamic generation of code in the generated output.
   This is necessary to satisfy CSP restrictions
-  (see [W3C Content Security Policy.](http://www.w3.org/TR/CSP/))
+  (see [W3C Content Security Policy.](https://www.w3.org/TR/CSP/))
 
 `--dump-info`
 : Generates a file (with the suffix `.info.json`)
@@ -190,7 +190,7 @@ To debug in Chrome:
 1. Open the Developer Tools window, as described in the
    [Chrome DevTools documentation.](https://developer.chrome.com/devtools/index)
 2. Turn on source maps, as described in the video
-   [SourceMaps in Chrome.](http://bit.ly/YugIUY)
+   [SourceMaps in Chrome.](https://bit.ly/YugIUY)
 3. Enable debugging, either on all exceptions or only on uncaught exceptions,
    as described in
    [How to set breakpoints.](https://developers.google.com/web/tools/chrome-devtools/debug/breakpoints/add-breakpoints)
@@ -203,7 +203,7 @@ To debug in Internet Explorer:
 1. Update to the latest version of Internet Explorer. (Source-map support
    was added to IE in April 2014).
 2. Load **Developer Tools** (**F12**). For more information, see
-   [Using the F12 developer tools.](http://msdn.microsoft.com/library/ie/bg182326(v=vs.85))
+   [Using the F12 developer tools.](https://msdn.microsoft.com/library/ie/bg182326(v=vs.85))
 3. Reload the app. The **debugger** tab shows source-mapped files.
 4. Exception behavior can be controlled through **Ctrl+Shift+E**;
    the default is **Break on unhandled exceptions**.

--- a/src/tools/dartpad/privacy.md
+++ b/src/tools/dartpad/privacy.md
@@ -14,5 +14,5 @@ example, we may use the source code to help offer better code completion
 suggestions. The raw source code is deleted after no more than 60 days.
 
 Learn more about Google's [privacy
-policy.](http://www.google.com/policies/privacy/) We look forward to your
+policy.](https://www.google.com/policies/privacy/) We look forward to your
 [feedback.](https://github.com/dart-lang/dart-pad/issues)

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -146,7 +146,7 @@ development and is using other packages that are being developed at the
 same time. To make that easier, you can depend directly on a package
 stored in a [Git][] repository.
 
-[git]: http://git-scm.com/
+[git]: https://git-scm.com/
 
 {% prettify yaml %}
 dependencies:
@@ -180,7 +180,7 @@ dependencies:
 
 The ref can be anything that Git allows to [identify a commit.][commit]
 
-[commit]: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html#naming-commits
+[commit]: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#naming-commits
 
 Pub assumes that the package is in the root of the Git repository.
 To specify a different location in the repo, use the `path` argument:
@@ -416,4 +416,4 @@ to differentiate versions. <a href="#fnref:semver">↩</a>
 
 [GitHub SSH]: https://help.github.com/articles/connecting-to-github-with-ssh/
 [pubsite]: {{site.pub}}
-[semantic versioning]: http://semver.org/spec/v2.0.0-rc.1.html
+[semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -78,7 +78,7 @@ constraints](#version-constraint) should be as wide as possible while still
 ensuring that the dependencies will be compatible with the versions that were
 tested against.
 
-Since [semantic versioning](http://semver.org/spec/v2.0.0-rc.1.html) requires
+Since [semantic versioning](https://semver.org/spec/v2.0.0-rc.1.html) requires
 that libraries increment their major version numbers for any backwards
 incompatible changes, library packages will usually require their dependencies'
 versions to be greater than or equal to the versions that were tested and less

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -123,7 +123,7 @@ your code.
 If your README ends in `.md`, it's parsed as
 [Markdown.][markdown]
 
-[markdown]: http://daringfireball.net/projects/markdown/
+[markdown]: https://daringfireball.net/projects/markdown/
 
 ## CHANGELOG
 
@@ -239,7 +239,7 @@ enchilada/
 
 While most library packages exist to let you reuse Dart code, you can also
 reuse other kinds of content. For example, a package for
-[Bootstrap](http://getbootstrap.com/) might include a number of CSS files
+[Bootstrap](https://getbootstrap.com/) might include a number of CSS files
 for consumers of the package to use.
 
 These go in the top-level `lib` directory. You can put any kind of file

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -26,8 +26,8 @@ changes will help make your package play nicer with the Dart ecosystem. There
 are a few additional requirements for uploading a package:
 
 * You must include a license file (named `LICENSE`, `COPYING`, or some
-  variation) that contains an [open-source license](http://opensource.org/). We
-  recommend the [BSD license](http://opensource.org/licenses/BSD-2-Clause),
+  variation) that contains an [open-source license](https://opensource.org/). We
+  recommend the [BSD license](https://opensource.org/licenses/BSD-2-Clause),
   which is used by Dart itself. You must also have the legal right to
   redistribute anything that you upload as part of your package.
 

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -7,7 +7,7 @@ Every [pub package](/guides/packages) needs some metadata so it can specify its
 others also need to provide some other information so users can discover them.
 All of this metadata goes in the package's _pubspec:_
 a file named `pubspec.yaml` that's written in the
-[YAML](http://www.yaml.org/) language.
+[YAML](https://yaml.org/) language.
 
 {% comment %}
 PENDING: acknowledge the existence of pubspec.lock files.
@@ -157,7 +157,7 @@ anymore. To make more changes, you'll need a new version.
 
 When you select a version, follow [semantic versioning.][semantic versioning]
 
-[semantic versioning]: http://semver.org/spec/v2.0.0.html
+[semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html
 
 ### Description
 
@@ -330,4 +330,4 @@ at least 1.19.0, to ensure that older versions of pub won't
 accidentally install packages that need Flutter.
 
 [pubsite]: {{site.pub}}
-[semantic versioning]: http://semver.org/spec/v2.0.0-rc.1.html
+[semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -1,4 +1,4 @@
-[Install Homebrew](http://brew.sh), and then run:
+[Install Homebrew](https://brew.sh), and then run:
 
 {% if site.data.pkg-vers.SDK.channel == 'dev' %}
 ```terminal

--- a/src/tools/sdk/dart_sdk_archive/README.md
+++ b/src/tools/sdk/dart_sdk_archive/README.md
@@ -1,4 +1,4 @@
-Scripts and utilities for [dart.dev/tools/sdk/archive](http://dart.dev/tools/sdk/archive)
+Scripts and utilities for [dart.dev/tools/sdk/archive](https://dart.dev/tools/sdk/archive)
 
 ## Developing
 

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -66,7 +66,7 @@ For more information about the SDK, see its
 ## Filing bugs and feature requests
 
 To see existing issues or create a new one,
-go to [dartbug.com](http://dartbug.com).
+go to [dartbug.com](https://dartbug.com).
 Here are some handy searches:
 
 * [dart (VM) issues](https://github.com/dart-lang/sdk/labels/Area-VM)

--- a/src/web/deployment.md
+++ b/src/web/deployment.md
@@ -144,7 +144,7 @@ and were built using [peanut.][peanut]
 ### Firebase
 
 For a walk-through of using Firebase to serve a chat app, see
-[Build a Real-Time Chat Web App with Dart, Angular 2, and Firebase 3.](http://dart.academy/build-a-real-time-chat-web-app-with-dart-angular-2-and-firebase-3/)
+[Build a Real-Time Chat Web App with Dart, Angular 2, and Firebase 3.](https://dart.academy/build-a-real-time-chat-web-app-with-dart-angular-2-and-firebase-3/)
 {% comment %}
 TODO: Instead of just pointing to that very long article,
 show how to deploy here.


### PR DESCRIPTION
Just a lot of nits upgrading HTTP to HTTPS links whenever possible.

I found one or two links that didn't work or which seemed broken, so I left those alone.