### PR TITLE
Fix padding for alerts

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -1067,7 +1067,7 @@ h3.popover-header {
   border-radius: 0;
   color: $site-color-body;
   margin-top: 32px;
-  padding: 30px 40px;
+  padding: 30px 30px;
 
   pre, code {
     background-color: transparent;


### PR DESCRIPTION
This was bothering me a bit on https://dart.dev/null-safety#enable-null-safety; the left margin wasn't aligned across code snippets and alerts. I think this aligns them across the board.

### Before

<img width="364" alt="Screenshot 2020-08-27 at 09 42 52" src="https://user-images.githubusercontent.com/13644170/91412287-dca0be00-e849-11ea-9ab1-1f462f7055cb.png">

### After

<img width="380" alt="Screenshot 2020-08-27 at 09 42 40" src="https://user-images.githubusercontent.com/13644170/91412284-db6f9100-e849-11ea-8a7a-d923f2aea902.png">
