### PR TITLE
Linking Brew, Choco and apt-get beta/dev instructions

### DIFF
--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -29,8 +29,9 @@ As the following instructions show,
 you can use a package manager
 to easily install and update a stable channel Dart SDK.
 Alternatively, you can
-[build the SDK from source][] or install from [any release channel](#release-channels) by
-[downloading the SDK as a zip file](/tools/sdk/archive).
+[build the SDK from source][] or install from
+[any release channel](#release-channels) by
+[downloading the SDK as a zip file][].
 {% comment %}
 NOTE to editors: Keep the zip file link as the last thing in the paragraph,
 so it's easy to find (but not more tempting than package managers).
@@ -89,14 +90,15 @@ prerelease and prerelease patch versions, and `beta` or `dev` is the channel.
 
 You can get stable channel releases using
 the [instructions above](#install), or you can
-get stable, beta, or dev channel releases by
-[downloading the SDK as a zip file](/tools/sdk/archive) or you can use
-[Homebrew, Chocolatey or `apt-get`][].
+get stable, beta, or dev channel releases
+using [a package manager][]
+or by [downloading the SDK as a zip file][].
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [Dart 2]: /dart-2
 [build the SDK from source]: https://github.com/dart-lang/sdk/wiki/Building
 [Dart libraries]: /guides/libraries/library-tour
+[downloading the SDK as a zip file]: /tools/sdk/archive
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html
-[Homebrew, Chocolatey or `apt-get`]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get
+[a package manager]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -91,7 +91,7 @@ You can get stable channel releases using
 the [instructions above](#install), or you can
 get stable, beta, or dev channel releases by
 [downloading the SDK as a zip file](/tools/sdk/archive) or you can use
-[Homebrew, Chocolatey or `apt-get`](brew_choco_apt-get).
+[Homebrew, Chocolatey or `apt-get`][].
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [Dart 2]: /dart-2
@@ -99,4 +99,4 @@ get stable, beta, or dev channel releases by
 [Dart libraries]: /guides/libraries/library-tour
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html
-[brew_choco_apt-get]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get
+[Homebrew, Chocolatey or `apt-get`]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -90,7 +90,8 @@ prerelease and prerelease patch versions, and `beta` or `dev` is the channel.
 You can get stable channel releases using
 the [instructions above](#install), or you can
 get stable, beta, or dev channel releases by
-[downloading the SDK as a zip file](/tools/sdk/archive).
+[downloading the SDK as a zip file](/tools/sdk/archive) or you can use
+[Homebrew, Chocolatey or `apt-get`](brew_choco_apt-get).
 
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [Dart 2]: /dart-2
@@ -98,3 +99,4 @@ get stable, beta, or dev channel releases by
 [Dart libraries]: /guides/libraries/library-tour
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html
+[brew_choco_apt-get]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get


### PR DESCRIPTION
I'd like to link the dart-lang/sdk wiki's "Installing beta and dev releases with brew, choco, and apt get" documentation to make it a lot easier to find. Thoughts?