### PR TITLE
use double quotes to expand PATH

### DIFF
--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -78,5 +78,5 @@ $ export PATH="$PATH:/usr/lib/dart/bin"
 To change the PATH for future terminal sessions, use a command like this:
 
 ```terminal
-$ echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> ~/.profile
+$ echo "export PATH=\"${PATH}:/usr/lib/dart/bin\"" >> ~/.profile
 ```


### PR DESCRIPTION
Expressions don't expand in single quotes, use double quotes for that.
This caused me installation errors.

I should save this in my .profile file:
export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/dart/bin"

But he kept this without expanding:
export PATH="$PATH:/usr/lib/dart/bin"