### PR TITLE
Add missing space to ref in SDK

### DIFF
--- a/src/tools/sdk/archive/out/web/download_archive.dart.js
+++ b/src/tools/sdk/archive/out/web/download_archive.dart.js
@@ -6478,7 +6478,7 @@ f=H.f(g.insertCell(-1),"$ia5")
 f.textContent=h.l(i)
 h=document
 e=h.createElement("span")
-e.textContent="("+H.h(S.kp(b2))+")"
+e.textContent=" ("+H.h(S.kp(b2))+")"
 e.classList.add("muted")
 f.appendChild(e)
 H.f(g.insertCell(-1),"$ia5").textContent=p
@@ -6520,7 +6520,7 @@ r=J.A(u)
 g.setAttribute(a9,r.l(u))
 g.setAttribute("data-os","api")
 a7=document.createElement("span")
-a7.textContent="  ("+H.h(S.kp(b2))+")"
+a7.textContent=" ("+H.h(S.kp(b2))+")"
 a7.classList.add("muted")
 q=H.f(g.insertCell(-1),"$ia5")
 q.textContent=r.l(u)

--- a/src/tools/sdk/dart_sdk_archive/lib/src/version_selector.dart
+++ b/src/tools/sdk/dart_sdk_archive/lib/src/version_selector.dart
@@ -156,7 +156,7 @@ class VersionSelector {
           ..attributes['data-os'] = archiveMap[name];
         var versionCell = row.addCell()..text = versionInfo.version.toString();
         versionCell.append(SpanElement()
-          ..text = '(${_prettyRevRef(versionInfo)})'
+          ..text = ' (${_prettyRevRef(versionInfo)})'
           ..classes.add('muted'));
         row.addCell()..text = name;
         row.addCell()
@@ -234,7 +234,7 @@ class VersionSelector {
       ..attributes['data-version'] = versionInfo.version.toString()
       ..attributes['data-os'] = 'api';
     var rev = SpanElement()
-      ..text = '  (${_prettyRevRef(versionInfo)})'
+      ..text = ' (${_prettyRevRef(versionInfo)})'
       ..classes.add('muted');
     row.addCell()
       ..text = versionInfo.version.toString()


### PR DESCRIPTION
Minor tweak, but I can't unsee this missing space before the first ref [here](https://dart.dev/tools/sdk/archive) 😃

![Screenshot 2020-04-27 at 09 46 26](https://user-images.githubusercontent.com/1078012/80352574-fb774f80-886b-11ea-8be4-b2ad8baee630.png)

This adds the space (and also removes the superfluous space in the place that already had it for consistency).