### PR TITLE
Server > Get Started: fix front matter

### DIFF
--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -7,7 +7,7 @@ nextpage:
 prevpage:
   url: /tutorials/server
   title: Dart command-line and server tutorials
-js: [{url: https://dartpad.dev/experimental/inject_embed.dart.js, defer: true}]
+js: [{url: 'https://dartpad.dev/experimental/inject_embed.dart.js', defer: true}]
 ---
 
 Follow these steps to start using the Dart SDK to develop command-line and server apps.

--- a/tool/build.sh
+++ b/tool/build.sh
@@ -18,6 +18,7 @@ done
 
 travis_fold start build_site
   (
+    bundle exec jekyll --version;
     set -x;
     bundle exec jekyll build;
   )


### PR DESCRIPTION
Followup to #2092.

It seems that the Jekyll YAML parser under MacOS is different from (more lenient than) the Linux one. Under Linux, a YAML syntax error was reported, but not under MacOS.

cc @kwalrath @johnpryan @legalcodes 