### PR TITLE
Fixing outdated instruction on toggling off the html and css

### DIFF
--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -89,10 +89,10 @@ To create a simple command-line app, use **New Pad**.
   </li>
 
   <li markdown="1">
-  Clear the **Show web content** checkbox,
-  at the bottom right of DartPad.
-
+  Toggle off the **HTML** Tag,
+  underneath the Dart logo.
   The HTML and CSS tabs disappear.
+  
   </li>
 
   <li markdown="1">

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -92,7 +92,6 @@ To create a simple command-line app, use **New Pad**.
   Turn off **HTML**, using the toggle
   underneath the Dart logo.
   The HTML and CSS tabs disappear.
-  
   </li>
 
   <li markdown="1">

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -89,7 +89,7 @@ To create a simple command-line app, use **New Pad**.
   </li>
 
   <li markdown="1">
-  Toggle off the **HTML** Tag,
+  Turn off **HTML**, using the toggle
   underneath the Dart logo.
   The HTML and CSS tabs disappear.
   
@@ -154,4 +154,3 @@ For technical details on embedding DartPads, see the
 [best practices for using DartPad in tutorials]: /resources/dartpad-best-practices
 [DartPad embedding guide.]: https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide
 [futures codelab]: /codelabs/async-await
-


### PR DESCRIPTION
fixes #2593 
Original Steps:
![image](https://user-images.githubusercontent.com/57803819/91811594-5fac8480-ec4d-11ea-8146-56c0d11f4537.png)

Error in Step 2:
```bash
2. Clear the Show web content checkbox, at the bottom right of the DartPad,
```

Problem:
![image](https://user-images.githubusercontent.com/57803819/91812032-0f81f200-ec4e-11ea-812d-3fcaf8909b81.png)

Changed to:
```bash
2. Toggle off the HTML Tag, underneath the Dart logo.
```