### PR TITLE
Include --pause-isolates-on-start in Dart DevTools

### DIFF
--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -147,7 +147,9 @@ Serving DevTools at http://127.0.0.1.9100
 ### 3. Start the target app
 
 Use the `dart --observe` command to execute the main file
-for the Dart command-line app that you want to debug or observe. Optionally, you can also include the `--pause-isolates-on-start` option which will automatically break the execution at start of the script:
+for the Dart command-line app that you want to debug or observe.
+Optionally add `--pause-isolates-on-start`,
+which automatically breaks execution at the start of the script.
 
 ```terminal
 $ cd path/to/dart/app

--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -147,7 +147,7 @@ Serving DevTools at http://127.0.0.1.9100
 ### 3. Start the target app
 
 Use the `dart --observe` command to execute the main file
-for the Dart command-line app that you want to debug or observe:
+for the Dart command-line app that you want to debug or observe. Optionally, you can also include the `--pause-isolates-on-start` option which will automatically break the execution at start of the script:
 
 ```terminal
 $ cd path/to/dart/app


### PR DESCRIPTION
I think it would be helpful for people to know about this important and handy option. It took me some time to dig it up, and it would have helped if it was there upfront.