### PR TITLE
docs: Added more resources

### DIFF
--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -25,7 +25,7 @@ Check out the following Dart language resources:
   
   <div class="card">
     <h3><a href="/faq">Dart FAQ</a></h3>
-    <p>Collection of top questions we’ve heard from the community.</p>
+    <p>Answers to questions from the Dart community.</p>
   </div> 
 
   <div class="card">

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -20,7 +20,7 @@ Check out the following Dart language resources:
 
   <div class="card">
     <h3><a href="/code-of-conduct">Code of conduct</a></h3>
-    <p>Dart community members' code of conduct.</p>
+    <p>Keeping community spaces safe and respectful.</p>
   </div>
   
   <div class="card">

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -15,7 +15,7 @@ Check out the following Dart language resources:
   
   <div class="card">
     <h3><a href="/resources/dartpad-best-practices">DartPad in tutorials: best practices</a></h3>
-    <p>A guide introducing DartPad.</p>
+    <p>A guide to using embedded DartPads in educational content for Dart and Flutter users.</p>
   </div>
 
   <div class="card">

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -6,14 +6,27 @@ toc: false
 
 Check out the following Dart language resources:
 
-{% comment %} PENDING: Add links to other resources if we keep the Resources menu. 
-{% endcomment %}
 
 <div class="card-grid">
   <div class="card">
     <h3><a href="/resources/books">Books</a></h3>
     <p>A collection of books about Dart.</p>
   </div>
+  
+  <div class="card">
+    <h3><a href="/resources/dartpad-best-practices">DartPad in tutorials: best practices</a></h3>
+    <p>A guide introducing DartPad.</p>
+  </div>
+
+  <div class="card">
+    <h3><a href="/code-of-conduct">Code of conduct</a></h3>
+    <p>Dart community members' code of conduct.</p>
+  </div>
+  
+  <div class="card">
+    <h3><a href="/faq">Dart FAQ</a></h3>
+    <p>Collection of top questions we’ve heard from the community.</p>
+  </div> 
 
   <div class="card">
     <h3><a href="/resources/videos">Videos</a></h3>


### PR DESCRIPTION
The [Resources page](https://dart.dev/resources) previously had only two cards(Book and Video) on it, but the side nav showed a lot more items.
This would fix #2614