### PR TITLE
Add missing type annotations

### DIFF
--- a/examples/misc/test/language_tour/basic_test.dart
+++ b/examples/misc/test/language_tour/basic_test.dart
@@ -6,12 +6,12 @@ void main() {
   test('basic', () {
     // #docregion
     // Define a function.
-    printInteger(int aNumber) {
+    void printInteger(int aNumber) {
       print('The number is $aNumber.'); // Print to console.
     }
 
     // This is where the app starts executing.
-    main() {
+    void main() {
       var number = 42; // Declare and initialize a variable.
       printInteger(number); // Call a function.
     }

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -34,12 +34,12 @@ The following code uses many of Dart’s most basic features:
 <?code-excerpt "misc/test/language_tour/basic_test.dart"?>
 ```dart
 // Define a function.
-printInteger(int aNumber) {
+void printInteger(int aNumber) {
   print('The number is $aNumber.'); // Print to console.
 }
 
 // This is where the app starts executing.
-main() {
+void main() {
   var number = 42; // Declare and initialize a variable.
   printInteger(number); // Call a function.
 }


### PR DESCRIPTION
Hello,

I suppose that this example sets the types better than omit the types.
Because Dart recommends type annotations.

I just started studying Dart. So, this PR maybe not a good...

thanks,