### PR TITLE
Add avoid_init_to_null lint rule reference to Effective Dart: Usage

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -731,6 +731,8 @@ The following best practices describe how to best use variables in Dart.
 
 ### DON'T explicitly initialize variables to `null`.
 
+{% include linter-rule.html rule="avoid_init_to_null" %}
+
 In Dart, a variable or field that is not explicitly initialized automatically
 gets initialized to `null`. This is reliably specified by the language. There's
 no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and


### PR DESCRIPTION
Adds a reference to the [`avoid_init_to_null `](https://dart-lang.github.io/linter/lints/avoid_init_to_null.html) lint rule to Effective Dart: Usage.

This reference missing. It's only mentioned above in the section about parameters.