### PR TITLE
remove redundant docregion tag

### DIFF
--- a/examples/extension_methods/lib/string_extensions/usage_simple_extension.dart
+++ b/examples/extension_methods/lib/string_extensions/usage_simple_extension.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: dead_code
 // #docregion import-and-use
 // Import a library that contains an extension on String.
-// #docregion basic, import-and-use
+// #docregion basic
 import 'string_apis.dart';
 // #enddocregion basic, import-and-use
 


### PR DESCRIPTION
This tag is already declared on line 2, resulting in a warning:

```
[WARNING] code_excerpter:code_excerpter on examples/misc/test/tutorial/futures_test.dart:
repeated start for region "import-and-use" at examples/extension_methods/lib/string_extensions/usage_simple_extension.dart:14
```