### PR TITLE
Add avoid_types_on_closure_parameters lint rule reference to Effective Dart: Design

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1189,6 +1189,8 @@ if (node is Constructor) {
 
 ### AVOID annotating inferred parameter types on function expressions.
 
+{% include linter-rule.html rule="avoid_types_on_closure_parameters" %}
+
 Anonymous functions are almost always immediately passed to a method taking a
 callback of some type. (If the function isn't used immediately, it's usually
 worth making it a named declaration.) When a function expression is created in a


### PR DESCRIPTION
Adds a reference to the [`avoid_types_on_closure_parameters`](https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html) lint rule to Effective Dart: Design.