### PR TITLE
Markdown cleanup: use code fences in prep for DartPad updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -117,6 +117,9 @@ alert:
   note: >-
     <aside class="alert alert-info" role="alert" markdown="1">
     <i class="fas fa-info-circle"></i> **Note:**
+  version-note: >-
+    <aside class="alert alert-info" role="alert" markdown="1">
+    <i class="fas fa-code-branch"></i> **Version note:**
   secondary: >-
     <aside class="alert alert-secondary" role="alert" markdown="1">
   tip: >-

--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -9,23 +9,20 @@ $pre-bg: #F5F5F5; // TODO(chalin): use $site-color-codeblock-bg?
 
 @import 'code_shared';
 
-// code {
-//   background-color: transparent;
-// }
 pre {
   @include pre-defaults;
 
-  &.prettyprint {
-    .com { color: #6E6E70; }
-    // TODO(chalin): dropping the following overrides would allow us to be consistent with Flutter
-    .kwd { color: #BC0056; }
-    .pln { color: #7500A0; }
-    .lit,
-    .str { color: #00677A; }
-  }
   a {
     font-family: inherit;
     font-weight: inherit;
   }
 }
 
+@media screen {
+  .com { color: #6E6E70; }
+  // TODO(chalin): dropping the following overrides would allow us to be consistent with Flutter
+  .kwd { color: #BC0056; }
+  .pln { color: #7500A0; }
+  .lit,
+  .str { color: #00677A; }
+}

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -31,7 +31,7 @@ consult the [Dart language specification][].
 The following code uses many of Dart’s most basic features:
 
 <?code-excerpt "misc/test/language_tour/basic_test.dart"?>
-{% prettify dart %}
+```dart
 // Define a function.
 printInteger(int aNumber) {
   print('The number is $aNumber.'); // Print to console.
@@ -42,55 +42,46 @@ main() {
   var number = 42; // Declare and initialize a variable.
   printInteger(number); // Call a function.
 }
-{% endprettify %}
+```
 
 Here’s what this program uses that applies to all (or almost all) Dart
 apps:
 
 <code>// <em>This is a comment.</em> </code>
-
 :   A single-line comment.
     Dart also supports multi-line and document comments.
     For details, see [Comments](#comments).
 
 `int`
-
 :   A type. Some of the other [built-in types](#built-in-types)
     are `String`, `List`, and `bool`.
 
 `42`
-
 :   A number literal. Number literals are a kind of compile-time constant.
 
 `print()`
-
 :   A handy way to display output.
 
 `'...'` (or `"..."`)
-
 :   A string literal.
 
 <code>$<em>variableName</em></code> (or <code>${<em>expression</em>}</code>)
-
 :   String interpolation: including a variable or expression’s string
     equivalent inside of a string literal. For more information, see
     [Strings](#strings).
 
 `main()`
-
 :   The special, *required*, top-level function where app execution
     starts. For more information, see
     [The main() function](#the-main-function).
 
 `var`
-
 :   A way to declare a variable without specifying its type.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-This site's code follows the conventions in the
-[Dart style guide](/guides/language/effective-dart/style).
-</div>
+{{site.alert.note}}
+  This site's code follows the conventions in the
+  [Dart style guide](/guides/language/effective-dart/style).
+{{site.alert.end}}
 
 
 ## Important concepts
@@ -263,9 +254,9 @@ which can't be identifiers.
 Here’s an example of creating a variable and initializing it:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (var-decl)"?>
-{% prettify dart %}
+```dart
 var name = 'Bob';
-{% endprettify %}
+```
 
 Variables store references. The variable called `name` contains a
 reference to a `String` object with a value of “Bob”.
@@ -281,23 +272,22 @@ specify the `Object` or `dynamic` type, following
 {% endcomment %}
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (type-decl)"?>
-{% prettify dart %}
+```dart
 dynamic name = 'Bob';
-{% endprettify %}
+```
 
 Another option is to explicitly declare the type that would be inferred:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (static-types)"?>
-{% prettify dart %}
+```dart
 String name = 'Bob';
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-This page follows the
-[style guide recommendation](/guides/language/effective-dart/design#types)
-of using `var`, rather than type annotations, for local variables.
-</div>
+{{site.alert.note}}
+  This page follows the
+  [style guide recommendation](/guides/language/effective-dart/design#types)
+  of using `var`, rather than type annotations, for local variables.
+{{site.alert.end}}
 
 
 ### Default value
@@ -307,20 +297,16 @@ with numeric types are initially null, because numbers—like everything
 else in Dart—are objects.
 
 <?code-excerpt "misc/test/language_tour/variables_test.dart (var-null-init)"?>
-{% prettify dart %}
+```dart
 int lineCount;
 assert(lineCount == null);
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Production code ignores the `assert()` call.
-During development, on the other hand,
-<code>assert(<em>condition</em>)</code> throws an exception if
-_condition_ is false.
-For details, see [Assert](#assert).
-</div>
-
+{{site.alert.note}}
+  Production code ignores the `assert()` call. During development, on the other
+  hand, <code>assert(<em>condition</em>)</code> throws an exception if
+  _condition_ is false. For details, see [Assert](#assert).
+{{site.alert.end}}
 
 ### Final and const
 
@@ -330,30 +316,29 @@ only once; a const variable is a compile-time constant. (Const variables
 are implicitly final.) A final top-level or class variable is initialized
 the first time it's used.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Instance variables can be `final` but not `const`.
-Final instance variables must be initialized before
-the constructor body starts —
-at the variable declaration, by a constructor parameter,
-or in the constructor's [initializer list](#initializer-list).
-</div>
+{{site.alert.note}}
+  Instance variables can be `final` but not `const`.
+  Final instance variables must be initialized before
+  the constructor body starts —
+  at the variable declaration, by a constructor parameter,
+  or in the constructor's [initializer list](#initializer-list).
+{{site.alert.end}}
 
 Here's an example of creating and setting a final variable:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (final)"?>
-{% prettify dart %}
+```dart
 final name = 'Bob'; // Without a type annotation
 final String nickname = 'Bobby';
-{% endprettify %}
+```
 
 You can't change the value of a final variable:
 
 {:.fails-sa}
 <?code-excerpt "misc/lib/language_tour/variables.dart (cant-assign-to-final)"?>
-{% prettify dart %}
+```dart
 name = 'Alice'; // Error: a final variable can only be set once.
-{% endprettify %}
+```
 
 Use `const` for variables that you want to be **compile-time constants**. If
 the const variable is at the class level, mark it `static const`.
@@ -362,10 +347,10 @@ such as a number or string literal, a const
 variable, or the result of an arithmetic operation on constant numbers:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (const)"?>
-{% prettify dart %}
+```dart
 const bar = 1000000; // Unit of pressure (dynes/cm2)
 const double atm = 1.01325 * bar; // Standard atmosphere
-{% endprettify %}
+```
 
 The `const` keyword isn't just for declaring constant variables.
 You can also use it to create constant _values_,
@@ -373,11 +358,11 @@ as well as to declare constructors that _create_ constant values.
 Any variable can have a constant value.
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (const-vs-final)"?>
-{% prettify dart %}
+```dart
 var foo = const [];
 final bar = const [];
 const baz = []; // Equivalent to `const []`
-{% endprettify %}
+```
 
 You can omit `const` from the initializing expression of a `const` declaration,
 like for `baz` above. For details, see [DON’T use const redundantly][].
@@ -386,17 +371,17 @@ You can change the value of a non-final, non-const variable,
 even if it used to have a const value:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (reassign-to-non-final)"?>
-{% prettify dart %}
+```dart
 foo = [1, 2, 3]; // Was const []
-{% endprettify %}
+```
 
 You can't change the value of a const variable:
 
 {:.fails-sa}
 <?code-excerpt "misc/lib/language_tour/variables.dart (cant-assign-to-const)"?>
-{% prettify dart %}
+```dart
 baz = [42]; // Error: Constant variables can't be assigned a value.
-{% endprettify %}
+```
 
 As of Dart 2.5, you can define constants that use
 [type checks and casts](#type-test-operators) (`is` and `as`),
@@ -480,38 +465,37 @@ Integers are numbers without a decimal point. Here are some examples of
 defining integer literals:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (integer-literals)"?>
-{% prettify dart %}
+```dart
 var x = 1;
 var hex = 0xDEADBEEF;
-{% endprettify %}
+```
 
 If a number includes a decimal, it is a double. Here are some examples
 of defining double literals:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (double-literals)"?>
-{% prettify dart %}
+```dart
 var y = 1.1;
 var exponents = 1.42e5;
-{% endprettify %}
+```
 
 As of Dart 2.1, integer literals are automatically converted to doubles
 when necessary:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (int-to-double)"?>
-{% prettify dart %}
+```dart
 double z = 1; // Equivalent to double z = 1.0.
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:**
-  Before Dart 2.1, it was an error to use an integer literal
-  in a double context.
-</aside>
+{{site.alert.version-note}}
+  Before Dart 2.1, it was an error to use an integer literal in a double
+  context.
+{{site.alert.end}}
 
 Here’s how you turn a string into a number, or vice versa:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (number-conversion)"?>
-{% prettify dart %}
+```dart
 // String -> int
 var one = int.parse('1');
 assert(one == 1);
@@ -527,17 +511,17 @@ assert(oneAsString == '1');
 // double -> String
 String piAsString = 3.14159.toStringAsFixed(2);
 assert(piAsString == '3.14');
-{% endprettify %}
+```
 
 The int type specifies the traditional bitwise shift (\<\<, \>\>), AND
 (&), and OR (|) operators. For example:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (bit-shifting)"?>
-{% prettify dart %}
+```dart
 assert((3 << 1) == 6); // 0011 << 1 == 0110
 assert((3 >> 1) == 1); // 0011 >> 1 == 0001
 assert((3 | 4) == 7); // 0011 | 0100 == 0111
-{% endprettify %}
+```
 
 Literal numbers are compile-time constants.
 Many arithmetic expressions are also compile-time constants,
@@ -545,11 +529,11 @@ as long as their operands are
 compile-time constants that evaluate to numbers.
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (const-num)"?>
-{% prettify dart %}
+```dart
 const msPerSecond = 1000;
 const secondsUntilRetry = 5;
 const msUntilRetry = secondsUntilRetry * msPerSecond;
-{% endprettify %}
+```
 
 
 ### Strings
@@ -558,12 +542,12 @@ A Dart string is a sequence of UTF-16 code units. You can use either
 single or double quotes to create a string:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (quoting)"?>
-{% prettify dart %}
+```dart
 var s1 = 'Single quotes work well for string literals.';
 var s2 = "Double quotes work just as well.";
 var s3 = 'It\'s easy to escape the string delimiter.';
 var s4 = "It's even easier to use the other delimiter.";
-{% endprettify %}
+```
 
 You can put the value of an expression inside a string by using
 `${`*`expression`*`}`. If the expression is an identifier, you can skip
@@ -571,7 +555,7 @@ the {}. To get the string corresponding to an object, Dart calls the
 object’s `toString()` method.
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (string-interpolation)"?>
-{% prettify dart %}
+```dart
 var s = 'string interpolation';
 
 assert('Dart has $s, which is very handy.' ==
@@ -581,20 +565,19 @@ assert('That deserves all caps. ' +
         '${s.toUpperCase()} is very handy!' ==
     'That deserves all caps. ' +
         'STRING INTERPOLATION is very handy!');
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-The `==` operator tests whether two objects are equivalent. Two
-strings are equivalent if they contain the same sequence of code
-units.
-</div>
+{{site.alert.note}}
+  The `==` operator tests whether two objects are equivalent. Two
+  strings are equivalent if they contain the same sequence of code
+  units.
+{{site.alert.end}}
 
 You can concatenate strings using adjacent string literals or the `+`
 operator:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (adjacent-string-literals)"?>
-{% prettify dart %}
+```dart
 var s1 = 'String '
     'concatenation'
     " works even over line breaks.";
@@ -604,13 +587,13 @@ assert(s1 ==
 
 var s2 = 'The + operator ' + 'works, as well.';
 assert(s2 == 'The + operator works, as well.');
-{% endprettify %}
+```
 
 Another way to create a multi-line string: use a triple quote with
 either single or double quotation marks:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (triple-quotes)"?>
-{% prettify dart %}
+```dart
 var s1 = '''
 You can create
 multi-line strings like this one.
@@ -618,14 +601,14 @@ multi-line strings like this one.
 
 var s2 = """This is also a
 multi-line string.""";
-{% endprettify %}
+```
 
 You can create a “raw” string by prefixing it with `r`:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (raw-strings)"?>
-{% prettify dart %}
+```dart
 var s = r'In a raw string, not even \n gets special treatment.';
-{% endprettify %}
+```
 
 See [Runes](#runes) for details on how to express Unicode
 characters in a string.
@@ -635,7 +618,7 @@ as long as any interpolated expression is a compile-time constant
 that evaluates to null or a numeric, string, or boolean value.
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (string-literals)"?>
-{% prettify dart %}
+```dart
 // These work in a const string.
 const aConstNum = 0;
 const aConstBool = true;
@@ -649,7 +632,7 @@ const aConstList = [1, 2, 3];
 
 const validConstString = '$aConstNum $aConstBool $aConstString';
 // const invalidConstString = '$aNum $aBool $aString $aConstList';
-{% endprettify %}
+```
 
 For more information on using strings, see
 [Strings and regular expressions](/guides/libraries/library-tour#strings-and-regular-expressions).
@@ -667,7 +650,7 @@ Dart's type safety means that you can't use code like
 Instead, explicitly check for values, like this:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (no-truthy)"?>
-{% prettify dart %}
+```dart
 // Check for an empty string.
 var fullName = '';
 assert(fullName.isEmpty);
@@ -683,7 +666,7 @@ assert(unicorn == null);
 // Check for NaN.
 var iMeantToDoThis = 0 / 0;
 assert(iMeantToDoThis.isNaN);
-{% endprettify %}
+```
 
 
 ### Lists
@@ -696,18 +679,16 @@ Dart list literals look like JavaScript array literals. Here’s a simple
 Dart list:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (list-literal)"?>
-{% prettify dart %}
+```dart
 var list = [1, 2, 3];
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  Dart infers that `list` has type `List<int>`.
-  If you try to add non-integer objects to this list,
-  the analyzer or runtime raises an error.
-  For more information, read about
+{{site.alert.note}}
+  Dart infers that `list` has type `List<int>`. If you try to add non-integer
+  objects to this list, the analyzer or runtime raises an error. For more
+  information, read about
   [type inference.](/guides/language/sound-dart#type-inference)
-</aside>
+{{site.alert.end}}
 
 Lists use zero-based indexing, where 0 is the index of the first element
 and `list.length - 1` is the index of the last element. You can get a
@@ -715,23 +696,23 @@ list’s length and refer to list elements just as you would in
 JavaScript:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-indexing)"?>
-{% prettify dart %}
+```dart
 var list = [1, 2, 3];
 assert(list.length == 3);
 assert(list[1] == 2);
 
 list[1] = 1;
 assert(list[1] == 1);
-{% endprettify %}
+```
 
 To create a list that's a compile-time constant,
 add `const` before the list literal:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (const-list)"?>
-{% prettify dart %}
+```dart
 var constantList = const [1, 2, 3];
 // constantList[1] = 1; // Uncommenting this causes an error.
-{% endprettify %}
+```
 
 <a id="spread-operator"> </a>
 Dart 2.3 introduced the **spread operator** (`...`) and the
@@ -742,21 +723,21 @@ For example, you can use the spread operator (`...`) to insert
 all the elements of a list into another list:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-spread)"?>
-{% prettify dart %}
+```dart
 var list = [1, 2, 3];
 var list2 = [0, ...list];
 assert(list2.length == 4);
-{% endprettify %}
+```
 
 If the expression to the right of the spread operator might be null,
 you can avoid exceptions by using a null-aware spread operator (`...?`):
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-null-spread)"?>
-{% prettify dart %}
+```dart
 var list;
 var list2 = [0, ...?list];
 assert(list2.length == 1);
-{% endprettify %}
+```
 
 For more details and examples of using the spread operator, see the
 [spread operator proposal.][spread proposal]
@@ -770,28 +751,28 @@ Here's an example of using **collection if**
 to create a list with three or four items in it:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-if)"?>
-{% prettify dart %}
+```dart
 var nav = [
   'Home',
   'Furniture',
   'Plants',
   if (promoActive) 'Outlet'
 ];
-{% endprettify %}
+```
 
 Here's an example of using **collection for**
 to manipulate the items of a list before
 adding them to another list:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-for)"?>
-{% prettify dart %}
+```dart
 var listOfInts = [1, 2, 3];
 var listOfStrings = [
   '#0',
   for (var i in listOfInts) '#$i'
 ];
 assert(listOfStrings[1] == '#1');
-{% endprettify %}
+```
 
 For more details and examples of using collection if and for, see the
 [control flow collections proposal.][collections proposal]
@@ -810,69 +791,66 @@ information about lists, see [Generics](#generics) and
 A set in Dart is an unordered collection of unique items.
 Dart support for sets is provided by set literals and the [Set][] type.
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:** Although the Set _type_ has always been a core part of Dart,
-  set _literals_ were introduced in Dart 2.2.
-</aside>
+{{site.alert.version-note}}
+  Although the Set _type_ has always been a core part of Dart, set _literals_
+  were introduced in Dart 2.2.
+{{site.alert.end}}
 
 Here is a simple Dart set, created using a set literal:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (set-literal)"?>
-{% prettify dart %}
+```dart
 var halogens = {'fluorine', 'chlorine', 'bromine', 'iodine', 'astatine'};
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  Dart infers that `halogens` has the type
-  `Set<String>`. If you try to add the wrong type of value
-  to the set, the analyzer or runtime raises an error.
-  For more information, read about
+{{site.alert.note}}
+  Dart infers that `halogens` has the type `Set<String>`. If you try to add the
+  wrong type of value to the set, the analyzer or runtime raises an error. For
+  more information, read about
   [type inference.](/guides/language/sound-dart#type-inference)
-</aside>
+{{site.alert.end}}
 
 To create an empty set, use `{}` preceded by a type argument,
 or assign `{}` to a variable of type `Set`:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (set-vs-map)"?>
-{% prettify dart %}
+```dart
 var names = <String>{};
 // Set<String> names = {}; // This works, too.
 // var names = {}; // Creates a map, not a set.
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Set or map?**
-  The syntax for map literals is similar to that for set literals.
-  Because map literals came first, `{}` defaults to the `Map` type.
-  If you forget the type annotation on `{}` or the variable it's assigned to,
-  then Dart creates an object of type `Map<dynamic, dynamic>`.
-</aside>
+{{site.alert.info}}
+  **Set or map?** The syntax for map literals is similar to that for set
+  literals. Because map literals came first, `{}` defaults to the `Map` type. If
+  you forget the type annotation on `{}` or the variable it's assigned to, then
+  Dart creates an object of type `Map<dynamic, dynamic>`.
+{{site.alert.end}}
 
 Add items to an existing set using the `add()` or `addAll()` methods:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (set-add-items)"?>
-{% prettify dart %}
+```dart
 var elements = <String>{};
 elements.add('fluorine');
 elements.addAll(halogens);
-{% endprettify %}
+```
 
 Use `.length` to get the number of items in the set:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (set-length)"?>
-{% prettify dart %}
+```dart
 var elements = <String>{};
 elements.add('fluorine');
 elements.addAll(halogens);
 assert(elements.length == 5);
-{% endprettify %}
+```
 
 To create a set that's a compile-time constant,
 add `const` before the set literal:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (const-set)"?>
-{% prettify dart %}
+```dart
 final constantSet = const {
   'fluorine',
   'chlorine',
@@ -881,7 +859,7 @@ final constantSet = const {
   'astatine',
 };
 // constantSet.add('helium'); // Uncommenting this causes an error.
-{% endprettify %}
+```
 
 As of Dart 2.3, sets support spread operators (`...` and `...?`)
 and collection ifs and fors,
@@ -904,7 +882,7 @@ is provided by map literals and the [Map][] type.
 Here are a couple of simple Dart maps, created using map literals:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (map-literal)"?>
-{% prettify dart %}
+```dart
 var gifts = {
   // Key:    Value
   'first': 'partridge',
@@ -917,22 +895,19 @@ var nobleGases = {
   10: 'neon',
   18: 'argon',
 };
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  Dart infers that `gifts` has the type
-  `Map<String, String>` and `nobleGases` has the type
-  `Map<int, String>`. If you try to add the wrong type of value
-  to either map, the analyzer or runtime raises an error.
-  For more information, read about
-  [type inference.](/guides/language/sound-dart#type-inference)
-</aside>
+{{site.alert.note}}
+  Dart infers that `gifts` has the type `Map<String, String>` and `nobleGases`
+  has the type `Map<int, String>`. If you try to add the wrong type of value to
+  either map, the analyzer or runtime raises an error. For more information,
+  read about [type inference.](/guides/language/sound-dart#type-inference)
+{{site.alert.end}}
 
 You can create the same objects using a Map constructor:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (map-constructor)"?>
-{% prettify dart %}
+```dart
 var gifts = Map();
 gifts['first'] = 'partridge';
 gifts['second'] = 'turtledoves';
@@ -942,54 +917,53 @@ var nobleGases = Map();
 nobleGases[2] = 'helium';
 nobleGases[10] = 'neon';
 nobleGases[18] = 'argon';
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-**Note:**
-You might expect to see `new Map()` instead of just `Map()`.
-As of Dart 2, the `new` keyword is optional.
-For details, see [Using constructors](#using-constructors).
-</aside>
+{{site.alert.note}}
+  You might expect to see `new Map()` instead of just `Map()`.
+  As of Dart 2, the `new` keyword is optional.
+  For details, see [Using constructors](#using-constructors).
+{{site.alert.end}}
 
 Add a new key-value pair to an existing map just as you would in
 JavaScript:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (map-add-item)"?>
-{% prettify dart %}
+```dart
 var gifts = {'first': 'partridge'};
 gifts['fourth'] = 'calling birds'; // Add a key-value pair
-{% endprettify %}
+```
 
 Retrieve a value from a map the same way you would in JavaScript:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-retrieve-item)"?>
-{% prettify dart %}
+```dart
 var gifts = {'first': 'partridge'};
 assert(gifts['first'] == 'partridge');
-{% endprettify %}
+```
 
 If you look for a key that isn’t in a map, you get a null in return:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-missing-key)"?>
-{% prettify dart %}
+```dart
 var gifts = {'first': 'partridge'};
 assert(gifts['fifth'] == null);
-{% endprettify %}
+```
 
 Use `.length` to get the number of key-value pairs in the map:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-length)"?>
-{% prettify dart %}
+```dart
 var gifts = {'first': 'partridge'};
 gifts['fourth'] = 'calling birds';
 assert(gifts.length == 2);
-{% endprettify %}
+```
 
 To create a map that's a compile-time constant,
 add `const` before the map literal:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (const-map)"?>
-{% prettify dart %}
+```dart
 final constantMap = const {
   2: 'helium',
   10: 'neon',
@@ -997,7 +971,7 @@ final constantMap = const {
 };
 
 // constantMap[2] = 'Helium'; // Uncommenting this causes an error.
-{% endprettify %}
+```
 
 As of Dart 2.3, maps support spread operators (`...` and `...?`)
 and collection if and for, just like lists do.
@@ -1040,7 +1014,7 @@ https://gist.github.com/589bc5c95318696cefe5
 Unicode emoji: https://unicode.org/emoji/charts/full-emoji-list.html
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (runes)"?>
-{% prettify dart %}
+```dart
 void main() {
   var clapping = '\u{1f44f}';
   print(clapping);
@@ -1051,7 +1025,7 @@ void main() {
       Runes('\u2665  \u{1f605}  \u{1f60e}  \u{1f47b}  \u{1f596}  \u{1f44d}');
   print(String.fromCharCodes(input));
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -1061,14 +1035,14 @@ src="{{site.dartpad-embed-inline}}?id=589bc5c95318696cefe5"
     style="border: 1px solid #ccc;">
 </iframe>
 
-<div class="alert alert-warning" markdown="1">
-**Note:**
-Be careful when manipulating runes using list operations.
-This approach can easily break down,
-depending on the particular language, character set, and operation.
-For more information, see
-[How do I reverse a String in Dart?](https://stackoverflow.com/questions/21521729/how-do-i-reverse-a-string-in-dart) on Stack Overflow.
-</div>
+{{site.alert.note}}
+  Be careful when manipulating runes using list operations. This approach can
+  easily break down, depending on the particular language, character set, and
+  operation. For more information, see [How do I reverse a String in Dart?][] on
+  Stack Overflow.
+
+  [How do I reverse a String in Dart?]: https://stackoverflow.com/questions/21521729/how-do-i-reverse-a-string-in-dart
+{{site.alert.end}}
 
 ### Symbols
 
@@ -1090,7 +1064,7 @@ To get the symbol for an identifier, use a symbol literal, which is just
 The code from the following excerpt isn't actually what is being shown in the page
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (symbols)"?>
-{% prettify dart %}
+```dart
 // MOVE TO library tour?
 
 void main() {
@@ -1104,7 +1078,7 @@ void main() {
 int handleError(String source) {
   return 0;
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 Symbol literals are compile-time constants.
@@ -1121,54 +1095,50 @@ it were a function. For details, see [Callable classes](#callable-classes).
 Here’s an example of implementing a function:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function)"?>
-{% prettify dart %}
+```dart
 bool isNoble(int atomicNumber) {
   return _nobleGases[atomicNumber] != null;
 }
-{% endprettify %}
+```
 
 Although Effective Dart recommends
 [type annotations for public APIs](/guides/language/effective-dart/design#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious),
 the function still works if you omit the types:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function-omitting-types)"?>
-{% prettify dart %}
+```dart
 isNoble(atomicNumber) {
   return _nobleGases[atomicNumber] != null;
 }
-{% endprettify %}
+```
 
 For functions that contain just one expression, you can use a shorthand
 syntax:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function-shorthand)"?>
-{% prettify dart %}
+```dart
 bool isNoble(int atomicNumber) => _nobleGases[atomicNumber] != null;
-{% endprettify %}
+```
 
 The <code>=> <em>expr</em></code> syntax is a shorthand for
 <code>{ return <em>expr</em>; }</code>. The `=>` notation
 is sometimes referred to as _arrow_ syntax.
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  Only an *expression*—not a *statement*—can appear between the arrow
-  (=\>) and the semicolon (;). For example, you can’t put an [if
-  statement](#if-and-else) there, but you can use a [conditional
-  expression](#conditional-expressions).
-</aside>
+{{site.alert.note}}
+  Only an *expression*—not a *statement*—can appear between the arrow (=\>) and
+  the semicolon (;). For example, you can’t put an [if statement](#if-and-else)
+  there, but you can use a [conditional expression](#conditional-expressions).
+{{site.alert.end}}
 
 A function can have two types of parameters: _required_ and _optional_.
 The required parameters are listed first, followed by any optional parameters.
 Optional parameters can be _named_ or _positional_.
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
-  Some APIs — notably [Flutter][] widget constructors —
-  use only named parameters,
-  even for parameters that are mandatory.
-  See the next section for details.
-</aside>
+{{site.alert.note}}
+  Some APIs — notably [Flutter][] widget constructors — use only named
+  parameters, even for parameters that are mandatory. See the next section for
+  details.
+{{site.alert.end}}
 
 ### Optional parameters
 
@@ -1180,19 +1150,19 @@ When calling a function, you can specify named parameters using
 <code><em>paramName</em>: <em>value</em></code>. For example:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (use-named-parameters)"?>
-{% prettify dart %}
+```dart
 enableFlags(bold: true, hidden: false);
-{% endprettify %}
+```
 
 When defining a function, use
 <code>{<em>param1</em>, <em>param2</em>, …}</code>
 to specify named parameters:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (specify-named-parameters)"?>
-{% prettify dart %}
+```dart
 /// Sets the [bold] and [hidden] flags ...
 void enableFlags({bool bold, bool hidden}) {...}
-{% endprettify %}
+```
 
 Although named parameters are a kind of optional parameter,
 you can annotate them with [@required][] to indicate
@@ -1218,7 +1188,7 @@ Wrapping a set of function parameters in `[]` marks them as optional
 positional parameters:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-parameters)"?>
-{% prettify dart %}
+```dart
 String say(String from, String msg, [String device]) {
   var result = '$from says $msg';
   if (device != null) {
@@ -1226,23 +1196,23 @@ String say(String from, String msg, [String device]) {
   }
   return result;
 }
-{% endprettify %}
+```
 
 Here’s an example of calling this function without the optional
 parameter:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (call-without-optional-param)"?>
-{% prettify dart %}
+```dart
 assert(say('Bob', 'Howdy') == 'Bob says Howdy');
-{% endprettify %}
+```
 
 And here’s an example of calling this function with the third parameter:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (call-with-optional-param)"?>
-{% prettify dart %}
+```dart
 assert(say('Bob', 'Howdy', 'smoke signal') ==
     'Bob says Howdy with a smoke signal');
-{% endprettify %}
+```
 
 <a id="default-parameters"></a>
 #### Default parameter values
@@ -1254,23 +1224,22 @@ If no default value is provided, the default value is `null`.
 Here's an example of setting default values for named parameters:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (named-parameter-default-values)"?>
-{% prettify dart %}
+```dart
 /// Sets the [bold] and [hidden] flags ...
 void enableFlags({bool bold = false, bool hidden = false}) {...}
 
 // bold will be true; hidden will be false.
 enableFlags(bold: true);
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Deprecation note:**
-Old code might use a colon (`:`) instead of `=`
-to set default values of named parameters.
-The reason is that originally, only `:` was supported for named parameters.
-That support might be deprecated,
-so we recommend that you
-**[use `=` to specify default values.](/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value)**
-</div>
+{{site.alert.info}}
+  **Deprecation note:** Old code might use a colon (`:`) instead of `=` to set
+  default values of named parameters. The reason is that originally, only `:`
+  was supported for named parameters. That support might be deprecated, so we
+  recommend that you **[use `=` to specify default values.][use =]**
+
+  [use =]: /guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value
+{{site.alert.end}}
 
 {% comment %}
 PENDING: I don't see evidence that we've dropped support for `:`.
@@ -1281,7 +1250,7 @@ See `defaultNamedParameter` in the language spec.
 The next example shows how to set default values for positional parameters:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-param-default)"?>
-{% prettify dart %}
+```dart
 String say(String from, String msg,
     [String device = 'carrier pigeon', String mood]) {
   var result = '$from says $msg';
@@ -1296,7 +1265,7 @@ String say(String from, String msg,
 
 assert(say('Bob', 'Howdy') ==
     'Bob says Howdy with a carrier pigeon');
-{% endprettify %}
+```
 
 You can also pass lists or maps as default values.
 The following example defines a function, `doStuff()`,
@@ -1308,7 +1277,7 @@ list and map default values in action.
 {% endcomment %}
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (list-map-default-function-param)"?>
-{% prettify dart %}
+```dart
 void doStuff(
     {List<int> list = const [1, 2, 3],
     Map<String, String> gifts = const {
@@ -1319,7 +1288,7 @@ void doStuff(
   print('list:  $list');
   print('gifts: $gifts');
 }
-{% endprettify %}
+```
 
 {% comment %}
 https://gist.github.com/d988cfce0a54c6853799
@@ -1343,26 +1312,25 @@ optional `List<String>` parameter for arguments.
 Here's an example of the `main()` function for a web app:
 
 <?code-excerpt "misc/test/language_tour/browser_test.dart (simple-web-main-function)"?>
-{% prettify dart %}
+```dart
 void main() {
   querySelector('#sample_text_id')
     ..text = 'Click me!'
     ..onClick.listen(reverseText);
 }
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-The `..` syntax in the preceding code is called a [cascade](#cascade-notation-).
-With cascades,
-you can perform multiple operations on the members of a single object.
-</div>
+{{site.alert.note}}
+  The `..` syntax in the preceding code is called a
+  [cascade](#cascade-notation-). With cascades, you can perform multiple
+  operations on the members of a single object.
+{{site.alert.end}}
 
 Here's an example of the `main()` function for a command-line app that
 takes arguments:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (main-args)"?>
-{% prettify dart %}
+```dart
 // Run the app like this: dart args.dart 1 test
 void main(List<String> arguments) {
   print(arguments);
@@ -1371,7 +1339,7 @@ void main(List<String> arguments) {
   assert(int.parse(arguments[0]) == 1);
   assert(arguments[1] == 'test');
 }
-{% endprettify %}
+```
 
 You can use the [args library]({{site.pub}}/packages/args) to
 define and parse command-line arguments.
@@ -1381,7 +1349,7 @@ define and parse command-line arguments.
 You can pass a function as a parameter to another function. For example:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function-as-param)"?>
-{% prettify dart %}
+```dart
 void printElement(int element) {
   print(element);
 }
@@ -1390,15 +1358,15 @@ var list = [1, 2, 3];
 
 // Pass printElement as a parameter.
 list.forEach(printElement);
-{% endprettify %}
+```
 
 You can also assign a function to a variable, such as:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (function-as-var)"?>
-{% prettify dart %}
+```dart
 var loudify = (msg) => '!!! ${msg.toUpperCase()} !!!';
 assert(loudify('hello') == '!!! HELLO !!!');
-{% endprettify %}
+```
 
 This example uses an anonymous function.
 More about those in the next section.
@@ -1428,12 +1396,12 @@ The function, invoked for each item in the list,
 prints a string that includes the value at the specified index.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anonymous-function)"?>
-{% prettify dart %}
+```dart
 var list = ['apples', 'bananas', 'oranges'];
 list.forEach((item) {
   print('${list.indexOf(item)}: $item');
 });
-{% endprettify %}
+```
 
 Click **Run** to execute the code.
 
@@ -1454,10 +1422,10 @@ notation. Paste the following line into DartPad and click **Run** to verify that
 it is functionally equivalent.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anon-func)"?>
-{% prettify dart %}
+```dart
 list.forEach(
     (item) => print('${list.indexOf(item)}: $item'));
-{% endprettify %}
+```
 
 
 ### Lexical scope
@@ -1471,7 +1439,7 @@ Here is an example of nested functions with variables at each scope
 level:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (nested-functions)"?>
-{% prettify dart %}
+```dart
 bool topLevel = true;
 
 void main() {
@@ -1490,7 +1458,7 @@ void main() {
     }
   }
 }
-{% endprettify %}
+```
 
 Notice how `nestedFunction()` can use variables from every level, all
 the way up to the top level.
@@ -1507,7 +1475,7 @@ following example, `makeAdder()` captures the variable `addBy`. Wherever the
 returned function goes, it remembers `addBy`.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (function-closure)"?>
-{% prettify dart %}
+```dart
 /// Returns a function that adds [addBy] to the
 /// function's argument.
 Function makeAdder(num addBy) {
@@ -1524,7 +1492,7 @@ void main() {
   assert(add2(3) == 5);
   assert(add4(3) == 7);
 }
-{% endprettify %}
+```
 
 
 ### Testing functions for equality
@@ -1533,7 +1501,7 @@ Here's an example of testing top-level functions, static methods, and
 instance methods for equality:
 
 <?code-excerpt "misc/lib/language_tour/function_equality.dart"?>
-{% prettify dart %}
+```dart
 void foo() {} // A top-level function
 
 class A {
@@ -1566,7 +1534,7 @@ void main() {
   // so they're unequal.
   assert(v.baz != w.baz);
 }
-{% endprettify %}
+```
 
 
 ### Return values
@@ -1575,11 +1543,11 @@ All functions return a value. If no return value is specified, the
 statement `return null;` is implicitly appended to the function body.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (implicit-return-null)"?>
-{% prettify dart %}
+```dart
 foo() {}
 
 assert(foo() == null);
-{% endprettify %}
+```
 
 
 ## Operators
@@ -1609,25 +1577,24 @@ You can override many of these operators, as described in
 | assignment               | `=`    `*=`    `/=`    `+=`    `-=`    `&=`    `^=`    <em>etc.</em> |
 {:.table .table-striped}
 
-<aside class="alert alert-warning" markdown="1">
-  **Warning:**
+{{site.alert.warning}}
   Operator precedence is an approximation of the behavior of a Dart parser.
   For definitive answers, consult the grammar in the
   [Dart language specification][].
-</aside>
+{{site.alert.end}}
 
 When you use operators, you create expressions. Here are some examples
 of operator expressions:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (expressions)" replace="/,//g"?>
-{% prettify dart %}
+```dart
 a++
 a + b
 a = b
 a == b
 c ? a : b
 a is T
-{% endprettify %}
+```
 
 In the [operator table](#operators),
 each operator has higher precedence than the operators in the rows
@@ -1638,21 +1605,19 @@ precedence means that the following two lines of code execute the same
 way:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (precedence)"?>
-{% prettify dart %}
+```dart
 // Parentheses improve readability.
 if ((n % i == 0) && (d % i == 0)) ...
 
 // Harder to read, but equivalent.
 if (n % i == 0 && d % i == 0) ...
-{% endprettify %}
+```
 
-<div class="alert alert-warning" markdown="1">
-**Warning:**
-For operators that work on two operands, the leftmost operand
-determines which version of the operator is used. For example, if you
-have a Vector object and a Point object, `aVector + aPoint` uses the
-Vector version of +.
-</div>
+{{site.alert.warning}}
+  For operators that work on two operands, the leftmost operand determines which
+  version of the operator is used. For example, if you have a Vector object and
+  a Point object, `aVector + aPoint` uses the Vector version of +.
+{{site.alert.end}}
 
 
 ### Arithmetic operators
@@ -1674,7 +1639,7 @@ Dart supports the usual arithmetic operators, as shown in the following table.
 Example:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (arithmetic)"?>
-{% prettify dart %}
+```dart
 assert(2 + 3 == 5);
 assert(2 - 3 == -1);
 assert(2 * 3 == 6);
@@ -1683,7 +1648,7 @@ assert(5 ~/ 2 == 2); // Result is an int
 assert(5 % 2 == 1); // Remainder
 
 assert('5/2 = ${5 ~/ 2} r ${5 % 2}' == '5/2 = 2 r 1');
-{% endprettify %}
+```
 
 Dart also supports both prefix and postfix increment and decrement
 operators.
@@ -1700,7 +1665,7 @@ operators.
 Example:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (increment-decrement)"?>
-{% prettify dart %}
+```dart
 var a, b;
 
 a = 0;
@@ -1718,7 +1683,7 @@ assert(a == b); // -1 == -1
 a = 0;
 b = a--; // Decrement a AFTER b gets its value.
 assert(a != b); // -1 != 0
-{% endprettify %}
+```
 
 
 ### Equality and relational operators
@@ -1755,14 +1720,14 @@ Here’s an example of using each of the equality and relational
 operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (relational)"?>
-{% prettify dart %}
+```dart
 assert(2 == 2);
 assert(2 != 3);
 assert(3 > 2);
 assert(2 < 3);
 assert(3 >= 3);
 assert(2 <= 3);
-{% endprettify %}
+```
 
 
 ### Type test operators
@@ -1787,27 +1752,25 @@ followed by an expression using that object. For example, consider the
 following code:
 
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp is Person)"?>
-{% prettify dart %}
+```dart
 if (emp is Person) {
   // Type check
   emp.firstName = 'Bob';
 }
-{% endprettify %}
+```
 
 You can make the code shorter using the `as` operator:
 
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp as Person)"?>
-{% prettify dart %}
+```dart
 (emp as Person).firstName = 'Bob';
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-The code isn’t equivalent. If `emp` is null or not a Person, the
-first example (with `is`) does nothing; the second (with `as`) throws
-an exception.
-</div>
-
+{{site.alert.note}}
+  The code isn’t equivalent. If `emp` is null or not a Person, the
+  first example (with `is`) does nothing; the second (with `as`) throws
+  an exception.
+{{site.alert.end}}
 
 ### Assignment operators
 
@@ -1816,12 +1779,12 @@ To assign only if the assigned-to variable is null,
 use the `??=` operator.
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (assignment)"?>
-{% prettify dart %}
+```dart
 // Assign value to a
 a = value;
 // Assign value to b if b is null; otherwise, b stays the same
 b ??= value;
-{% endprettify %}
+```
 
 {% comment %}
 <!-- embed a dartpad when we can hide code -->
@@ -1829,7 +1792,7 @@ https://gist.github.com/9de887c4daf76d39e524
 {{site.dartpad}}/9de887c4daf76d39e524
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (assignment-gist-main-body)" plaster="none"?>
-{% prettify dart %}
+```dart
 void assignValues(int a, int b, int value) {
   print('Initially: a == $a, b == $b');
   // Assign value to a
@@ -1843,7 +1806,7 @@ main() {
   assignValues(0, 0, 1);
   assignValues(null, null, 1);
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 Compound assignment operators such as `+=` combine
@@ -1866,11 +1829,11 @@ The following example uses assignment and compound assignment
 operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (op-assign)"?>
-{% prettify dart %}
+```dart
 var a = 2; // Assign using =
 a *= 3; // Assign and multiply: a = a * 3
 assert(a == 6);
-{% endprettify %}
+```
 
 
 ### Logical operators
@@ -1889,11 +1852,11 @@ operators.
 Here’s an example of using the logical operators:
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (op-logical)"?>
-{% prettify dart %}
+```dart
 if (!done && (col == 0 || col == 3)) {
   // ...Do something...
 }
-{% endprettify %}
+```
 
 
 ### Bitwise and shift operators
@@ -1915,7 +1878,7 @@ you’d use these bitwise and shift operators with integers.
 Here’s an example of using bitwise and shift operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (op-bitwise)"?>
-{% prettify dart %}
+```dart
 final value = 0x22;
 final bitmask = 0x0f;
 
@@ -1925,7 +1888,7 @@ assert((value | bitmask) == 0x2f); // OR
 assert((value ^ bitmask) == 0x2d); // XOR
 assert((value << 4) == 0x220); // Shift left
 assert((value >> 4) == 0x02); // Shift right
-{% endprettify %}
+```
 
 
 ### Conditional expressions
@@ -1946,23 +1909,23 @@ based on a boolean expression,
 consider using `?:`.
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (if-then-else-operator)"?>
-{% prettify dart %}
+```dart
 var visibility = isPublic ? 'public' : 'private';
-{% endprettify %}
+```
 
 If the boolean expression tests for null,
 consider using `??`.
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (if-null)"?>
-{% prettify dart %}
+```dart
 String playerName(String name) => name ?? 'Guest';
-{% endprettify %}
+```
 
 The previous example could have been written at least two other ways,
 but not as succinctly:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (if-null-alt)"?>
-{% prettify dart %}
+```dart
 // Slightly longer version uses ?: operator.
 String playerName(String name) => name != null ? name : 'Guest';
 
@@ -1974,7 +1937,7 @@ String playerName(String name) {
     return 'Guest';
   }
 }
-{% endprettify %}
+```
 
 <a id="cascade"></a>
 ### Cascade notation (..)
@@ -1988,12 +1951,12 @@ allows you to write more fluid code.
 Consider the following code:
 
 <?code-excerpt "misc/test/language_tour/browser_test.dart (cascade-operator)"?>
-{% prettify dart %}
+```dart
 querySelector('#confirm') // Get an object.
   ..text = 'Confirm' // Use its members.
   ..classes.add('important')
   ..onClick.listen((e) => window.alert('Confirmed!'));
-{% endprettify %}
+```
 
 The first method call, `querySelector()`, returns a selector object.
 The code that follows the cascade notation operates
@@ -2003,17 +1966,17 @@ might be returned.
 The previous example is equivalent to:
 
 <?code-excerpt "misc/test/language_tour/browser_test.dart (cascade-operator-example-expanded)"?>
-{% prettify dart %}
+```dart
 var button = querySelector('#confirm');
 button.text = 'Confirm';
 button.classes.add('important');
 button.onClick.listen((e) => window.alert('Confirmed!'));
-{% endprettify %}
+```
 
 You can also nest your cascades. For example:
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (nested-cascades)"?>
-{% prettify dart %}
+```dart
 final addressBook = (AddressBookBuilder()
       ..name = 'jenny'
       ..email = 'jenny@example.com'
@@ -2022,27 +1985,25 @@ final addressBook = (AddressBookBuilder()
             ..label = 'home')
           .build())
     .build();
-{% endprettify %}
+```
 
 Be careful to construct your cascade on a function that returns
 an actual object. For example, the following code fails:
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (cannot-cascade-on-void)" plaster="none"?>
-{% prettify dart %}
+```dart
 var sb = StringBuffer();
 sb.write('foo')
   ..write('bar'); // Error: method 'write' isn't defined for 'void'.
-{% endprettify %}
+```
 
 The `sb.write()` call returns void,
 and you can't construct a cascade on `void`.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Strictly speaking,
-the "double dot" notation for cascades is not an operator.
-It's just part of the Dart syntax.
-</div>
+{{site.alert.note}}
+  Strictly speaking, the "double dot" notation for cascades is not an operator.
+  It's just part of the Dart syntax.
+{{site.alert.end}}
 
 ### Other operators
 
@@ -2082,7 +2043,7 @@ Dart supports `if` statements with optional `else` statements, as the
 next sample shows. Also see [conditional expressions](#conditional-expressions).
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (if-else)"?>
-{% prettify dart %}
+```dart
 if (isRaining()) {
   you.bringRainCoat();
 } else if (isSnowing()) {
@@ -2090,7 +2051,7 @@ if (isRaining()) {
 } else {
   car.putTopDown();
 }
-{% endprettify %}
+```
 
 Unlike JavaScript, conditions must use boolean values, nothing else. See
 [Booleans](#booleans) for more information.
@@ -2101,24 +2062,24 @@ Unlike JavaScript, conditions must use boolean values, nothing else. See
 You can iterate with the standard `for` loop. For example:
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (for)"?>
-{% prettify dart %}
+```dart
 var message = StringBuffer('Dart is fun');
 for (var i = 0; i < 5; i++) {
   message.write('!');
 }
-{% endprettify %}
+```
 
 Closures inside of Dart’s `for` loops capture the _value_ of the index,
 avoiding a common pitfall found in JavaScript. For example, consider:
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (for-and-closures)"?>
-{% prettify dart %}
+```dart
 var callbacks = [];
 for (var i = 0; i < 2; i++) {
   callbacks.add(() => print(i));
 }
 callbacks.forEach((c) => c());
-{% endprettify %}
+```
 
 The output is `0` and then `1`, as expected. In contrast, the example
 would print `2` and then `2` in JavaScript.
@@ -2128,20 +2089,20 @@ If the object that you are iterating over is an Iterable, you can use the
 know the current iteration counter:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (forEach)"?>
-{% prettify dart %}
+```dart
 candidates.forEach((candidate) => candidate.interview());
-{% endprettify %}
+```
 
 Iterable classes such as List and Set also support the `for-in` form of
 [iteration](/guides/libraries/library-tour#iteration):
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (collection)"?>
-{% prettify dart %}
+```dart
 var collection = [0, 1, 2];
 for (var x in collection) {
   print(x); // 0 1 2
 }
-{% endprettify %}
+```
 
 
 ### While and do-while
@@ -2149,20 +2110,20 @@ for (var x in collection) {
 A `while` loop evaluates the condition before the loop:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (while)"?>
-{% prettify dart %}
+```dart
 while (!isDone()) {
   doSomething();
 }
-{% endprettify %}
+```
 
 A `do`-`while` loop evaluates the condition *after* the loop:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (do-while)"?>
-{% prettify dart %}
+```dart
 do {
   printLine();
 } while (!atEndOfPage());
-{% endprettify %}
+```
 
 
 ### Break and continue
@@ -2170,17 +2131,17 @@ do {
 Use `break` to stop looping:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (while-break)"?>
-{% prettify dart %}
+```dart
 while (true) {
   if (shutDownRequested()) break;
   processIncomingRequests();
 }
-{% endprettify %}
+```
 
 Use `continue` to skip to the next loop iteration:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (for-continue)"?>
-{% prettify dart %}
+```dart
 for (int i = 0; i < candidates.length; i++) {
   var candidate = candidates[i];
   if (candidate.yearsExperience < 5) {
@@ -2188,17 +2149,17 @@ for (int i = 0; i < candidates.length; i++) {
   }
   candidate.interview();
 }
-{% endprettify %}
+```
 
 You might write that example differently if you’re using an
 [Iterable][] such as a list or set:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (where)"?>
-{% prettify dart %}
+```dart
 candidates
     .where((c) => c.yearsExperience >= 5)
     .forEach((c) => c.interview());
-{% endprettify %}
+```
 
 
 ### Switch and case
@@ -2209,11 +2170,10 @@ same class (and not of any of its subtypes), and the class must not
 override `==`.
 [Enumerated types](#enumerated-types) work well in `switch` statements.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Switch statements in Dart are intended for limited circumstances,
-such as in interpreters or scanners.
-</div>
+{{site.alert.note}}
+  Switch statements in Dart are intended for limited circumstances,
+  such as in interpreters or scanners.
+{{site.alert.end}}
 
 Each non-empty `case` clause ends with a `break` statement, as a rule.
 Other valid ways to end a non-empty `case` clause are a `continue`,
@@ -2222,7 +2182,7 @@ Other valid ways to end a non-empty `case` clause are a `continue`,
 Use a `default` clause to execute code when no `case` clause matches:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (switch)"?>
-{% prettify dart %}
+```dart
 var command = 'OPEN';
 switch (command) {
   case 'CLOSED':
@@ -2243,13 +2203,13 @@ switch (command) {
   default:
     executeUnknown();
 }
-{% endprettify %}
+```
 
 The following example omits the `break` statement in a `case` clause,
 thus generating an error:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (switch-break-omitted)" plaster="none"?>
-{% prettify dart %}
+```dart
 var command = 'OPEN';
 switch (command) {
   case 'OPEN':
@@ -2260,13 +2220,13 @@ switch (command) {
     executeClosed();
     break;
 }
-{% endprettify %}
+```
 
 However, Dart does support empty `case` clauses, allowing a form of
 fall-through:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (switch-empty-case)"?>
-{% prettify dart %}
+```dart
 var command = 'CLOSED';
 switch (command) {
   case 'CLOSED': // Empty case falls through.
@@ -2275,13 +2235,13 @@ switch (command) {
     executeNowClosed();
     break;
 }
-{% endprettify %}
+```
 
 If you really want fall-through, you can use a `continue` statement and
 a label:
 
 <?code-excerpt "misc/lib/language_tour/control_flow.dart (switch-continue)"?>
-{% prettify dart %}
+```dart
 var command = 'CLOSED';
 switch (command) {
   case 'CLOSED':
@@ -2295,7 +2255,7 @@ switch (command) {
     executeNowClosed();
     break;
 }
-{% endprettify %}
+```
 
 A `case` clause can have local variables, which are visible only inside
 the scope of that clause.
@@ -2310,7 +2270,7 @@ condition is false. You can find examples of assert statements
 throughout this tour. Here are some more:
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (assert)"?>
-{% prettify dart %}
+```dart
 // Make sure the variable has a non-null value.
 assert(text != null);
 
@@ -2319,16 +2279,16 @@ assert(number < 100);
 
 // Make sure this is an https URL.
 assert(urlString.startsWith('https'));
-{% endprettify %}
+```
 
 To attach a message to an assertion,
 add a string as the second argument to `assert`.
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (assert-with-message)"?>
-{% prettify dart %}
+```dart
 assert(urlString.startsWith('https'),
     'URL ($urlString) should start with "https".');
-{% endprettify %}
+```
 
 The first argument to `assert` can be any expression that
 resolves to a boolean value. If the expression’s value
@@ -2370,29 +2330,29 @@ non-null object—not just Exception and Error objects—as an exception.
 Here’s an example of throwing, or *raising*, an exception:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (throw-FormatException)"?>
-{% prettify dart %}
+```dart
 throw FormatException('Expected at least 1 section');
-{% endprettify %}
+```
 
 You can also throw arbitrary objects:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (out-of-llamas)"?>
-{% prettify dart %}
+```dart
 throw 'Out of llamas!';
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-  **Note:** Production-quality code usually throws types that implement
-  [Error][] or [Exception][].
-</div>
+{{site.alert.note}}
+  Production-quality code usually throws types that implement [Error][] or
+  [Exception][].
+{{site.alert.end}}
 
 Because throwing an exception is an expression, you can throw exceptions
 in =\> statements, as well as anywhere else that allows expressions:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (throw-is-an-expression)"?>
-{% prettify dart %}
+```dart
 void distanceTo(Point other) => throw UnimplementedError();
-{% endprettify %}
+```
 
 
 ### Catch
@@ -2402,13 +2362,13 @@ propagating (unless you rethrow the exception).
 Catching an exception gives you a chance to handle it:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (try)"?>
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } on OutOfLlamasException {
   buyMoreLlamas();
 }
-{% endprettify %}
+```
 
 To handle code that can throw more than one type of exception, you can
 specify multiple catch clauses. The first catch clause that matches the
@@ -2416,7 +2376,7 @@ thrown object’s type handles the exception. If the catch clause does not
 specify a type, that clause can handle any type of thrown object:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (try-catch)"?>
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } on OutOfLlamasException {
@@ -2429,7 +2389,7 @@ try {
   // No specified type, handles all
   print('Something really unknown: $e');
 }
-{% endprettify %}
+```
 
 As the preceding code shows, you can use either `on` or `catch` or both.
 Use `on` when you need to specify the exception type. Use `catch` when
@@ -2484,19 +2444,19 @@ a `finally` clause. If no `catch` clause matches the exception, the
 exception is propagated after the `finally` clause runs:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (finally)"?>
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } finally {
   // Always clean up, even if an exception is thrown.
   cleanLlamaStalls();
 }
-{% endprettify %}
+```
 
 The `finally` clause runs after any matching `catch` clauses:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (try-catch-finally)"?>
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } catch (e) {
@@ -2504,7 +2464,7 @@ try {
 } finally {
   cleanLlamaStalls(); // Then clean up.
 }
-{% endprettify %}
+```
 
 Learn more by reading the
 [Exceptions](/guides/libraries/library-tour#exceptions)
@@ -2530,7 +2490,7 @@ data.
 Use a dot (`.`) to refer to an instance variable or method:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (object-members)"?>
-{% prettify dart %}
+```dart
 var p = Point(2, 2);
 
 // Set the value of the instance variable y.
@@ -2541,7 +2501,7 @@ assert(p.y == 3);
 
 // Invoke distanceTo() on p.
 num distance = p.distanceTo(Point(4, 4));
-{% endprettify %}
+```
 
 Use `?.` instead of `.` to avoid an exception
 when the leftmost operand is null:
@@ -2552,10 +2512,10 @@ https://gist.github.com/0cb25997742ed5382e4a
 {% endcomment %}
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (safe-member-access)"?>
-{% prettify dart %}
+```dart
 // If p is non-null, set its y value to 4.
 p?.y = 4;
-{% endprettify %}
+```
 
 
 ### Using constructors
@@ -2567,83 +2527,82 @@ the following code creates `Point` objects using the
 `Point()` and `Point.fromJson()` constructors:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (object-creation)" replace="/ as .*?;/;/g"?>
-{% prettify dart %}
+```dart
 var p1 = Point(2, 2);
 var p2 = Point.fromJson({'x': 1, 'y': 2});
-{% endprettify %}
+```
 
 The following code has the same effect, but
 uses the optional `new` keyword before the constructor name:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (object-creation-new)" replace="/ as .*?;/;/g"?>
-{% prettify dart %}
+```dart
 var p1 = new Point(2, 2);
 var p2 = new Point.fromJson({'x': 1, 'y': 2});
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:** The `new` keyword became optional in Dart 2.
-</aside>
+{{site.alert.version-note}}
+  The `new` keyword became optional in Dart 2.
+{{site.alert.end}}
 
 Some classes provide [constant constructors](#constant-constructors).
 To create a compile-time constant using a constant constructor,
 put the `const` keyword before the constructor name:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (const)"?>
-{% prettify dart %}
+```dart
 var p = const ImmutablePoint(2, 2);
-{% endprettify %}
+```
 
 Constructing two identical compile-time constants results in a single,
 canonical instance:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (identical)"?>
-{% prettify dart %}
+```dart
 var a = const ImmutablePoint(1, 1);
 var b = const ImmutablePoint(1, 1);
 
 assert(identical(a, b)); // They are the same instance!
-{% endprettify %}
+```
 
 Within a _constant context_, you can omit the `const` before a constructor
 or literal. For example, look at this code, which creates a const map:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (const-context-withconst)" replace="/pointAndLine1/pointAndLine/g"?>
-{% prettify dart %}
+```dart
 // Lots of const keywords here.
 const pointAndLine = const {
   'point': const [const ImmutablePoint(0, 0)],
   'line': const [const ImmutablePoint(1, 10), const ImmutablePoint(-2, 11)],
 };
-{% endprettify %}
+```
 
 You can omit all but the first use of the `const` keyword:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (const-context-noconst)" replace="/pointAndLine2/pointAndLine/g"?>
-{% prettify dart %}
+```dart
 // Only one const, which establishes the constant context.
 const pointAndLine = {
   'point': [ImmutablePoint(0, 0)],
   'line': [ImmutablePoint(1, 10), ImmutablePoint(-2, 11)],
 };
-{% endprettify %}
+```
 
 If a constant constructor is outside of a constant context
 and is invoked without `const`,
 it creates a **non-constant object**:
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (nonconst-const-constructor)"?>
-{% prettify dart %}
+```dart
 var a = const ImmutablePoint(1, 1); // Creates a constant
 var b = ImmutablePoint(1, 1); // Does NOT create a constant
 
 assert(!identical(a, b)); // NOT the same instance!
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:** The `const` keyword became optional
-  within a constant context in Dart 2.
-</aside>
+{{site.alert.version-note}}
+  The `const` keyword became optional within a constant context in Dart 2.
+{{site.alert.end}}
 
 
 ### Getting an object's type
@@ -2653,9 +2612,9 @@ you can use Object's `runtimeType` property,
 which returns a [Type][] object.
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (runtimeType)"?>
-{% prettify dart %}
+```dart
 print('The type of a is ${a.runtimeType}');
-{% endprettify %}
+```
 
 Up to here, you've seen how to _use_ classes.
 The rest of this section shows how to _implement_ classes.
@@ -2666,13 +2625,13 @@ The rest of this section shows how to _implement_ classes.
 Here’s how you declare instance variables:
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class)"?>
-{% prettify dart %}
+```dart
 class Point {
   num x; // Declare instance variable x, initially null.
   num y; // Declare y, initially null.
   num z = 0; // Declare z, initially 0.
 }
-{% endprettify %}
+```
 
 All uninitialized instance variables have the value `null`.
 
@@ -2681,7 +2640,7 @@ instance variables also generate an implicit *setter* method. For details,
 see [Getters and setters](#getters-and-setters).
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class+main)" replace="/(num .*?;).*/$1/g" plaster="none"?>
-{% prettify dart %}
+```dart
 class Point {
   num x;
   num y;
@@ -2693,7 +2652,7 @@ void main() {
   assert(point.x == 4); // Use the getter method for x.
   assert(point.y == null); // Values default to null.
 }
-{% endprettify %}
+```
 
 If you initialize an instance variable where it is declared (instead of
 in a constructor or method), the value is set when the instance is
@@ -2710,7 +2669,7 @@ The most common form of constructor, the generative constructor, creates
 a new instance of a class:
 
 <?code-excerpt "misc/lib/language_tour/classes/point_alt.dart (constructor-long-way)" plaster="none"?>
-{% prettify dart %}
+```dart
 class Point {
   num x, y;
 
@@ -2720,21 +2679,20 @@ class Point {
     this.y = y;
   }
 }
-{% endprettify %}
+```
 
 The `this` keyword refers to the current instance.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Use `this` only when there is a name conflict. Otherwise, Dart style
-omits the `this`.
-</div>
+{{site.alert.note}}
+  Use `this` only when there is a name conflict. Otherwise, Dart style
+  omits the `this`.
+{{site.alert.end}}
 
 The pattern of assigning a constructor argument to an instance variable
 is so common, Dart has syntactic sugar to make it easy:
 
 <?code-excerpt "misc/lib/language_tour/classes/point.dart (constructor-initializer)" plaster="none"?>
-{% prettify dart %}
+```dart
 class Point {
   num x, y;
 
@@ -2742,7 +2700,7 @@ class Point {
   // before the constructor body runs.
   Point(this.x, this.y);
 }
-{% endprettify %}
+```
 
 #### Default constructors
 
@@ -2807,7 +2765,7 @@ https://gist.github.com/Sfshaza/e57aa06401e6618d4eb8
 {{site.dartpad}}/e57aa06401e6618d4eb8
 
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart" plaster="none"?>
-{% prettify dart %}
+```dart
 class Person {
   String firstName;
 
@@ -2836,7 +2794,7 @@ void main() {
   }
   (emp as Person).firstName = 'Bob';
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -2851,18 +2809,17 @@ invoking the constructor, an argument can be an expression such as a
 function call:
 
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart (method-then-constructor)"?>
-{% prettify dart %}
+```dart
 class Employee extends Person {
   Employee() : super.fromJson(getDefaultData());
   // ···
 }
-{% endprettify %}
+```
 
-<div class="alert alert-warning" markdown="1">
-**Warning:**
-Arguments to the superclass constructor do not have access to `this`.
-For example, arguments can call static methods but not instance methods.
-</div>
+{{site.alert.warning}}
+  Arguments to the superclass constructor do not have access to `this`. For
+  example, arguments can call static methods but not instance methods.
+{{site.alert.end}}
 
 #### Initializer list
 
@@ -2871,7 +2828,7 @@ instance variables before the constructor body runs. Separate
 initializers with commas.
 
 <?code-excerpt "misc/lib/language_tour/classes/point_alt.dart (initializer-list)"?>
-{% prettify dart %}
+```dart
 // Initializer list sets instance variables before
 // the constructor body runs.
 Point.fromJson(Map<String, num> json)
@@ -2879,12 +2836,11 @@ Point.fromJson(Map<String, num> json)
       y = json['y'] {
   print('In Point.fromJson(): ($x, $y)');
 }
-{% endprettify %}
+```
 
-<div class="alert alert-warning" markdown="1">
-**Warning:**
-The right-hand side of an initializer does not have access to `this`.
-</div>
+{{site.alert.warning}}
+  The right-hand side of an initializer does not have access to `this`.
+{{site.alert.end}}
 
 During development, you can validate inputs by using `assert` in the
 initializer list.
@@ -2913,7 +2869,7 @@ https://gist.github.com/Sfshaza/7a9764702c0608711e08
 {{site.dartpad}}/a9764702c0608711e08
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_distance_field.dart"?>
-{% prettify dart %}
+```dart
 import 'dart:math';
 
 class Point {
@@ -2931,7 +2887,7 @@ void main() {
   var p = Point(2, 3);
   print(p.distanceFromOrigin);
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -2949,7 +2905,7 @@ constructor in the same class. A redirecting constructor’s body is
 empty, with the constructor call appearing after a colon (:).
 
 <?code-excerpt "misc/lib/language_tour/classes/point_redirecting.dart"?>
-{% prettify dart %}
+```dart
 class Point {
   num x, y;
 
@@ -2959,7 +2915,7 @@ class Point {
   // Delegates to the main constructor.
   Point.alongXAxis(num x) : this(x, 0);
 }
-{% endprettify %}
+```
 
 #### Constant constructors
 
@@ -2968,7 +2924,7 @@ objects compile-time constants. To do this, define a `const` constructor
 and make sure that all instance variables are `final`.
 
 <?code-excerpt "misc/lib/language_tour/classes/immutable_point.dart"?>
-{% prettify dart %}
+```dart
 class ImmutablePoint {
   static final ImmutablePoint origin =
       const ImmutablePoint(0, 0);
@@ -2977,7 +2933,7 @@ class ImmutablePoint {
 
   const ImmutablePoint(this.x, this.y);
 }
-{% endprettify %}
+```
 
 Constant constructors don't always create constants.
 For details, see the section on
@@ -2995,7 +2951,7 @@ The following example demonstrates a factory constructor returning
 objects from a cache:
 
 <?code-excerpt "misc/lib/language_tour/classes/logger.dart"?>
-{% prettify dart %}
+```dart
 class Logger {
   final String name;
   bool mute = false;
@@ -3016,20 +2972,19 @@ class Logger {
     if (!mute) print(msg);
   }
 }
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Factory constructors have no access to `this`.
-</div>
+{{site.alert.note}}
+  Factory constructors have no access to `this`.
+{{site.alert.end}}
 
 Invoke a factory constructor just like you would any other constructor:
 
 <?code-excerpt "misc/lib/language_tour/classes/logger.dart (logger)"?>
-{% prettify dart %}
+```dart
 var logger = Logger('UI');
 logger.log('Button clicked');
-{% endprettify %}
+```
 
 
 ### Methods
@@ -3043,7 +2998,7 @@ The `distanceTo()` method in the following sample is an example of an
 instance method:
 
 <?code-excerpt "misc/lib/language_tour/classes/point.dart (class-with-distanceTo)" plaster="none"?>
-{% prettify dart %}
+```dart
 import 'dart:math';
 
 class Point {
@@ -3057,7 +3012,7 @@ class Point {
     return sqrt(dx * dx + dy * dy);
   }
 }
-{% endprettify %}
+```
 
 #### Getters and setters
 
@@ -3068,7 +3023,7 @@ additional properties by implementing getters and setters, using the
 `get` and `set` keywords:
 
 <?code-excerpt "misc/lib/language_tour/classes/rectangle.dart"?>
-{% prettify dart %}
+```dart
 class Rectangle {
   num left, top, width, height;
 
@@ -3087,18 +3042,17 @@ void main() {
   rect.right = 12;
   assert(rect.left == -8);
 }
-{% endprettify %}
+```
 
 With getters and setters, you can start with instance variables, later
 wrapping them with methods, all without changing client code.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Operators such as increment (++) work in the expected way, whether or
-not a getter is explicitly defined. To avoid any unexpected side
-effects, the operator calls the getter exactly once, saving its value
-in a temporary variable.
-</div>
+{{site.alert.note}}
+  Operators such as increment (++) work in the expected way, whether or
+  not a getter is explicitly defined. To avoid any unexpected side
+  effects, the operator calls the getter exactly once, saving its value
+  in a temporary variable.
+{{site.alert.end}}
 
 #### Abstract methods
 
@@ -3109,7 +3063,7 @@ Abstract methods can only exist in [abstract classes](#abstract-classes).
 To make a method abstract, use a semicolon (;) instead of a method body:
 
 <?code-excerpt "misc/lib/language_tour/classes/doer.dart"?>
-{% prettify dart %}
+```dart
 abstract class Doer {
   // Define instance variables and methods...
 
@@ -3121,7 +3075,7 @@ class EffectiveDoer extends Doer {
     // Provide an implementation, so the method is not abstract here...
   }
 }
-{% endprettify %}
+```
 
 
 ### Abstract classes
@@ -3137,7 +3091,7 @@ Here’s an example of declaring an abstract class that has an abstract
 method:
 
 <?code-excerpt "misc/lib/language_tour/classes/misc.dart (abstract)"?>
-{% prettify dart %}
+```dart
 // This class is declared abstract and thus
 // can't be instantiated.
 abstract class AbstractContainer {
@@ -3145,7 +3099,7 @@ abstract class AbstractContainer {
 
   void updateChildren(); // Abstract method.
 }
-{% endprettify %}
+```
 
 
 ### Implicit interfaces
@@ -3160,7 +3114,7 @@ A class implements one or more interfaces by declaring them in an
 interfaces. For example:
 
 <?code-excerpt "misc/lib/language_tour/classes/impostor.dart"?>
-{% prettify dart %}
+```dart
 // A person. The implicit interface contains greet().
 class Person {
   // In the interface, but visible only in this library.
@@ -3186,15 +3140,15 @@ void main() {
   print(greetBob(Person('Kathy')));
   print(greetBob(Impostor()));
 }
-{% endprettify %}
+```
 
 Here’s an example of specifying that a class implements multiple
 interfaces:
 
 <?code-excerpt "misc/lib/language_tour/classes/misc.dart (point_interfaces)"?>
-{% prettify dart %}
+```dart
 class Point implements Comparable, Location {...}
-{% endprettify %}
+```
 
 
 ### Extending a class
@@ -3257,15 +3211,15 @@ Vector class, you might define a `+` method to add two vectors.
 `–`  | `%`  | `>>`
 {:.table}
 
-<div class="alert alert-info" markdown="1">
-  **Note:** You may have noticed that `!=` is not an overridable operator.
-  The expression `e1 != e2` is just syntactic sugar for `!(e1 == e2)`.
-</div>
+{{site.alert.note}}
+  You may have noticed that `!=` is not an overridable operator. The expression
+  `e1 != e2` is just syntactic sugar for `!(e1 == e2)`.
+{{site.alert.end}}
 
 Here’s an example of a class that overrides the `+` and `-` operators:
 
 <?code-excerpt "misc/lib/language_tour/classes/vector.dart"?>
-{% prettify dart %}
+```dart
 class Vector {
   final int x, y;
 
@@ -3285,7 +3239,7 @@ void main() {
   assert(v + w == Vector(4, 5));
   assert(v - w == Vector(0, 1));
 }
-{% endprettify %}
+```
 
 If you override `==`, you should also override Object's `hashCode` getter.
 For an example of overriding `==` and `hashCode`, see
@@ -3340,9 +3294,9 @@ a fixed number of constant values.
 Declare an enumerated type using the `enum` keyword:
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)"?>
-{% prettify dart %}
+```dart
 enum Color { red, green, blue }
-{% endprettify %}
+```
 
 Each value in an enum has an `index` getter,
 which returns the zero-based position of the value in the enum declaration.
@@ -3350,26 +3304,26 @@ For example, the first value has index 0,
 and the second value has index 1.
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (index)"?>
-{% prettify dart %}
+```dart
 assert(Color.red.index == 0);
 assert(Color.green.index == 1);
 assert(Color.blue.index == 2);
-{% endprettify %}
+```
 
 To get a list of all of the values in the enum,
 use the enum's `values` constant.
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (values)"?>
-{% prettify dart %}
+```dart
 List<Color> colors = Color.values;
 assert(colors[2] == Color.blue);
-{% endprettify %}
+```
 
 You can use enums in [switch statements](#switch-and-case), and
 you'll get a warning if you don't handle all of the enum's values:
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (switch)"?>
-{% prettify dart %}
+```dart
 var aColor = Color.blue;
 
 switch (aColor) {
@@ -3382,7 +3336,7 @@ switch (aColor) {
   default: // Without this, you see a WARNING.
     print(aColor); // 'Color.blue'
 }
-{% endprettify %}
+```
 
 Enumerated types have the following limits:
 
@@ -3422,7 +3376,7 @@ use the `mixin` keyword instead of `class`.
 For example:
 
 <?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (Musical)"?>
-{% prettify dart %}
+```dart
 mixin Musical {
   bool canPlayPiano = false;
   bool canCompose = false;
@@ -3438,29 +3392,24 @@ mixin Musical {
     }
   }
 }
-{% endprettify %}
+```
 
 To specify that only certain types can use the mixin — for example,
 so your mixin can invoke a method that it doesn't define —
 use `on` to specify the required superclass:
 
 <?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)"?>
-{% prettify dart %}
+```dart
 mixin MusicalPerformer on Musician {
   // ···
 }
-{% endprettify %}
+```
 
-<!-- Previous code snippet reveals an issue we expect to be fixed in 2.1.1:
-  https://github.com/dart-lang/sdk/issues/35011
--->
-
-<aside class="alert alert-info" markdown="1">
-  **Version note:** Support for the `mixin` keyword was introduced in Dart 2.1.
-  Code in earlier releases usually used `abstract class` instead.
-  For more information on 2.1 mixin changes, see the
-  [Dart SDK changelog][] and [2.1 mixin specification.][]
-</aside>
+{{site.alert.version-note}}
+  Support for the `mixin` keyword was introduced in Dart 2.1. Code in earlier
+  releases usually used `abstract class` instead. For more information on 2.1
+  mixin changes, see the [Dart SDK changelog][] and [2.1 mixin specification.][]
+{{site.alert.end}}
 
 [Dart SDK changelog]: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md
 [2.1 mixin specification.]: https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/feature-specification.md#dart-2-mixin-declarations
@@ -3476,7 +3425,7 @@ Static variables (class variables) are useful for class-wide state and
 constants:
 
 <?code-excerpt "misc/lib/language_tour/classes/misc.dart (static-field)"?>
-{% prettify dart %}
+```dart
 class Queue {
   static const initialCapacity = 16;
   // ···
@@ -3485,16 +3434,15 @@ class Queue {
 void main() {
   assert(Queue.initialCapacity == 16);
 }
-{% endprettify %}
+```
 
 Static variables aren’t initialized until they’re used.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-This page follows the [style guide
-recommendation](/guides/language/effective-dart/style#identifiers)
-of preferring `lowerCamelCase` for constant names.
-</div>
+{{site.alert.note}}
+  This page follows the [style guide
+  recommendation](/guides/language/effective-dart/style#identifiers)
+  of preferring `lowerCamelCase` for constant names.
+{{site.alert.end}}
 
 #### Static methods
 
@@ -3502,7 +3450,7 @@ Static methods (class methods) do not operate on an instance, and thus
 do not have access to `this`. For example:
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_distance_method.dart"?>
-{% prettify dart %}
+```dart
 import 'dart:math';
 
 class Point {
@@ -3523,13 +3471,12 @@ void main() {
   assert(2.8 < distance && distance < 2.9);
   print(distance);
 }
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Consider using top-level functions, instead of static methods, for
-common or widely used utilities and functionality.
-</div>
+{{site.alert.note}}
+  Consider using top-level functions, instead of static methods, for
+  common or widely used utilities and functionality.
+{{site.alert.end}}
 
 You can use static methods as compile-time constants. For example, you
 can pass a static method as a parameter to a constant constructor.
@@ -3562,11 +3509,11 @@ the list is probably a mistake. Here’s an example:
 
 {:.fails-sa}
 <?code-excerpt "misc/lib/language_tour/generics/misc.dart (why-generics)"?>
-{% prettify dart %}
+```dart
 var names = List<String>();
 names.addAll(['Seth', 'Kathy', 'Lars']);
 names.add(42); // Error
-{% endprettify %}
+```
 
 Another reason for using generics is to reduce code duplication.
 Generics let you share a single interface and implementation between
@@ -3575,23 +3522,23 @@ analysis. For example, say you create an interface for
 caching an object:
 
 <?code-excerpt "misc/lib/language_tour/generics/cache.dart (ObjectCache)"?>
-{% prettify dart %}
+```dart
 abstract class ObjectCache {
   Object getByKey(String key);
   void setByKey(String key, Object value);
 }
-{% endprettify %}
+```
 
 You discover that you want a string-specific version of this interface,
 so you create another interface:
 
 <?code-excerpt "misc/lib/language_tour/generics/cache.dart (StringCache)"?>
-{% prettify dart %}
+```dart
 abstract class StringCache {
   String getByKey(String key);
   void setByKey(String key, String value);
 }
-{% endprettify %}
+```
 
 Later, you decide you want a number-specific version of this
 interface... You get the idea.
@@ -3600,12 +3547,12 @@ Generic types can save you the trouble of creating all these interfaces.
 Instead, you can create a single interface that takes a type parameter:
 
 <?code-excerpt "misc/lib/language_tour/generics/cache.dart (Cache)"?>
-{% prettify dart %}
+```dart
 abstract class Cache<T> {
   T getByKey(String key);
   void setByKey(String key, T value);
 }
-{% endprettify %}
+```
 
 In this code, T is the stand-in type. It’s a placeholder that you can
 think of as a type that a developer will define later.
@@ -3620,7 +3567,7 @@ just like the literals you’ve already seen, except that you add
 before the opening bracket. Here is an example of using typed literals:
 
 <?code-excerpt "misc/lib/language_tour/generics/misc.dart (collection-literals)"?>
-{% prettify dart %}
+```dart
 var names = <String>['Seth', 'Kathy', 'Lars'];
 var uniqueNames = <String>{'Seth', 'Kathy', 'Lars'};
 var pages = <String, String>{
@@ -3628,7 +3575,7 @@ var pages = <String, String>{
   'robots.txt': 'Hints for web robots',
   'humans.txt': 'We are people, not machines'
 };
-{% endprettify %}
+```
 
 
 ### Using parameterized types with constructors
@@ -3637,9 +3584,9 @@ To specify one or more types when using a constructor, put the types in
 angle brackets (`<...>`) just after the class name. For example:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (constructor-1)"?>
-{% prettify dart %}
+```dart
 var nameSet = Set<String>.from(names);
-{% endprettify %}
+```
 
 {% comment %}[PENDING: update this sample; it ]{% endcomment %}
 
@@ -3647,9 +3594,9 @@ The following code creates a map that has integer keys and values of
 type View:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (constructor-2)"?>
-{% prettify dart %}
+```dart
 var views = Map<int, View>();
-{% endprettify %}
+```
 
 
 ### Generic collections and the types they contain
@@ -3659,18 +3606,17 @@ information around at runtime. For example, you can test the type of a
 collection:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (generic-collections)"?>
-{% prettify dart %}
+```dart
 var names = List<String>();
 names.addAll(['Seth', 'Kathy', 'Lars']);
 print(names is List<String>); // true
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-In contrast, generics in Java use *erasure*, which means that generic
-type parameters are removed at runtime. In Java, you can test whether
-an object is a List, but you can’t test whether it’s a `List<String>`.
-</div>
+{{site.alert.note}}
+  In contrast, generics in Java use *erasure*, which means that generic
+  type parameters are removed at runtime. In Java, you can test whether
+  an object is a List, but you can’t test whether it’s a `List<String>`.
+{{site.alert.end}}
 
 
 ### Restricting the parameterized type
@@ -3700,10 +3646,10 @@ var extenderFoo = [!Foo<Extender>!]();
 It's also OK to specify no generic argument:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (no-generic-arg-ok)" replace="/expect\((.*?).toString\(\), .(.*?).\);/print($1); \/\/ $2/g"?>
-{% prettify dart %}
+```dart
 var foo = Foo();
 print(foo); // Instance of 'Foo<SomeBaseClass>'
-{% endprettify %}
+```
 
 Specifying any non-`SomeBaseClass` type results in an error:
 
@@ -3762,9 +3708,9 @@ For example, Dart web apps generally use the [dart:html][]
 library, which they can import like this:
 
 <?code-excerpt "misc/test/language_tour/browser_test.dart (dart-html-import)"?>
-{% prettify dart %}
+```dart
 import 'dart:html';
-{% endprettify %}
+```
 
 The only required argument to `import` is a URI specifying the
 library.
@@ -3774,15 +3720,14 @@ scheme. The `package:` scheme specifies libraries provided by a package
 manager such as the pub tool. For example:
 
 <?code-excerpt "misc/test/language_tour/browser_test.dart (package-import)"?>
-{% prettify dart %}
+```dart
 import 'package:test/test.dart';
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-*URI* stands for uniform resource identifier.
-*URLs* (uniform resource locators) are a common kind of URI.
-</div>
+{{site.alert.note}}
+  *URI* stands for uniform resource identifier.
+  *URLs* (uniform resource locators) are a common kind of URI.
+{{site.alert.end}}
 
 
 #### Specifying a library prefix
@@ -3793,7 +3738,7 @@ and library2 both have an Element class, then you might have code like
 this:
 
 <?code-excerpt "misc/lib/language_tour/libraries/import_as.dart" replace="/(lib\d)\.dart/package:$1\/$&/g"?>
-{% prettify dart %}
+```dart
 import 'package:lib1/lib1.dart';
 import 'package:lib2/lib2.dart' as lib2;
 
@@ -3802,7 +3747,7 @@ Element element1 = Element();
 
 // Uses Element from lib2.
 lib2.Element element2 = lib2.Element();
-{% endprettify %}
+```
 
 #### Importing only part of a library
 
@@ -3810,13 +3755,13 @@ If you want to use only part of a library, you can selectively import
 the library. For example:
 
 <?code-excerpt "misc/lib/language_tour/libraries/show_hide.dart" replace="/(lib\d)\.dart/package:$1\/$&/g"?>
-{% prettify dart %}
+```dart
 // Import only foo.
 import 'package:lib1/lib1.dart' show foo;
 
 // Import all names EXCEPT foo.
 import 'package:lib2/lib2.dart' hide foo;
-{% endprettify %}
+```
 
 <a id="deferred-loading"></a>
 #### Lazily loading a library
@@ -3831,32 +3776,32 @@ Here are some cases when you might use deferred loading:
   alternative implementations of an algorithm, for example.
 * To load rarely used functionality, such as optional screens and dialogs.
 
-<aside class="alert alert-warning" markdown="1">
-**Only dart2js supports deferred loading.**
-Flutter, the Dart VM, and dartdevc don't support deferred loading.
-For more information, see
-[issue #33118](https://github.com/dart-lang/sdk/issues/33118) and
-[issue #27776.](https://github.com/dart-lang/sdk/issues/27776)
-</aside>
+{{site.alert.warn}}
+  **Only dart2js supports deferred loading.**
+  Flutter, the Dart VM, and dartdevc don't support deferred loading.
+  For more information, see
+  [issue #33118](https://github.com/dart-lang/sdk/issues/33118) and
+  [issue #27776.](https://github.com/dart-lang/sdk/issues/27776)
+{{site.alert.end}}
 
 To lazily load a library, you must first
 import it using `deferred as`.
 
 <?code-excerpt "misc/lib/language_tour/libraries/greeter.dart (import)" replace="/hello\.dart/package:greetings\/$&/g"?>
-{% prettify dart %}
+```dart
 import 'package:greetings/hello.dart' deferred as hello;
-{% endprettify %}
+```
 
 When you need the library, invoke
 `loadLibrary()` using the library's identifier.
 
 <?code-excerpt "misc/lib/language_tour/libraries/greeter.dart (loadLibrary)"?>
-{% prettify dart %}
+```dart
 Future greet() async {
   await hello.loadLibrary();
   hello.printGreeting();
 }
-{% endprettify %}
+```
 
 In the preceding code,
 the `await` keyword pauses execution until the library is loaded.
@@ -3924,9 +3869,9 @@ For example, here's some code that uses `await`
 to wait for the result of an asynchronous function:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (await-lookUpVersion)"?>
-{% prettify dart %}
+```dart
 await lookUpVersion();
-{% endprettify %}
+```
 
 To use `await`, code must be in an `async` function—a
 function marked as `async`:
@@ -3939,39 +3884,36 @@ Future checkVersion() [!async!] {
 }
 {% endprettify %}
 
-<aside class="alert alert-info" markdown="1">
-**Note:**
-Although an `async` function might perform time-consuming operations,
-it doesn't wait for those operations.
-Instead, the `async` function executes only until it encounters
-its first `await` expression
-([details][synchronous-async-start]).
-Then it returns a Future object,
-resuming execution only after the `await` expression completes.
-</aside>
+{{site.alert.note}}
+  Although an `async` function might perform time-consuming operations, it
+  doesn't wait for those operations. Instead, the `async` function executes only
+  until it encounters its first `await` expression
+  ([details][synchronous-async-start]). Then it returns a Future object,
+  resuming execution only after the `await` expression completes.
+{{site.alert.end}}
 
-Use `try`, `catch`, and `finally`
-to handle errors and cleanup in code that uses `await`:
+Use `try`, `catch`, and `finally` to handle errors and cleanup in code that uses
+`await`:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (try-catch)"?>
-{% prettify dart %}
+```dart
 try {
   version = await lookUpVersion();
 } catch (e) {
   // React to inability to look up the version
 }
-{% endprettify %}
+```
 
 You can use `await` multiple times in an `async` function.
 For example, the following code waits three times
 for the results of functions:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (repeated-await)"?>
-{% prettify dart %}
+```dart
 var entrypoint = await findEntrypoint();
 var exitCode = await runExecutable(entrypoint, args);
 await flushThenExit(exitCode);
-{% endprettify %}
+```
 
 In <code>await <em>expression</em></code>,
 the value of <code><em>expression</em></code> is usually a Future;
@@ -4005,18 +3947,18 @@ For example, consider this synchronous function,
 which returns a String:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (sync-lookUpVersion)"?>
-{% prettify dart %}
+```dart
 String lookUpVersion() => '1.0.0';
-{% endprettify %}
+```
 
 If you change it to be an `async` function—for example,
 because a future implementation will be time consuming—the
 returned value is a Future:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (async-lookUpVersion)"?>
-{% prettify dart %}
+```dart
 Future<String> lookUpVersion() async => '1.0.0';
-{% endprettify %}
+```
 
 Note that the function's body doesn't need to use the Future API.
 Dart creates the Future object if necessary.
@@ -4041,22 +3983,21 @@ you have two options:
 * Use the Stream API, as described
   [in the library tour](/guides/libraries/library-tour#stream).
 
-<aside class="alert alert-warning" markdown="1">
-**Note:**
-Before using `await for`, be sure that it makes the code clearer
-and that you really do want to wait for all of the stream's results.
-For example, you usually should **not** use `await for` for UI event listeners,
-because UI frameworks send endless streams of events.
-</aside>
+{{site.alert.note}}
+  Before using `await for`, be sure that it makes the code clearer and that you
+  really do want to wait for all of the stream's results. For example, you
+  usually should **not** use `await for` for UI event listeners, because UI
+  frameworks send endless streams of events.
+{{site.alert.end}}
 
 An asynchronous for loop has the following form:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (await-for)"?>
-{% prettify dart %}
+```dart
 await for (varOrType identifier in expression) {
   // Executes each time the stream emits a value.
 }
-{% endprettify %}
+```
 
 The value of <code><em>expression</em></code> must have type Stream.
 Execution proceeds as follows:
@@ -4107,37 +4048,37 @@ mark the function body as `sync*`,
 and use `yield` statements to deliver values:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (sync-generator)"?>
-{% prettify dart %}
+```dart
 Iterable<int> naturalsTo(int n) sync* {
   int k = 0;
   while (k < n) yield k++;
 }
-{% endprettify %}
+```
 
 To implement an **asynchronous** generator function,
 mark the function body as `async*`,
 and use `yield` statements to deliver values:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (async-generator)"?>
-{% prettify dart %}
+```dart
 Stream<int> asynchronousNaturalsTo(int n) async* {
   int k = 0;
   while (k < n) yield k++;
 }
-{% endprettify %}
+```
 
 If your generator is recursive,
 you can improve its performance by using `yield*`:
 
 <?code-excerpt "misc/test/language_tour/async_test.dart (recursive-generator)"?>
-{% prettify dart %}
+```dart
 Iterable<int> naturalsDownFrom(int n) sync* {
   if (n > 0) {
     yield n;
     yield* naturalsDownFrom(n - 1);
   }
 }
-{% endprettify %}
+```
 
 
 ## Callable classes
@@ -4154,7 +4095,7 @@ https://gist.github.com/405379bacf30335f3aed
 {{site.dartpad}}/405379bacf30335f3aed
 
 <?code-excerpt "misc/lib/language_tour/callable_classes.dart"?>
-{% prettify dart %}
+```dart
 class WannabeFunction {
   String call(String a, String b, String c) => '$a $b $c!';
 }
@@ -4163,7 +4104,7 @@ var wf = WannabeFunction();
 var out = wf('Hi', 'there,', 'gang');
 
 main() => print(out);
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -4210,7 +4151,7 @@ retains type information when a function type is assigned to a variable.
 Consider the following code, which doesn't use a typedef:
 
 <?code-excerpt "misc/lib/language_tour/typedefs/sorted_collection_1.dart"?>
-{% prettify dart %}
+```dart
 class SortedCollection {
   Function compare;
 
@@ -4229,7 +4170,7 @@ void main() {
   // but what type of function?
   assert(coll.compare is Function);
 }
-{% endprettify %}
+```
 
 Type information is lost when assigning `f` to `compare`. The type of
 `f` is `(Object, ``Object)` → `int` (where → means returns), yet the
@@ -4238,7 +4179,7 @@ names and retain type information, both developers and tools can use
 that information.
 
 <?code-excerpt "misc/lib/language_tour/typedefs/sorted_collection_2.dart"?>
-{% prettify dart %}
+```dart
 typedef Compare = int Function(Object a, Object b);
 
 class SortedCollection {
@@ -4255,19 +4196,18 @@ void main() {
   assert(coll.compare is Function);
   assert(coll.compare is Compare);
 }
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-**Note:**
-Currently, typedefs are restricted to function types. We expect this
-to change.
-</aside>
+{{site.alert.note}}
+  Currently, typedefs are restricted to function types. We expect this to
+  change.
+{{site.alert.end}}
 
 Because typedefs are simply aliases, they offer a way to check the type
 of any function. For example:
 
 <?code-excerpt "misc/lib/language_tour/typedefs/misc.dart (compare)"?>
-{% prettify dart %}
+```dart
 typedef Compare<T> = int Function(T a, T b);
 
 int sort(int a, int b) => a - b;
@@ -4275,7 +4215,7 @@ int sort(int a, int b) => a - b;
 void main() {
   assert(sort is Compare<int>); // True!
 }
-{% endprettify %}
+```
 
 ## Metadata
 
@@ -4308,7 +4248,7 @@ You can define your own metadata annotations. Here’s an example of
 defining a @todo annotation that takes two arguments:
 
 <?code-excerpt "misc/lib/language_tour/metadata/todo.dart"?>
-{% prettify dart %}
+```dart
 library todo;
 
 class Todo {
@@ -4317,19 +4257,19 @@ class Todo {
 
   const Todo(this.who, this.what);
 }
-{% endprettify %}
+```
 
 And here’s an example of using that @todo annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/misc.dart"?>
-{% prettify dart %}
+```dart
 import 'todo.dart';
 
 @Todo('seth', 'make this do something')
 void doSomething() {
   print('do something');
 }
-{% endprettify %}
+```
 
 Metadata can appear before a library, class, typedef, type parameter,
 constructor, factory, function, field, parameter, or variable
@@ -4349,12 +4289,12 @@ A single-line comment begins with `//`. Everything between `//` and the
 end of line is ignored by the Dart compiler.
 
 <?code-excerpt "misc/lib/language_tour/comments.dart (single-line-comments)"?>
-{% prettify dart %}
+```dart
 void main() {
   // TODO: refactor into an AbstractLlamaGreetingFactory?
   print('Welcome to my Llama farm!');
 }
-{% endprettify %}
+```
 
 
 ### Multi-line comments
@@ -4365,7 +4305,7 @@ comment is a documentation comment; see the next section). Multi-line
 comments can nest.
 
 <?code-excerpt "misc/lib/language_tour/comments.dart (multi-line-comments)"?>
-{% prettify dart %}
+```dart
 void main() {
   /*
    * This is a lot of work. Consider raising chickens.
@@ -4376,7 +4316,7 @@ void main() {
   larry.clean();
    */
 }
-{% endprettify %}
+```
 
 
 ### Documentation comments
@@ -4395,7 +4335,7 @@ Here is an example of documentation comments with references to other
 classes and arguments:
 
 <?code-excerpt "misc/lib/language_tour/comments.dart (doc-comments)"?>
-{% prettify dart %}
+```dart
 /// A domesticated South American camelid (Lama glama).
 ///
 /// Andean cultures have used llamas as meat and pack
@@ -4416,7 +4356,7 @@ class Llama {
     // ...
   }
 }
-{% endprettify %}
+```
 
 In the generated documentation, `[Food]` becomes a link to the API docs
 for the Food class.

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -11,15 +11,12 @@ this page can help. To learn more, read about
 [Dart's type system](/guides/language/sound-dart),
 and see [these other resources](/guides/language/sound-dart#other-resources).
 
-<aside class="alert alert-info" markdown="1">
-**Help us improve this page!**
-If you encounter a warning or error that isn't listed here,
-please file an issue by clicking the **bug icon** at the top right.
-Include the **warning or error message** and,
-if possible, the code for both a small reproducible case
-and its correct equivalent.
-</aside>
-
+{{site.alert.info}}
+  **Help us improve this page!** If you encounter a warning or error that isn't
+  listed here, please file an issue by clicking the **bug icon** at the top
+  right. Include the **warning or error message** and, if possible, the code for
+  both a small reproducible case and its correct equivalent.
+{{site.alert.end}}
 
 ## Troubleshooting
 
@@ -207,11 +204,10 @@ error • '...'  isn't a valid override of '...'  • invalid_override
 These errors typically occur when a subclass tightens up a method's
 parameter types by specifying a subclass of the original class.
 
-<aside class="alert alert-info" markdown="1">
-**Note:** This issue can also occur when a generic subclass neglects
-to specify a type. For more information, see
-[Missing type arguments](#missing-type-arguments).
-</aside>
+{{site.alert.note}}
+  This issue can also occur when a generic subclass neglects to specify a type.
+  For more information, see [Missing type arguments](#missing-type-arguments).
+{{site.alert.end}}
 
 #### Example
 
@@ -269,10 +265,10 @@ class MyAdder extends NumberAdder {
 
 For more information, see [Use proper input parameter types when overriding methods](/guides/language/sound-dart#use-proper-param-types).
 
-<aside class="alert alert-info" markdown="1">
-  **Note:** If you have a valid reason to use a subtype, you can use the
+{{site.alert.note}}
+  If you have a valid reason to use a subtype, you can use the
   [covariant keyword](#the-covariant-keyword).
-</aside>
+{{site.alert.end}}
 
 <hr>
 
@@ -574,10 +570,9 @@ var names = json['names'] as List;
 assumeStrings(names.[!cast!]<String>());
 {% endprettify %}
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:**
+{{site.alert.version-note}}
   The `cast()` method was introduced in 2.0.0-dev.22.0.
-</aside>
+{{site.alert.end}}
 
 If you can't tighten the type or use `cast`, you can copy the object
 in a different way. For example:
@@ -607,11 +602,10 @@ tell the analyzer that you are doing this intentionally.
 This removes the static error and instead checks for an invalid
 argument type at runtime.
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:**
-  The `covariant` keyword was introduced in 1.22.
-  It replaces the `@checked` annotation.
-</aside>
+{{site.alert.version-note}}
+  The `covariant` keyword was introduced in 1.22. It replaces the `@checked`
+  annotation.
+{{site.alert.end}}
 
 The following shows how you might use `covariant`:
 

--- a/src/_guides/libraries/_dart-html-tour.md
+++ b/src/_guides/libraries/_dart-html-tour.md
@@ -1,7 +1,6 @@
-Use the [dart:html][] library to
-program the browser, manipulate objects and elements in the DOM, and
-access HTML5 APIs. DOM stands for *Document Object Model*, which
-describes the hierarchy of an HTML page.
+Use the [dart:html][] library to program the browser, manipulate objects and
+elements in the DOM, and access HTML5 APIs. DOM stands for *Document Object
+Model*, which describes the hierarchy of an HTML page.
 
 Other common uses of dart:html are manipulating styles (*CSS*), getting
 data using HTTP requests, and exchanging data using
@@ -10,20 +9,16 @@ HTML5 (and dart:html) has many
 additional APIs that this section doesn’t cover. Only web apps can use
 dart:html, not command-line apps.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-For a higher level approach to web app UIs, use a web framework such as
-[AngularDart.]({{site.angulardart}})
-</div>
+{{site.alert.note}}
+  For a higher level approach to web app UIs, use a web framework such as
+  [AngularDart.]({{site.angulardart}})
+{{site.alert.end}}
 
 To use the HTML library in your web app, import dart:html:
 
 {% comment %}
-TODO: Figure out why we get ERRORs when using code-excerpt with triple ticks.
-Workaround: use prettify dart (with liquid syntax,
-surrounded with braces and percent marks).
-
-TODO: Consider helping users run these examples in DartPad.
+  TODO: Switch back to using code-excerpt instructions.
+  TODO: Consider helping users run these examples in DartPad.
 {% endcomment %}
 
 {% comment %} code-excerpt "lib/html.dart (import)" {% endcomment %}
@@ -343,12 +338,12 @@ from a web server. Use `await` with the `getString()` call
 to ensure that you have the data before continuing execution.
 
 {% comment %}code-excerpt "test/html_test.dart (getString)" plaster="none" replace="/await.*;/[!$&!]/g"{% endcomment %}
-```dart
+{% prettify dart %}
   Future main() async {
     String pageHtml = [!await HttpRequest.getString(url);!]
     // Do something with pageHtml...
   }
-```
+{% endprettify %}
 
 Use try-catch to specify an error handler:
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -43,10 +43,10 @@ You can find API documentation for all dart:* libraries in the
 [Dart API reference][Dart API] or, if you're using Flutter,
 the [Flutter API reference.][docs.flutter]
 
-<aside class="alert alert-info" markdown="1">
+{{site.alert.info}}
   **DartPad tip:** You can play with the code in this page by copying it into a
   [DartPad.]({{site.dartpad}})
-</aside>
+{{site.alert.end}}
 
 
 ## dart:core - numbers, collections, strings, and more
@@ -63,10 +63,10 @@ and displays that object's string value (as returned by `toString()`)
 in the console.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (print)"?>
-{% prettify dart %}
+```dart
 print(anObject);
 print('I drink $tea.');
-{% endprettify %}
+```
 
 For more information on basic strings and `toString()`, see
 [Strings](/guides/language/language-tour#strings) in the language tour.
@@ -81,28 +81,28 @@ You can convert a string into an integer or double with the `parse()`
 methods of int and double, respectively:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (int|double.parse)"?>
-{% prettify dart %}
+```dart
 assert(int.parse('42') == 42);
 assert(int.parse('0x42') == 66);
 assert(double.parse('0.50') == 0.5);
-{% endprettify %}
+```
 
 Or use the parse() method of num, which creates an integer if possible
 and otherwise a double:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (num-parse)"?>
-{% prettify dart %}
+```dart
 assert(num.parse('42') is int);
 assert(num.parse('0x42') is int);
 assert(num.parse('0.50') is double);
-{% endprettify %}
+```
 
 To specify the base of an integer, add a `radix` parameter:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (radix)"?>
-{% prettify dart %}
+```dart
 assert(int.parse('42', radix: 16) == 66);
-{% endprettify %}
+```
 
 Use the `toString()` method to convert an
 int or double to a string. To specify the number of digits to the right
@@ -111,7 +111,7 @@ number of significant digits in the string, use
 [toStringAsPrecision():][toStringAsPrecision()]
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (toString())"?>
-{% prettify dart %}
+```dart
 // Convert an int to a string.
 assert(42.toString() == '42');
 
@@ -124,7 +124,7 @@ assert(123.456.toStringAsFixed(2) == '123.46');
 // Specify the number of significant figures.
 assert(123.456.toStringAsPrecision(2) == '1.2e+2');
 assert(double.parse('1.2e+2') == 120.0);
-{% endprettify %}
+```
 
 For more information, see the API documentation for
 [int,][int] [double,][double] and [num.][num] Also see
@@ -150,7 +150,7 @@ whether a string begins with or ends with a particular pattern. For
 example:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (contains-etc)"?>
-{% prettify dart %}
+```dart
 // Check whether a string contains another string.
 assert('Never odd or even'.contains('odd'));
 
@@ -162,7 +162,7 @@ assert('Never odd or even'.endsWith('even'));
 
 // Find the location of a string inside a string.
 assert('Never odd or even'.indexOf('odd') == 6);
-{% endprettify %}
+```
 
 #### Extracting data from a string
 
@@ -175,7 +175,7 @@ You can also extract a substring or split a string into a list of
 substrings:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (substring-etc)"?>
-{% prettify dart %}
+```dart
 // Grab a substring.
 assert('Never odd or even'.substring(6, 9) == 'odd');
 
@@ -198,7 +198,7 @@ for (var char in 'hello'.split('')) {
 var codeUnitList =
     'Never odd or even'.codeUnits.toList();
 assert(codeUnitList[0] == 78);
-{% endprettify %}
+```
 
 #### Converting to uppercase or lowercase
 
@@ -206,7 +206,7 @@ You can easily convert strings to their uppercase and lowercase
 variants:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (toUpperCase-toLowerCase)"?>
-{% prettify dart %}
+```dart
 // Convert to uppercase.
 assert('structured web apps'.toUpperCase() ==
     'STRUCTURED WEB APPS');
@@ -214,13 +214,12 @@ assert('structured web apps'.toUpperCase() ==
 // Convert to lowercase.
 assert('STRUCTURED WEB APPS'.toLowerCase() ==
     'structured web apps');
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-These methods don't work for every language. For example, the Turkish
-alphabet's dotless *I* is converted incorrectly.
-</div>
+{{site.alert.note}}
+  These methods don't work for every language. For example, the Turkish
+  alphabet's dotless *I* is converted incorrectly.
+{{site.alert.end}}
 
 
 #### Trimming and empty strings
@@ -229,7 +228,7 @@ Remove all leading and trailing white space with `trim()`. To check
 whether a string is empty (length is zero), use `isEmpty`.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (trim-etc)"?>
-{% prettify dart %}
+```dart
 // Trim a string.
 assert('  hello  '.trim() == 'hello');
 
@@ -238,7 +237,7 @@ assert(''.isEmpty);
 
 // Strings with only white space are not empty.
 assert('  '.isNotEmpty);
-{% endprettify %}
+```
 
 #### Replacing part of a string
 
@@ -250,14 +249,14 @@ the method `replaceAll()` returns a new String without changing the
 original String:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (replace)"?>
-{% prettify dart %}
+```dart
 var greetingTemplate = 'Hello, NAME!';
 var greeting =
     greetingTemplate.replaceAll(RegExp('NAME'), 'Bob');
 
 // greetingTemplate didn't change.
 assert(greeting != greetingTemplate);
-{% endprettify %}
+```
 
 #### Building a string
 
@@ -267,7 +266,7 @@ called. The `writeAll()` method has an optional second parameter that
 lets you specify a separator—in this case, a space.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (StringBuffer)"?>
-{% prettify dart %}
+```dart
 var sb = StringBuffer();
 sb
   ..write('Use a StringBuffer for ')
@@ -278,7 +277,7 @@ var fullString = sb.toString();
 
 assert(fullString ==
     'Use a StringBuffer for efficient string creation.');
-{% endprettify %}
+```
 
 #### Regular expressions
 
@@ -287,7 +286,7 @@ expressions. Use regular expressions for efficient searching and pattern
 matching of strings.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (RegExp)"?>
-{% prettify dart %}
+```dart
 // Here's a regular expression for one or more digits.
 var numbers = RegExp(r'\d+');
 
@@ -301,13 +300,13 @@ assert(someDigits.contains(numbers));
 // Replace every match with another string.
 var exedOut = someDigits.replaceAll(numbers, 'XX');
 assert(exedOut == 'llamas live XX to XX years');
-{% endprettify %}
+```
 
 You can work directly with the RegExp class, too. The Match class
 provides access to a regular expression match.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (match)"?>
-{% prettify dart %}
+```dart
 var numbers = RegExp(r'\d+');
 var someDigits = 'llamas live 15 to 20 years';
 
@@ -318,7 +317,7 @@ assert(numbers.hasMatch(someDigits));
 for (var match in numbers.allMatches(someDigits)) {
   print(match.group(0)); // 15, then 20
 }
-{% endprettify %}
+```
 
 #### More information
 
@@ -339,7 +338,7 @@ constructors. The List class also defines several methods for adding
 items to and removing items from lists.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (List)"?>
-{% prettify dart %}
+```dart
 // Use a List constructor.
 var vegetables = List();
 
@@ -363,12 +362,12 @@ assert(fruits.length == 4);
 // Remove all elements from a list.
 fruits.clear();
 assert(fruits.isEmpty);
-{% endprettify %}
+```
 
 Use `indexOf()` to find the index of an object in a list:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (indexOf)"?>
-{% prettify dart %}
+```dart
 var fruits = ['apples', 'oranges'];
 
 // Access a list item by index.
@@ -376,7 +375,7 @@ assert(fruits[0] == 'apples');
 
 // Find an item in a list.
 assert(fruits.indexOf('apples') == 0);
-{% endprettify %}
+```
 
 Sort a list using the `sort()` method. You can provide a sorting
 function that compares two objects. This sorting function must return \<
@@ -385,32 +384,32 @@ example uses `compareTo()`, which is defined by
 [Comparable][] and implemented by String.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (compareTo)"?>
-{% prettify dart %}
+```dart
 var fruits = ['bananas', 'apples', 'oranges'];
 
 // Sort a list.
 fruits.sort((a, b) => a.compareTo(b));
 assert(fruits[0] == 'apples');
-{% endprettify %}
+```
 
 Lists are parameterized types, so you can specify the type that a list
 should contain:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (List-of-String)"?>
-{% prettify dart %}
+```dart
 // This list should contain only strings.
 var fruits = List<String>();
 
 fruits.add('apples');
 var fruit = fruits[0];
 assert(fruit is String);
-{% endprettify %}
+```
 
 {:.fails-sa}
 <?code-excerpt "misc/lib/library_tour/core/collections.dart (List-of-String)"?>
-{% prettify dart %}
+```dart
 fruits.add(5); // Error: 'int' can't be assigned to 'String'
-{% endprettify %}
+```
 
 Refer to the [List API reference][List] for a full list of methods.
 
@@ -420,7 +419,7 @@ A set in Dart is an unordered collection of unique items. Because a set
 is unordered, you can’t get a set’s items by index (position).
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Set)"?>
-{% prettify dart %}
+```dart
 var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 assert(ingredients.length == 3);
@@ -432,13 +431,13 @@ assert(ingredients.length == 3);
 // Remove an item from a set.
 ingredients.remove('gold');
 assert(ingredients.length == 2);
-{% endprettify %}
+```
 
 Use `contains()` and `containsAll()` to check whether one or more
 objects are in a set:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (contains)"?>
-{% prettify dart %}
+```dart
 var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 
@@ -447,12 +446,12 @@ assert(ingredients.contains('titanium'));
 
 // Check whether all the items are in the set.
 assert(ingredients.containsAll(['titanium', 'xenon']));
-{% endprettify %}
+```
 
 An intersection is a set whose items are in two other sets.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (intersection)"?>
-{% prettify dart %}
+```dart
 var ingredients = Set();
 ingredients.addAll(['gold', 'titanium', 'xenon']);
 
@@ -461,7 +460,7 @@ var nobleGases = Set.from(['xenon', 'argon']);
 var intersection = ingredients.intersection(nobleGases);
 assert(intersection.length == 1);
 assert(intersection.contains('xenon'));
-{% endprettify %}
+```
 
 Refer to the [Set API reference][Set] for a full list of methods.
 
@@ -475,7 +474,7 @@ You can declare a map using a terse literal syntax, or you can use a
 traditional constructor:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Map)"?>
-{% prettify dart %}
+```dart
 // Maps often use strings as keys.
 var hawaiianBeaches = {
   'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
@@ -489,13 +488,13 @@ var searchTerms = Map();
 // Maps are parameterized types; you can specify what
 // types the key and value should be.
 var nobleGases = Map<int, String>();
-{% endprettify %}
+```
 
 You add, get, and set map items using the bracket syntax. Use `remove()`
 to remove a key and its value from a map.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (remove)"?>
-{% prettify dart %}
+```dart
 var nobleGases = {54: 'xenon'};
 
 // Retrieve a value with a key.
@@ -507,12 +506,12 @@ assert(nobleGases.containsKey(54));
 // Remove a key and its value.
 nobleGases.remove(54);
 assert(!nobleGases.containsKey(54));
-{% endprettify %}
+```
 
 You can retrieve all the values or all the keys from a map:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (keys)"?>
-{% prettify dart %}
+```dart
 var hawaiianBeaches = {
   'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
   'Big Island': ['Wailea Bay', 'Pololu Beach'],
@@ -531,14 +530,14 @@ assert(Set.from(keys).contains('Oahu'));
 var values = hawaiianBeaches.values;
 assert(values.length == 3);
 assert(values.any((v) => v.contains('Waikiki')));
-{% endprettify %}
+```
 
 To check whether a map contains a key, use `containsKey()`. Because map
 values can be null, you cannot rely on simply getting the value for the
 key and checking for null to determine the existence of a key.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (containsKey)"?>
-{% prettify dart %}
+```dart
 var hawaiianBeaches = {
   'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
   'Big Island': ['Wailea Bay', 'Pololu Beach'],
@@ -547,19 +546,19 @@ var hawaiianBeaches = {
 
 assert(hawaiianBeaches.containsKey('Oahu'));
 assert(!hawaiianBeaches.containsKey('Florida'));
-{% endprettify %}
+```
 
 Use the `putIfAbsent()` method when you want to assign a value to a key
 if and only if the key does not already exist in a map. You must provide
 a function that returns the value.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (putIfAbsent)"?>
-{% prettify dart %}
+```dart
 var teamAssignments = {};
 teamAssignments.putIfAbsent(
     'Catcher', () => pickToughestKid());
 assert(teamAssignments['Catcher'] != null);
-{% endprettify %}
+```
 
 Refer to the [Map API reference][Map] for a full list of methods.
 
@@ -569,70 +568,67 @@ List, Set, and Map share common functionality found in many collections.
 Some of this common functionality is defined by the Iterable class,
 which List and Set implement.
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-Although Map doesn’t implement Iterable, you can get Iterables from it
-using the Map `keys` and `values` properties.
-</div>
+{{site.alert.note}}
+  Although Map doesn’t implement Iterable, you can get Iterables from it using
+  the Map `keys` and `values` properties.
+{{site.alert.end}}
 
 Use `isEmpty` or `isNotEmpty` to check whether a list, set, or map has items:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (isEmpty)"?>
-{% prettify dart %}
+```dart
 var coffees = [];
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 assert(coffees.isEmpty);
 assert(teas.isNotEmpty);
-{% endprettify %}
+```
 
 To apply a function to each item in a list, set, or map, you can use
 `forEach()`:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (List.forEach)"?>
-{% prettify dart %}
+```dart
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
 teas.forEach((tea) => print('I drink $tea'));
-{% endprettify %}
+```
 
 When you invoke `forEach()` on a map, your function must take two
 arguments (the key and value):
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Map.forEach)"?>
-{% prettify dart %}
+```dart
 hawaiianBeaches.forEach((k, v) {
   print('I want to visit $k and swim at $v');
   // I want to visit Oahu and swim at
   // [Waikiki, Kailua, Waimanalo], etc.
 });
-{% endprettify %}
+```
 
 Iterables provide the `map()` method, which gives you all the results in
 a single object:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (List.map)"?>
-{% prettify dart %}
+```dart
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
 var loudTeas = teas.map((tea) => tea.toUpperCase());
 loudTeas.forEach(print);
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-The object returned by `map()` is an Iterable that’s *lazily
-evaluated*: your function isn’t called until you ask for an item from
-the returned object.
-</div>
+{{site.alert.note}}
+  The object returned by `map()` is an Iterable that’s *lazily evaluated*: your
+  function isn’t called until you ask for an item from the returned object.
+{{site.alert.end}}
 
 To force your function to be called immediately on each item, use
 `map().toList()` or `map().toSet()`:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (toList)"?>
-{% prettify dart %}
+```dart
 var loudTeas =
     teas.map((tea) => tea.toUpperCase()).toList();
-{% endprettify %}
+```
 
 Use Iterable’s `where()` method to get all the items that match a
 condition. Use Iterable’s `any()` and `every()` methods to check whether
@@ -644,7 +640,7 @@ cities instead of isDecaffeinated.
 
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (where-etc)"?>
-{% prettify dart %}
+```dart
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
 // Chamomile is not caffeinated.
@@ -664,7 +660,7 @@ assert(teas.any(isDecaffeinated));
 // Use every() to check whether all the items in a
 // collection satisfy a condition.
 assert(!teas.every(isDecaffeinated));
-{% endprettify %}
+```
 
 For a full list of methods, refer to the [Iterable API reference,][Iterable]
 as well as those for [List,][List] [Set,][Set] and [Map.][Map]
@@ -690,7 +686,7 @@ URI (such as `/`, `:`, `&`, `#`), use the `encodeFull()` and
 a fully qualified URI, leaving intact special URI characters.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (encodeFull)"?>
-{% prettify dart %}
+```dart
 var uri = 'http://example.org/api?foo=some message';
 
 var encoded = Uri.encodeFull(uri);
@@ -699,7 +695,7 @@ assert(encoded ==
 
 var decoded = Uri.decodeFull(encoded);
 assert(uri == decoded);
-{% endprettify %}
+```
 
 Notice how only the space between `some` and `message` was encoded.
 
@@ -710,7 +706,7 @@ meaning in a URI, including (but not limited to) `/`, `&`, and `:`, use
 the `encodeComponent()` and `decodeComponent()` methods.
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (encodeComponent)"?>
-{% prettify dart %}
+```dart
 var uri = 'http://example.org/api?foo=some message';
 
 var encoded = Uri.encodeComponent(uri);
@@ -719,7 +715,7 @@ assert(encoded ==
 
 var decoded = Uri.decodeComponent(encoded);
 assert(uri == decoded);
-{% endprettify %}
+```
 
 Notice how every special character is encoded. For example, `/` is
 encoded to `%2F`.
@@ -731,7 +727,7 @@ Uri fields such as `path`. To create a Uri from a string, use the
 `parse()` static method:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri.parse)"?>
-{% prettify dart %}
+```dart
 var uri =
     Uri.parse('http://example.org:8080/foo/bar#frag');
 
@@ -740,7 +736,7 @@ assert(uri.host == 'example.org');
 assert(uri.path == '/foo/bar');
 assert(uri.fragment == 'frag');
 assert(uri.origin == 'http://example.org:8080');
-{% endprettify %}
+```
 
 See the [Uri API reference][Uri] for more URI components that you can get.
 
@@ -750,7 +746,7 @@ You can build up a URI from individual parts using the `Uri()`
 constructor:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri)"?>
-{% prettify dart %}
+```dart
 var uri = Uri(
     scheme: 'http',
     host: 'example.org',
@@ -758,7 +754,7 @@ var uri = Uri(
     fragment: 'frag');
 assert(
     uri.toString() == 'http://example.org/foo/bar#frag');
-{% endprettify %}
+```
 
 
 ### Dates and times
@@ -769,7 +765,7 @@ local time zone.
 You can create DateTime objects using several constructors:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (DateTime)"?>
-{% prettify dart %}
+```dart
 // Get the current date and time.
 var now = DateTime.now();
 
@@ -788,13 +784,13 @@ y2k = DateTime.fromMillisecondsSinceEpoch(946684800000,
 
 // Parse an ISO 8601 date.
 y2k = DateTime.parse('2000-01-01T00:00:00Z');
-{% endprettify %}
+```
 
 The `millisecondsSinceEpoch` property of a date returns the number of
 milliseconds since the “Unix epoch”—January 1, 1970, UTC:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (millisecondsSinceEpoch)"?>
-{% prettify dart %}
+```dart
 // 1/1/2000, UTC
 var y2k = DateTime.utc(2000);
 assert(y2k.millisecondsSinceEpoch == 946684800000);
@@ -802,13 +798,13 @@ assert(y2k.millisecondsSinceEpoch == 946684800000);
 // 1/1/1970, UTC
 var unixEpoch = DateTime.utc(1970);
 assert(unixEpoch.millisecondsSinceEpoch == 0);
-{% endprettify %}
+```
 
 Use the Duration class to calculate the difference between two dates and
 to shift a date forward or backward:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Duration)"?>
-{% prettify dart %}
+```dart
 var y2k = DateTime.utc(2000);
 
 // Add one year.
@@ -824,14 +820,13 @@ assert(december2000.month == 12);
 // Returns a Duration object.
 var duration = y2001.difference(y2k);
 assert(duration.inDays == 366); // y2k was a leap year.
-{% endprettify %}
+```
 
-<div class="alert alert-warning" markdown="1">
-**Warning:**
-Using a Duration to shift a DateTime by days can be problematic, due
-to clock shifts (to daylight saving time, for example). Use UTC dates
-if you must shift days.
-</div>
+{{site.alert.warning}}
+  Using a Duration to shift a DateTime by days can be problematic, due to clock
+  shifts (to daylight saving time, for example). Use UTC dates if you must shift
+  days.
+{{site.alert.end}}
 
 For a full list of methods,
 refer to the API reference for [DateTime][] and [Duration.][Duration]
@@ -850,7 +845,7 @@ usually for sorting. The `compareTo()` method returns \< 0 for
 *smaller*, 0 for the *same*, and \> 0 for *bigger*.
 
 <?code-excerpt "misc/lib/library_tour/core/comparable.dart"?>
-{% prettify dart %}
+```dart
 class Line implements Comparable<Line> {
   final int length;
   const Line(this.length);
@@ -864,7 +859,7 @@ void main() {
   var long = const Line(100);
   assert(short.compareTo(long) < 0);
 }
-{% endprettify %}
+```
 
 #### Implementing map keys
 
@@ -883,7 +878,7 @@ convention, NaN != NaN.
 {% endcomment %}
 
 <?code-excerpt "misc/lib/library_tour/core/hash_code.dart"?>
-{% prettify dart %}
+```dart
 class Person {
   final String firstName, lastName;
 
@@ -918,7 +913,7 @@ void main() {
   assert(p1 == p2);
   assert(p1 != p3);
 }
-{% endprettify %}
+```
 
 #### Iteration
 
@@ -928,7 +923,7 @@ whenever you create a class that can provide Iterators for use in for-in
 loops. Implement Iterator to define the actual iteration ability.
 
 <?code-excerpt "misc/lib/library_tour/core/iterator.dart"?>
-{% prettify dart %}
+```dart
 class Process {
   // Represents a process...
 }
@@ -953,7 +948,7 @@ void main() {
     // Do something with the process.
   }
 }
-{% endprettify %}
+```
 
 
 ### Exceptions
@@ -978,7 +973,7 @@ that an error has occurred. You can define a custom exception by
 implementing the Exception interface:
 
 <?code-excerpt "misc/lib/library_tour/core/exception.dart"?>
-{% prettify dart %}
+```dart
 class FooException implements Exception {
   final String msg;
 
@@ -987,7 +982,7 @@ class FooException implements Exception {
   @override
   String toString() => msg ?? 'FooException';
 }
-{% endprettify %}
+```
 
 For more information, see
 [Exceptions](/guides/language/language-tour#exceptions)
@@ -1003,28 +998,25 @@ future. A Stream is a way to get a sequence of values, such as events.
 Future, Stream, and more are in the
 dart:async library ([API reference][dart:async]).
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-You don't always need to use the Future or Stream APIs directly.
-The Dart language supports asynchronous coding
-using keywords such as `async` and `await`.
-See the [asynchronous programming codelab](/codelabs/async-await)
-for details.
-</div>
+{{site.alert.note}}
+  You don't always need to use the Future or Stream APIs directly. The Dart
+  language supports asynchronous coding using keywords such as `async` and
+  `await`. See the [asynchronous programming codelab](/codelabs/async-await) for
+  details.
+{{site.alert.end}}
 
 The dart:async library works in both web apps and command-line apps. To
 use it, import dart:async:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (import)"?>
-{% prettify dart %}
+```dart
 import 'dart:async';
-{% endprettify %}
+```
 
-<aside class="alert alert-info" markdown="1">
-  **Version note:**
-  As of Dart 2.1, you don't need to import dart:async to
-  use the Future and Stream APIs, because dart:core exports those classes.
-</aside>
+{{site.alert.version-note}}
+  As of Dart 2.1, you don't need to import dart:async to use the Future and
+  Stream APIs, because dart:core exports those classes.
+{{site.alert.end}}
 
 ### Future
 
@@ -1044,33 +1036,33 @@ to execute three asynchronous functions in a row,
 waiting for each one to complete before executing the next one.
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (runUsingFuture)"?>
-{% prettify dart %}
+```dart
 runUsingFuture() {
   // ...
   findEntryPoint().then((entryPoint) {
     return runExecutable(entryPoint, args);
   }).then(flushThenExit);
 }
-{% endprettify %}
+```
 
 The equivalent code with await expressions
 looks more like synchronous code:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (runUsingAsyncAwait)"?>
-{% prettify dart %}
+```dart
 runUsingAsyncAwait() async {
   // ...
   var entryPoint = await findEntryPoint();
   var exitCode = await runExecutable(entryPoint, args);
   await flushThenExit(exitCode);
 }
-{% endprettify %}
+```
 
 An `async` function can catch exceptions from Futures.
 For example:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (catch)"?>
-{% prettify dart %}
+```dart
 var entryPoint = await findEntryPoint();
 try {
   var exitCode = await runExecutable(entryPoint, args);
@@ -1078,15 +1070,13 @@ try {
 } catch (e) {
   // Handle the error...
 }
-{% endprettify %}
+```
 
-<div class="alert alert-warning" markdown="1">
-**Important:**
-Async functions return Futures.
-If you don't want your function to return a future,
-then use a different solution.
-For example, you might call an `async` function from your function.
-</div>
+{{site.alert.important}}
+  Async functions return Futures. If you don't want your function to return a
+  future, then use a different solution. For example, you might call an `async`
+  function from your function.
+{{site.alert.end}}
 
 For more information on using `await` and related Dart language features,
 see the [asynchronous programming codelab](/codelabs/async-await).
@@ -1104,34 +1094,33 @@ can take a while. Using `then()` lets you run some code when that Future
 has completed and the promised string value is available:
 
 <?code-excerpt "misc/lib/library_tour/async/basic.dart (then)"?>
-{% prettify dart %}
+```dart
 HttpRequest.getString(url).then((String result) {
   print(result);
 });
-{% endprettify %}
+```
 
 Use `catchError()` to handle any errors or exceptions that a Future
 object might throw.
 
 <?code-excerpt "misc/lib/library_tour/async/basic.dart (catchError)"?>
-{% prettify dart %}
+```dart
 HttpRequest.getString(url).then((String result) {
   print(result);
 }).catchError((e) {
   // Handle or ignore the error.
 });
-{% endprettify %}
+```
 
 The `then().catchError()` pattern is the asynchronous version of
 `try`-`catch`.
 
-<div class="alert alert-warning" markdown="1">
-**Important:**
-Be sure to invoke `catchError()` on the result of `then()`—not on the
-result of the original Future. Otherwise, the `catchError()` can
-handle errors only from the original Future's computation, but not
-from the handler registered by `then()`.
-</div>
+{{site.alert.important}}
+  Be sure to invoke `catchError()` on the result of `then()`—not on the result
+  of the original Future. Otherwise, the `catchError()` can handle errors only
+  from the original Future's computation, but not from the handler registered by
+  `then()`.
+{{site.alert.end}}
 
 
 #### Chaining multiple asynchronous methods
@@ -1143,7 +1132,7 @@ equivalent Future. If the callback returns a value of any other type,
 `then()` creates a new Future that completes with the value.
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (then-chain)"?>
-{% prettify dart %}
+```dart
 Future result = costlyQuery(url);
 result
     .then((value) => expensiveWork(value))
@@ -1152,7 +1141,7 @@ result
     .catchError((exception) {
   /* Handle exception... */
 });
-{% endprettify %}
+```
 
 In the preceding example, the methods run in the following order:
 
@@ -1163,7 +1152,7 @@ In the preceding example, the methods run in the following order:
 Here is the same code written using await:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (then-chain-as-await)"?>
-{% prettify dart %}
+```dart
 try {
   final value = await costlyQuery(url);
   await expensiveWork(value);
@@ -1172,7 +1161,7 @@ try {
 } catch (e) {
   /* Handle exception... */
 }
-{% endprettify %}
+```
 
 
 #### Waiting for multiple futures
@@ -1182,7 +1171,7 @@ wait for them all to complete before continuing. Use the [Future.wait()][]
 static method to manage multiple Futures and wait for them to complete:
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (wait)" replace="/elideBody;/\/* ... *\//g"?>
-{% prettify dart %}
+```dart
 Future deleteLotsOfFiles() async =>  ...
 Future copyLotsOfFiles() async =>  ...
 Future checksumLotsOfOtherFiles() async =>  ...
@@ -1193,7 +1182,7 @@ await Future.wait([
   checksumLotsOfOtherFiles(),
 ]);
 print('Done with all the long steps!');
-{% endprettify %}
+```
 
 
 ### Stream
@@ -1260,15 +1249,13 @@ Future main(List<String> arguments) async {
 }
 {% endprettify %}
 
-<div class="alert alert-warning" markdown="1">
-**Important:**
-Before using `await for`, make sure that it makes the code clearer
-and that you really do want to wait for all of the stream's results.
-For example, you usually should **not** use `await for` for DOM event listeners,
-because the DOM sends endless streams of events.
-If you use `await for` to register two DOM event listeners in a row,
-then the second kind of event is never handled.
-</div>
+{{site.alert.important}}
+  Before using `await for`, make sure that it makes the code clearer and that
+  you really do want to wait for all of the stream's results. For example, you
+  usually should **not** use `await for` for DOM event listeners, because the
+  DOM sends endless streams of events. If you use `await for` to register two
+  DOM event listeners in a row, then the second kind of event is never handled.
+{{site.alert.end}}
 
 For more information on using `await` and related
 Dart language features, see the
@@ -1280,10 +1267,10 @@ Dart language features, see the
 To get each value as it arrives, either use `await for` or
 subscribe to the stream using the `listen()` method:
 
-<?code-excerpt "misc/lib/library_tour/async/stream_web.dart (listen)" replace="/await for/[!$&!]/g"?>
+<?code-excerpt "misc/lib/library_tour/async/stream_web.dart (listen)" replace="/listen/[!$&!]/g"?>
 {% prettify dart %}
 // Find a button by ID and add an event handler.
-querySelector('#submitInfo').onClick.listen((e) {
+querySelector('#submitInfo').onClick.[!listen!]((e) {
   // When the button is clicked, it runs this code.
   submitData();
 });
@@ -1313,11 +1300,11 @@ use it. Use the `transform()` method to produce a stream with a
 different type of data:
 
 <?code-excerpt "misc/lib/library_tour/async/stream.dart (transform)"?>
-{% prettify dart %}
+```dart
 var lines = inputStream
     .transform(utf8.decoder)
     .transform(LineSplitter());
-{% endprettify %}
+```
 
 This example uses two transformers. First it uses utf8.decoder to
 transform the stream of integers into a stream of strings. Then it uses
@@ -1406,9 +1393,9 @@ functionality in the Math library is implemented as top-level functions.
 To use this library in your app, import dart:math.
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (import)"?>
-{% prettify dart %}
+```dart
 import 'dart:math';
-{% endprettify %}
+```
 
 
 ### Trigonometry
@@ -1416,7 +1403,7 @@ import 'dart:math';
 The Math library provides basic trigonometric functions:
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (trig)"?>
-{% prettify dart %}
+```dart
 // Cosine
 assert(cos(pi) == -1.0);
 
@@ -1427,12 +1414,11 @@ var radians = degrees * (pi / 180);
 var sinOf30degrees = sin(radians);
 // sin 30° = 0.5
 assert((sinOf30degrees - 0.5).abs() < 0.01);
-{% endprettify %}
+```
 
-<div class="alert alert-info" markdown="1">
-**Note:**
-These functions use radians, not degrees!
-</div>
+{{site.alert.note}}
+  These functions use radians, not degrees!
+{{site.alert.end}}
 
 
 ### Maximum and minimum
@@ -1440,10 +1426,10 @@ These functions use radians, not degrees!
 The Math library provides `max()` and `min()` methods:
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (min-max)"?>
-{% prettify dart %}
+```dart
 assert(max(1, 1000) == 1000);
 assert(min(1, -1000) == -1000);
-{% endprettify %}
+```
 
 
 ### Math constants
@@ -1451,12 +1437,12 @@ assert(min(1, -1000) == -1000);
 Find your favorite constants—*pi*, *e*, and more—in the Math library:
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (constants)"?>
-{% prettify dart %}
+```dart
 // See the Math library for additional constants.
 print(e); // 2.718281828459045
 print(pi); // 3.141592653589793
 print(sqrt2); // 1.4142135623730951
-{% endprettify %}
+```
 
 
 ### Random numbers
@@ -1465,19 +1451,19 @@ Generate random numbers with the [Random][] class. You can
 optionally provide a seed to the Random constructor.
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (Random)"?>
-{% prettify dart %}
+```dart
 var random = Random();
 random.nextDouble(); // Between 0.0 and 1.0: [0, 1)
 random.nextInt(10); // Between 0 and 9.
-{% endprettify %}
+```
 
 You can even generate random booleans:
 
 <?code-excerpt "misc/test/library_tour/math_test.dart (Random-bool)"?>
-{% prettify dart %}
+```dart
 var random = Random();
 random.nextBool(); // true or false
-{% endprettify %}
+```
 
 
 ### More information
@@ -1499,9 +1485,9 @@ The dart:convert library works in both web apps and command-line apps.
 To use it, import dart:convert.
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (import)"?>
-{% prettify dart %}
+```dart
 import 'dart:convert';
-{% endprettify %}
+```
 
 
 ### Decoding and encoding JSON
@@ -1509,7 +1495,7 @@ import 'dart:convert';
 Decode a JSON-encoded string into a Dart object with `jsonDecode()`:
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (json-decode)"?>
-{% prettify dart %}
+```dart
 // NOTE: Be sure to use double quotes ("),
 // not single quotes ('), inside the JSON string.
 // This string is JSON, not Dart.
@@ -1526,13 +1512,13 @@ assert(scores is List);
 var firstScore = scores[0];
 assert(firstScore is Map);
 assert(firstScore['score'] == 40);
-{% endprettify %}
+```
 
 Encode a supported Dart object into a JSON-formatted string with
 `jsonEncode()`:
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (json-encode)"?>
-{% prettify dart %}
+```dart
 var scores = [
   {'score': 40},
   {'score': 80},
@@ -1544,7 +1530,7 @@ assert(jsonText ==
     '[{"score":40},{"score":80},'
         '{"score":100,"overtime":true,'
         '"special_guest":null}]');
-{% endprettify %}
+```
 
 Only objects of type int, double, String, bool, null, List, or Map (with
 string keys) are directly encodable into JSON. List and Map objects are
@@ -1565,7 +1551,7 @@ For more examples and links to JSON-related packages, see
 Use `utf8.decode()` to decode UTF8-encoded bytes to a Dart string:
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (utf8-decode)" replace="/ \/\/line-br.*//g"?>
-{% prettify dart %}
+```dart
 List<int> utf8Bytes = [
   0xc3, 0x8e, 0xc3, 0xb1, 0xc5, 0xa3, 0xc3, 0xa9,
   0x72, 0xc3, 0xb1, 0xc3, 0xa5, 0xc5, 0xa3, 0xc3,
@@ -1577,7 +1563,7 @@ List<int> utf8Bytes = [
 var funnyWord = utf8.decode(utf8Bytes);
 
 assert(funnyWord == 'Îñţérñåţîöñåļîžåţîờñ');
-{% endprettify %}
+```
 
 To convert a stream of UTF-8 characters into a Dart string, specify
 `utf8.decoder` to the Stream `transform()` method:
@@ -1600,14 +1586,14 @@ Use `utf8.encode()` to encode a Dart string as a list of UTF8-encoded
 bytes:
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (utf8-encode)" replace="/ \/\/line-br.*//g"?>
-{% prettify dart %}
+```dart
 List<int> encoded = utf8.encode('Îñţérñåţîöñåļîžåţîờñ');
 
 assert(encoded.length == utf8Bytes.length);
 for (int i = 0; i < encoded.length; i++) {
   assert(encoded[i] == utf8Bytes[i]);
 }
-{% endprettify %}
+```
 
 
 ### Other functionality
@@ -1618,7 +1604,7 @@ The dart:convert library also has converters for ASCII and ISO-8859-1
 
 ## dart:html - browser-based apps {#darthtml}
 
-{% include_relative dart-html-tour.md %}
+{% include_relative _dart-html-tour.md %}
 
 
 ## dart:io - I/O for servers and command-line apps {#dartio}

--- a/src/_includes/async-await-2.0.md
+++ b/src/_includes/async-await-2.0.md
@@ -1,5 +1,5 @@
-<aside class="alert alert-info" markdown="1">
-  **Version note:** In Dart 1.x, async functions immediately suspended
-  execution. In Dart 2, instead of immediately suspending, async functions
-  execute synchronously until the first `await` or `return`.
-</aside>
+{{site.alert.version-note}}
+  In Dart 1.x, async functions immediately suspended execution. In Dart 2,
+  instead of immediately suspending, async functions execute synchronously until
+  the first `await` or `return`.
+{{site.alert.end}}

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -65,7 +65,7 @@ generating a simple stream of integers using an `async*` function:
 https://gist.github.com/Sfshaza/15d5ef986238c97dbc14
 
 <?code-excerpt "misc/lib/tutorial/sum_stream.dart"?>
-{% prettify dart %}
+```dart
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
   await for (var value in stream) {
@@ -85,7 +85,7 @@ main() async {
   var sum = await sumStream(stream);
   print(sum); // 55
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -95,9 +95,9 @@ src="{{site.dartpad-embed-inline}}?id=15d5ef986238c97dbc14"
     style="border: 1px solid #ccc;">
 </iframe>
 
-<aside class="alert alert-info" markdown="1">
-**Note:** Click **Run** to see the result in the **Console**.
-</aside>
+{{site.alert.note}}
+  Click **Run** to see the result in the **Console**.
+{{site.alert.end}}
 
 ## Error events
 
@@ -127,7 +127,7 @@ error when the loop iterator equals 4:
 https://gist.github.com/chalin/df7c1168a5c6b20fda2a76d6ff33a1da
 
 <?code-excerpt "misc/lib/tutorial/sum_stream_with_catch.dart"?>
-{% prettify dart %}
+```dart
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
   try {
@@ -155,7 +155,7 @@ main() async {
   var sum = await sumStream(stream);
   print(sum); // -1
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -165,9 +165,9 @@ src="{{site.dartpad-embed-inline}}?id=df7c1168a5c6b20fda2a76d6ff33a1da"
     style="border: 1px solid #ccc;">
 </iframe>
 
-<aside class="alert alert-info" markdown="1">
-**Note:** Click **Run** to see the result in the **Console**.
-</aside>
+{{site.alert.note}}
+  Click **Run** to see the result in the **Console**.
+{{site.alert.end}}
 
 
 ## Working with streams
@@ -179,10 +179,10 @@ For example, you can find the last positive integer in a stream using
 `lastWhere()` from the Stream API.
 
 <?code-excerpt "misc/lib/tutorial/misc.dart (lastPositive)"?>
-{% prettify dart %}
+```dart
 Future<int> lastPositive(Stream<int> stream) =>
     stream.lastWhere((x) => x >= 0);
-{% endprettify %}
+```
 
 ## Two kinds of streams {#two-kinds-of-streams}
 
@@ -221,7 +221,7 @@ The following methods on [Stream\<T>][Stream] process the stream and return a
 result:
 
 <?code-excerpt "misc/lib/tutorial/stream_interface.dart (main-stream-members)" remove="/^\s*Stream/"?>
-{% prettify dart %}
+```dart
 Future<T> get first;
 Future<bool> get isEmpty;
 Future<T> get last;
@@ -242,7 +242,7 @@ Future<T> reduce(T Function(T previous, T element) combine);
 Future<T> singleWhere(bool Function(T element) test, {T Function() orElse});
 Future<List<T>> toList();
 Future<Set<T>> toSet();
-{% endprettify %}
+```
 
 All of these functions, except `drain()` and `pipe()`,
 correspond to a similar function on [Iterable.][Iterable]
@@ -251,7 +251,7 @@ with an **await for** loop (or just using one of the other methods).
 For example, some implementations could be:
 
 <?code-excerpt "misc/lib/tutorial/misc.dart (mock-stream-method-implementations)"?>
-{% prettify dart %}
+```dart
 Future<bool> contains(Object needle) async {
   await for (var event in this) {
     if (event == needle) return true;
@@ -273,7 +273,7 @@ Future<List<T>> toList() async {
 
 Future<String> join([String separator = ""]) async =>
     (await this.toList()).join(separator);
-{% endprettify %}
+```
 
 (The actual implementations are slightly more complex,
 but mainly for historical reasons.)
@@ -286,7 +286,7 @@ Each one waits until someone listens on the new stream before
 listening on the original.
 
 <?code-excerpt "misc/lib/tutorial/stream_interface.dart (main-stream-members)" remove="/async\w+|distinct|transform/" retain="/^\s*Stream/"?>
-{% prettify dart %}
+```dart
 Stream<R> cast<R>();
 Stream<S> expand<S>(Iterable<S> Function(T element) convert);
 Stream<S> map<S>(S Function(T event) convert);
@@ -295,7 +295,7 @@ Stream<T> skipWhile(bool Function(T element) test);
 Stream<T> take(int count);
 Stream<T> takeWhile(bool Function(T element) test);
 Stream<T> where(bool Function(T event) test);
-{% endprettify %}
+```
 
 The preceding methods correspond to similar methods on [Iterable][]
 which transform an iterable into another iterable.
@@ -303,11 +303,11 @@ All of these can be written easily using an `async` function
 with an **await for** loop.
 
 <?code-excerpt "misc/lib/tutorial/stream_interface.dart (main-stream-members)" remove="/transform/" retain="/async\w+|distinct/"?>
-{% prettify dart %}
+```dart
 Stream<E> asyncExpand<E>(Stream<E> Function(T event) convert);
 Stream<E> asyncMap<E>(FutureOr<E> Function(T event) convert);
 Stream<T> distinct([bool Function(T previous, T next) equals]);
-{% endprettify %}
+```
 
 The `asyncExpand()` and `asyncMap()` functions are similar to
 `expand()` and `map()`,
@@ -315,12 +315,12 @@ but allow their function argument to be an asynchronous function.
 The `distinct()` function doesn't exist on `Iterable`, but it could have.
 
 <?code-excerpt "misc/lib/tutorial/stream_interface.dart (special-stream-members)"?>
-{% prettify dart %}
+```dart
 Stream<T> handleError(Function onError, {bool test(error)});
 Stream<T> timeout(Duration timeLimit,
     {void Function(EventSink<T> sink) onTimeout});
 Stream<S> transform<S>(StreamTransformer<T, S> streamTransformer);
-{% endprettify %}
+```
 
 The final three functions are more special.
 They involve error handling which an **await for** loop
@@ -343,7 +343,7 @@ A transformer requires only one function, [bind()][], which can be
 easily implemented by an `async` function.
 
 <?code-excerpt "misc/lib/tutorial/misc.dart (mapLogErrors)"?>
-{% prettify dart %}
+```dart
 Stream<S> mapLogErrors<S, T>(
   Stream<T> stream,
   S Function(T event) convert,
@@ -353,7 +353,7 @@ Stream<S> mapLogErrors<S, T>(
     yield convert(event);
   }
 }
-{% endprettify %}
+```
 
 ### Reading and decoding a file {#reading-decoding-file}
 
@@ -363,7 +363,7 @@ a [LineSplitter.][LineSplitter]
 All lines are printed, except any that begin with a hashtag, `#`.
 
 <?code-excerpt "misc/bin/cat_no_hash.dart"?>
-{% prettify dart %}
+```dart
 import 'dart:convert';
 import 'dart:io';
 
@@ -376,7 +376,7 @@ Future<void> main(List<String> args) async {
     if (!line.startsWith('#')) print(line);
   }
 }
-{% endprettify %}
+```
 
 ## The listen() method {#listen-method}
 
@@ -384,10 +384,10 @@ The final method on Stream is `listen()`. This is a "low-level"
 method&mdash;all other stream functions are defined in terms of `listen()`.
 
 <?code-excerpt "misc/lib/tutorial/stream_interface.dart (listen)"?>
-{% prettify dart %}
+```dart
 StreamSubscription<T> listen(void Function(T event) onData,
     {Function onError, void Function() onDone, bool cancelOnError});
-{% endprettify %}
+```
 
 To create a new `Stream` type, you can just extend the `Stream`
 class and implement the `listen()` method&mdash;all other methods

--- a/src/_tutorials/web/fetch-data.md
+++ b/src/_tutorials/web/fetch-data.md
@@ -58,7 +58,7 @@ to have more space for the app's code and UI.
 https://gist.github.com/chalin/1d42e4eadb75bcc1ffbc079e299b862e
 
 <!--?code-excerpt "web/main.dart" indent-by="0"?-->
-{% prettify %}
+```dart
 // Copyright (c) 2015, the Dart project authors.
 // Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed
@@ -173,7 +173,7 @@ void showJson(Event _) {
   listAsJson.text = json.encode(favoriteThings);
   mapAsJson.text = json.encode(formData);
 }
-{% endprettify %}
+```
 {% endcomment %}
 
 <iframe
@@ -196,9 +196,9 @@ To use these functions,
 you need to import dart:convert into your Dart code:
 
 <!--?code-excerpt "web/main.dart" retain="dart:convert"?-->
-{% prettify dart %}
-  import 'dart:convert';
-{% endprettify %}
+```dart
+import 'dart:convert';
+```
 
 The `json.encode()` and `json.decode()` functions can handle these Dart types
 automatically:
@@ -279,7 +279,7 @@ The example initially populates the values in the form
 from this JSON string:
 
 <!--?code-excerpt "web/main.dart (jsonDataAsString)" indent-by="0" ?-->
-{% prettify dart %}
+```dart
 final jsonDataAsString = '''{
   "favoriteNumber": 73,
   "valueOfPi": 3.141592,
@@ -289,15 +289,15 @@ final jsonDataAsString = '''{
 }''';
 
 Map jsonData = json.decode(jsonDataAsString);
-{% endprettify %}
+```
 
 This code calls [json.decode()][] with a properly formatted JSON
 string.
 
-<aside class="alert alert-warning" markdown="1">
-  **Note:** Dart strings can use either single or double
+{{site.alert.warning}}
+  Dart strings can use either single or double
   quotes to denote strings. **JSON requires double quotes**.
-</aside>
+{{site.alert.end}}
 
 In this example, the full JSON string is hard coded into the Dart code,
 but it could be created by the form itself
@@ -360,25 +360,18 @@ HTTP requests from web apps are primarily useful for
 retrieving information in files specific to
 and co-located with the app.
 
-<aside class="alert alert-info" markdown="1">
-  **Security note:**
-  Browsers place tight security restrictions on HTTP requests
-  made by embedded apps.
-  Specifically, any resources requested by a web app
-  must be served from the same origin.
-  That is, the resources must be from the same protocol, host, and port
-  as the app itself.
-  This means that your web app cannot request
-  just any resource from the web with HTTP requests through the browser,
-  even if that request is seemingly harmless (like a GET.)
+{{site.alert.warn}}
+  **Security note:** Browsers place tight security restrictions on HTTP requests
+  made by embedded apps. Specifically, any resources requested by a web app must
+  be served from the same origin. That is, the resources must be from the same
+  protocol, host, and port as the app itself. This means that your web app
+  cannot request just any resource from the web with HTTP requests through the
+  browser, even if that request is seemingly harmless (like a GET.)
 
-  Some servers do allow cross-origin requests
-  through a mechanism called
-  CORS (Cross-origin resource sharing),
-  which uses headers in an HTTP request
-  to ask for and receive permission.
-  CORS is server specific.
-</aside>
+  Some servers do allow cross-origin requests through a mechanism called CORS
+  (Cross-origin resource sharing), which uses headers in an HTTP request to ask
+  for and receive permission. CORS is server specific.
+{{site.alert.end}}
 
 The SDK provides these useful classes for
 formulating URIs and making HTTP requests:
@@ -400,17 +393,14 @@ When you click the button,
 the app makes a GET request of the server
 and loads the file.
 
-<aside class="alert alert-info" markdown="1">
-  **Implementation note:**
-  The original portmanteaux example loaded the co-located file `portmanteaux.json`.
-  When we moved the example into [**DartPad**]({{site.dartpad}}),
-  we couldn't co-locate the JSON file because DartPad
-  supports at most 3 files: one Dart file, one HTML file,
-  and one CSS file.
-  A workaround was to move `portmanteaux.json` to dart.dev and
-  configure dart.dev's CORS headers to allow read-only access
-  from everywhere.
-</aside>
+{{site.alert.info}}
+  **Implementation note:** The original portmanteaux example loaded the
+  co-located file `portmanteaux.json`. When we moved the example into
+  [DartPad]({{site.dartpad}}), we couldn't co-locate the JSON file because
+  DartPad supports at most 3 files: one Dart file, one HTML file, and one CSS
+  file. A workaround was to move `portmanteaux.json` to dart.dev and configure
+  dart.dev's CORS headers to allow read-only access from everywhere.
+{{site.alert.end}}
 
 **Try it!** Click **Run** and then click the **Get portmanteaux** button.
 
@@ -487,7 +477,7 @@ and then sends the request.
 Let's take a look at the Dart code:
 
 <!--?code-excerpt "web/portmanteaux2/main.dart (makeRequest)" indent-by="0" remove="FIXME" replace="/\/\/ \w.*/[!$&!]/g"?-->
-{% prettify dart %}
+```dart
 Future<void> makeRequest(Event _) async {
   const path = 'https://dart.dev/f/portmanteaux.json';
   final httpRequest = HttpRequest();
@@ -496,7 +486,7 @@ Future<void> makeRequest(Event _) async {
     ..onLoadEnd.listen((e) => requestComplete(httpRequest))
     ..send('');
 }
-{% endprettify %}
+```
 
 <img class="scale-img-max" src="images/portmanteaux-code.png"
      alt="Making an HTTP GET request">
@@ -505,9 +495,9 @@ Future<void> makeRequest(Event _) async {
 
 The [send()][] method sends the request to the server.
 
-{% prettify dart %}
+```dart
 httpRequest.send('');
-{% endprettify %}
+```
 
 Because the request in this example is a simple GET request,
 the code can send an empty string.

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -154,13 +154,11 @@ and step through your app's Dart code.
 For setup details and a walkthrough, see
 [Debugging Dart Web Apps][].
 
-<aside class="alert alert-info" markdown="1">
-  **Feeling lost? Don't worry!**
-  This was a whirlwind introduction to Dart and web programming
-  that left out many details.
-  For a gentler approach, try a
+{{site.alert.info}}
+  **Feeling lost? Don't worry!** This was a whirlwind introduction to Dart and
+  web programming that left out many details. For a gentler approach, try a
   [low-level HTML tutorial for Dart][].
-</aside>
+{{site.alert.end}}
 
 
 ## What next?

--- a/src/codelabs/async-await.md
+++ b/src/codelabs/async-await.md
@@ -8,6 +8,7 @@ editors, you can test your knowledge by running example code and completing
 exercises.
 
 To get the most out of this codelab, you should have the following:
+
 * Knowledge of [basic Dart syntax](/samples).
 * Some experience writing asynchronous code in another language.
 
@@ -16,7 +17,7 @@ This codelab covers the following material:
 * How and when to use the `async` and `await` keywords.
 * How using `async` and `await` affects execution order.
 * How to handle errors from an asynchronous call using `try-catch` expressions
-in `async` functions.
+  in `async` functions.
 
 Estimated time to complete this codelab: 40-60 minutes.
 
@@ -43,7 +44,6 @@ The following example shows the wrong way to use an asynchronous function
 Before running this example, try to spot the issue -- what do you think the
 output will be?
 
-[//]: https://gist.github.com/5c8c7716b6b4284842f15fe079f61e47
 <iframe
   src="{{site.dartpad-embed}}?id=5c8c7716b6b4284842f15fe079f61e47"
   style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
@@ -56,36 +56,38 @@ Here's why the example fails to print the value that `getUserOrder()` eventually
 produces:
 
 * `getUserOrder()` is an asynchronous function that, after a delay,
-provides a string that describes the user's order: a "Large Latte".
+  provides a string that describes the user's order: a "Large Latte".
 * To get the user's order, `createOrderMessage()` should call `getUserOrder()`
-and wait for it to finish. Because `createOrderMessage()` does *not* wait
-for `getUserOrder()` to finish, `createOrderMessage()` fails to get the string
-value that `getUserOrder()` eventually provides.
+  and wait for it to finish. Because `createOrderMessage()` does *not* wait
+  for `getUserOrder()` to finish, `createOrderMessage()` fails to get the string
+  value that `getUserOrder()` eventually provides.
 * Instead, `createOrderMessage()` gets a representation of pending work to be
-done: an uncompleted future. You'll learn more about futures in the next section.
+  done: an uncompleted future. You'll learn more about futures in the next section.
 * Because `createOrderMessage()` fails to get the value describing the user's
-order, the example fails to print "Large Latte" to the console, and instead
-prints "Your order is: Instance of '_Future<String>'".
+  order, the example fails to print "Large Latte" to the console, and instead
+  prints "Your order is: Instance of '_Future<String>'".
 
 In the next sections you'll learn the about futures, `async`, and `await`
 so that you'll be able to write the code necessary to make `getUserOrder()`
 print the desired value ("Large Latte") to the console.
 
- {{site.alert.secondary}}
- **Key terms:**
-* **synchronous operation**: A synchronous operation blocks other operations
-from executing until it completes.
-* **synchronous function**: A synchronous function only performs synchronous
-operations.
-* **asynchronous operation**: Once initiated, an asynchronous operation allows
-other operations to execute before it completes.
-* **asynchronous function**: An asynchronous function performs at least one
-asynchronous operation and can also perform _synchronous_ operations.
- {{site.alert.end}}
+{{site.alert.secondary}}
+  **Key terms:**
+
+  * **synchronous operation**: A synchronous operation blocks other operations
+    from executing until it completes.
+  * **synchronous function**: A synchronous function only performs synchronous
+    operations.
+  * **asynchronous operation**: Once initiated, an asynchronous operation allows
+    other operations to execute before it completes.
+  * **asynchronous function**: An asynchronous function performs at least one
+    asynchronous operation and can also perform _synchronous_ operations.
+{{site.alert.end}}
 
 
 ## What is a future?
-A future (lower case "f") is an instance of the [Future][future class]
+
+A future (lower case "f") is an instance of the [Future][]
 (capitalized "F") class. A future represents the result of an asynchronous
 operation, and can have two states: uncompleted or completed.
 
@@ -101,6 +103,7 @@ That future is waiting for the function's asynchronous operation to finish or to
 throw an error.
 
 ### Completed
+
 If the asynchronous operation succeeds, the future completes with a
 value. Otherwise it completes with an error.
 
@@ -123,7 +126,6 @@ printing to the console. Because it doesn't return a usable value,
 `getUserOrder()` has the type `Future<void>`. Before you run the example,
 try to predict which will print first: "Large Latte" or "Fetching user order...".
 
-[//]: https://gist.github.com/57e6085344cbd1719ed42b32f8ad1bce
 <iframe
   src="{{site.dartpad-embed}}?id=57e6085344cbd1719ed42b32f8ad1bce"
   style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
@@ -138,10 +140,10 @@ the `print()` call on line 8, the console shows the output from line 8
 This is because `getUserOrder()` delays before it prints "Large Latte".
 
 ### Example: Completing with an error
+
 Run the following example to see how a future completes with an error.
 A bit later you'll learn how to handle the error.
 
-[//]: https://gist.github.com/d843061bbd9388b837c57613dc6d5125
 <iframe
   src="{{site.dartpad-embed}}?id=d843061bbd9388b837c57613dc6d5125"
   style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
@@ -159,19 +161,20 @@ results with the `async` and `await` keywords.
 
 {{site.alert.secondary}}
   **Quick review:**
-  * A [Future\<T\>][future class] instance produces a value of type `T`.
+
+  * A [Future\<T\>][Future] instance produces a value of type `T`.
   * If a future doesn't produce a usable value, then the future's type is
-  `Future<void>`.
+    `Future<void>`.
   * A future can be in one of two states: uncompleted or completed.
   * When you call a function that returns a future, the function queues up
-  work to be done and returns an uncompleted future.
+    work to be done and returns an uncompleted future.
   * When a future's operation finishes, the future completes with a value or
-  with an error.
+    with an error.
 
-**Key terms:**
-* **Future**: the Dart [Future][future class] class.
+  **Key terms:**
 
-* **future**: an instance of the Dart Future class.
+  * **Future**: the Dart [Future][] class.
+  * **future**: an instance of the Dart `Future` class.
 {{site.alert.end}}
 
 ## Working with futures: async and await
@@ -179,6 +182,7 @@ results with the `async` and `await` keywords.
 The `async` and `await` keywords provide a declarative way to define
 asynchronous functions and use their results. Remember these two basic guidelines
 when using `async` and `await`:
+
 * __To define an async function, add `async` before the function body:__
 * __The `await` keyword works only in `async` functions.__
 
@@ -186,17 +190,16 @@ Here's an example  that converts `main()` from a synchronous to asynchronous
 function.
 
 First, add the `async` keyword before the function body:
+
 {% prettify dart %}
-    main() [!async!] {
+main() [!async!] {
 {% endprettify %}
 
-{{site.alert.info}}
-  You might have noticed that some functions (like `main()`, above)
-  don't have return types.
-  That's because Dart can [infer the return type][infer] for you.
-  Omitting return types is fine when you're prototyping,
-  but when you write production code,
-  we recommend that you specify the return type.
+{{site.alert.note}}
+  You might have noticed that some functions (like `main()`, above) don't have
+  return types. That's because Dart can [infer the return type][infer] for you.
+  Omitting return types is fine when you're prototyping, but when you write
+  production code, we recommend that you specify the return type.
 {{site.alert.end}}
 
 [infer]: https://dart.dev/guides/language/sound-dart#type-inference
@@ -207,14 +210,15 @@ If the function doesn't explicitly return a value, then the return type is
 `Future<void>`:
 
 {% prettify dart %}
-    [!Future<void>!] main() async {
+[!Future<void>!] main() async {
 {% endprettify %}
 
 Now that you have an `async` function, you can use the `await` keyword to wait
 for a future to complete:
-{% prettify dart %}
-    print(await createOrderMessage());
-{% endprettify %}
+
+```dart
+print(await createOrderMessage());
+```
 
 
 As the following two examples show, the `async` and `await` keywords result in
@@ -223,11 +227,11 @@ The only differences are highlighted in the asynchronous example, which — if
 your window is wide enough — is to the right of the synchronous example.
 
 <div class="container">
-  <div class="row">
-    <div class="col-sm">
-    <h4> Example: synchronous functions</h4>
+<div class="row">
+<div class="col-sm" markdown="1">
+#### Example: synchronous functions
 
-{% prettify dart %}
+```dart
 // Synchronous
 String createOrderMessage() {
   var order = getUserOrder();
@@ -250,55 +254,56 @@ main() {
 
 // 'Fetching user order...'
 // 'Your order is: Instance of _Future<String>'
-{% endprettify %}
-    </div>
-    <div class="col-sm">
-    <h4> Example: asynchronous functions</h4>
+```
+</div>
+<div class="col-sm" markdown="1">
+#### Example: asynchronous functions
 
 {% prettify dart %}
 // Asynchronous
 [!Future<String>!] createOrderMessage() [!async!] {
-  var order = [!await!] getUserOrder();
-  return 'Your order is: $order';
+var order = [!await!] getUserOrder();
+return 'Your order is: $order';
 }
 
 Future<String> getUserOrder() {
-  // Imagine that this function is
-  // more complex and slow.
-  return
-   Future.delayed(
-     Duration(seconds: 4), () => 'Large Latte');
+// Imagine that this function is
+// more complex and slow.
+return
+  Future.delayed(
+    Duration(seconds: 4), () => 'Large Latte');
 }
 
 // Asynchronous
 main() [!async!] {
-  print('Fetching user order...');
-  print([!await!] createOrderMessage());
+print('Fetching user order...');
+print([!await!] createOrderMessage());
 }
 
 // 'Fetching user order...'
 // 'Your order is: Large Latte'
 {% endprettify %}
-    </div>
-  </div>
+</div>
+</div>
 </div>
 
 The asynchronous example is different in three ways:
-  * The return type for `createOrderMessage()` changes from `String` to
+
+* The return type for `createOrderMessage()` changes from `String` to
   `Future<String>`.
-  * The **`async`** keyword appears before the function bodies for
+* The **`async`** keyword appears before the function bodies for
   `createOrderMessage()` and `main()`.
-  * The **`await`** keyword appears before calling the asynchronous functions
+* The **`await`** keyword appears before calling the asynchronous functions
   `getUserOrder()` and `createOrderMessage()`.
 
 {{site.alert.secondary}}
   **Key terms:**
-* **async**: You can use the `async` keyword before a function's body to mark it as
-asynchronous.
-* **async function**:  An `async` function is a function labeled with the `async`
-keyword.
-* **await**: You can use the `await` keyword to get the completed result of an
-asynchronous expression. The `await` keyword only works within an `async` function.
+  * **async**: You can use the `async` keyword before a function's body to mark it as
+    asynchronous.
+  * **async function**:  An `async` function is a function labeled with the `async`
+    keyword.
+  * **await**: You can use the `await` keyword to get the completed result of an
+    asynchronous expression. The `await` keyword only works within an `async` function.
 {{site.alert.end}}
 
 ### Execution flow with async and await
@@ -307,16 +312,15 @@ An `async` function runs synchronously until the first
 `await` keyword. This means that within an `async` function body, all
 synchronous code before the first `await` keyword executes immediately.
 
-{{site.alert.note}}
-Before Dart 2.0, an `async` function returned immediately,
-without executing any code within the `async` function body.
+{{site.alert.version-note}}
+  Before Dart 2.0, an `async` function returned immediately, without executing
+  any code within the `async` function body.
 {{site.alert.end}}
 
 ### Example: Execution within async functions
 Run the following example to see how execution proceeds within an `async`
 function body. What do you think the output will be?
 
-[//]: https://gist.github.com/d7abfdea1ae5596e96c7c0203d975dba
 <iframe
   src="{{site.dartpad-embed}}?id=d7abfdea1ae5596e96c7c0203d975dba"
   style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 40px"
@@ -327,10 +331,10 @@ function body. What do you think the output will be?
 
 After running the code in the preceding example, try reversing line 4 and line 5:
 
-{% prettify dart %}
-  var order = await getUserOrder();
-  print('Awaiting user order...');
-{% endprettify %}
+```dart
+var order = await getUserOrder();
+print('Awaiting user order...');
+```
 
 Notice that timing of the output shifts, now that `print('Awaiting user order')`
 appears after the first `await` keyword in `createOrderMessage()`.
@@ -356,24 +360,28 @@ provided for you:
 #### Part 1: `reportUserRole()`
 
 Add code to the `reportUserRole()` function so that it does the following:
-<!-- Some bulleted items are intentionally lacking punctuation to avoid
-confusing the users about characters in string values -->
+{% comment %}
+  Some bulleted items are intentionally lacking punctuation to avoid
+  confusing the users about characters in string values
+{% endcomment -%}
+
 * Returns a future that completes with the following
-string: `"User role: <user role>"`
+  string: `"User role: <user role>"`
   * Note: You must use the actual value returned by `getRole()`; copying and
-  pasting the example return value won't make the test pass.
+    pasting the example return value won't make the test pass.
   * Example return value: `"User role: tester"`
 * Gets the user role by calling the provided function `getRole()`.
 
 ####  Part 2: `reportLogins()`
+
 Implement an `async` function `reportLogins()` so that it does the following:
+
 * Returns the string `"Total number of logins: <# of logins>"`.
   * Note: You must use the actual value returned by `getLoginAmount()`; copying
-  and pasting the example return value won't make the test pass.
+    and pasting the example return value won't make the test pass.
   * Example return value from `reportLogins()`: `"Total number of logins: 57"`
 * Gets the number of logins by calling the provided function `getLoginAmount()`.
 
-<!-- [//]: https://gist.github.com/f751b692502c4ee43d932f745860b056 -->
 <iframe
   src="{{site.dartpad-embed}}?id=f751b692502c4ee43d932f745860b056&theme=dark"
   frameborder="no"
@@ -381,34 +389,37 @@ Implement an `async` function `reportLogins()` so that it does the following:
   width="100%">
 </iframe>
 
-  {{site.alert.info}}
-    If your code passes the tests, you can ignore [info-level messages.](/guides/language/analysis-options#customizing-analysis-rules)
-  {{site.alert.end}}
+{{site.alert.info}}
+  If your code passes the tests, you can ignore
+  [info-level messages.](/guides/language/analysis-options#customizing-analysis-rules)
+{{site.alert.end}}
 
 ## Handling errors
 To handle errors in an `async` function, use try-catch:
 
 ```dart
-  try {
-    var order = await getUserOrder();
-    print('Awaiting user order...');
-  } catch (err) {
-    print('Caught error: $err');
-  }
+try {
+  var order = await getUserOrder();
+  print('Awaiting user order...');
+} catch (err) {
+  print('Caught error: $err');
+}
 ```
+
 Within an `async` function, you can write [try-catch clauses](/guides/language/language-tour#catch)
 the same way you would in synchronous code.
 
 ### Example: async and await with try-catch
+
 Run the following example to see how to handle an error from an
 asynchronous function. What do you think the output will be?
-<!-- [//]: https://gist.github.com/25ade03f0632878a9169209e3cd7bef2 -->
+
 <iframe
   src="{{site.dartpad-embed}}?id=25ade03f0632878a9169209e3cd7bef2"
   style="border: 1px solid lightgrey;"
   frameborder="no"
   height="525"
-  width="100%" >
+  width="100%">
 </iframe>
 
 ### Exercise: Practice handling errors
@@ -425,22 +436,28 @@ operations, your code will call the following function, which is provided for yo
 
 Use `async` and `await` to implement an asynchronous `changeUsername()` function
 that does the following:
+
 * Calls the provided asynchronous function `getNewUsername()` and returns its result.
   * Example return value from `changeUsername()`: `"jane_smith_92"`
 * Catches any error that occurs and returns the string value of the error.
-  * You can use the [toString()]({{site.dart_api}}/stable/dart-core/ArgumentError/toString.html) method to stringify both [Exceptions]({{site.dart_api}}/stable/dart-core/Exception-class.html) and [Errors.]({{site.dart_api}}/stable/dart-core/Error-class.html)
-
-<!-- [//]: https://gist.github.com/858f71f0ad0e70051999bcafa41806a3 -->
+  * You can use the
+    [toString()]({{site.dart_api}}/stable/dart-core/ArgumentError/toString.html)
+    method to stringify both
+    [Exceptions]({{site.dart_api}}/stable/dart-core/Exception-class.html) and
+    [Errors.]({{site.dart_api}}/stable/dart-core/Error-class.html)
 
 <iframe
-src="{{site.dartpad-embed}}?id=858f71f0ad0e70051999bcafa41806a3&theme=dark"
-frameborder="no"
-height="525"
-width="100%" >
+  src="{{site.dartpad-embed}}?id=858f71f0ad0e70051999bcafa41806a3&theme=dark"
+  frameborder="no"
+  height="525"
+  width="100%">
 </iframe>
 
-<!-- TODO: Consider summary section before final exercise -->
-<!-- TODO: Consider adding new content to final section (not repeating same stuff) -->
+{% comment %}
+TODO: Consider summary section before final exercise
+TODO: Consider adding new content to final section (not repeating same stuff)
+{% endcomment -%}
+
 ## Exercise: Putting it all together
 
 It's time to practice what you've learned in one final exercise.
@@ -450,18 +467,20 @@ functions `getUsername()` and `logoutUser()`:
 |------------------+-----------------------------------+-------------|
 | Function         | Type signature                    | Description |
 |------------------|-----------------------------------|-------------|
-| getUsername()    | `Future<String> getUsername()`    |      Returns the name associated with the current user.|
-| logoutUser()    | `Future<String> logoutUser()`    |      Performs logout of current user and returns the username that was logged out.|
+| getUsername()    | `Future<String> getUsername()`    | Returns the name associated with the current user.|
+| logoutUser()     | `Future<String> logoutUser()`     | Performs logout of current user and returns the username that was logged out.|
 {:.table .table-striped}
 
 Write the following:
 
 ####  Part 1: `addHello()`
+
 * Write a function `addHello()` that takes a single String argument.
 * `addHello()` returns its String argument preceded by 'Hello '.<br>
   Example: `addHello('Jon')` returns `'Hello Jon'`.
 
 ####  Part 2: `greetUser()`
+
 * Write a function `greetUser()` that takes no arguments.
 * To get the username, `greetUser()` calls the provided asynchronous
   function `getUsername()`.
@@ -471,6 +490,7 @@ Write the following:
   `greetUser()` returns `'Hello Jenny'`.
 
 ####  Part 3: `sayGoodbye()`
+
 * Write a function `sayGoodbye()` that does the following:
   * Takes no arguments.
   * Catches any errors.
@@ -480,7 +500,6 @@ Write the following:
   `'<result> Thanks, see you next time'`, where `<result>` is
   the String value returned by calling `logoutUser()`.
 
-{% comment %}https://gist.github.com/f601d25bc2833c957186e3c6bf71effc{% endcomment -%}
 <iframe
   src="{{site.dartpad-embed}}?id=f601d25bc2833c957186e3c6bf71effc&theme=dark"
   frameborder="no"
@@ -494,25 +513,24 @@ Write the following:
 Congratulations, you've finished the codelab! If you'd like to learn more, here
 are some suggestions for where to go next:
 
-* Play with [DartPad.]({{site.dartpad}})
-* Try another [codelab](/codelabs).
-* Learn more about futures and asynchrony:
-  * [Streams tutorial](/tutorials/language/streams):
+- Play with [DartPad.]({{site.dartpad}})
+- Try another [codelab](/codelabs).
+- Learn more about futures and asynchrony:
+  - [Streams tutorial](/tutorials/language/streams):
     Learn how to work with a sequence of asynchronous events.
-  * [Dart videos from Google:][Dart videos]
+  - [Dart videos from Google:][Dart videos]
     Watch one or more of the videos about asynchronous coding.
     Or, if you prefer, read the articles that are based on these videos.
     (Start with [isolates and event loops.][article])
-* [Get the Dart SDK.](/get-dart)
+- [Get the Dart SDK.](/get-dart)
 
-If you're interested in using embedded DartPads,
-like this codelab does,
-see [best practices for using DartPad in tutorials][].
+If you're interested in using embedded DartPads, like this codelab does, see
+[best practices for using DartPad in tutorials][].
 
 [best practices for using DartPad in tutorials]: /resources/dartpad-tutorials.pdf
 [Dart videos]: https://www.youtube.com/playlist?list=PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J
 [article]: https://medium.com/dartlang/dart-asynchronous-programming-isolates-and-event-loops-bffc3e296a6a
-[future class]: {{site.dart_api}}/stable/dart-async/Future-class.html
+[Future]: {{site.dart_api}}/stable/dart-async/Future-class.html
 [style guide]: /guides/language/effective-dart/style
 [documentation guide]: /guides/language/effective-dart/documentation
 [usage guide]: /guides/language/effective-dart/usage

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -83,10 +83,10 @@ Another null-aware operator is `??`,
 which returns the expression on its left unless that expression's value is null,
 in which case it evaluates and returns the expression on its right:
 
-{% prettify dart %}
-    print(1 ?? 3); // <-- Prints 1.
-    print(null ?? 12); // <-- Prints 12.
-{% endprettify %}
+```dart
+print(1 ?? 3); // <-- Prints 1.
+print(null ?? 12); // <-- Prints 12.
+```
 
 ### Code example
 
@@ -100,21 +100,21 @@ Try putting the `??=` and `??` operators to work below.
 To guard access to a property or method of an object that might be null,
 put a question mark (`?`) before the dot (`.`):
 
-{% prettify dart %}
+```dart
 myObject?.someProperty
-{% endprettify %}
+```
 
 The preceding code is equivalent to the following:
 
-{% prettify dart %}
+```dart
 (myObject != null) ? myObject.someProperty : null
-{% endprettify %}
+```
 
 You can chain multiple uses of `?.` together in a single expression:
 
-{% prettify dart %}
+```dart
 myObject?.someProperty?.someMethod()
-{% endprettify %}
+```
 
 The preceding code returns null (and never calls `someMethod()`) if either
 `myObject` or `myObject.someProperty` is
@@ -133,7 +133,7 @@ Try using conditional property access to finish the code snippet below.
 Dart has built-in support for lists, maps, and sets.
 You can create them using literals:
 
-{% prettify dart %}
+```dart
 final aListOfStrings = ['one', 'two', 'three'];
 final aSetOfStrings = {'one', 'two', 'three'};
 final aMapOfStringsToInts = {
@@ -141,7 +141,7 @@ final aMapOfStringsToInts = {
   'two': 2,
   'three': 3,
 };
-{% endprettify %}
+```
 
 Dart's type inference can assign types to these variables for you.
 In this case, the inferred types are `List<String>`,
@@ -149,18 +149,18 @@ In this case, the inferred types are `List<String>`,
 
 Or you can specify the type yourself:
 
-{% prettify dart %}
+```dart
 final aListOfInts = <int>[];
 final aSetOfInts = <int>{};
 final aMapOfIntToDouble = <int, double>{};
-{% endprettify %}
+```
 
 Specifying types is handy when you initialize a list with contents of a subtype,
 but still want the list to be `List<BaseType>`:
 
-{% prettify dart %}
+```dart
 final aListOfBaseType = <BaseType>[SubType(), SubType()];
-{% endprettify %}
+```
 
 ### Code example
 
@@ -178,17 +178,17 @@ expression to its right and returns its value.
 For example, consider this call to the `List` class's
 `any()` method:
 
-{% prettify dart %}
+```dart
 bool hasEmpty = aListOfStrings.any((s) {
   return s.isEmpty;
 });
-{% endprettify %}
+```
 
 Here’s a simpler way to write that code:
 
-{% prettify dart %}
+```dart
 bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
-{% endprettify %}
+```
 
 ### Code example
 
@@ -210,18 +210,18 @@ but they don't use `///`, and they end in `:`, not `.`.
 To perform a sequence of operations on the same object, use cascades (`..`).
 We've all seen an expression like this:
 
-{% prettify dart %}
+```dart
 myObject.someMethod()
-{% endprettify %}
+```
 
 It invokes `someMethod()` on `myObject`, and the result of
 the expression is the return value of `someMethod()`.
 
 Here's the same expression with a cascade:
 
-{% prettify dart %}
+```dart
 myObject..someMethod()
-{% endprettify %}
+```
 
 Although it still invokes `someMethod()` on `myObject`, the result
 of the expression **isn't** the return value — it's a reference to `myObject`!
@@ -229,22 +229,22 @@ Using cascades, you can chain together operations that
 would otherwise require separate statements.
 For example, consider this code:
 
-{% prettify dart %}
+```dart
 var button = querySelector('#confirm');
 button.text = 'Confirm';
 button.classes.add('important');
 button.onClick.listen((e) => window.alert('Confirmed!'));
-{% endprettify %}
+```
 
 With cascades, the code becomes much shorter,
 and you don’t need the `button` variable:
 
-{% prettify dart %}
+```dart
 querySelector('#confirm')
 ..text = 'Confirm'
 ..classes.add('important')
 ..onClick.listen((e) => window.alert('Confirmed!'));
-{% endprettify %}
+```
 
 ### Code example
 
@@ -264,7 +264,7 @@ than a simple field allows.
 
 For example, you can make sure a property's value is valid:
 
-{% prettify dart %}
+```dart
 class MyClass {
   int _aProperty = 0;
 
@@ -276,11 +276,11 @@ class MyClass {
     }
   }
 }
-{% endprettify %}
+```
 
 You can also use a getter to define a computed property:
 
-{% prettify dart %}
+```dart
 class MyClass {
   List<int> _values = [];
 
@@ -293,7 +293,7 @@ class MyClass {
     return _values.length;
   }
 }
-{% endprettify %}
+```
 
 ### Code example
 
@@ -314,17 +314,17 @@ Add the following:
 Dart has two kinds of function parameters: positional and named. Positional parameters are the kind
 you're likely familiar with:
 
-{% prettify dart %}
+```dart
 int sumUp(int a, int b, int c) {
   return a + b + c;
 }
 
 int total = sumUp(1, 2, 3);
-{% endprettify %}
+```
 
 With Dart, you can make these positional parameters optional by wrapping them in brackets:
 
-{% prettify dart %}
+```dart
 int sumUpToFive(int a, [int b, int c, int d, int e]) {
   int sum = a;
   if (b != null) sum += b;
@@ -336,20 +336,20 @@ int sumUpToFive(int a, [int b, int c, int d, int e]) {
 
 int total = sumUptoFive(1, 2);
 int otherTotal = sumUpToFive(1, 2, 3, 4, 5);
-{% endprettify %}
+```
 
 Optional positional parameters are always last
 in a function's parameter list.
 Their default value is null unless you provide another default value:
 
-{% prettify dart %}
+```dart
 int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
   ...
 }
 
 int newTotal = sumUpToFive(1);
 print(newTotal); // <-- prints 15
-{% endprettify %}
+```
 
 ### Code example
 
@@ -373,23 +373,23 @@ Here are some examples of function calls and returned values:
 Using a curly brace syntax,
 you can define optional parameters that have names.
 
-{% prettify dart %}
+```dart
 void printName(String firstName, String lastName, {String suffix}) {
   print('$firstName $lastName ${suffix ?? ''}');
 }
 
 printName('Avinash', 'Gupta');
 printName('Poshmeister', 'Moneybuckets', suffix: 'IV');
-{% endprettify %}
+```
 
 As you might expect, the value of these parameters is null by default,
 but you can provide default values:
 
-{% prettify dart %}
+```dart
 void printName(String firstName, String lastName, {String suffix = ''}) {
   print('$firstName $lastName ${suffix}');
 }
-{% endprettify %}
+```
 
 A function can't have both optional positional and optional named parameters.
 
@@ -422,14 +422,14 @@ any exceptions.
 Dart provides `Exception` and `Error` types, but you're
 allowed to throw any non-null object:
 
-{% prettify dart %}
+```dart
 throw Exception('Something bad happened.');
 throw 'Waaaaaaah!';
-{% endprettify %}
+```
 
 Use the `try`, `on`, and `catch` keywords when handling exceptions:
 
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } on OutOfLlamasException {
@@ -442,7 +442,7 @@ try {
   // No specified type, handles all
   print('Something really unknown: $e');
 }
-{% endprettify %}
+```
 
 The `try` keyword works as it does in most other languages.
 Use the `on` keyword to filter for specific exceptions by type,
@@ -451,19 +451,19 @@ and the `catch` keyword to get a reference to the exception object.
 If you can't completely handle the exception, use the `rethrow` keyword
 to propagate the exception:
 
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } catch (e) {
   print('I was just trying to breed llamas!.');
   rethrow;
 }
-{% endprettify %}
+```
 
 To execute code whether or not an exception is thrown,
 use `finally`:
 
-{% prettify dart %}
+```dart
 try {
   breedMoreLlamas();
 } catch (e) {
@@ -472,7 +472,7 @@ try {
   // Always clean up, even if an exception is thrown.
   cleanLlamaStalls();
 }
-{% endprettify %}
+```
 
 ### Code example
 
@@ -518,7 +518,7 @@ Dart provides a handy shortcut for assigning
 values to properties in a constructor:
 use `this.propertyName` when declaring the constructor:
 
-{% prettify dart %}
+```dart
 class MyColor {
   int red;
   int green;
@@ -528,12 +528,12 @@ class MyColor {
 }
 
 final color = MyColor(80, 80, 128);
-{% endprettify %}
+```
 
 This technique works for named parameters, too.
 Property names become the names of the parameters:
 
-{% prettify dart %}
+```dart
 class MyColor {
   ...
 
@@ -541,15 +541,15 @@ class MyColor {
 }
 
 final color = MyColor(red: 80, green: 80, blue: 80);
-{% endprettify %}
+```
 
 For optional parameters, default values work as expected:
 
-{% prettify dart %}
+```dart
 MyColor([this.red = 0, this.green = 0, this.blue = 0]);
 // or
 MyColor({this.red = 0, this.green = 0, this.blue = 0});
-{% endprettify %}
+```
 
 ### Code example
 
@@ -576,24 +576,24 @@ before the constructor body executes.
 Do this work in an initializer list,
 which goes between the constructor's signature and its body:
 
-{% prettify dart %}
+```dart
 Point.fromJson(Map<String, num> json)
     : x = json['x'],
       y = json['y'] {
   print('In Point.fromJson(): ($x, $y)');
 }
-{% endprettify %}
+```
 
 The initializer list is also a handy place to put asserts,
 which run only during development:
 
-{% prettify dart %}
+```dart
 NonNegativePoint(this.x, this.y)
     : assert(x >= 0),
       assert(y >= 0) {
   print('I just made a NonNegativePoint: ($x, $y)');
 }
-{% endprettify %}
+```
 
 ### Code example
 
@@ -629,7 +629,7 @@ so I deleted that. We can add it back if we can word it better.]
 To allow classes to have multiple constructors,
 Dart supports named constructors:
 
-{% prettify dart %}
+```dart
 class Point {
   num x, y;
 
@@ -640,13 +640,13 @@ class Point {
     y = 0;
   }
 }
-{% endprettify %}
+```
 
 To use a named constructor, invoke it using its full name:
 
-{% prettify dart %}
+```dart
 final myPoint = Point.origin();
-{% endprettify %}
+```
 
 ### Code example
 
@@ -667,7 +667,7 @@ Dart supports factory constructors,
 which can return subtypes or even null.
 To create a factory constructor, use the `factory` keyword:
 
-{% prettify dart %}
+```dart
 class Square extends Shape {}
 
 class Circle extends Shape {}
@@ -683,7 +683,7 @@ class Shape {
     return null;
   }
 }
-{% endprettify %}
+```
 
 ### Code example
 
@@ -712,7 +712,7 @@ another constructor in the same class.
 A redirecting constructor’s body is empty,
 with the constructor call appearing after a colon (`:`).
 
-{% prettify dart %}
+```dart
 class Automobile {
   String make;
   String model;
@@ -727,7 +727,7 @@ class Automobile {
   // Delegates to a named constructor
   Automobile.fancyHybrid() : this.hybrid('Futurecar', 'Mark 2');
 }
-{% endprettify %}
+```
 
 ### Code example
 
@@ -744,7 +744,7 @@ If your class produces objects that never change, you can make these objects com
 do this, define a `const` constructor and make sure that all instance variables
 are final.
 
-{% prettify dart %}
+```dart
 class ImmutablePoint {
   const ImmutablePoint(this.x, this.y);
 
@@ -754,7 +754,7 @@ class ImmutablePoint {
   static const ImmutablePoint origin =
       ImmutablePoint(0, 0);
 }
-{% endprettify %}
+```
 
 ### Code example
 


### PR DESCRIPTION
- Switch to code fences, everywhere possible, in prep for upcoming DartPad updates. (Only pages with DartPad iframes have been updated.)
- Also clean up alerts: use site.alert.foo instead.
- Define and use site.alert.version-note
- Closes #2102
- Closes #2103
- Contributes to #1803

Best reviewed by ignoring changes in whitespace.