### PR TITLE
docs: update for-in example

### DIFF
--- a/examples/misc/test/language_tour/control_flow_test.dart
+++ b/examples/misc/test/language_tour/control_flow_test.dart
@@ -29,14 +29,14 @@ void main() {
   test('collection', () {
     _test() {
       // #docregion collection
-      var collection = [0, 1, 2];
+      var collection = [1, 2, 3];
       for (var x in collection) {
-        print(x); // 0 1 2
+        print(x); // 1 2 3
       }
       // #enddocregion collection
     }
 
-    expect(_test, m.prints([0, 1, 2]));
+    expect(_test, m.prints([1, 2, 3]));
   });
 
   test('assert', () {

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2092,9 +2092,9 @@ Iterable classes such as List and Set also support the `for-in` form of
 
 <?code-excerpt "misc/test/language_tour/control_flow_test.dart (collection)"?>
 ```dart
-var collection = [0, 1, 2];
+var collection = [1, 2, 3];
 for (var x in collection) {
-  print(x); // 0 1 2
+  print(x); // 1 2 3
 }
 ```
 


### PR DESCRIPTION
Remove ambiguity in list index and value.

In language like JavaScript `for-in` gets list index instead. Example is updated to highlight the difference.