### PR TITLE
Remove Dart 2 prereleases references

### DIFF
--- a/src/_includes/pub-in-prereleases.html
+++ b/src/_includes/pub-in-prereleases.html
@@ -1,9 +1,0 @@
-<aside class="alert alert-warning" markdown="1">
-  **SDK constraints and Dart 2 prereleases:**
-  The pub version solver in Dart 2 prereleases can choose package versions that
-  haven’t been verified to work with Dart 2.
-  If you find a package that has Dart 2 issues,
-  please report those issues immediately to the package maintainer,
-  and let the Dart community know about any workarounds you find.
-  For more information, see the [Dart 2 page](/dart-2).
-</aside>

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -51,8 +51,6 @@ This is the primary difference between `pub get` and
 [`pub upgrade`](/tools/pub/cmd/pub-upgrade), which always tries to
 get the latest versions of all dependencies.
 
-{% include pub-in-prereleases.html %}
-
 ## Package resolution
 
 By default, pub creates a `.packages` file


### PR DESCRIPTION
Remove dated references which focus on using Dart 2 before it has shipped.