### PR TITLE
Fixed backslash removing from code exceprts

### DIFF
--- a/src/_plugins/code_excerpt_framer.rb
+++ b/src/_plugins/code_excerpt_framer.rb
@@ -4,7 +4,7 @@ module DartSite
   # some framing HTML: e.g., a div with possible excerpt title in a header.
   class CodeExcerptFramer
     def frame_code(title, classes, attrs, escaped_code, indent)
-      _unindented_template(title, classes, attrs, escaped_code)
+      _unindented_template(title, classes, attrs, escaped_code.gsub('\\','\\\\\\\\'))
     end
 
     private


### PR DESCRIPTION
Backslash is not a special character in HTML, so `CGI.escapeHTML` kept it intact and passed into the frame_code function.
At the same time backslash is a special character for `sub`, so it must be escaped before using as a replacement string.

The error effect now is present in the code here https://dart.dev/codelabs/dart-cheatsheet#factory-constructors
```print('I don\'t recognize $typeName');```
became
```print('I donescaped_code#39;t recognize $typeName');```