### PR TITLE
Tweak `!` warning in null safety page

### DIFF
--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -156,7 +156,7 @@ int value = aNullableInt!; // `aNullableInt!` is an int.
 
 {{site.alert.important}}
   If you aren't positive that a value is non-null,
-  **don't use `!`**.
+  **don't use the `!` operator**.
 {{site.alert.end}}
 
 If you need to change the type of a nullable variable —


### PR DESCRIPTION
Tweak wording, per a discussion in #2522.