### PR TITLE
Update Windows pub cache path from APPDATA to LOCALAPPDATA

### DIFF
--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -105,7 +105,7 @@ downloaded and stored locally once.
 
 By default, the system package cache is located in the `.pub-cache`
 subdirectory of your home directory (on Mac and Linux),
-or in `%APPDATA%\Pub\Cache` (on Windows;
+or in `%LOCALAPPDATA%\Pub\Cache` (on Windows;
 the location might vary depending on the Windows version).
 You can configure the location of the cache by setting the
 [`PUB_CACHE`](/tools/pub/environment-variables)

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -128,7 +128,7 @@ locate the file for your platform and add it.
 |      Platform     |      Cache location       |
 |-------------------|---------------------------|
 | macOS or Linux | `$HOME/.pub-cache/bin`        |
-| Windows<sup><strong>*</strong></sup> | `%APPDATA%\Pub\Cache\bin` |
+| Windows<sup><strong>*</strong></sup> | `%LOCALAPPDATA%\Pub\Cache\bin` |
 {:.table .table-striped}
 
 <sup><strong>*</strong></sup> The exact location of the system cache

--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -10,7 +10,7 @@ Environment variables allow you to customize pub to suit your needs.
 : Some of pub's dependencies are downloaded to the pub cache.
   By default, this directory is located under `.pub-cache`
   in your home directory (on Mac and Linux),
-  or in `%APPDATA%\Pub\Cache` (on Windows). (The precise location of the
+  or in `%LOCALAPPDATA%\Pub\Cache` (on Windows). (The precise location of the
   cache may vary depending on the Windows version.)
   You can use the `PUB_CACHE` environment
   variable to specify another location. For more information, see

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -141,7 +141,7 @@ different [supported sources](/tools/pub/dependencies#dependency-sources) are av
 When pub gets a remote package,
 it downloads it into a single _system cache_ directory maintained by
 pub. On Mac and Linux, this directory defaults to `~/.pub-cache`.
-On Windows, the file lives in `%APPDATA%\Pub\Cache\bin`,
+On Windows, the file lives in `%LOCALAPPDATA%\Pub\Cache\bin`,
 though its exact location may vary depending on the Windows version.
 You can specify a different location using the
 [PUB_CACHE](/tools/pub/environment-variables) environment variable.


### PR DESCRIPTION
https://github.com/dart-lang/pub/pull/2297 changed the default pub cache path on Windows to from `%APPDATA%\Pub\Cache` to `%LOCALAPPDATA%\Pub\Cache`

Fixes https://github.com/dart-lang/site-www/issues/2526.