### PR TITLE
Roll Dart SDK version used for analysis

### DIFF
--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.6.0"
+    "vers": "2.8.0"
   }
 }


### PR DESCRIPTION
I noticed on https://dart.dev/tools/sdk that we're still using 2.6.0