### PR TITLE
Improve sizing of embedded DartPad

### DIFF
--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -4,6 +4,7 @@
 $dash-row-height: 640px;
 $dash-info-size: 512px;
 $dash-info-padding: 24px;
+$dash-max-width: 1330px;
 
 // Colors
 $dash-callout: #121a26;
@@ -270,7 +271,7 @@ $dash-dartpad-border: #293542;
 
 .dash-header video {
   width: 100%;
-  max-width: 1330px;
+  max-width: $dash-max-width;
   margin-bottom: -10px;
   @include media-breakpoint-down(md) {
     padding-top:30px;
@@ -288,6 +289,7 @@ $dash-dartpad-border: #293542;
   width: 100vw;
   height: 100vh;
   padding: 32px;
+  margin-block-end: 50px;
 
   background-color: $dash-callout;
 
@@ -313,7 +315,7 @@ $dash-dartpad-border: #293542;
   #dartpad-host {
     height: 100%;
     width: 100%;
-    max-width: 1200px;
+    max-width: $dash-max-width;
     display: flex;
 
     iframe {

--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -285,6 +285,8 @@ $dash-dartpad-border: #293542;
   flex-direction: column;
   align-items: center;
 
+  width: 100vw;
+  height: 100vh;
   padding: 32px;
 
   background-color: $dash-callout;
@@ -309,9 +311,9 @@ $dash-dartpad-border: #293542;
   }
 
   #dartpad-host {
-    height: 512px;
+    height: 100%;
     width: 100%;
-    max-width: 896px;
+    max-width: 1200px;
     display: flex;
 
     iframe {
@@ -352,4 +354,8 @@ $dash-dartpad-border: #293542;
   &:focus{
     outline: $dash-highlight auto 2px;
   }
+}
+
+a.frontanchor {
+  padding-top: 50px;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -405,7 +405,7 @@ js:
     </section>
     <section class="row">
         <div class="dash-dartpad">
-            <a name="try-dart"></a>
+            <a name="try-dart" class="frontanchor"></a>
             <h2>Try Dart in your browser</h2>
             <select id="dartpad-select"></select>
             <div id="dartpad-host"></div>


### PR DESCRIPTION
Goals:

- Clicking Try Dart in the top-nav should bring the viewport to show just DartPad with no disturbing content around it
- The embedded DartPad should size itself to better use the space in larger browser windows

Staging link: https://mit-staging.firebaseapp.com/#try-dart