### PR TITLE
add a short redirect link for docs referenced by 'run run test' help

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -129,6 +129,7 @@
 
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration", "type": 301 },
+      { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },


### PR DESCRIPTION
- add a short redirect link for docs referenced by 'run run test' help

This will redirect from:

```
https://dart.dev/go/test-docs/json_reporter.md
```

to:

```
https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md
```

Currently the `pun run test` command line help is using a goo.gl link, but:
- this isn't possible to update after the tool is shipped (the URL has been out of date twice), and
- we've used the `go` link pattern a few other places in our CLI tools.

@kwalrath @grouma @natebosch 
