### PR TITLE
add dart.cn site

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -54,7 +54,7 @@ Our wonderful community has provided these resources.
 
 * [Dart Academy](https://dart.academy/) - Tutorials
   and articles written by the Dart community
-* [Chinese version of this site (此网站的中文版)](https://www.dartdoc.cn)
+* [Chinese version of this site (此网站的中文版)](https://dart.cn)
 * [Russian version of this site (Русскоязычная версия сайта)](https://www.dart-lang.ru)
 
 


### PR DESCRIPTION
Hi team:

This PR is to add dart.cn since the dartdoc.cn is now redirected to dart.cn.

Special thanks to Haijun(@amisare), who did the first Dart Chinese doc in China. 
We've met offline, and now we are working together to maintain the dart.cn site.

Thanks!