### PR TITLE
Change external link alignment to baseline

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -84,7 +84,7 @@ a, button {
  &.external {
   &:after {
     content: $icon-external;
-    vertical-align: top;
+    vertical-align: baseline;
     margin-left: 2px;
     font-family: 'dart' !important;
     font-size: 11px;


### PR DESCRIPTION
To resolve the weird spacing with the external link icon, change the alignment to baseline. Resolves https://github.com/dart-lang/site-www/issues/2211.

**Old**
<img src="https://user-images.githubusercontent.com/2164483/89439588-46242580-d6ff-11ea-8170-77463c15a24d.png">

**New**
<img width="148" alt="Screen Shot 2020-10-02 at 5 32 36 PM" src="https://user-images.githubusercontent.com/9971478/94981638-f8564e80-04f0-11eb-8ff7-ff3839c16a99.png">
