### PR TITLE
Try to clarify optional parameter restrictions

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1129,7 +1129,7 @@ is sometimes referred to as _arrow_ syntax.
 
 A function can have two types of parameters: _required_ and _optional_.
 The required parameters are listed first, followed by any optional parameters.
-Optional parameters can be _named_ or _positional_.
+Optional parameters can be either _named_ or _positional_.
 
 {{site.alert.note}}
   Some APIs — notably [Flutter][] widget constructors — use only named
@@ -1139,7 +1139,8 @@ Optional parameters can be _named_ or _positional_.
 
 ### Optional parameters
 
-Optional parameters can be either named or positional, but not both.
+A function can have optional positional parameters or optional named parameters,
+but not both.
 
 #### Named parameters
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1127,20 +1127,23 @@ is sometimes referred to as _arrow_ syntax.
   there, but you can use a [conditional expression](#conditional-expressions).
 {{site.alert.end}}
 
-A function can have two types of parameters: _required_ and _optional_.
-The required parameters are listed first, followed by any optional parameters.
-Optional parameters can be either _named_ or _positional_.
+### Parameters
+
+A function can have any number of *required positional* parameters. These may be
+followed either by *optional positional* parameters or by *optional named*
+parameters.  A function can have optional positional parameters or optional
+named parameters, but not both.
+{% comment %}
+NULLSAFE: Replace "optional named" above with just "named" and add:
+
+A named parameter can be either optional or `required`.
+{% endcomment %}
 
 {{site.alert.note}}
   Some APIs — notably [Flutter][] widget constructors — use only named
   parameters, even for parameters that are mandatory. See the next section for
   details.
 {{site.alert.end}}
-
-### Optional parameters
-
-A function can have optional positional parameters or optional named parameters,
-but not both.
 
 #### Named parameters
 
@@ -1180,7 +1183,11 @@ then the analyzer reports an issue.
 To use the [@required][] annotation,
 depend on the [meta][] package and import `package:meta/meta.dart`.
 
-#### Positional parameters
+{% comment %}
+NULLSAFE: Rewrite this section.
+{% endcomment %}
+
+#### Optional positional parameters
 
 Wrapping a set of function parameters in `[]` marks them as optional
 positional parameters:

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1129,15 +1129,9 @@ is sometimes referred to as _arrow_ syntax.
 
 ### Parameters
 
-A function can have any number of *required positional* parameters. These may be
-followed either by *optional positional* parameters or by *optional named*
-parameters.  A function can have optional positional parameters or optional
-named parameters, but not both.
-{% comment %}
-NULLSAFE: Replace "optional named" above with just "named" and add:
-
-A named parameter can be either optional or `required`.
-{% endcomment %}
+A function can have any number of *required positional* parameters. These can be
+followed either by *named* parameters or by *optional positional* parameters
+(but not both).
 
 {{site.alert.note}}
   Some APIs — notably [Flutter][] widget constructors — use only named
@@ -1146,6 +1140,8 @@ A named parameter can be either optional or `required`.
 {{site.alert.end}}
 
 #### Named parameters
+
+Named parameters are optional unless they're specifically marked as required.
 
 When calling a function, you can specify named parameters using
 <code><em>paramName</em>: <em>value</em></code>. For example:


### PR DESCRIPTION
The Language Tour currently states:

> Optional parameters can be either named or positional, but not
> both.

That statement can be interpreted to mean that any individual
parameter cannot be both named and positional.  However, the actual
restriction is stronger: a function cannot have both optional named
and optional positional parameters (see
https://github.com/dart-lang/language/issues/1076).