### PR TITLE
null-safety index.md: Correct variable name

### DIFF
--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -305,9 +305,9 @@ an `if` statement or the [`??` operator][`??`].
 Here's an example of using the value `0` if the lookup returns a null value:
 
 ```dart
-var aList = <String, int>{'one': 1};
+var aMap = <String, int>{'one': 1};
 ...
-int value = aList['one'] ?? 0;
+int value = aMap['one'] ?? 0;
 ```
 
 ## Enabling null safety {#enable-null-safety}


### PR DESCRIPTION
The given example is for a Map, not a List. Update the variable name to aMap to reflect this.