### PR TITLE
/docs -> /guides in topnav

### DIFF
--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -10,7 +10,7 @@
       If you edit this list, also edit navigation-side.html (mobile).
     {% endcomment %}
     <li class="mainnav__get-started">
-      <a href="/docs" class="nav-link
+      <a href="/guides" class="nav-link
         {%- if page_url_path contains '/*/guides/' or page_url_path contains '/*/dart-2/' or page_url_path contains '/*/codelabs/' or page_url_path contains '/*/samples/' or page_url_path contains '/*/tools/' or page_url_path contains '/*/tutorials/' or page_url_path contains '/*/server/' or page_url_path contains '/*/web/' %} active {%- endif -%}"><span>Docs</span></a>
     </li>
     <li>


### PR DESCRIPTION
Not sure why we had /docs, but it results in a bunch of redirects, which seems unnecessary and bloats the CI output.

Let's see what happens when we change /docs to /guides.