### PR TITLE
Add avoid_catching_errors lint rule reference to Effective Dart: Usage

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1335,6 +1335,8 @@ one of the core Exception classes or some other type.
 
 ### DON'T explicitly catch `Error` or types that implement it.
 
+{% include linter-rule.html rule="avoid_catching_errors" %}
+
 This follows from the above. Since an Error indicates a bug in your code, it
 should unwind the entire callstack, halt the program, and print a stack trace so
 you can locate and fix the bug.


### PR DESCRIPTION
Adds a reference to the [`avoid_catching_errors`](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html) lint rule to Effective Dart: Usage.