### PR TITLE
Language versioning docs

### DIFF
--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -12,7 +12,6 @@ If you want details about the currently supported language, see the
 To use a language feature that was introduced after 2.0,
 specify [SDK constraints][] that are no lower than
 the release when the feature was first supported.
-(Details are in the [language versioning section][] of this page.)
 For example, to use extension methods, which were [supported starting in 2.7][],
 the `pubspec.yaml` file can have 2.7.0 as the lower constraint:
 
@@ -172,83 +171,113 @@ analogous to the Flutter SDK's `flutter` tool.
 
 ## Language versioning
 
-Before language versioning,
-Dart tools assumed that all Dart code could use all features
-that were supported by the tool's SDK version.
-This assumption causes problems when a package
-that uses a _newer_ language feature
-has [SDK constraints][] that are too low.
-For example, consider a package that uses set literals (2.2)
-but has the SDK constraints `">=2.0.0 <3.0.0"`.
-People using Dart 2.0.0 or 2.1.0 can download the package,
-but their tools can't understand the set literals.
+A single Dart SDK can simultaneously support
+multiple versions of the Dart language.
+The compiler determines what version the code is targeting,
+and it interprets the code according to that version.
 
-With language versioning,
-a single Dart SDK simultaneously supports
-multiple different versions of the Dart language.
-When you compile some Dart code,
-Dart figures out what version the code is targeting,
-and you're warned if the code uses a feature
-that was introduced after the version in the lower SDK constraint.
-
-On rare occasions, Dart introduces a
-backwards-incompatible feature like [null safety][].
-Previously valid code might not work with null safety,
-so to get the benefits of null safety you'll need to migrate your code.
-And because migrating to null safety can't be completely automated,
-you'll need to be able to migrate one library
-(usually one Dart file) at a time.
+Language versioning is important on the rare occasions
+when Dart introduces an incompatible feature like [null safety][].
+Code that used to compile cleanly before null safety
+(but perhaps crash at runtime)
+might no longer compile once null safety is enabled.
+Because migrating your apps and packages
+— and all the packages they depend on —
+to null safety might take a while,
+Dart uses language versioning to support
+using non-null-safe code alongside null-safe code.
 
 {% comment %}
   Once /null-safety/migrating-to-null-safety exists,
   the previous paragraph should link to it.
 {% endcomment %}
 
-To enable file-by-file migration,
-Dart 2.10 introduced **per-library language version selection**.
-**[PENDING: was it really a 2.10 feature?]**
-Here's how it works:
+Each package has a default language version,
+equal to the `<major>.<minor>` part of the
+**lower SDK constraint** in the pubspec.
+For example, the following entry in a `pubspec.yaml` file
+indicates that this package uses the Dart 2.7 language version.
 
-* Each package has a default language version,
-  which is specified as the **lower SDK constraint** in the pubspec.
+```yaml
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+```
 
-* Each Dart library can opt to have a different language version,
-  specified using a comment of the following form:
 
-  ```dart
-  // @dart = <major>.<minor>
-  ```
- 
-  For example:
+### Language version numbers
 
-  ```dart
-  // Description of what's in this file.
-  // @dart = 2.7
-  import 'dart:math';
-  ...
-  ```
+Dart language versions are identified by a major and minor number
+that match the first two components of the Dart SDK.
+For example, the latest language version supported by
+the 2.7.3 Dart SDK is Dart 2.7.
+Each Dart SDK supports all of the language versions covered
+by its major version number.
+That means that the 2.7.3 Dart SDK supports language
+versions 2.7, 2.6, 2.5, and so on, down to 2.0.
 
-  The `@dart` string must be in a `//` comment
-  (not `///` or `/*`),
-  and it must appear before any Dart code in the file.
-  Whitespace (tabs and spaces) doesn't matter,
-  except within the `@dart` and version strings.
-  As the example above shows,
-  other comments can appear before the `@dart` comment.
+Deriving the language version from the SDK version
+implies the following:
 
-  The library language version is usually lower than
-  the package default language version,
-  but it doesn't have to be:
-  the `@dart` string can use any version up to the
-  version of the Dart SDK that you're using.
- 
-For more information, see the
+* Whenever a minor version of the SDK ships,
+  a new language version appears.
+  In practice, many of these language versions are very similar to
+  and entirely compatible with previous versions.
+  For example, the Dart 2.9 language is essentially identical to
+  the Dart 2.8 language.
+
+* When a patch version of the SDK ships,
+  it cannot introduce any language features.
+  For example, because 2.7.2 is language version 2.7,
+  it must be completely compatible with 2.7.1 and 2.7.0.
+
+
+### Per-library language version selection
+
+By default, every Dart file
+in a package uses the same language version —
+the language version indicated by
+the lower SDK constraint in the pubspec.
+Sometimes, however, a Dart file
+might need to use an older language version.
+For example,
+you might not be able to migrate all the files in a package
+to null safety at the same time.
+
+The Dart 2.8 compiler introduced support for
+per-library language version selection.
+A [Dart library][] can opt to have a different language version
+by using a comment of the following form:
+
+```dart
+// @dart = <major>.<minor>
+```
+
+For example:
+
+```dart
+// Description of what's in this file.
+// @dart = 2.7
+import 'dart:math';
+...
+```
+
+The `@dart` string must be in a `//` comment
+(not `///` or `/*`),
+and it must appear before any Dart code in the file.
+Whitespace (tabs and spaces) doesn't matter,
+except within the `@dart` and version strings.
+As the example above shows,
+other comments can appear before the `@dart` comment.
+
+
+For more information about how language versioning works, see the
 [language versioning specification][language versioning feature].
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
 [calling native C code]: /guides/libraries/c-interop
 [collection for]: /guides/language/language-tour#collection-operators
 [collection if]: /guides/language/language-tour#collection-operators
+[Dart library]: /guides/libraries/create-library-packages#organizing-a-library-package
 [`dart2native`]: /tools/dart2native
 [dart-tool]: /tools/dart-tool
 [extension methods]: /guides/language/extension-methods

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -9,17 +9,38 @@ If you want details about the currently supported language, see the
 [language tour][] or the
 [language specification][].
 
-For a peek into current features being discussed, investigated, and added to the
-Dart language, see the [language funnel][] tracker in the Dart
-language GitHub repo.
+To use a language feature that was introduced after 2.0,
+specify [SDK constraints][] that are no lower than
+the release when the feature was first supported.
+(Details are in the [language versioning section][] of this page.)
+For example, to use extension methods, which were [supported starting in 2.7][],
+the `pubspec.yaml` file can have 2.7.0 as the lower constraint:
 
-## Dart 2.0
+```yaml
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+```
+
+[supported starting in 2.7]: #dart-27
+[SDK constraints]: /tools/pub/pubspec#sdk-constraints
+[language versioning section]: #language-versioning
+
+{{ site.alert.tip }}
+  For a peek into current features being
+  discussed, investigated, and added to the Dart language,
+  see the [language funnel][] tracker in the Dart language GitHub repo.
+{{ site.alert.end }}
+
+
+## Changes in each release
+
+### Dart 2.0
 
 Dart 2.0 implemented a new **[sound type system][]**. Before
 Dart 2.0, types weren't fully sound, and Dart relied heavily on runtime type
 checking. Dart 1.x code had to be [migrated to Dart 2][].
 
-## Dart 2.1
+### Dart 2.1
 
 Dart 2.1 added support for **int-to-double conversion**, allowing developers to
 set `double` values using integer literals. This feature removed the annoyance
@@ -34,7 +55,7 @@ padding: const EdgeInsets.symmetric(
 )
 ```
 
-## Dart 2.2
+### Dart 2.2
 
 Dart has always supported literal lists and maps, but
 Dart 2.2 added support for **[set literals][]**:
@@ -42,7 +63,7 @@ Dart 2.2 added support for **[set literals][]**:
 ```dart
 const Set<String> currencies = {'EUR', 'USD', 'JPY'};
 ```
-## Dart 2.3
+### Dart 2.3
 
 Dart 2.3 added three operators designed to improve code that performs
 list manipulation, such as declarative UI code.
@@ -92,24 +113,27 @@ Widget build(BuildContext context) {
 }
 ```
 
-## Dart 2.5
+### Dart 2.5
 
 Dart 2.5 didn't add any features to the Dart language, but it did add
 support for [calling native C code][] from Dart code
 using a new **core library, `dart:ffi`.**
 
-## Dart 2.6
+### Dart 2.6
 
 Dart 2.6 didn't add any features to the Dart language, but it did add a
 **new tool, [`dart2native`][],** for compiling Dart code to
 native executables.
 
-## Dart 2.7
+### Dart 2.7
 
 Dart 2.7 added support for **[extension methods][]**,
 enabling you to add functionality to any type —
 even types you don’t control — with the brevity and auto-complete experience
 of regular method calls.
+Because the tech preview for this feature was in 2.6,
+you can use extension methods without warnings if you
+specify 2.6.0 or a later release as the lower SDK constraint.
 
 The following example extends the `String` class from `dart:core` with a new
 `parseInt()` method:
@@ -127,25 +151,94 @@ void main() {
 }
 ```
 
-## Dart 2.8
+### Dart 2.8
 
 Dart 2.8 didn't add any features to the Dart language, but it did
 contain a number of preparatory [breaking changes][2.8 breaking changes] to ensure great
 nullability-related usability and performance in the upcoming
-null safety feature.
+[null safety][] feature.
 
 It also contained a faster pub tool, and a new [pub outdated][] command.
 
-## Dart 2.9
+### Dart 2.9
 
 Dart 2.9 didn't add any features to the Dart language.
 
-## Dart 2.10
+### Dart 2.10
 
 Dart 2.10 didn't add any features to the Dart language,
 but it added an expanded [`dart` tool][dart-tool] that's 
 analogous to the Flutter SDK's `flutter` tool.
 
+## Language versioning
+
+Before language versioning,
+Dart tools assumed that all Dart code could use all features
+that were supported by the tool's SDK version.
+This assumption causes problems when a package
+that uses a _newer_ language feature
+has [SDK constraints][] that are too low.
+For example, consider a package that uses set literals (2.2)
+but has the SDK constraints `">=2.0.0 <3.0.0"`.
+People using Dart 2.0.0 or 2.1.0 can download the package,
+but their tools can't understand the set literals.
+
+With language versioning,
+a single Dart SDK simultaneously supports
+multiple different versions of the Dart language.
+When you compile some Dart code,
+Dart figures out what version the code is targeting,
+and you're warned if the code uses a feature
+that was introduced after the version in the lower SDK constraint.
+
+On rare occasions, Dart introduces a
+backwards-incompatible feature like [null safety][].
+Previously valid code might not work with null safety,
+so you need to [migrate your code][ns migration] when you're ready.
+And because migrating to null safety can't be completely automated,
+you need to be able to migrate one library
+(usually one Dart file) at a time.
+
+To enable file-by-file migration,
+Dart 2.10 introduced **per-library language version selection**.
+**[PENDING: was it really a 2.10 feature?]**
+Here's how it works:
+
+* Each package has a default language version,
+  which is specified as the **lower SDK constraint** in the pubspec.
+
+* Each Dart library can opt to have a different language version,
+  specified using a comment of the following form:
+
+  ```dart
+  // @dart = <major>.<minor>
+  ```
+ 
+  For example:
+
+  ```dart
+  // Description of what's in this file.
+  // @dart = 2.7
+  import 'dart:math';
+  ...
+  ```
+
+  The `@dart` string must be in a `//` comment
+  (not `///` or `/*`),
+  and it must appear before any Dart code in the file.
+  Whitespace (tabs and spaces) doesn't matter,
+  except within the `@dart` and version strings.
+  As the example above shows,
+  other comments can appear before the `@dart` comment.
+
+  The library language version is usually lower than
+  the package default language version,
+  but it doesn't have to be:
+  the `@dart` string can use any version up to the
+  version of the Dart SDK that you're using.
+ 
+For more information, see the
+[language versioning specification][language versioning feature].
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
 [calling native C code]: /guides/libraries/c-interop
@@ -157,7 +250,10 @@ analogous to the Flutter SDK's `flutter` tool.
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language specification]: /guides/language/spec
 [language tour]: /guides/language/language-tour
+[language versioning feature]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/feature-specification.md#dart-language-versioning
 [migrated to Dart 2]: /dart-2
+[ns migration]: /null-safety/migrating-to-null-safety
+[null safety]: /null-safety
 [set literals]: /guides/language/language-tour#sets
 [sound type system]: /guides/language/type-system
 [spread operator]: /guides/language/language-tour#spread-operator

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -194,10 +194,15 @@ that was introduced after the version in the lower SDK constraint.
 On rare occasions, Dart introduces a
 backwards-incompatible feature like [null safety][].
 Previously valid code might not work with null safety,
-so you need to [migrate your code][ns migration] when you're ready.
+so to get the benefits of null safety you'll need to migrate your code.
 And because migrating to null safety can't be completely automated,
-you need to be able to migrate one library
+you'll need to be able to migrate one library
 (usually one Dart file) at a time.
+
+{% comment %}
+  Once /null-safety/migrating-to-null-safety exists,
+  the previous paragraph should link to it.
+{% endcomment %}
 
 To enable file-by-file migration,
 Dart 2.10 introduced **per-library language version selection**.
@@ -252,7 +257,6 @@ For more information, see the
 [language tour]: /guides/language/language-tour
 [language versioning feature]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/feature-specification.md#dart-language-versioning
 [migrated to Dart 2]: /dart-2
-[ns migration]: /null-safety/migrating-to-null-safety
 [null safety]: /null-safety
 [set literals]: /guides/language/language-tour#sets
 [sound type system]: /guides/language/type-system

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -8,6 +8,13 @@ You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
 
+{{ site.alert.version-note }}
+  To use extension methods in a package,
+  the pubspec must have a [minimum SDK constraint][] of at least 2.7.0.
+{{ site.alert.end }}
+
+[minimum SDK constraint]: /tools/pub/pubspec#sdk-constraints
+
 <iframe width="560" height="315"
   src="https://www.youtube.com/embed/D3j0OSfT9ZI"
   frameborder="0"

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -99,12 +99,12 @@ description: >-
 homepage: https://example-pet-store.com/newtify
 documentation: https://example-pet-store.com/newtify/docs
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 dependencies:
   efts: ^2.0.4
   transmogrify: ^0.4.0
 dev_dependencies:
-  test: '>=0.6.0 <0.12.0'
+  test: '>=1.15.0 <2.0.0'
 {% endprettify %}
 
 
@@ -285,12 +285,21 @@ and uses the same
 [version constraint](/tools/pub/dependencies#version-constraints) syntax as
 dependencies.
 
+{{ site.alert.version-note }}
+  For a package to use a feature introduced after 2.0,
+  its pubspec must have a lower constraint that's at least
+  the version when the feature was introduced.
+  For details, see the [language evolution page][].
+{{ site.alert.end }}
+
+[language evolution page]: /guides/language/evolution
+
 For example, the following constraint says that this package
-works with any **Dart 2** SDK that's version 2.0.0 or higher:
+works with any Dart SDK that's version 2.10.0 or higher:
 
 {% prettify yaml tag=pre+code %}
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 {% endprettify %}
 
 Pub tries to find the latest version of a package whose SDK constraint works


### PR DESCRIPTION
One PENDING question:
When was per-library language version selection introduced? 2.10? (If so, I should probably add it to the 2.10 item, no?)

I started making related changes (lower SDK constraints) in other files, but I'll probably finish those in another PR.

Staged:
https://kw-dartlang-3.firebaseapp.com/guides/language/evolution#language-versioning

Contributes to #2694
Related PR: #2628

/cc @kevmoo @mit-mit 