### PR TITLE
Simplify default parameters example

### DIFF
--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -27,7 +27,8 @@ void main() {
 
   test('optional-positional-param-default', () {
     // #docregion optional-positional-param-default
-    String say(String from, String msg, [String device = 'carrier pigeon']) {
+    String say(String from, String msg, 
+        [String device = 'carrier pigeon']) {
       var result = '$from says $msg with a $device';
       return result;
     }

--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -27,7 +27,7 @@ void main() {
 
   test('optional-positional-param-default', () {
     // #docregion optional-positional-param-default
-    String say(String from, String msg, 
+    String say(String from, String msg,
         [String device = 'carrier pigeon']) {
       var result = '$from says $msg with a $device';
       return result;

--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -27,15 +27,8 @@ void main() {
 
   test('optional-positional-param-default', () {
     // #docregion optional-positional-param-default
-    String say(String from, String msg,
-        [String device = 'carrier pigeon', String mood]) {
-      var result = '$from says $msg';
-      if (device != null) {
-        result = '$result with a $device';
-      }
-      if (mood != null) {
-        result = '$result (in a $mood mood)';
-      }
+    String say(String from, String msg, [String device = 'carrier pigeon']) {
+      var result = '$from says $msg with a $device';
       return result;
     }
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1258,15 +1258,8 @@ The next example shows how to set default values for positional parameters:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-param-default)"?>
 ```dart
-String say(String from, String msg,
-    [String device = 'carrier pigeon', String mood]) {
-  var result = '$from says $msg';
-  if (device != null) {
-    result = '$result with a $device';
-  }
-  if (mood != null) {
-    result = '$result (in a $mood mood)';
-  }
+String say(String from, String msg, [String device = 'carrier pigeon']) {
+  var result = '$from says $msg with a $device';
   return result;
 }
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1258,7 +1258,7 @@ The next example shows how to set default values for positional parameters:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-param-default)"?>
 ```dart
-String say(String from, String msg, 
+String say(String from, String msg,
     [String device = 'carrier pigeon']) {
   var result = '$from says $msg with a $device';
   return result;

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1258,7 +1258,8 @@ The next example shows how to set default values for positional parameters:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-param-default)"?>
 ```dart
-String say(String from, String msg, [String device = 'carrier pigeon']) {
+String say(String from, String msg, 
+    [String device = 'carrier pigeon']) {
   var result = '$from says $msg with a $device';
   return result;
 }


### PR DESCRIPTION
Fixes #1242 

Simplifies the default parameters example so it is much more clear by removing unecessary `if` statements and the `mood` variable. 