### PR TITLE
Add more detailed Emacs instructions

### DIFF
--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -17,13 +17,8 @@ All the steps are identical for enabling Flutter since
 * [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode. Features like
   helpers, auto-complete, error listing and other typical feature that you
   expect from an IDE. (Requires SDK).
-
-{% comment %}
-
-Add a vanilla Emacs config that has all above + hooks and stuff.
-
-{% endcomment %}
   
+## Doom Emacs
 [Doom Emacs][doom-emacs] is a popular Doom configuration framework that has
 these modes pre-setup.
 
@@ -36,9 +31,80 @@ command.
 
 {% comment %}
 
-Add a Spacemacs config that has all above + hooks and stuff.
+*Add more details on Vanilla Emacs. More specific.*
 
 {% endcomment %}
+
+## Vanilla Emacs
+
+Unless you want to build the packages from the source, you must use [MELPA][melpa] and
+GNU to install the packages.
+
+In detail instructions are addressed in each repository. A summary is as below.
+
+* Make or find your [Init File](https://www.emacswiki.org/emacs/InitFile)
+  (Default: `~/.emacs.d/init.el`).
+
+* Add and enable MELPA and GNU
+
+  To enable MELPA and GNU you just need to paste the code below in your init
+  file.
+
+  ```lisp
+  (require 'package)
+  (setq package-archives
+      '(("gnu" . "https://elpa.gnu.org/packages/")
+        ("melpa" . "https://melpa.org/packages/")))
+  (package-initialize)
+  ```
+
+* Once MELPA is added you can append the code below to get all the packages installed.
+  Or you can (`Alt-x`) `M-x package-list-packages` to install your packages of choice manually.
+
+  ```lisp
+  (setq package-list
+      '(dart-mode
+        lsp-mode
+        yasnippet
+        flutter))
+
+  (unless package-archive-contents
+    (package-refresh-contents))
+
+  (dolist (package package-list)
+    (unless (package-installed-p package)
+      (package-install package)))
+
+  (add-to-list 'load-path "~/.emacs.d/plugins/dart-snippets")
+  (require 'dart-snippets)
+  ```
+
+* At last just clone [Dart-Snippets][dart-snippets] to your
+  `~/.emacs/plugins/dart-snippets` folder.
+
+  ```shell
+  mkdir -p '~/.emacs.d/plugins'
+  cd '~/.emacs.d/plugins'
+  git clone https://github.com/MYDavoodeh/dart-snippets
+  ```
+
+{{site.alert.warning}} In order to get the Flutter.el to work correctly,
+you need `flutter` in your PATH and preferably have Flutter installed
+in `~/.flutter/` or have `~/.flutter/` linked to your installation folder.
+{{site.alert.end}}
+
+{% comment %}
+
+## Spacemacs
+
+Add a Spacemacs config that has all above + hooks and stuff.
+
+# Configuration
+
+Go thro common `def-cutoms` if ever needed.
+
+{% endcomment %}
+
 
 [dart-mode]: https://github.com/bradyt/dart-mode
 [dart-snippets]: https://github.com/MYDavoodeh/dart-snippets
@@ -46,3 +112,4 @@ Add a Spacemacs config that has all above + hooks and stuff.
 [dart-flags]: https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/dart/README.org#module-flags
 [lsp-mode]: https://github.com/emacs-lsp/lsp-mode
 [flutter-mode]: https://github.com/amake/flutter.el
+[melpa]: http://melpa.org/

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -121,6 +121,21 @@ Go thro common `def-cutoms` if ever needed.
 
 {% endcomment %}
 
+# Known issues
+
+## Slow auto-completion
+
+This problem may happen due to large index of Company.
+The best temporary solution for this, is to disable Company and only wake it up
+when you require it.
+
+To do so, append the code below to your `init.el` or `doom.d/config.el` in case of
+Doom Emacs.
+
+```lisp
+(setq company-idle-delay nil) ; Disable Company-Auto-Completion
+```
+
 
 [dart-mode]: https://github.com/bradyt/dart-mode
 [dart-snippets]: https://github.com/MYDavoodeh/dart-snippets

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -31,6 +31,12 @@ After enabling dart module (and flags of your choice, see [flags in
 README][dart-flags]), refresh your Doom by `doom refresh`
 command.
 
+{% comment %}
+
+Add a Spacemacs config that has all above + hooks and stuff.
+
+{% endcomment %}
+
 [dart-mode]: https://github.com/bradyt/dart-mode
 [dart-snippets]: https://github.com/MYDavoodeh/dart-snippets
 [doom-emacs]: https://github.com/hlissner/doom-emacs

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -26,6 +26,13 @@ It is available on MELPA and can be an alternative to
 [Dart-Snippets][dart-snippets] if you prefer to have all your packages installed
 from MELPA. {{site.alert.end}}
 
+There are additional packages to add more conventional functionality to LSP and
+Emacs. These packages (and more) come pre-installed in [Doom Emacs][doom-emacs]
+but in bare Emacs you must install them. Further instructions in:
+
+* [LSP-UI](https://github.com/emacs-lsp/lsp-ui)
+* [company-capf](https://github.com/company-mode/company-mode/blob/master/company-capf.el)
+
 ## Doom Emacs
 [Doom Emacs][doom-emacs] is a popular Doom configuration framework that has
 these modes pre-setup.

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -18,6 +18,12 @@ All the steps are identical for enabling Flutter since
   helpers, auto-complete, error listing and other typical feature that you
   expect from an IDE. (Requires SDK).
   
+{{site.alert.note}} [Yasnippet-Snippets][yas-snippets] is a general snippet
+package containing a limited collection of the most common snippets.
+It is available on MELPA and can be an alternative to
+[Dart-Snippets][dart-snippets] if you prefer to have all your packages installed
+from MELPA. {{site.alert.end}}
+
 ## Doom Emacs
 [Doom Emacs][doom-emacs] is a popular Doom configuration framework that has
 these modes pre-setup.
@@ -66,6 +72,7 @@ In detail instructions are addressed in each repository. A summary is as below.
       '(dart-mode
         lsp-mode
         yasnippet
+        ;; yasnippet-snippets
         flutter))
 
   (unless package-archive-contents
@@ -113,3 +120,4 @@ Go thro common `def-cutoms` if ever needed.
 [lsp-mode]: https://github.com/emacs-lsp/lsp-mode
 [flutter-mode]: https://github.com/amake/flutter.el
 [melpa]: http://melpa.org/
+[yas-snippets]: https://github.com/AndreaCrotti/yasnippet-snippets

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -13,7 +13,7 @@ All the steps are identical for enabling Flutter since
 * [Dart-Mode][dart-mode] is the main mode for development.
 * [Dart-Snippets][dart-snippets] enables [Visual Studio Code](/tools/vs-code)
   like snippets and more. Snippets like `if` that expand to structured code upon
-  pressing shift.
+  pressing the tab key.
 * [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode. Features like
   helpers, auto-complete, error listing and other typical feature that you
   expect from an IDE. (Requires SDK).

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -24,6 +24,9 @@ Add a vanilla Emacs config that has all above + hooks and stuff.
 
 {% endcomment %}
   
+[Doom Emacs][doom-emacs] is a popular Doom configuration framework that has
+these modes pre-setup.
+
 To enable and configure all above in [Doom Emacs][doom-emacs], you 
 need to enable `:lang dart` in your `init.el` file in your `$DOOMDIR`
 directory, which by default is in `~/.doom.d`.

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -21,11 +21,11 @@ Add a vanilla Emacs config that has all above + hooks and stuff.
 
 {% endcomment %}
   
-To enable and configure all above in [Doom Emacs][doom-emacs], you simply
+To enable and configure all above in [Doom Emacs][doom-emacs], you 
 need to enable `:lang dart` in your `init.el` file in your `$DOOMDIR`
 directory, which by default is in `~/.doom.d`.
 After enabling dart module (and flags of your choice, see [flags in
-README][dart-flags]), you simply need to refresh your Doom by `doom refresh`
+README][dart-flags]), refresh your Doom by `doom refresh`
 command.
 
 [dart-mode]: https://github.com/bradyt/dart-mode

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -16,7 +16,9 @@ All the steps are identical for enabling Flutter since
   pressing the tab key.
 * [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode. Features like
   helpers, auto-complete, error listing and other typical feature that you
-  expect from an IDE. (Requires SDK).
+  expect from an IDE (Requires SDK).
+  In the setup below, this is replaced with a minimum [LSP-Dart][lsp-dart] which
+  only adds LSP support for Dart language.
   
 {{site.alert.note}} [Yasnippet-Snippets][yas-snippets] is a general snippet
 package containing a limited collection of the most common snippets.
@@ -70,7 +72,7 @@ In detail instructions are addressed in each repository. A summary is as below.
   ```lisp
   (setq package-list
       '(dart-mode
-        lsp-mode
+        lsp-dart
         yasnippet
         ;; yasnippet-snippets
         flutter))
@@ -118,6 +120,7 @@ Go thro common `def-cutoms` if ever needed.
 [doom-emacs]: https://github.com/hlissner/doom-emacs
 [dart-flags]: https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/dart/README.org#module-flags
 [lsp-mode]: https://github.com/emacs-lsp/lsp-mode
+[lsp-dart]: https://github.com/emacs-lsp/lsp-dart
 [flutter-mode]: https://github.com/amake/flutter.el
 [melpa]: http://melpa.org/
 [yas-snippets]: https://github.com/AndreaCrotti/yasnippet-snippets

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -12,8 +12,11 @@ All the steps are identical for enabling Flutter since
 
 * [Dart-Mode][dart-mode] is the main mode for development.
 * [Dart-Snippets][dart-snippets] enables [Visual Studio Code](/tools/vs-code)
-  like snippets and more.
-* [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode.
+  like snippets and more. Snippets like `if` that expand to structured code upon
+  pressing shift.
+* [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode. Features like
+  helpers, auto-complete, error listing and other typical feature that you
+  expect from an IDE. (Requires SDK).
 
 {% comment %}
 

--- a/src/tools/emacs.md
+++ b/src/tools/emacs.md
@@ -1,0 +1,36 @@
+---
+title: Emacs
+description: Use Dart on Emacs and its flavors
+toc: false
+---
+
+Emacs has a few major and minor modes built for Dart and Flutter development.
+
+All the steps are identical for enabling Flutter since
+[Dart-Snippets][dart-snippets] contain Flutter snippets too.
+[Flutter.el][flutter-mode] only allows you to run Flutter commands inside your Emacs.
+
+* [Dart-Mode][dart-mode] is the main mode for development.
+* [Dart-Snippets][dart-snippets] enables [Visual Studio Code](/tools/vs-code)
+  like snippets and more.
+* [LSP-Mode][lsp-mode] adds IDE-like features to Dart mode.
+
+{% comment %}
+
+Add a vanilla Emacs config that has all above + hooks and stuff.
+
+{% endcomment %}
+  
+To enable and configure all above in [Doom Emacs][doom-emacs], you simply
+need to enable `:lang dart` in your `init.el` file in your `$DOOMDIR`
+directory, which by default is in `~/.doom.d`.
+After enabling dart module (and flags of your choice, see [flags in
+README][dart-flags]), you simply need to refresh your Doom by `doom refresh`
+command.
+
+[dart-mode]: https://github.com/bradyt/dart-mode
+[dart-snippets]: https://github.com/MYDavoodeh/dart-snippets
+[doom-emacs]: https://github.com/hlissner/doom-emacs
+[dart-flags]: https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/dart/README.org#module-flags
+[lsp-mode]: https://github.com/emacs-lsp/lsp-mode
+[flutter-mode]: https://github.com/amake/flutter.el

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -67,7 +67,7 @@ thanks to the Dart community.
 <ul class="col2">
 <li>
 <img src="{% asset tools/emacs.png @path %}" alt="Emacs logo">
-<a class="no-automatic-external" href="https://github.com/nex3/dart-mode"><b>Emacs</b></a>
+<a href="/tools/emacs"><b>Emacs</b></a>
 </li>
 <li>
 <img src="{% asset tools/vim.png @path %}" alt="Vim logo">


### PR DESCRIPTION
Adding Dart to Emacs to a decent and expected degree is not simply
just adding a mode. There are a few related modes and since Doom has its
own Dart module now I thought it must be in here.