### PR TITLE
Server > Get Started: use tested sources for DartPad Hello World

### DIFF
--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -295,11 +295,6 @@ body.homepage .get-started-section {
 	.alert, pre {
 		border: 1px solid black;
 	}
-
-	/* Hide "Open Dartpad" link */
-	.run-in-dartpad {
-		display: none;
-	}
 }
 
 /* Overwrite bootstrap: don't wrap code */

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -628,19 +628,6 @@ img {
   }
 }
 
-
-/* -----------------------------------------
- Dartpad
- ----------------------------------------- */
-
-#run-dartpad {
-  position: relative;
-  padding: 15px 0;
-  background: $gray-light;
-  border-top: 1px solid $gray;
-  z-index: 5;
-}
-
 /* -----------------------------------------
  Search
  ----------------------------------------- */
@@ -813,51 +800,6 @@ main .content {
   padding: 5px 10px;
   color: $blue;
   border-radius: 8px;
-}
-
-.codesample__open-in-dartpad {
-  display: block;
-  position: absolute;
-  width: auto;
-  z-index: 10;
-  padding: 5px 10px 5px 35px;
-  top: 35px;
-  right: 38px;
-  background-color: $gray;
-  color: $gray-base;
-
-  font-weight: normal;
-  font-size: $font-size-base * 0.91;
-  @include media-breakpoint-up(md) {
-    font-size: $font-size-base * 0.8;
-  }
-  @include media-breakpoint-up(lg) {
-    font-size: $font-size-base * 0.91;
-  }
-
-  &.top {
-    top: 0;
-  }
-  &:visited, &:active {
-    color: $gray-base;
-  }
-  &:hover {
-    background-color: darken($gray, 10%);
-    color: $white-base;
-  }
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 5px;
-    left: 10px;
-    width: 18px;
-    height: 18px;
-    background-image: asset_url('shared/dart/logo/default.svg');
-    background-size: cover;
-    background-position: center center;
-    background-repeat: no-repeat;
-  }
 }
 
 // Columns

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -7,36 +7,43 @@ nextpage:
 prevpage:
   url: /tutorials/server
   title: Dart command-line and server tutorials
+js: [{url: https://dartpad.dev/experimental/inject_embed.dart.js, defer: true}]
 ---
 
 Follow these steps to start using the Dart SDK to develop command-line and server apps.
-First you’ll play with the Dart language and libraries in your browser, no download required.
+First you’ll play with the Dart language in your browser, no download required.
 Then you’ll install the Dart SDK, write a small program, and run that program using the Dart VM.
 Finally, you'll use an AOT (_ahead of time_) compiler to compile your finished program to native machine code,
 which you'll execute using the Dart runtime.
 
 ## 1. Play with Dart code in DartPad
 
-With DartPad you can experiment with the Dart language and APIs,
-no download necessary.
+With [DartPad](/tools/dartpad) you can experiment with the Dart language and
+APIs, no download necessary.
 
 For example, here's an embedded DartPad that lets you play with the code for a
-small Hello World program. Click **Run** to run the app; the console output
-appears beneath the code. Try editing the source code—perhaps you'd like to
-change the greeting to use another language. To get the full DartPad experience,
-<a href="{{site.dartpad}}/27e044ec9e2957d9c5c7062871ce8bf3" target="_blank">open
-the example at dartpad.dev.</a>
+small Hello World program. Click **Run** to run the app; output appears in the
+console view. Try editing the source code &mdash; perhaps you'd like to change the
+greeting to use another language.
 
 {{site.alert.note}}
   {% include dartpad-embedded-troubleshooting.md %}
 {{site.alert.end}}
 
-<iframe
-    src="{{site.dartpad-embed-inline}}?id=27e044ec9e2957d9c5c7062871ce8bf3"
-    width="100%"
-    height="300px"
-    style="border: 1px solid #ccc;">
-</iframe>
+<style>
+iframe[src^="https://dartpad"] {
+  border: 1px solid #ccc;
+  margin-bottom: 1rem;
+  width: 100%;
+}
+</style>
+
+<?code-excerpt "misc/test/samples_test.dart (hello-world)"?>
+```dart:run-dartpad
+void main() {
+  print('Hello, World!');
+}
+```
 
 More information:
 


### PR DESCRIPTION
Contributes to #1803 by replacing a Gist-based DartPad with a DartPad initialized from an analyzed and tested code excerpt from our examples folder.

**Notes:**
- This PR uses the **_experimental_** DartPad [inject_embed feature](https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide#converting-code-blocks-to-dartpad).
- The DartPad is initialized with the base Hello World excerpt that was already a part of our examples, rather than create a new Hello World variant that illustrates use of `const`.

Followup to #1921
Related to #1919

### Staged
https://dart-dev-staging-1.firebaseapp.com/tutorials/server/get-started

### Screen shot

> <img width="483" alt="Screen Shot 2019-11-14 at 12 12 35" src="https://user-images.githubusercontent.com/4140793/68881127-91faee80-06da-11ea-9479-907bc672718c.png">

cc @johnpryan @legalcodes @RedBrogdon 