### PR TITLE
Fix Flutter version number

### DIFF
--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -11,7 +11,7 @@ The Dart SDK has the libraries and command-line tools that you need to develop
 Dart command-line, server, and non-Flutter web apps.
 For details, see the [Dart SDK overview](/tools/sdk).
 
-**As of Flutter 1.21, the [Flutter SDK][flutter] includes the Dart SDK.**
+**As of Flutter 1.2.1, the [Flutter SDK][flutter] includes the Dart SDK.**
 So if you have Flutter installed,
 you might not need to explicitly download the Dart SDK.
 Consider downloading the Dart SDK if

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -18,7 +18,7 @@ Consider downloading the Dart SDK if
 any of the following are true:
 
 * You don't use Flutter.
-* You use a pre-1.21 version of Flutter.
+* You use a pre-1.2.1 version of Flutter.
 * You want to reduce disk space requirements or download time,
   and your use case doesn't require Flutter.
   For example, you might have a continuous integration (CI)


### PR DESCRIPTION
In this page says "As of Flutter 1.21, the Flutter SDK includes the Dart SDK." but the correct version it's `1.2.1` (just a typo, a missing dot/period).
- Source: https://flutter.dev/docs/development/tools/sdk/release-notes/release-notes-1.2.1#dart