### PR TITLE
Fix wrong version number in 'brew switch' command

### DIFF
--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -22,7 +22,7 @@ To switch between locally installed Dart releases, use
 `brew switch dart <version>`. Example:
 
 ```terminal
-$ brew switch dart 2.1.0
+$ brew switch dart 2.10.1
 ```
 
 To see which versions of Dart you've installed:


### PR DESCRIPTION
Fixes #2672

I fixed the version number for the moment.
However, we will need to fix whenever dart version up in this correcting method.

Would it be better if we don't write directly version number as below?

```diff
- $ brew switch dart 2.10.1
+ $ brew switch dart <version>
```

Could you let me know if you have any other better ideas?