### PR TITLE
Add camel_case_extensions lint rule reference to Effective Dart: Style

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -81,6 +81,8 @@ class C { ... }
 
 ### DO name extensions using `UpperCamelCase`.
 
+{% include linter-rule.html rule="camel_case_extensions" %}
+
 Like types, extensions should capitalize the first letter of each word
 (including the first word), 
 and use no separators.


### PR DESCRIPTION
Adds a reference to the [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html) lint rule to Effective Dart: Style.