### PR TITLE
Remove code excerpt from index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -410,8 +410,6 @@ js:
             <select id="dartpad-select"></select>
             <div id="dartpad-host"></div>
             <h3>Want more practice? <a href="/codelabs">Try a codelab</a>. Or <a href="/get-dart">download Dart</a>.</h3>
-            {% capture md %}{% include_relative _try-dart-examples.md %}{% endcapture %}
-            {{ md | markdownify }}
         </div>
     </section>
 </div>


### PR DESCRIPTION
This should have been removed as part of #2570. This can be removed since the embed isn't using code excerpts for it's snippets

fixes #2604