### PR TITLE
add a redirect / shorten link for the nnbd migration tool

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -126,6 +126,7 @@
       { "source": "/events/2016{,/**}", "destination": "https://events.dartlang.org/2016/summit", "type": 301 },
       { "source": "/events{,/**}", "destination": "https://events.dartlang.org", "type": 301 },
       { "source": "/flutter", "destination": "https://flutter.io", "type": 301 },
+      { "source": "/go/null-safety-migration", "destination": "https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration#providing-feedback", "type": 301 },
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },
       { "source": "/guides/language/library-tour", "destination": "/guides/libraries/library-tour", "type": 301 },


### PR DESCRIPTION
- add a redirect / short link for the nnbd migration tool
- this will allow us to replace the long 'https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration#providing-feedback' link (referenced from the `dart migrate` command line tool) with a shorter `dart.dev/go/null-safety-migration` link.

This idea is borrowed from the flutter.dev 'go' redirects: https://github.com/flutter/website/blob/master/firebase.json#L122.
