### PR TITLE
Document a CHANGELOG.md format for use on pub.dev

### DIFF
--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -128,12 +128,45 @@ enchilada/
   CHANGELOG.md
 {% endprettify %}
 
-To show users the latest changes to your package, you can include a changelog
-file where you can write a short note about the changes in your latest
-release. When you upload your package to the
-[pub.dev site,]({{site.pub}}) your package's `CHANGELOG.md` file (if any)
-appears in the changelog tab, rendered as [Markdown.][Markdown]
+To help users of your package upgrade between versions of your package, you
+should include a `CHANGELOG.md` file. This file should contain a section for
+each release with notes about changes.
 
+When you upload your package to the [pub.dev site,]({{site.pub}})
+your package's `CHANGELOG.md` file (if any)
+appears in the changelog tab, rendered as [Markdown.][Markdown]
+The file should use level-1 or level-2 sections for each version, the section
+title should contain a package version number (optionally prefixed `v`).
+As illustrated below additional subsections within a section is permitted.
+
+{% prettify markdown tag=pre+code %}
+# 1.0.1
+
+ * Fixed missing exclamation mark in `sayHi()` method.
+
+# 1.0.0
+
+ * **Breaking**, removed deprecated `sayHello()` method.
+ * Initial stable release.
+
+### Upgrading from 0.1.x
+Replace all calls for `sayHello()` with `sayHi()`.
+
+# 0.1.1
+
+ * Deprecated the `sayHello()` method, use `sayHi()` instead.
+
+# 0.1.0
+
+ * Initial development release.
+
+{% endprettify %}
+
+Following this changelog format allows tooling to parse your `CHANGELOG.md` and
+present relevant sections to package consumers.
+Consumers of your package will often review the `CHANGELOG.md` to discover
+bug fixes and new features, or determine how much effort it will take to upgrade
+to the latest version of your package.
 
 ## Public directories
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -128,45 +128,52 @@ enchilada/
   CHANGELOG.md
 {% endprettify %}
 
-To help users of your package upgrade between versions of your package, you
-should include a `CHANGELOG.md` file. This file should contain a section for
-each release with notes about changes.
+Include a `CHANGELOG.md` file that has a section for
+each release of your package,
+with notes to help users of your package upgrade.
+Users of your package often review the changelog
+to discover bug fixes and new features,
+or to determine how much effort it will take to upgrade
+to the latest version of your package.
+
+To support tools that parse `CHANGELOG.md`,
+use the following format:
+
+* Each version has its own section with a heading.
+* The version headings are either all level 1 or all level 2.
+* The version heading text contains a package version number,
+  optionally prefixed with "v".
 
 When you upload your package to the [pub.dev site,]({{site.pub}})
 your package's `CHANGELOG.md` file (if any)
-appears in the changelog tab, rendered as [Markdown.][Markdown]
-The file should use level-1 or level-2 sections for each version, the section
-title should contain a package version number (optionally prefixed `v`).
-As illustrated below additional subsections within a section is permitted.
+appears in the **Changelog** tab, rendered as [Markdown.][Markdown]
+
+Here's an example of a `CHANGELOG.md` file.
+As the example shows, you can add subsections.
 
 {% prettify markdown tag=pre+code %}
 # 1.0.1
 
- * Fixed missing exclamation mark in `sayHi()` method.
+* Fixed missing exclamation mark in `sayHi()` method.
 
 # 1.0.0
 
- * **Breaking**, removed deprecated `sayHello()` method.
- * Initial stable release.
+* **Breaking change:** Removed deprecated `sayHello()` method.
+* Initial stable release.
 
-### Upgrading from 0.1.x
-Replace all calls for `sayHello()` with `sayHi()`.
+## Upgrading from 0.1.x
+
+Change all calls to `sayHello()` to instead be to `sayHi()`.
 
 # 0.1.1
 
- * Deprecated the `sayHello()` method, use `sayHi()` instead.
+* Deprecated the `sayHello()` method; use `sayHi()` instead.
 
 # 0.1.0
 
- * Initial development release.
-
+* Initial development release.
 {% endprettify %}
 
-Following this changelog format allows tooling to parse your `CHANGELOG.md` and
-present relevant sections to package consumers.
-Consumers of your package will often review the `CHANGELOG.md` to discover
-bug fixes and new features, or determine how much effort it will take to upgrade
-to the latest version of your package.
 
 ## Public directories
 


### PR DESCRIPTION
@kwalrath I'm not sure the explanations needs to be this long... But embedding an example would be very nice.

---------

New upcoming design of pub.dev will "parse" the changelog. And display
the section headers for versions differently. In the future more tooling
might parse or read changelogs. So this is an attempt to document a
format for changelogs that can be easily parsed.

This does not provide a formal specification of all CHANGELOG.md formats
accepted by pub.dev, but it should provide sufficient documentation that
package authors can write CHANGELOG.md files that will be parsed
correctly on pub.dev.