### PR TITLE
style: prevent table overflow in mobile

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -149,6 +149,7 @@ The following table lists the words that the Dart language treats specially.
 {% assign ckw = '&nbsp;<sup title="contextual keyword" alt="contextual keyword">1</sup>' %}
 {% assign bii = '&nbsp;<sup title="built-in-identifier" alt="built-in-identifier">2</sup>' %}
 {% assign lrw = '&nbsp;<sup title="limited reserved word" alt="limited reserved word">3</sup>' %}
+<div class="table-wrapper" markdown="1">
 | [abstract][]{{bii}}   | [else][]              | [import][]{{bii}}     | [super][]         |
 | [as][]{{bii}}         | [enum][]              | [in][]                | [switch][]        |
 | [assert][]            | [export][]{{bii}}     | [interface][]{{bii}}  | [sync][]{{ckw}}   |
@@ -166,6 +167,7 @@ The following table lists the words that the Dart language treats specially.
 | [do][]                | [if][]                | [show][]{{ckw}}       |                   |
 | [dynamic][]{{bii}}    | [implements][]{{bii}} | [static][]{{bii}}     |                   |
 {:.table .table-striped .nowrap}
+</div>
 
 [abstract]: #abstract-classes
 [as]: #type-test-operators


### PR DESCRIPTION
When viewing https://dart.dev/guides/language/language-tour in the mobile viewport, because the `keywords` table has a slightly longer width, there will be an offset across the page.

![image](https://user-images.githubusercontent.com/15034155/96327829-c9eb7e00-106f-11eb-91e5-7db2cf615567.png)
