### PR TITLE
Update language-tour.md

### DIFF
--- a/examples/misc/lib/language_tour/classes/orchestra.dart
+++ b/examples/misc/lib/language_tour/classes/orchestra.dart
@@ -52,15 +52,26 @@ class Maestro extends Person
 }
 // #enddocregion Musician-and-Maestro
 
-// Musician2 is a workaround for https://github.com/dart-lang/sdk/issues/35011.
+// Musician2 was a workaround for https://github.com/dart-lang/sdk/issues/35011,
+// which has been marked as fixed.
 
 class Musician2 extends Performer with Musical {
   Musician2() : super('Anonymous');
   Musician2.withName(String name) : super(name);
 }
 
+// Simple version of Musician for the mixin example.
+/*
+// #docregion mixin-on
+class Musician {
+  // ...
+}
+// #enddocregion mixin-on
+*/
+
 // #docregion mixin-on
 mixin MusicalPerformer on Musician2 {
+  // ...
   // #enddocregion mixin-on
   bool canDance = true;
 
@@ -73,10 +84,14 @@ mixin MusicalPerformer on Musician2 {
 }
 // #enddocregion mixin-on
 
+// #docregion mixin-on
 class SingerDancer extends Musician2 with MusicalPerformer {
-//  SingerDancer(String name) : super(name);
+  // ...
+  // #enddocregion mixin-on
   SingerDancer(String name) : super.withName(name);
+// #docregion mixin-on
 }
+// #enddocregion mixin-on
 
 void main() {
   var director = Maestro('Allen');

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3432,12 +3432,12 @@ that the mixin doesn't define.
 As the following example shows, you can restrict a mixin's use
 by using the `on` keyword to specify the required superclass:
 
-<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)" plaster="none" replace="/on Musician/[!$&!]/g" ?>
+<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)" plaster="none" replace="/on Musician2/[!on Musician!]/g" ?>
 ```dart
 class Musician {
   // ...
 }
-mixin MusicalPerformer [!on Musician!]2 {
+mixin MusicalPerformer [!on Musician!] {
   // ...
 }
 class SingerDancer extends Musician with MusicalPerformer {
@@ -3448,7 +3448,8 @@ class SingerDancer extends Musician with MusicalPerformer {
 In the preceding code,
 only classes that extend or implement the `Musician` class
 can use the mixin `MusicalPerformer`.
-Because `MusicBand` extends `Musician`, it can mix in `MusicalPerformer`.
+Because `SingerDancer` extends `Musician`,
+`SingerDancer` can mix in `MusicalPerformer`.
 
 {{site.alert.version-note}}
   Support for the `mixin` keyword was introduced in Dart 2.1. Code in earlier

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3432,19 +3432,16 @@ that the mixin doesn't define.
 As the following example shows, you can restrict a mixin's use
 by using the `on` keyword to specify the required superclass:
 
-<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)"
-  plaster="none" replace="/on Musician/[!$&!]/g" ?>
+<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)" plaster="none" replace="/on Musician/[!$&!]/g" ?>
 ```dart
 class Musician {
-  //...
+  // ...
 }
-
-mixin MusicalPerformer [!on Musician!] {
-  // ···
+mixin MusicalPerformer [!on Musician!]2 {
+  // ...
 }
-
 class SingerDancer extends Musician with MusicalPerformer {
-  //...
+  // ...
 }
 ```
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3432,19 +3432,24 @@ that the mixin doesn't define.
 As the following example shows, you can restrict a mixin's use
 by using the `on` keyword to specify the required superclass:
 
-<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)"?>
+<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)"
+  plaster="none" replace="/on Musician/[!$&!]/g" ?>
 ```dart
 class Musician {
   //...
 }
-mixin MusicalPerformer on Musician {
+
+mixin MusicalPerformer [!on Musician!] {
   // ···
 }
-class MusicBand extends Musician with MusicalPerformer {
+
+class SingerDancer extends Musician with MusicalPerformer {
   //...
 }
 ```
-In the preceding code, only classes that extend or implement the `Musician` class
+
+In the preceding code,
+only classes that extend or implement the `Musician` class
 can use the mixin `MusicalPerformer`.
 Because `MusicBand` extends `Musician`, it can mix in `MusicalPerformer`.
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3426,16 +3426,24 @@ mixin Musical {
 }
 ```
 
-To specify that only certain types can use the mixin — for example,
-so your mixin can invoke a method that it doesn't define —
-use `on` to specify the required superclass:
+To restrict mixin's use to only classes which either extends or implements the class on which it is declared on - 
+we use the 'on' keyword.
+For example:
 
 <?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (mixin-on)"?>
 ```dart
+class Musician{
+  //...
+}
 mixin MusicalPerformer on Musician {
   // ···
 }
+class MusicBand extends Musician with MusicalPerformer{
+  //...
+}
 ```
+In the above code we are restricting mixin MusicalPerformer to be only used by the classes which either
+extend or implement the Musician class.
 
 {{site.alert.version-note}}
   Support for the `mixin` keyword was introduced in Dart 2.1. Code in earlier


### PR DESCRIPTION
Language tour - mixin issue resolved
Clearly defined the use of 'on' keyword using an appropriate example.
Fixes #2227