### PR TITLE
Change double quotes to single quotes

### DIFF
--- a/examples/httpserver/bin/basic_writer_server.dart
+++ b/examples/httpserver/bin/basic_writer_server.dart
@@ -33,12 +33,12 @@ Future main() async {
       } catch (e) {
         response
           ..statusCode = HttpStatus.internalServerError
-          ..write("Exception during file I/O: $e.");
+          ..write('Exception during file I/O: $e.');
       }
     } else {
       response
         ..statusCode = HttpStatus.methodNotAllowed
-        ..write("Unsupported request: ${req.method}.");
+        ..write('Unsupported request: ${req.method}.');
     }
     await response.close();
   }

--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -671,12 +671,12 @@ Future main() async {
       } catch (e) {
         response
           ..statusCode = HttpStatus.internalServerError
-          ..write("Exception during file I/O: $e.");
+          ..write('Exception during file I/O: $e.');
       }
     } else {
       response
         ..statusCode = HttpStatus.methodNotAllowed
-        ..write("Unsupported request: ${req.method}.");
+        ..write('Unsupported request: ${req.method}.');
     }
     await response.close();
   }


### PR DESCRIPTION
Suggestion to change the double quotes for the example code from `basic_writer_server.dart` to single quotes to comply with the `prefer_single_quotes` rule. This is on the documentation page for writing HTTP servers and clients. https://dart.dev/tutorials/server/httpserver

I also created a PR to apply the same changes in the actual examples files. https://github.com/dart-lang/dart-tutorials-samples/pull/57