### PR TITLE
change bin/main.exe -> bin/cli.exe

### DIFF
--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -112,7 +112,7 @@ To run the app from the command line, use the Dart VM by running the
 [`dart`](/tools/dart-vm) command:
 
 ```terminal
-$ dart bin/main.dart
+$ dart bin/cli.dart
 Hello world: 42!
 ```
 
@@ -138,7 +138,7 @@ Let's customize the app you just created.
  1. Rerun the main entrypoint of your app:
 
     ```terminal
-    $ dart bin/main.dart
+    $ dart bin/cli.dart
     Hello world: 21!
     ```
 
@@ -155,12 +155,12 @@ it's time to AOT compile your Dart code to optimized native machine code.
 Use the `dart2native` tool to AOT compile the program to machine code:
 
 ```terminal
-$ dart2native bin/main.dart
+$ dart2native bin/cli.dart
 ```
 Notice how the compiled program starts instantly, completing quickly:
 
 ```terminal
-$ time bin/main.exe
+$ time bin/cli.exe
 Hello world: 21!
 
 real	0m0.016s


### PR DESCRIPTION
This PR fixes a typo in the Getting Started Tutorial.
When stagehand is run in the "cli" folder as instructed, lib/cli.dart and bin/cli.exe are created by default and not lib/main.dart and bin/main.exe.
I changed each reference from "main" to "cli".
