### PR TITLE
Added "void" as return type.

### DIFF
--- a/examples/strong/lib/covariant.dart
+++ b/examples/strong/lib/covariant.dart
@@ -6,5 +6,6 @@ class Animal {
 class Mouse extends Animal {/* ... */}
 
 class Cat extends Animal {
+  @override
   void chase(covariant Mouse x) {/* ... */}
 }

--- a/examples/strong/test/strong_test.dart
+++ b/examples/strong/test/strong_test.dart
@@ -173,7 +173,7 @@ void main() {
 
 // ignore_for_file: type_annotate_public_apis
 // #docregion downcast-check
-assumeStrings(List<Object> objects) {
+void assumeStrings(List<Object> objects) {
   // ignore_for_file: stable, dev, invalid_assignment
   List<String> strings = objects; // Runtime downcast check
   String string = strings[0]; // Expect a String value

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -342,7 +342,7 @@ When the code adds a (String, float) pair, the analyzer complains:
 {% prettify dart tag=pre+code %}
 // Inferred as Map<String, int>
 var map = {'a': 1, 'b': 2, 'c': 3};
-map['d'] = [!1.5!]; // a double is not an int
+map['d'] = [!1.5!]; // A double is not an int.
 {% endprettify %}
 
 {% comment %}
@@ -505,7 +505,7 @@ To ensure type safety, Dart needs to insert _runtime_ checks in some cases. Cons
 {:.passes-sa}
 <?code-excerpt "strong/test/strong_test.dart (downcast-check)" replace="/string = objects/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-assumeStrings(List<Object> objects) {
+void assumeStrings(List<Object> objects) {
   List<String> strings = objects; // Runtime downcast check
   String string = strings[0]; // Expect a String value
 }
@@ -619,6 +619,7 @@ class Animal {
 class Mouse extends Animal { ... }
 
 class Cat extends Animal {
+  @override
   void chase([!covariant!] Mouse x) { ... }
 }
 {% endprettify %}


### PR DESCRIPTION
Made 2 changes on [this page](https://dart.dev/guides/language/sound-problems). 

- Added `void` as a return type. 
- Added `override` annotation. 

