### PR TITLE
Fix linkcheck-skip-list.txt localhost rule

### DIFF
--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -1,6 +1,7 @@
 # Enter regexp pattern, one per line.
 
-^(https?://)?localhost\b
+# Skip links used by example web apps
+localhost:(404\d|8080)
 
 # FIXME(Temporary): linkcheck seems to be intermittently failing when accessing main.css
 # https://github.com/dart-lang/site-www/issues/1107


### PR DESCRIPTION
Followup of #2120. Thanks to @kwalrath for double checking with me!

The old rules, prior to #2120 resulted in the following stats (when doing external link checking, which is more inclusive):

```nocode
Stats:
   20710 links
     740 destination URLs
     325 URLs ignored
      50 warnings
       0 errors
```

The new replacement rule has the following stats:

```nocode
Stats:
   20710 links
     739 destination URLs
     324 URLs ignored
      49 warnings
       0 errors
```

The one warning less, it because the following link is, as of this PR, being correctly skipped (but wasn't being skipped by the old rules):

```nocode
http://localhost:4000/tutorials/server/httpserver
- (1638:0) 'localhos..' => http://localhost:4048 (connection failed)
```

So the old rule set was incomplete.