### PR TITLE
use Dart ^2.7.0 in examples/misc

### DIFF
--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,10 +2,11 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dev_dependencies:
   args: ^1.5.0
-  examples_util: {path: ../util}
+  examples_util:
+    path: ../util
   pedantic: ^1.0.0
   test: ^1.0.0


### PR DESCRIPTION
Effective Dart uses extension methods, and the 2.8.0 SDK produces an analyzer warning  if a package that uses extension methods doesn't specify the correct SDK version.

fixes #2214