### PR TITLE
Update pub-downgrade.md

### DIFF
--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -6,7 +6,7 @@ description: Use pub downgrade to get the lowest versions of all dependencies us
 _Downgrade_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify sh %}
-$ pub downgrade [args] [dependencies] [--offline] [--no-offline] [--dry-run]
+$ pub downgrade [--[no]-offline] [-n|--dry-run] [dependencies...] 
 {% endprettify %}
 
 Without any additional arguments, `pub downgrade` gets the lowest versions of
@@ -105,15 +105,12 @@ available.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`--offline`
-: Use locally cached packages instead of accessing the network.
-
-`--no-offline`
-: Connect to the network to check for hosted dependencies. This is the 
-default setting.
+`--[no]-offline`
+: By default, pub connects to the network to check for hosted 
+dependencies (`--no-offline`). To use cached packages instead, use `--offline`.
 
 `--dry-run` or `-n`
-: Report what dependencies would change but would not change any.
+: Report what dependencies would change but don't change any.
 
 
 <aside class="alert alert-info" markdown="1">

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -99,13 +99,22 @@ trying to find a set of versions that work with your package from what's already
 available.
 
 
-## Options {#options}
 
-The `pub downgrade` command supports the
-[`pub get` options](/tools/pub/cmd/pub-get#options).
+## Options
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
+
+`--offline`
+: Uses locally cached packages instead of accessing the network.
+
+`--no-offline`
+: Connects to the network to check for hosted dependencies. This is the 
+default setting.
+
+`--dry-run` or `-n`
+: Reports what dependencies would change but would not change any.
+
 
 <aside class="alert alert-info" markdown="1">
   *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -6,7 +6,7 @@ description: Use pub downgrade to get the lowest versions of all dependencies us
 _Downgrade_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify sh %}
-$ pub downgrade [args] [dependencies]
+$ pub downgrade [args] [dependencies] [--offline] [--no-offline] [--dry-run]
 {% endprettify %}
 
 Without any additional arguments, `pub downgrade` gets the lowest versions of
@@ -106,14 +106,14 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 `--offline`
-: Uses locally cached packages instead of accessing the network.
+: Use locally cached packages instead of accessing the network.
 
 `--no-offline`
-: Connects to the network to check for hosted dependencies. This is the 
+: Connect to the network to check for hosted dependencies. This is the 
 default setting.
 
 `--dry-run` or `-n`
-: Reports what dependencies would change but would not change any.
+: Report what dependencies would change but would not change any.
 
 
 <aside class="alert alert-info" markdown="1">

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -6,7 +6,7 @@ description: Use pub downgrade to get the lowest versions of all dependencies us
 _Downgrade_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify sh %}
-$ pub downgrade [--[no]-offline] [-n|--dry-run] [dependencies...] 
+$ pub downgrade [--[no-]offline] [-n|--dry-run] [dependencies...] 
 {% endprettify %}
 
 Without any additional arguments, `pub downgrade` gets the lowest versions of
@@ -105,7 +105,7 @@ available.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`--[no]-offline`
+`--[no-]offline`
 : By default, pub connects to the network to check for hosted 
 dependencies (`--no-offline`). To use cached packages instead, use `--offline`.
 


### PR DESCRIPTION
Update description for pub downgrade options.

Note: There is no option for `--precompile` in `pub downgrade`: https://github.com/dart-lang/pub/blob/master/lib/src/command/downgrade.dart

Contributes to #1256.