### PR TITLE
Fixed "displays" being displayed 2 times

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -90,7 +90,7 @@ Using a verified publisher has the following advantages:
 
 * The consumers of your package know that the publisher domain has been verified.
 * You can avoid having pub.dev display your personal email address.
-  Instead, pub.dev displays displays the publisher domain and contact address.
+  Instead, pub.dev displays the publisher domain and contact address.
 * A verified publisher badge {% asset verified-publisher.svg
   alt="pub.dev verified publisher logo" %} is displayed next to your package name
   on both search pages and individual package pages.


### PR DESCRIPTION
The word "displays" was displayed two times, I removed one. 

Quoting [this](https://dart.dev/tools/pub/publishing#verified-publisher)

>You can avoid having pub.dev display your personal email address. Instead, pub.dev **displays** **displays** the publisher domain and contact address.