### PR TITLE
[WIP] Update diagnostic-messages

### DIFF
--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -18,6 +18,7 @@ For more information about the analyzer, see
 This page uses the following terms.
 
 [constant context]: #constant-context
+[override inference]: #override-inference
 [potentially non-nullable]: #potentially-non-nullable
 
 ### Constant context
@@ -59,6 +60,64 @@ contexts:
     }
   }
   ```
+
+### Override inference
+
+Override inference is the process by which any missing types in a method
+declaration are inferred based on the corresponding types from the method or
+methods that it overrides.
+
+If a candidate method (the method that's missing type information) overrides a
+single inherited method, then the corresponding types from the overridden method
+are inferred. For example, consider the following code:
+
+```dart
+class A {
+  int m(String s) => 0;
+}
+
+class B extends A {
+  @override
+  m(s) => 1;
+}
+```
+
+The declaration of `m` in `B` is a candidate because it's missing both the
+return type and the parameter type. Because it overrides a single method (the
+method `m` in `A`), the types from the overridden method will be used to infer
+the missing types and it will be as if the method in `B` had been declared as
+`int m(String s) => 1;`.
+
+If a candidate method overrides multiple methods, and the function type one of
+those overridden methods, M<sub>s</sub>, is a supertype of the function types of
+all of the other overridden methods, then M<sub>s</sub> is used to infer the
+missing types. For example, consider the following code:
+
+```dart
+class A {
+  int m(num n) => 0;
+}
+
+class B {
+  num m(int i) => 0;
+}
+
+class C implements A, B {
+  @override
+  m(n) => 1;
+}
+```
+
+The declaration of `m` in `C` is a candidate for override inference because it's
+missing both the return type and the parameter type. It overrides both `m` in
+`A` and `m` in `B`, so we need to choose one of them from which the missing
+types can be inferred. But because the function type of `m` in `A`
+(`int Function(num)`) is a supertype of the function type of `m` in `B`
+(`num Function(int)`), the function in `A` is used to infer the missing types.
+The result is the same as declaring the method in `C` as `int m(num n) => 1;`.
+
+It is an error if none of the overridden methods has a function type that is a
+supertype of all the other overridden methods.
 
 ### Potentially non-nullable
 
@@ -576,6 +635,47 @@ class C {
 
 Rewrite the code so that there isn't an assignment to a method.
 
+### await_in_late_local_variable_initializer
+
+_The 'await' expression can't be used in a 'late' local variable's initializer._
+
+#### Description
+
+The analyzer produces this diagnostic when a local variable that has the
+'late' modifier uses an 'await' expression in the initializer.
+
+#### Example
+
+The following code produces this diagnostic because an 'await' expression
+is used in the initializer for 'v', a local variable that is marked 'late':
+
+{% prettify dart tag=pre+code %}
+Future<int> f() async {
+  late v = [!await!] 42;
+  return v;
+}
+{% endprettify %}
+
+#### Common fixes
+
+If the initializer can be rewritten to not use 'await', then rewrite it:
+
+{% prettify dart tag=pre+code %}
+Future<int> f() async {
+  late v = 42;
+  return v;
+}
+{% endprettify %}
+
+If the initializer can't be rewritten, then remove the 'late' modifier:
+
+{% prettify dart tag=pre+code %}
+Future<int> f() async {
+  var v = await 42;
+  return v;
+}
+{% endprettify %}
+
 ### body_might_complete_normally
 
 _The body might complete normally, causing 'null' to be returned, but the return
@@ -584,9 +684,8 @@ type is a potentially non-nullable type._
 #### Description
 
 The analyzer produces this diagnostic when a method or function has a
-return type that's [potentially non-nullable][]
- but would implicitly return `null` if control reached the
-end of the function.
+return type that's [potentially non-nullable][] but would implicitly return
+`null` if control reached the end of the function.
 
 #### Example
 
@@ -865,7 +964,8 @@ abstract class C {
 
 ### const_constructor_param_type_mismatch
 
-_A value of type '{0}' can't be assigned to a parameter of type '{1}'._
+_A value of type '{0}' can't be assigned to a parameter of type '{1}' in a const
+constructor._
 
 #### Description
 
@@ -907,6 +1007,50 @@ const dynamic i = 0;
 
 void f() {
   const C('$i');
+}
+{% endprettify %}
+
+### const_constructor_with_field_initialized_by_non_const
+
+_Can't define the 'const' constructor because the field '{0}' is initialized
+with a non-constant value._
+
+#### Description
+
+The analyzer produces this diagnostic when a constructor has the keyword
+`const`, but a field in the class is initialized to a non-constant value.
+
+#### Example
+
+The following code produces this diagnostic because the field `s` is
+initialized to a non-constant value:
+
+{% prettify dart tag=pre+code %}
+class C {
+  final String s = 3.toString();
+  [!const!] C();
+}
+{% endprettify %}
+
+#### Common fixes
+
+If the field can be initialized to a constant value, then change the
+initializer to a constant expression:
+
+{% prettify dart tag=pre+code %}
+class C {
+  final String s = '3';
+  const C();
+}
+{% endprettify %}
+
+If the field can't be initialized to a constant value, then remove the
+keyword `const` from the constructor:
+
+{% prettify dart tag=pre+code %}
+class C {
+  final String s = 3.toString();
+  C();
 }
 {% endprettify %}
 
@@ -1196,6 +1340,54 @@ class C {
 C f(int i) => C(i);
 {% endprettify %}
 
+### creation_with_non_type
+
+_The name '{0}' isn't a class._
+
+_The name '{0}' isn't a class._
+
+#### Description
+
+The analyzer produces this diagnostic when an instance creation using
+either `new` or `const` specifies a name that isn't defined as a class.
+
+#### Example
+
+The following code produces this diagnostic because `f` is a function
+rather than a class:
+
+{% prettify dart tag=pre+code %}
+int f() => 0;
+
+void g() {
+  new [!f!]();
+}
+{% endprettify %}
+
+#### Common fixes
+
+If a class should be created, then replace the invalid name with the name
+of a valid class:
+
+{% prettify dart tag=pre+code %}
+int f() => 0;
+
+void g() {
+  new Object();
+}
+{% endprettify %}
+
+If the name is the name of a function and you want that function to be
+invoked, then remove the `new` or `const` keyword:
+
+{% prettify dart tag=pre+code %}
+int f() => 0;
+
+void g() {
+  f();
+}
+{% endprettify %}
+
 ### dead_code
 
 _Dead code._
@@ -1466,6 +1658,36 @@ computed, then use `List.generate`:
 
 {% prettify dart tag=pre+code %}
 var l = List.generate(3, (i) => i);
+{% endprettify %}
+
+### default_value_in_function_type
+
+_Parameters in a function type can't have default values._
+
+#### Description
+
+The analyzer produces this diagnostic when a function type associated with
+a parameter includes optional parameters that have a default value. This
+isn't allowed because the default values of parameters aren't part of the
+function's type, and therefore including them doesn't provide any value.
+
+#### Example
+
+The following code produces this diagnostic because the parameter `p` has a
+default value even though it's part of the type of the parameter `g`:
+
+{% prettify dart tag=pre+code %}
+void f(void Function([int p [!=!] 0]) g) {
+}
+{% endprettify %}
+
+#### Common fixes
+
+Remove the default value from the function-type's parameter:
+
+{% prettify dart tag=pre+code %}
+void f(void Function([int p]) g) {
+}
 {% endprettify %}
 
 ### definitely_unassigned_late_local_variable
@@ -1907,7 +2129,7 @@ values are returned by an iterator.
 ### export_legacy_symbol
 
 _The symbol '{0}' is defined in a legacy library, and can't be re-exported from
-a non-nullable by default library._
+a library with null safety enabled._
 
 #### Description
 
@@ -2214,7 +2436,7 @@ extension._
 #### Description
 
 The analyzer produces this diagnostic when an extension override is the
-target of the invocation of a static member. Similar to static members in
+receiver of the invocation of a static member. Similar to static members in
 classes, the static members of an extension should be accessed using the
 name of the extension, not an extension override.
 
@@ -2286,8 +2508,8 @@ void f() {
 {% endprettify %}
 
 If there's a different extension that's valid for the type of the argument,
-then either replace the name of the extension or unwrap the target so that
-the correct extension is found.
+then either replace the name of the extension or unwrap the argument so
+that the correct extension is found.
 
 ### extension_override_without_access
 
@@ -2330,7 +2552,7 @@ void f(int i) {
 }
 {% endprettify %}
 
-If you don't want to invoke a member, then unwrap the target:
+If you don't want to invoke a member, then unwrap the argument:
 
 {% prettify dart tag=pre+code %}
 extension E on int {
@@ -2344,14 +2566,14 @@ void f(int i) {
 
 ### extension_override_with_cascade
 
-_Extension overrides have no value so they can't be used as the target of a
+_Extension overrides have no value so they can't be used as the receiver of a
 cascade expression._
 
 #### Description
 
 The analyzer produces this diagnostic when an extension override is used as
-the target of a cascade expression. The value of a cascade expression
-`e..m` is the value of the target `e`, but extension overrides aren't
+the receiver of a cascade expression. The value of a cascade expression
+`e..m` is the value of the receiver `e`, but extension overrides aren't
 expressions and don't have a value.
 
 #### Examples
@@ -2364,7 +2586,7 @@ extension E on int {
   void m() {}
 }
 f() {
-  E(3)[!..!]m();
+  [!E!](3)..m();
 }
 {% endprettify %}
 
@@ -2509,6 +2731,9 @@ class C {
 {% endprettify %}
 
 ### field_initializer_not_assignable
+
+_The initializer type '{0}' can't be assigned to the field type '{1}' in a const
+constructor._
 
 _The initializer type '{0}' can't be assigned to the field type '{1}'._
 
@@ -2724,6 +2949,56 @@ void f(Map<String, String> m) {
   for (String s in m.values) {
     print(s);
   }
+}
+{% endprettify %}
+
+### getter_not_subtype_setter_types
+
+_The return type of getter '{0}' is '{1}' which isn't a subtype of the type
+'{2}' of its setter '{3}'._
+
+#### Description
+
+The analyzer produces this diagnostic when the return type of a getter
+isn't a subtype of the type of the parameter of a setter with the same
+name.
+
+The subtype relationship is a requirement whether the getter and setter are
+in the same class or whether one of them is in a superclass of the other.
+
+#### Example
+
+The following code produces this diagnostic because the return type of the
+getter `x` is `num`, the parameter type of the setter `x` is `int`, and
+`num` isn't a subtype of `int`:
+
+{% prettify dart tag=pre+code %}
+class C {
+  num get [!x!] => 0;
+
+  set x(int y) {}
+}
+{% endprettify %}
+
+#### Common fixes
+
+If the type of the getter is correct, then change the type of the setter:
+
+{% prettify dart tag=pre+code %}
+class C {
+  num get x => 0;
+
+  set x(num y) {}
+}
+{% endprettify %}
+
+If the type of the setter is correct, then change the type of the getter:
+
+{% prettify dart tag=pre+code %}
+class C {
+  int get x => 0;
+
+  set x(int y) {}
 }
 {% endprettify %}
 
@@ -3229,6 +3504,80 @@ var c = new [!C!]();
 If there's a concrete subclass of the abstract class that can be used, then
 create an instance of the concrete subclass.
 
+### invalid_annotation
+
+_Annotation must be either a const variable reference or const constructor
+invocation._
+
+_Getters can't be used as annotations._
+
+#### Description
+
+The analyzer produces this diagnostic when an annotation is found that is
+using something that is neither a variable marked as `const` or the
+invocation of a `const` constructor.
+
+Getters can't be used as annotations.
+
+#### Example
+
+The following code produces this diagnostic because the variable `v` isn't
+a `const` variable:
+
+{% prettify dart tag=pre+code %}
+var v = 0;
+
+[!@v!]
+void f() {
+}
+{% endprettify %}
+
+The following code produces this diagnostic because `f` isn't a variable:
+
+{% prettify dart tag=pre+code %}
+[!@f!]
+void f() {
+}
+{% endprettify %}
+
+The following code produces this diagnostic because `f` isn't a
+constructor:
+
+{% prettify dart tag=pre+code %}
+[!@f()!]
+void f() {
+}
+{% endprettify %}
+
+The following code produces this diagnostic because `g` is a getter:
+
+{% prettify dart tag=pre+code %}
+[!@g!]
+int get g => 0;
+{% endprettify %}
+
+#### Common fixes
+
+If the annotation is referencing a variable that isn't a `const`
+constructor, add the keyword `const` to the variable's declaration:
+
+{% prettify dart tag=pre+code %}
+const v = 0;
+
+@v
+void f() {
+}
+{% endprettify %}
+
+If the annotation isn't referencing a variable, then remove it:
+
+{% prettify dart tag=pre+code %}
+int v = 0;
+
+void f() {
+}
+{% endprettify %}
+
 ### invalid_assignment
 
 _A value of type '{0}' can't be assigned to a variable of type '{1}'._
@@ -3442,8 +3791,10 @@ var x;
 
 ### invalid_null_aware_operator
 
-_The target expression can't be null, so the null-aware operator '{0}' can't be
-used._
+_The receiver can't be null because of short-circuiting, so the null-aware
+operator '{0}' can't be used._
+
+_The receiver can't be null, so the null-aware operator '{0}' can't be used._
 
 #### Description
 
@@ -3467,6 +3818,25 @@ The following code produces this diagnostic because `a` can't be `null`:
 var a = [];
 var b = [[!...?!]a];
 {% endprettify %}
+
+The following code produces this diagnostic because `s?.length` can't
+return `null`:
+
+{% prettify dart tag=pre+code %}
+void f(String? s) {
+  s?.length[!?.!]isEven;
+}
+{% endprettify %}
+
+The reason `s?.length` can't return `null` is because the null-aware
+operator following `s` short-circuits the evaluation of both `length` and
+`isEven` if `s` is `null`. In other words, if `s` is `null`, then neither
+`length` nor `isEven` will be invoked, and if `s` is non-`null`, then
+`length` can't return a `null` value. Either way, `isEven` can't be invoked
+on a `null` value, so the null-aware operator is neither necessary nor
+allowed. See
+[Understanding null safety](https://dart.dev/null-safety/understanding-null-safety#smarter-null-aware-methods)
+for more details.
 
 #### Common fixes
 
@@ -3823,6 +4193,104 @@ int f() => x;
 var y = f();
 {% endprettify %}
 
+### late_final_field_with_const_constructor
+
+_Can't have a late final field in a class with a const constructor._
+
+#### Description
+
+The analyzer produces this diagnostic when a class that has at least one
+`const` constructor also has a field marked both `late` and `final`.
+
+#### Example
+
+The following code produces this diagnostic because the class `A` has a
+`const` constructor and the `final` field `f` is marked as `late`:
+
+{% prettify dart tag=pre+code %}
+class A {
+  [!late!] final int f;
+
+  const A();
+}
+{% endprettify %}
+
+#### Common fixes
+
+If the field doesn't need to be marked `late`, then remove the `late`
+modifier from the field:
+
+{% prettify dart tag=pre+code %}
+class A {
+  final int f = 0;
+
+  const A();
+}
+{% endprettify %}
+
+If the field must be marked `late`, then remove the `const` modifier from
+the constructors:
+
+{% prettify dart tag=pre+code %}
+class A {
+  late final int f;
+
+  A();
+}
+{% endprettify %}
+
+### late_final_local_already_assigned
+
+_The late final local variable is already assigned._
+
+#### Description
+
+The analyzer produces this diagnostic when the analyzer can prove that a
+local variable marked as both `late` and `final` was already assigned a
+value at the point where another assignment occurs.
+
+Because `final` variables can only be assigned once, subsequent assignments
+are guaranteed to fail, so they're flagged.
+
+#### Example
+
+The following code produces this diagnostic because the `final` variable
+`v` is assigned a value in two places:
+
+{% prettify dart tag=pre+code %}
+int f() {
+  late final int v;
+  v = 0;
+  [!v!] += 1;
+  return v;
+}
+{% endprettify %}
+
+#### Common fixes
+
+If you need to be able to reassign the variable, then remove the `final`
+keyword:
+
+{% prettify dart tag=pre+code %}
+int f() {
+  late int v;
+  v = 0;
+  v += 1;
+  return v;
+}
+{% endprettify %}
+
+If you don't need to reassign the variable, then remove all except the
+first of the assignments:
+
+{% prettify dart tag=pre+code %}
+int f() {
+  late final int v;
+  v = 0;
+  return v;
+}
+{% endprettify %}
+
 ### list_element_type_not_assignable
 
 _The element type '{0}' can't be assigned to the list type '{1}'._
@@ -3977,11 +4445,11 @@ non-null default value is provided._
 #### Description
 
 The analyzer produces this diagnostic when an optional parameter, whether
-positional or named, has a [potentially non-nullable][]
- type and doesn't specify a default value. Optional
-parameters that have no explicit default value have an implicit default
-value of `null`. If the type of the parameter doesn't allow the parameter
-to have a value of `null`, then the implicit default value isn't valid.
+positional or named, has a [potentially non-nullable][] type and doesn't
+specify a default value. Optional parameters that have no explicit default
+value have an implicit default value of `null`. If the type of the
+parameter doesn't allow the parameter to have a value of `null`, then the
+implicit default value isn't valid.
 
 #### Example
 
@@ -4754,7 +5222,7 @@ _The values in a const list literal must be constants._
 The analyzer produces this diagnostic when an element in a constant list
 literal isn't a constant value. The list literal can be constant either
 explicitly (because it's prefixed by the `const` keyword) or implicitly
-(because it appears in a [constant context][].
+(because it appears in a [constant context][]).
 
 #### Examples
 
@@ -5450,6 +5918,62 @@ class C {
 var x;
 {% endprettify %}
 
+### no_combined_super_signature
+
+_Can't infer missing types in '{0}' from overridden methods: {1}._
+
+#### Description
+
+The analyzer produces this diagnostic when there is a method declaration
+for which one or more types needs to be inferred, and those types can't be
+inferred because none of the overridden methods has a function type that is
+a supertype of all the other overridden methods, as specified by
+[override inference][].
+
+#### Example
+
+The following code produces this diagnostic because the method `m` declared
+in the class `C` is missing both the return type and the type of the
+parameter `a`, and neither of the missing types can be inferred for it:
+
+{% prettify dart tag=pre+code %}
+abstract class A {
+  A m(String a);
+}
+
+abstract class B {
+  B m(int a);
+}
+
+abstract class C implements A, B {
+  [!m!](a);
+}
+{% endprettify %}
+
+In this example, override inference can't be performed because the
+overridden methods are incompatible in these ways:
+- Neither parameter type (`String` and `int`) is a supertype of the other.
+- Neither return type is a subtype of the other.
+
+#### Common fixes
+
+If possible, add types to the method in the subclass that are consistent
+with the types from all the overridden methods:
+
+{% prettify dart tag=pre+code %}
+abstract class A {
+  A m(String a);
+}
+
+abstract class B {
+  B m(int a);
+}
+
+abstract class C implements A, B {
+  C m(Object a);
+}
+{% endprettify %}
+
 ### nullable_type_in_catch_clause
 
 _A potentially nullable type can't be used in an 'on' clause because it isn't
@@ -5753,6 +6277,47 @@ directive with an import directive:
 
 {% prettify dart tag=pre+code %}
 import 'a.dart';
+{% endprettify %}
+
+### prefix_collides_with_top_level_member
+
+_The name '{0}' is already used as an import prefix and can't be used to name a
+top-level element._
+
+#### Description
+
+The analyzer produces this diagnostic when a name is used as both an import
+prefix and the name of a top-level declaration in the same library.
+
+#### Example
+
+The following code produces this diagnostic because `f` is used as both an
+import prefix and the name of a function:
+
+{% prettify dart tag=pre+code %}
+import 'dart:math' as f;
+
+int [!f!]() => f.min(0, 1);
+{% endprettify %}
+
+#### Common fixes
+
+If you want to use the name for the import prefix, then rename the
+top-level declaration:
+
+{% prettify dart tag=pre+code %}
+import 'dart:math' as f;
+
+int g() => f.min(0, 1);
+{% endprettify %}
+
+If you want to use the name for the top-level declaration, then rename the
+import prefix:
+
+{% prettify dart tag=pre+code %}
+import 'dart:math' as math;
+
+int f() => math.min(0, 1);
 {% endprettify %}
 
 ### prefix_identifier_not_followed_by_dot
@@ -6218,11 +6783,10 @@ version 2.3.2, but this code is required to be able to run on earlier versions._
 #### Description
 
 The analyzer produces this diagnostic when an `as` expression inside a
-[constant context][] is found in code that has an SDK
-constraint whose lower bound is less than 2.3.2. Using an `as` expression
-in a [constant context][] wasn't supported in earlier
-versions, so this code won't be able to run against earlier versions of the
-SDK.
+[constant context][] is found in code that has an SDK constraint whose
+lower bound is less than 2.3.2. Using an `as` expression in a
+[constant context][] wasn't supported in earlier versions, so this code
+won't be able to run against earlier versions of the SDK.
 
 #### Examples
 
@@ -6269,11 +6833,11 @@ supported until version 2.3.2, but this code is required to be able to run on ea
 #### Description
 
 The analyzer produces this diagnostic when any use of the `&`, `|`, or `^`
-operators on the class `bool` inside a
-[constant context][] is found in code that has an SDK
-constraint whose lower bound is less than 2.3.2. Using these operators in a
-[constant context][] wasn't supported in earlier versions,
-so this code won't be able to run against earlier versions of the SDK.
+operators on the class `bool` inside a [constant context][] is found in
+code that has an SDK constraint whose lower bound is less than 2.3.2. Using
+these operators in a [constant context][] wasn't supported in earlier
+versions, so this code won't be able to run against earlier versions of the
+SDK.
 
 #### Examples
 
@@ -6322,11 +6886,10 @@ _Using the operator '==' for non-primitive types wasn't supported until version
 #### Description
 
 The analyzer produces this diagnostic when the operator `==` is used on a
-non-primitive type inside a [constant context][] is found
-in code that has an SDK constraint whose lower bound is less than 2.3.2.
-Using this operator in a [constant context][] wasn't
-supported in earlier versions, so this code won't be able to run against
-earlier versions of the SDK.
+non-primitive type inside a [constant context][] is found in code that has
+an SDK constraint whose lower bound is less than 2.3.2. Using this operator
+in a [constant context][] wasn't supported in earlier versions, so this
+code won't be able to run against earlier versions of the SDK.
 
 #### Examples
 
@@ -6432,11 +6995,10 @@ version 2.3.2, but this code is required to be able to run on earlier versions._
 #### Description
 
 The analyzer produces this diagnostic when an `is` expression inside a
-[constant context][] is found in code that has an SDK
-constraint whose lower bound is less than 2.3.2. Using an `is` expression
-in a [constant context][] wasn't supported in earlier
-versions, so this code won't be able to run against earlier versions of the
-SDK.
+[constant context][] is found in code that has an SDK constraint whose
+lower bound is less than 2.3.2. Using an `is` expression in a
+[constant context][] wasn't supported in earlier versions, so this code
+won't be able to run against earlier versions of the SDK.
 
 #### Examples
 
@@ -6585,11 +7147,10 @@ version 2.5.0, but this code is required to be able to run on earlier versions._
 #### Description
 
 The analyzer produces this diagnostic when an if or spread element inside
-a [constant context][] is found in code that has an
-SDK constraint whose lower bound is less than 2.5.0. Using an if or
-spread element inside a [constant context][] wasn't
-supported in earlier versions, so this code won't be able to run against
-earlier versions of the SDK.
+a [constant context][] is found in code that has an SDK constraint whose
+lower bound is less than 2.5.0. Using an if or spread element inside a
+[constant context][] wasn't supported in earlier versions, so this code
+won't be able to run against earlier versions of the SDK.
 
 #### Examples
 
@@ -6686,6 +7247,69 @@ class C {
 }
 
 int f(C c) => c.b;
+{% endprettify %}
+
+### subtype_of_disallowed_type
+
+_''{0}' can't be used as a superclass constraint._
+
+_Classes and mixins can't implement '{0}'._
+
+_Classes can't extend '{0}'._
+
+_Classes can't mixin '{0}'._
+
+#### Description
+
+The analyzer produces this diagnostic when one of the restricted classes is
+used in either an `extends`, `implements`, `with`, or `on` clause. The
+classes `bool`, `double`, `FutureOr`, `int`, `Null`, `num`, and `String`
+are all restricted in this way, to allow for more efficient
+implementations.
+
+#### Example
+
+The following code produces this diagnostic because `String` is used in an
+`extends` clause:
+
+{% prettify dart tag=pre+code %}
+class A extends [!String!] {}
+{% endprettify %}
+
+The following code produces this diagnostic because `String` is used in an
+`implements` clause:
+
+{% prettify dart tag=pre+code %}
+class B implements [!String!] {}
+{% endprettify %}
+
+The following code produces this diagnostic because `String` is used in a
+`with` clause:
+
+{% prettify dart tag=pre+code %}
+class C with [!String!] {}
+{% endprettify %}
+
+The following code produces this diagnostic because `String` is used in an
+`on` clause:
+
+{% prettify dart tag=pre+code %}
+mixin M on [!String!] {}
+{% endprettify %}
+
+#### Common fixes
+
+If a different type should be specified, then replace the type:
+
+{% prettify dart tag=pre+code %}
+class A extends Object {}
+{% endprettify %}
+
+If there isn't a different type that would be appropriate, then remove the
+type, and possibly the whole clause:
+
+{% prettify dart tag=pre+code %}
+class B {}
 {% endprettify %}
 
 ### super_in_extension
@@ -6898,8 +7522,8 @@ dereferenced._
 #### Description
 
 The analyzer produces this diagnostic when an expression whose type is
-[potentially non-nullable][] is
-dereferenced without first verifying that the value isn't `null`.
+[potentially non-nullable][] is dereferenced without first verifying that
+the value isn't `null`.
 
 #### Example
 
@@ -7644,7 +8268,7 @@ void f(C c) {
 {% endprettify %}
 
 If a subclass adds a parameter with the name in question, then cast the
-target to the subclass:
+receiver to the subclass:
 
 {% prettify dart tag=pre+code %}
 class C {
@@ -7806,20 +8430,26 @@ import 'dart:math' show min;
 var x = min(0, 1);
 {% endprettify %}
 
-### undefined_super_method
+### undefined_super_member
+
+_The getter '{0}' isn't defined in a superclass of '{1}'._
 
 _The method '{0}' isn't defined in a superclass of '{1}'._
 
+_The operator '{0}' isn't defined in a superclass of '{1}'._
+
+_The setter '{0}' isn't defined in a superclass of '{1}'._
+
 #### Description
 
-The analyzer produces this diagnostic when an inherited method is
-referenced using `super`, but there’s no method with that name in the
-superclass chain.
+The analyzer produces this diagnostic when an inherited member (method,
+getter, setter, or operator) is referenced using `super`, but there’s no
+member with that name in the superclass chain.
 
 #### Examples
 
 The following code produces this diagnostic because `Object` doesn't define
-a member named `n`:
+a method named `n`:
 
 {% prettify dart tag=pre+code %}
 class C {
@@ -7829,16 +8459,27 @@ class C {
 }
 {% endprettify %}
 
+The following code produces this diagnostic because `Object` doesn't define
+a getter named `g`:
+
+{% prettify dart tag=pre+code %}
+class C {
+  void m() {
+    super.[!g!];
+  }
+}
+{% endprettify %}
+
 #### Common fixes
 
-If the inherited method you intend to invoke has a different name, then
-make the name of the invoked method  match the inherited method.
+If the inherited member you intend to invoke has a different name, then
+make the name of the invoked member match the inherited member.
 
-If the method you intend to invoke is defined in the same class, then
+If the member you intend to invoke is defined in the same class, then
 remove the `super.`.
 
-If not, then either add the method to one of the superclasses or remove the
-invocation.
+If the member isn’t defined, then either add the member to one of the
+superclasses or remove the invocation.
 
 ### unnecessary_cast
 
@@ -7876,7 +8517,7 @@ void f(num n) {
 
 ### unnecessary_non_null_assertion
 
-_The '!' will have no effect because the target expression can't be null._
+_The '!' will have no effect because the receiver can't be null._
 
 #### Description
 
@@ -8102,13 +8743,20 @@ void f() {
 
 ### unused_element
 
+_A value for optional parameter '{0}' isn't ever given._
+
 _The declaration '{0}' isn't referenced._
 
 #### Description
 
-The analyzer produces this diagnostic when a private class, enum, mixin,
-typedef, top level variable, top level function, or method is declared but
-never referenced.
+The analyzer produces this diagnostic when a private declaration isn't
+referenced in the library that contains the declaration. The following
+kinds of declarations are analyzed:
+- Private top-level declarations, such as classes, enums, mixins, typedefs,
+  top-level variables, and top-level functions
+- Private static and instance methods
+- Optional parameters of private functions for which a value is never
+  passed, even when the parameter doesn't have a private name
 
 #### Examples
 
@@ -8119,11 +8767,30 @@ produces this diagnostic:
 class [!_C!] {}
 {% endprettify %}
 
+Assuming that no code in the library passes a value for `y` in any
+invocation of `_m`, the following code produces this diagnostic:
+
+{% prettify dart tag=pre+code %}
+class C {
+  void _m(int x, [int [!y!]]) {}
+
+  void n() => _m(0);
+}
+{% endprettify %}
+
 #### Common fixes
 
-If the declaration isn't needed, then remove it.
+If the declaration isn't needed, then remove it:
 
-If the declaration was intended to be used, then add the missing code.
+{% prettify dart tag=pre+code %}
+class C {
+  void _m(int x) {}
+
+  void n() => _m(0);
+}
+{% endprettify %}
+
+If the declaration is intended to be used, then add the code to use it.
 
 ### unused_field
 
@@ -8370,7 +9037,7 @@ code so that it doesn't depend on the value.
 
 ### variable_type_mismatch
 
-_A value of type '{0}' can't be assigned to a variable of type '{1}'._
+_A value of type '{0}' can't be assigned to a const variable of type '{1}'._
 
 #### Description
 
@@ -8521,3 +9188,56 @@ class C<E> {}
 
 void f(C<int> x) {}
 {% endprettify %}
+
+### wrong_number_of_type_arguments_method
+
+_The method '{0}' is declared with {1} type parameters, but {2} type arguments
+are given._
+
+#### Description
+
+The analyzer produces this diagnostic when a method or function is invoked
+with a different number of type arguments than the number of type
+parameters specified in its declaration. There must either be no type
+arguments or the number of arguments must match the number of parameters.
+
+#### Example
+
+The following code produces this diagnostic because the invocation of the
+method `m` has two type arguments, but the declaration of `m` only has one
+type parameter:
+
+{% prettify dart tag=pre+code %}
+class C {
+  int m<A>(A a) => 0;
+}
+
+int f(C c) => c.m[!<int, int>!](2);
+{% endprettify %}
+
+#### Common fixes
+
+If the type arguments are necessary, then make them match the number of
+type parameters by either adding or removing type arguments:
+
+{% prettify dart tag=pre+code %}
+class C {
+  int m<A>(A a) => 0;
+}
+
+int f(C c) => c.m<int>(2);
+{% endprettify %}
+
+If the type arguments aren't necessary, then remove them:
+
+{% prettify dart tag=pre+code %}
+class C {
+  int m<A>(A a) => 0;
+}
+
+int f(C c) => c.m(2);
+{% endprettify %}
+
+### undefined_super_method
+
+See [undefined_super_member](#undefined-super-member).

--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -15,11 +15,17 @@ For more information about the analyzer, see
 
 ## Glossary
 
-This page uses the following terms.
+This page uses the following terms:
+
+* [constant context][]
+* [override inference][]
+* [potentially non-nullable][]
+* [definite assignment][] **[PENDING: That linked-to page mentions definite assignment analysis but never defines that or definite assignment. Should we add a definition here? Or point instead to https://en.wikipedia.org/wiki/Definite_assignment_analysis?]**
 
 [constant context]: #constant-context
 [override inference]: #override-inference
 [potentially non-nullable]: #potentially-non-nullable
+[definite assignment]: https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md
 
 ### Constant context
 
@@ -1697,9 +1703,8 @@ _The late local variable '{0}' is definitely unassigned at this point._
 #### Description
 
 The analyzer produces this diagnostic when
-[definite assignment](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md)
-analysis shows that a local variable that's marked as `late` is read before
-being assigned.
+[definite assignment][] analysis shows that
+a local variable that's marked as `late` is read before being assigned.
 
 #### Example
 
@@ -3835,7 +3840,7 @@ operator following `s` short-circuits the evaluation of both `length` and
 `length` can't return a `null` value. Either way, `isEven` can't be invoked
 on a `null` value, so the null-aware operator is neither necessary nor
 allowed. See
-[Understanding null safety](https://dart.dev/null-safety/understanding-null-safety#smarter-null-aware-methods)
+[Understanding null safety](/null-safety/understanding-null-safety#smarter-null-aware-methods)
 for more details.
 
 #### Common fixes
@@ -5533,7 +5538,7 @@ and has all these characteristics:
 - Isn't marked as `late`.
 - The analyzer can't prove that the local variable will be assigned before
   the reference based on the specification of
-  [definite assignment](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md).
+  [definite assignment.][definite assignment]
 
 #### Example
 
@@ -9240,4 +9245,4 @@ int f(C c) => c.m(2);
 
 ### undefined_super_method
 
-See [undefined_super_member](#undefined-super-member).
+See [undefined_super_member](#undefined_super_member).


### PR DESCRIPTION
While updating the diagnostic messages page (using the process in #1949) and doing a couple of minor link fixes, I noticed a couple of things:

1. We should probably list the words that are in the glossary.
2. The definite assignment link barely mentions definite assignment. Maybe we should add an entry for definite assignment?

Staged at https://kw-staging-dartlang-2.firebaseapp.com/tools/diagnostic-messages.