### PR TITLE
Clarify caret syntax usage in pubspec.md

### DIFF
--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -297,9 +297,10 @@ Pub tries to find the latest version of a package whose SDK constraint works
 with the version of the Dart SDK that you have installed.
 
 <aside class="alert alert-warning" markdown="1">
-  **Don't use caret syntax** (`^`) for the SDK constraint,
-  and **do include an upper bound** (`<3.0.0`, usually).
-  For more information, see the [Dart 2 page](/dart-2).
+  Caret syntax (^) is a compact way to represent version ranges, but **don't use
+  it for the SDK constraint**. **Do include an upper bound for the SDK**
+  (`<3.0.0`, usually) instead. For more information, see the
+  [Caret syntax](/tools/pub/dependencies#caret-syntax) documentation.
 </aside>
 
 

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -297,9 +297,9 @@ Pub tries to find the latest version of a package whose SDK constraint works
 with the version of the Dart SDK that you have installed.
 
 <aside class="alert alert-warning" markdown="1">
-  Caret syntax (^) is a compact way to represent version ranges, but **don't use
-  it for the SDK constraint**. **Do include an upper bound for the SDK**
-  (`<3.0.0`, usually) instead. For more information, see the
+  Caret syntax (`^`) is a compact way to represent version ranges, but **don't use
+  it for the SDK constraint.** Instead, **include an upper bound for the SDK**
+  (`<3.0.0`, usually). For more information, see the
   [Caret syntax](/tools/pub/dependencies#caret-syntax) documentation.
 </aside>
 


### PR DESCRIPTION
pubspec.md's references to caret syntax were confusing.

* It mentioned caret syntax without explaining what it is.
* Its use of bold text makes it seem like it's recommending not to use caret syntax at all even though that recommendation is specifically for the Dart SDK version constraint.
* It referenced the Dart 2 page for more information, but that's confusing because that page does not mention caret syntax at all.