### PR TITLE
Remove TOC entries for cards

### DIFF
--- a/src/_includes/server-tutorials.md
+++ b/src/_includes/server-tutorials.md
@@ -1,7 +1,7 @@
 The following tutorials show how to develop scripts, command-line apps,
 and server apps that can run in the standalone Dart VM.
 
-<div class="card-grid">
+<div class="card-grid no_toc_section">
   <div class="card">
     <h3><a href="/tutorials/server/get-started">Get started</a></h3>
     <p>Get Dart. Create a simple standalone app, run it in the Dart VM,

--- a/src/_includes/web-tutorials.md
+++ b/src/_includes/web-tutorials.md
@@ -1,6 +1,6 @@
 These tutorials cover topics relevant to Dart web apps.
 
-<div class="card-grid">
+<div class="card-grid no_toc_section">
   <div class="card">
     <h3><a href="/tutorials/web/fetch-data">Fetch data dynamically</a></h3>
     <p> Load data from a static file or from a server. </p>

--- a/src/_tutorials/index.md
+++ b/src/_tutorials/index.md
@@ -21,7 +21,7 @@ Once you're familiar with the language and futures,
 learn about _streams_ and _packages_,
 which are fundamental to most Dart programs.
 
-<div class="card-grid">
+<div class="card-grid no_toc_section">
   <div class="card">
     <h3><a href="/tutorials/language/streams">Asynchronous programming:
        streams</a></h3>

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -8,7 +8,7 @@ introduction to the language for people who like to learn by example.
 You might also want to check out the language and library tours,
 or the [Dart cheatsheet codelab](/codelabs/dart-cheatsheet).
 
-<div class="card-grid">
+<div class="card-grid no_toc_section">
   <div class="card">
     <h3><a href="/guides/language/language-tour">Language tour</a></h3>
     <p>


### PR DESCRIPTION
This fixes all the warnings currently generated by linkcheck.

Before:
https://dart.dev/tutorials
https://dart.dev/samples

After:
https://sz-www-1.firebaseapp.com/tutorials
https://sz-www-1.firebaseapp.com/samples