### PR TITLE
Fix linux get-sdk links

### DIFF
--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -62,11 +62,8 @@ $ sudo apt-get install dart
 
 Alternatively, download Dart SDK as Debian package in the `.deb` package format.
 
-{:.downloads}
-- [Stable channel](#){:.download-link #debian-link-stable
-  data-bits="64" data-os="debian" data-tool="sdk"}
-- [Dev channel](#){:.download-link #debian-link-dev
-  data-bits="64" data-os="debian" data-tool="sdk"}
+- [Stable channel](#){:.debian-link-stable}
+- [Dev channel](#){:.debian-link-dev}
 
 
 #### Modify PATH for access to all Dart binaries

--- a/src/tools/sdk/archive/assets/install.js
+++ b/src/tools/sdk/archive/assets/install.js
@@ -9,10 +9,10 @@ var updatePlaceholders = function(channel, version) {
   });
   var download = 'https://storage.googleapis.com/dart-archive/channels/' + channel + '/release/latest/linux_packages/dart_' + version + '-1_amd64.deb';
   if (channel == 'stable') {
-    var target = $("#debian-link-stable");
+    var target = $(".debian-link-stable");
     target.attr('href', download);
   } else {
-    var target = $("#debian-link-dev");
+    var target = $(".debian-link-dev");
     target.attr('href', download);
   }
 }


### PR DESCRIPTION
Closes #2054

Also cleaned up the list and links, dropping the unused CSS classes and custom data attributes.

Staged at https://dart-dev-staging-1.firebaseapp.com/get-dart

### Screenshot (Firefox)

Mouse is over the `stable` link, with the proper (generated) URL shown at the bottom of the window:
> ![image](https://user-images.githubusercontent.com/4140793/68607760-64663900-047f-11ea-8536-97d5f48cdb54.png)
