### PR TITLE
Fix a typo, add a link

### DIFF
--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -137,7 +137,11 @@ Here are the general-purpose tools you might want to install:
 ### Debugging and diagnostics
 
 [Dart DevTools](/tools/dart-devtools)
-: A suite of suite of debugging and performance tools.
+: A suite of debugging and performance tools.
+
+[Diagnostic messages](/tools/diagnostic-messages)
+: A list of diagnostic messages produced by the Dart analyzer,
+  with details about what those messages mean and how you can fix your code.
 
 ## Tools for developing web apps {#web}
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -134,14 +134,11 @@ Here are the general-purpose tools you might want to install:
 [dart_style]: {{site.pub-pkg}}/dart_style
 [dartfix]: {{site.pub-pkg}}/dartfix
 
-### Debugging and diagnostics
+### Debugging
 
 [Dart DevTools](/tools/dart-devtools)
 : A suite of debugging and performance tools.
 
-[Diagnostic messages](/tools/diagnostic-messages)
-: A list of diagnostic messages produced by the Dart analyzer,
-  with details about what those messages mean and how you can fix your code.
 
 ## Tools for developing web apps {#web}
 


### PR DESCRIPTION
It seems like the **Debugging and diagnostics** section should refer to the diagnostics page. Plus I saw a typo.