### PR TITLE
Fix Unicode emoji value in language-tour.md

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1003,7 +1003,7 @@ The usual way to express a Unicode code point is
 For example, the heart character (♥) is `\u2665`.
 To specify more or less than 4 hex digits,
 place the value in curly brackets.
-For example, the laughing emoji (😆) is `\u{1f600}`.
+For example, the laughing emoji (😆) is `\u{1f606}`.
 
 If you need to read or write individual Unicode characters,
 use the `characters` getter defined on String


### PR DESCRIPTION
`U+1F600` is actually the unicode for [the grinning face emoji](https://emojipedia.org/grinning-face/). I have changed the unicode value to be the actual value of the emoji listed, `U+1F606`.