### PR TITLE
Revise guidance on using "dynamic".

### DIFF
--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -233,15 +233,11 @@ void miscDeclAnalyzedButNotTested() {
 
   () {
     // #docregion Object-vs-dynamic
-    void log(Object object) {
-      print(object.toString());
-    }
-
     /// Returns a Boolean representation for [arg], which must
     /// be a String or bool.
-    bool convertToBool(dynamic arg) {
+    bool convertToBool(Object arg) {
       if (arg is bool) return arg;
-      if (arg is String) return arg == 'true';
+      if (arg is String) return arg.toLowerCase() == 'true';
       throw ArgumentError('Cannot convert $arg to a bool.');
     }
     // #enddocregion Object-vs-dynamic

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1533,7 +1533,7 @@ The new syntax is a little more verbose, but is consistent with other locations
 where you must use the new syntax.
 
 
-### AVOID using `dynamic` unless you want dynamic dispatch.
+### AVOID using `dynamic` unless you want to disable static checking.
 
 Some operations work with any possible object. For example, a `log()` method
 could take any object and call `toString()` on it. Two types in Dart permit all

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1565,9 +1565,9 @@ bool convertToBool(Object arg) {
 
 The main exception to this rule is when working with existing APIs that use
 `dynamic`, especially inside a generic type. For example, JSON objects have type
-`Map<String, dynamic>` and your code will thus need to accept that same type.
-Even so, when using a value from one of these APIs, it's often a good idea to
-cast it to a more precise type before accessing members.
+`Map<String, dynamic>` and your code will need to accept that same type. Even
+so, when using a value from one of these APIs, it's often a good idea to cast it
+to a more precise type before accessing members.
 
 
 ### DO use `Future<void>` as the return type of asynchronous members that do not produce values.

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -233,7 +233,7 @@
 * <a href='/guides/language/effective-dart/design#dont-use-the-legacy-typedef-syntax'>DON'T use the legacy typedef syntax.</a>
 * <a href='/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs'>PREFER inline function types over typedefs.</a>
 * <a href='/guides/language/effective-dart/design#consider-using-function-type-syntax-for-parameters'>CONSIDER using function type syntax for parameters.</a>
-* <a href='/guides/language/effective-dart/design#do-annotate-with-object-instead-of-dynamic-to-indicate-any-object-is-allowed'>DO annotate with <code>Object</code> instead of <code>dynamic</code> to indicate any object is allowed.</a>
+* <a href='/guides/language/effective-dart/design#avoid-using-dynamic-unless-you-want-to-disable-static-checking'>AVOID using <code>dynamic</code> unless you want to disable static checking.</a>
 * <a href='/guides/language/effective-dart/design#do-use-futurevoid-as-the-return-type-of-asynchronous-members-that-do-not-produce-values'>DO use <code>Future&lt;void&gt;</code> as the return type of asynchronous members that do not produce values.</a>
 * <a href='/guides/language/effective-dart/design#avoid-using-futureort-as-a-return-type'>AVOID using <code>FutureOr&lt;T&gt;</code> as a return type.</a>
 


### PR DESCRIPTION
These days, we no longer suggest "dynamic" for cases where the type
system can't express a type. Instead, "dynamic" really only comes into
play when you want dynamic dispatch.