### PR TITLE
Fix language spec latex file link

### DIFF
--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -20,7 +20,7 @@ backward-compatible. For details, see the [Dart 2 page](/dart-2).
 ### In-progress specification
 
 The in-progress formal Dart language specification is written as a
-[LaTeX file,](https://github.com/dart-lang/sdk/blob/master/docs/language/dartLangSpec.tex)
+[LaTeX file,](https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex)
 and is available as a [draft specification in PDF format.](https://spec.dart.dev/DartLangSpecDraft.pdf)
 
 New language features are typically described using informal language feature specifications in the dart-lang/language repo:


### PR DESCRIPTION
The previous link was broken, I believe this is the correct place now :).