### PR TITLE
Update the Effective Dart index

### DIFF
--- a/examples/misc/lib/effective_dart/style_lib_good.dart
+++ b/examples/misc/lib/effective_dart/style_lib_good.dart
@@ -21,13 +21,11 @@ import 'package:js/js.dart' as js;
 import 'dart:async';
 import 'dart:html';
 
-// #docregion pkg-import-before-local, third-party, sorted
+// #docregion pkg-import-before-local, sorted
 import 'package:examples/effective_dart/bar/bar.dart';
 import 'package:examples/effective_dart/foo/foo.dart';
 // #enddocregion dart-import-first, pkg-import-before-local, sorted
 
-import 'package:examples/effective_dart/foo.dart';
-// #enddocregion third-party
 // #docregion pkg-import-before-local, sorted
 
 import 'foo.dart';

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -31,7 +31,6 @@
 
 * <a href='/guides/language/effective-dart/style#do-place-dart-imports-before-other-imports'>DO place "dart:" imports before other imports.</a>
 * <a href='/guides/language/effective-dart/style#do-place-package-imports-before-relative-imports'>DO place "package:" imports before relative imports.</a>
-* <a href='/guides/language/effective-dart/style#prefer-placing-third-party-package-imports-before-other-imports'>PREFER placing external "package:" imports before other imports.</a>
 * <a href='/guides/language/effective-dart/style#do-specify-exports-in-a-separate-section-after-all-imports'>DO specify exports in a separate section after all imports.</a>
 * <a href='/guides/language/effective-dart/style#do-sort-sections-alphabetically'>DO sort sections alphabetically.</a>
 
@@ -95,7 +94,7 @@
 
 * <a href='/guides/language/effective-dart/usage#do-use-strings-in-part-of-directives'>DO use strings in <code>part of</code> directives.</a>
 * <a href='/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package'>DON'T import libraries that are inside the <code>src</code> directory of another package.</a>
-* <a href='/guides/language/effective-dart/usage#prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>PREFER relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
+* <a href='/guides/language/effective-dart/usage#do-use-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>DO use relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
 
 **Booleans**
 


### PR DESCRIPTION
Followup to #2404 and #2405

Also removes a bit of example code that's no longer needed due to the changes in #2405.