### PR TITLE
Add beta channel to /get-dart

### DIFF
--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -29,9 +29,8 @@ As the following instructions show,
 you can use a package manager
 to easily install and update a stable channel Dart SDK.
 Alternatively, you can
-[build the SDK from source][] or
-[download the SDK as a zip file](/tools/sdk/archive)
-for [any release channel](#release-channels).
+[build the SDK from source][] or install from [any release channel](#release-channels) by
+[downloading the SDK as a zip file](/tools/sdk/archive).
 {% comment %}
 NOTE to editors: Keep the zip file link as the last thing in the paragraph,
 so it's easy to find (but not more tempting than package managers).

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -19,10 +19,11 @@ To learn about what's in the SDK, see [Dart SDK overview](/tools/sdk).
 
 As the following instructions show,
 you can use a package manager
-to easily install and update the Dart SDK.
+to easily install and update a stable channel Dart SDK.
 Alternatively, you can
 [build the SDK from source][] or
-[download the SDK as a zip file](/tools/sdk/archive).
+[download the SDK as a zip file](/tools/sdk/archive)
+for [any release channel](#release-channels).
 {% comment %}
 NOTE to editors: Keep the zip file link as the last thing in the paragraph,
 so it's easy to find (but not more tempting than package managers).
@@ -47,7 +48,7 @@ so it's easy to find (but not more tempting than package managers).
 {% include_relative tools/sdk/_mac.md %}
 </div>
 
-## About release channels and version strings
+## About release channels and version strings {#release-channels}
 
 The Dart SDK has three release channels:
 
@@ -79,9 +80,10 @@ the patch version.
 hyphen follows the stable version scheme, `a` and `b` after the hyphen is the
 pre-release and pre-release patch versions, and `beta` or `dev` is the channel.
 
-You can get stable, beta, and dev channel releases using
+You can get stable channel releases using
 the [instructions above](#install), or you can
-[download the SDK as a zip file](/tools/sdk/archive).
+get stable, beta, or dev channel releases by
+[downloading the SDK as a zip file](/tools/sdk/archive).
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [Dart 2]: /dart-2

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -83,10 +83,10 @@ The Dart SDK has three release channels:
 letters, where `x` is the major version, `y` is the minor version, and `z` is
 the patch version.
 
-**Beta** and **Dev** channel releases of the Dart SDK (non-stable releases) have
+**Beta** and **dev** channel releases of the Dart SDK (non-stable releases) have
 `x.y.z-a.b.<beta|dev>` versions like `2.8.0-20.11.beta`. The part before the
-hyphen follows the stable version scheme, `a` and `b` after the hyphen is the
-pre-release and pre-release patch versions, and `beta` or `dev` is the channel.
+hyphen follows the stable version scheme, `a` and `b` after the hyphen are the
+prerelease and prerelease patch versions, and `beta` or `dev` is the channel.
 
 You can get stable channel releases using
 the [instructions above](#install), or you can

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -49,28 +49,37 @@ so it's easy to find (but not more tempting than package managers).
 
 ## About release channels and version strings
 
-The Dart SDK has two release channels:
+The Dart SDK has three release channels:
 
-* **stable** channel: **stable releases**,
-  updated no more frequently than every 6 weeks;
+* **stable** channel: **stable releases**, updated roughly every three months;
   currently `[calculating]`{:.editor-build-rev-stable}.
-* **dev** channel: **prereleases**, usually updated 1/week;
+  
+  Stable releases are suitable for production use.
+  
+* **beta** channel: **candidate releases**, usually updated every month;
+  currently `[calculating]`{:.editor-build-rev-beta}.
+  
+  Beta channel builds are candidate builds for the stable channel. We recommend
+  testing, but not releasing, your apps against beta to preview new features, or
+  test compatibility with future releases.
+  
+* **dev** channel: **pre-releases**, usually updated every;
   currently `[calculating]`{:.editor-build-rev-dev}.
+  
+  Dev channel releases are the most current with latest changes, may be broken,
+  are unsupported, and may contain unvetted breaking changes.
 
-{{site.alert.warning}}
-  To give you early access to new features and fixes,
-  dev channel releases are not as heavily tested as the stable release.
-{{site.alert.end}}
+**Stable** channel releases of the Dart SDK have `x.y.z` version strings like
+`1.24.3` and `2.1.0`. They consist of dot-separated integers, with no hyphens or
+letters, where `x` is the major version, `y` is the minor version, and `z` is
+the patch version.
 
-**Stable** channel releases of the Dart SDK have version strings like `1.24.3` and `2.1.0`.
-They consist of dot-separated integers, with no hyphens or letters.
+**Beta** and **Dev** channel releases of the Dart SDK (non-stable releases) have
+`x.y.z-a.b.<beta|dev>` versions like `2.8.0-20.11.beta`. The part before the
+hyphen follows the stable version scheme, `a` and `b` after the hyphen is the
+pre-release and pre-release patch versions, and `beta` or `dev` is the channel.
 
-**Dev** channel releases of the Dart SDK (prereleases)
-have additional characters, starting with a hyphen (`-`).
-For example, Dart 2 prereleases have version numbers starting with
-`2.0.0-dev` such as `2.0.0-dev.69.5`.
-
-You can get stable and dev channel releases using
+You can get stable, beta, and dev channel releases using
 the [instructions above](#install), or you can
 [download the SDK as a zip file](/tools/sdk/archive).
 

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -56,14 +56,14 @@ The Dart SDK has three release channels:
   
   Stable releases are suitable for production use.
   
-* **beta** channel: **candidate releases**, usually updated every month;
+* **beta** channel: **preview releases**, usually updated every month;
   currently `[calculating]`{:.editor-build-rev-beta}.
   
-  Beta channel builds are candidate builds for the stable channel. We recommend
+  Beta channel builds are preview builds for the stable channel. We recommend
   testing, but not releasing, your apps against beta to preview new features, or
   test compatibility with future releases.
   
-* **dev** channel: **pre-releases**, usually updated every;
+* **dev** channel: **pre-releases**, usually updated twice a week;
   currently `[calculating]`{:.editor-build-rev-dev}.
   
   Dev channel releases are the most current with latest changes, may be broken,

--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -22,29 +22,10 @@ $ sudo apt-get update
 $ sudo apt-get install dart
 ```
 
-Or, to install the **beta** channel release of the Dart SDK, run the one-time
-setup commands followed by:
-
-```terminal
- sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_testing.list > /etc/apt/sources.list.d/dart_testing.list'
- sudo apt-get update
- sudo apt-get install dart
-```
-
-Or, to install the **dev** channel release of the Dart SDK, run the one-time
-setup commands followed by:
-
-```terminal
-$ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
-$ sudo apt-get update
-$ sudo apt-get install dart
-```
 #### Install a Debian package
 
-Alternatively, download Dart SDK as Debian package in the `.deb` package format.
-
-- [Stable channel](#){:.debian-link-stable}
-- [Dev channel](#){:.debian-link-dev}
+Alternatively, download Dart SDK [as Debian package](#){:.debian-link-stable}
+in the `.deb` package format. 
 
 #### Modify PATH for access to all Dart binaries
 

--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -9,62 +9,42 @@ versions are released.
 
 Perform the following **one-time setup**:
 
-{% if site.data.pkg-vers.SDK.channel == 'dev' %}
-```terminal
-$ sudo apt-get update
-$ sudo apt-get install apt-transport-https
-$ sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-$ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
-```
-{% else %}
 ```terminal
 $ sudo apt-get update
 $ sudo apt-get install apt-transport-https
 $ sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 $ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 ```
-{% endif %}
-
-Then install the
-**{{site.data.pkg-vers.SDK.channel}}**
-release of the Dart SDK:
+Then install the stable release of the Dart SDK:
 
 ```terminal
 $ sudo apt-get update
 $ sudo apt-get install dart
 ```
 
-Or, to install the
-{% if site.data.pkg-vers.SDK.channel == 'dev' -%}
-**stable**
-{% else -%}
-**dev**
-{% endif -%}
-release of the Dart SDK,
-run the one-time setup commands followed by:
+Or, to install the **beta** channel release of the Dart SDK, run the one-time
+setup commands followed by:
 
-{% if site.data.pkg-vers.SDK.channel == 'dev' %}
 ```terminal
-$ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-$ sudo apt-get update
-$ sudo apt-get install dart
+ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_testing.list > /etc/apt/sources.list.d/dart_testing.list'
+ sudo apt-get update
+ sudo apt-get install dart
 ```
-{% else %}
+
+Or, to install the **dev** channel release of the Dart SDK, run the one-time
+setup commands followed by:
+
 ```terminal
 $ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
 $ sudo apt-get update
 $ sudo apt-get install dart
 ```
-{% endif %}
-
-
 #### Install a Debian package
 
 Alternatively, download Dart SDK as Debian package in the `.deb` package format.
 
 - [Stable channel](#){:.debian-link-stable}
 - [Dev channel](#){:.debian-link-dev}
-
 
 #### Modify PATH for access to all Dart binaries
 

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -1,21 +1,14 @@
 [Install Homebrew](https://brew.sh), and then run:
 
-{% if site.data.pkg-vers.SDK.channel == 'dev' %}
-```terminal
-$ brew tap dart-lang/dart
-$ brew install dart -- --devel
-```
-
-To install a **stable channel** release, don't use `--devel`:
-
-```terminal
-$ brew install dart
-```
-
-{% else %}
 ```terminal
 $ brew tap dart-lang/dart
 $ brew install dart
+```
+
+To install a **beta channel** release, use the `dart-beta` channel:
+
+```terminal
+$ brew install dart-beta
 ```
 
 To install a **dev channel** release, use `--devel`:
@@ -23,7 +16,6 @@ To install a **dev channel** release, use `--devel`:
 ```terminal
 $ brew install dart -- --devel
 ```
-{% endif %}
 
 {{site.alert.important}}
   Make sure the **Homebrew `bin` directory is in your `PATH`**. Setting up the

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -11,21 +11,16 @@ $ brew install dart
   FAQ.](https://docs.brew.sh/FAQ)
 {{site.alert.end}}
 
-### Upgrade
-
 To upgrade when a new release of Dart is available run:
 
 ```terminal
 $ brew upgrade dart
 ```
 
-### Switch release
-
 To switch between locally installed dart releases run
 `brew switch dart <version>`. Examples:
 
 ```terminal
-$ brew switch dart 2.
 $ brew switch dart 2.1.0
 ```
 
@@ -34,6 +29,3 @@ If you aren't sure which versions of dart you have installed, then run:
 ```terminal
 $ brew info dart
 ```
-
-The command output lists the latest stable and dev versions at the top,
-followed by your locally installed versions.

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -4,19 +4,6 @@
 $ brew tap dart-lang/dart
 $ brew install dart
 ```
-
-To install a **beta channel** release, use the `dart-beta` channel:
-
-```terminal
-$ brew install dart-beta
-```
-
-To install a **dev channel** release, use `--devel`:
-
-```terminal
-$ brew install dart -- --devel
-```
-
 {{site.alert.important}}
   Make sure the **Homebrew `bin` directory is in your `PATH`**. Setting up the
   path correctly makes it easier to use Dart SDK commands such as `dart` and
@@ -31,20 +18,6 @@ To upgrade when a new release of Dart is available run:
 ```terminal
 $ brew upgrade dart
 ```
-To install a stable channel release when a dev release is currently active,
-run:
-
-```terminal
-$ brew unlink dart
-$ brew install dart
-```
-
-To upgrade to a dev channel release when a stable release is
-currently active, run:
-
-```terminal
-$ brew upgrade --force dart -- --devel
-```
 
 ### Switch release
 
@@ -52,7 +25,7 @@ To switch between locally installed dart releases run
 `brew switch dart <version>`. Examples:
 
 ```terminal
-$ brew switch dart 1.24.3
+$ brew switch dart 2.
 $ brew switch dart 2.1.0
 ```
 

--- a/src/tools/sdk/_windows.md
+++ b/src/tools/sdk/_windows.md
@@ -7,10 +7,7 @@ command:
 C:\> choco install dart-sdk
 ```
 
-### Upgrade
-
 To **upgrade** the Dart SDK, run this command
-(add `--pre` to upgrade the dev release):
 
 ```terminal
 C:\> choco upgrade dart-sdk

--- a/src/tools/sdk/_windows.md
+++ b/src/tools/sdk/_windows.md
@@ -1,29 +1,17 @@
 You can install the Dart SDK using [Chocolatey.][Chocolatey]
 
-{% if site.data.pkg-vers.SDK.channel == 'dev' %}
-To install a **dev** release of the Dart SDK, run this command:
-
-```terminal
-C:\> choco install dart-sdk --pre
-```
-
-To install a **stable** release, run this command:
+To use [Chocolatey][] to install a **stable** release of the Dart SDK, run this
+command:
 
 ```terminal
 C:\> choco install dart-sdk
 ```
 
-To **upgrade** the dev release of the Dart SDK, run this command:
-(remove the `--pre` to upgrade the stable release):
+To install a **beta** release, run this command (you'll need the exact version
+number):
 
 ```terminal
-C:\> choco upgrade dart-sdk --pre
-```
-{% else %}
-To install a **stable** release of the Dart SDK, run this command:
-
-```terminal
-C:\> choco install dart-sdk
+C:\> choco install dart-sdk --pre --version 2.8.0.20-c-011-beta
 ```
 
 To install a **dev** release, run this command:
@@ -38,7 +26,5 @@ To **upgrade** the Dart SDK, run this command
 ```terminal
 C:\> choco upgrade dart-sdk
 ```
-{% endif %}
-
 
 [Chocolatey]: https://chocolatey.org

--- a/src/tools/sdk/_windows.md
+++ b/src/tools/sdk/_windows.md
@@ -7,18 +7,7 @@ command:
 C:\> choco install dart-sdk
 ```
 
-To install a **beta** release, run this command (you'll need the exact version
-number):
-
-```terminal
-C:\> choco install dart-sdk --pre --version 2.8.0.20-c-011-beta
-```
-
-To install a **dev** release, run this command:
-
-```terminal
-C:\> choco install dart-sdk --pre
-```
+### Upgrade
 
 To **upgrade** the Dart SDK, run this command
 (add `--pre` to upgrade the dev release):


### PR DESCRIPTION
* Update get-dart with beta channel description
* Add beta channel SDK instructions
* Clean up OS specific installation pages to always recommend stable SDKs first

Partial fix for https://github.com/dart-lang/site-www/issues/2326