### PR TITLE
Improve collapsed contents on smaller screens

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -544,7 +544,7 @@ img {
 
     &.toc-collapsed {
       .section-nav {
-        max-height: 72px;
+        max-height: 0px;
         overflow: hidden;
       }
 
@@ -554,6 +554,10 @@ img {
 
       .toc-toggle-down {
         display: inline-block;
+      }
+
+      .site-toc__title {
+        margin: 0px;
       }
     }
   }


### PR DESCRIPTION
Staged: https://jv-dart-dev-2.firebaseapp.com/guides/language/sound-dart

<img width="501" alt="after_contents" src="https://user-images.githubusercontent.com/9855136/71030657-bc1f4200-20c6-11ea-91d8-39ab65c2a6af.png">

Original: https://dart.dev/guides/language/sound-dart

<img width="503" alt="before_contents" src="https://user-images.githubusercontent.com/9855136/71030687-cccfb800-20c6-11ea-92e8-d78a268bbf0b.png">

Try resizing the screen on desktop.

When collapsed, some of the contents would be cut off with > 10 items.
Instead, don't show any of the contents until expanded.