### PR TITLE
Add a note with further resources on the choice of underscore rather than access modifier keywords in Dart.

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -135,6 +135,10 @@ mind:
     from executing at all; a run-time error results in an
     [exception](#exceptions) being raised while the code executes.
 
+{{site.alert.note}}
+  If you're curious why Dart uses underscores instead of access modifier keywords like `public` or `private`, see [SDK issue 33383](https://github.com/dart-lang/sdk/issues/33383).
+{{site.alert.end}}
+
 
 ## Keywords
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -136,7 +136,9 @@ mind:
     [exception](#exceptions) being raised while the code executes.
 
 {{site.alert.note}}
-  If you're curious why Dart uses underscores instead of access modifier keywords like `public` or `private`, see [SDK issue 33383](https://github.com/dart-lang/sdk/issues/33383).
+  If you're curious why Dart uses underscores instead of
+  access modifier keywords like `public` or `private`, see
+  [SDK issue 33383](https://github.com/dart-lang/sdk/issues/33383).
 {{site.alert.end}}
 
 


### PR DESCRIPTION
Closes #2671.