### PR TITLE
Make DartPad resizable in Tutorial > Server > Get started

### DIFF
--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -34,6 +34,8 @@ greeting to use another language.
 iframe[src^="https://dartpad"] {
   border: 1px solid #ccc;
   margin-bottom: 1rem;
+  min-height: 150px;
+  resize: vertical;
   width: 100%;
 }
 </style>


### PR DESCRIPTION
Adjustments to the DartPad in Tutorial > Server > Get started.

- Sets a min-height
- Make DartPad resizable -- addresses resize request from this thread: https://github.com/dart-lang/site-www/pull/2092/files#r346460620
   <img width="485" alt="Screen Shot 2019-11-14 at 15 23 24" src="https://user-images.githubusercontent.com/4140793/68893399-0d689a00-06f3-11ea-98fc-b80112f0003e.png">

Staged at https://dart-dev-staging-1.firebaseapp.com/tutorials/server/get-started

@kwalrath @johnpryan : do you still want the min-height to be 200px or more?

Followup to #2092