### PR TITLE
Add more two-letter acronym examples.

### DIFF
--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -15,14 +15,15 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion misc-names
   }
 
-  <DB, IOStream, Id>(uiHandler) => [
+  <IOStream, Id, DBIOPort, TVVcr>(uiHandler) => [
         // #docregion acronyms-and-abbreviations
         HttpConnectionInfo,
         uiHandler,
         IOStream,
         HttpRequest,
         Id,
-        DB,
+        DBIOPort
+        TVVcr
         // #enddocregion acronyms-and-abbreviations
       ];
 

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -22,7 +22,7 @@ void miscDeclAnalyzedButNotTested() {
         IOStream,
         HttpRequest,
         Id,
-        DBIOPort
+        DBIOPort,
         TVVcr
         // #enddocregion acronyms-and-abbreviations
       ];

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -84,7 +84,7 @@ class C { ... }
 {% include linter-rule.html rule="camel_case_extensions" %}
 
 Like types, extensions should capitalize the first letter of each word
-(including the first word), 
+(including the first word),
 and use no separators.
 
 {:.good}
@@ -254,7 +254,8 @@ uiHandler
 IOStream
 HttpRequest
 Id
-DB
+DBIOPort
+TVVcr
 {% endprettify %}
 
 {:.bad}
@@ -264,7 +265,8 @@ UiHandler
 IoStream
 HTTPRequest
 ID
-Db
+DbIOPort
+TvVcr
 {% endprettify %}
 
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -265,7 +265,7 @@ UiHandler
 IoStream
 HTTPRequest
 ID
-DbIOPort
+DbIoPort
 TvVcr
 {% endprettify %}
 


### PR DESCRIPTION
Fix #2511.