### PR TITLE
Update platforms.md

### DIFF
--- a/src/platforms.md
+++ b/src/platforms.md
@@ -75,7 +75,7 @@ More information: [Get started: web apps](/tutorials/web/get-started)
 
 ### Lightning fast developer workflow (Dart dev compiler)
 
-The Dart dev compiler (dartdevc) is a Dart-to-JavaScript compiler
+The Dart dev compiler (`dartdevc`) is a Dart-to-JavaScript compiler
 that's optimized for quick turnaround. Instead of using dartdevc directly,
 you use it with `webdev`, a tool that supports core developer tasks such as
 running, debugging, and building.

--- a/src/platforms.md
+++ b/src/platforms.md
@@ -76,7 +76,7 @@ More information: [Get started: web apps](/tutorials/web/get-started)
 ### Lightning fast developer workflow (Dart dev compiler)
 
 The Dart dev compiler (`dartdevc`) is a Dart-to-JavaScript compiler
-that's optimized for quick turnaround. Instead of using dartdevc directly,
+that's optimized for quick turnaround. Instead of using `dartdevc` directly,
 you use it with `webdev`, a tool that supports core developer tasks such as
 running, debugging, and building.
 


### PR DESCRIPTION
Made the display of the word "dartdevc" consistent with the display of other keywords (webdev, dart2js) in the section.