### PR TITLE
Update pkg-vers.json

### DIFF
--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.8.0"
+    "vers": "2.9.0"
   }
 }


### PR DESCRIPTION
The build is still broken, but at least the site will say we're 2.9.

More info on how this is visible: https://github.com/dart-lang/site-www/wiki/Updating-to-new-SDK-releases