### PR TITLE
Added `void` to the basic Dart program section of language tour.

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -71,6 +71,9 @@ apps:
     equivalent inside of a string literal. For more information, see
     [Strings](#strings).
 
+`void`
+:   A type(here, used as a return type of function). It can take anything as it's value, but it's value cannot be used anywhere. For more information, see [this article](https://medium.com/dartlang/future-void-vs-future-null-whats-the-difference-84a42d616e7d).
+
 `main()`
 :   The special, *required*, top-level function where app execution
     starts. For more information, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -53,8 +53,17 @@ apps:
     Dart also supports multi-line and document comments.
     For details, see [Comments](#comments).
 
+`void`
+:   A special type that indicates a value that's never used.
+    Functions like `printInteger()` and `main()` that don't explicitly return a value
+    have the `void` return type.
+    For more information, see [this article][void article].
+    
+[void article]: https://medium.com/dartlang/dart-2-legacy-of-the-void-e7afb5f44df0
+
 `int`
-:   A type. Some of the other [built-in types](#built-in-types)
+:   Another type, indicating an integer.
+    Some additional [built-in types](#built-in-types)
     are `String`, `List`, and `bool`.
 
 `42`
@@ -70,9 +79,6 @@ apps:
 :   String interpolation: including a variable or expression’s string
     equivalent inside of a string literal. For more information, see
     [Strings](#strings).
-
-`void`
-:   A type(here, used as a return type of function). It can take anything as it's value, but it's value cannot be used anywhere. For more information, see [this article](https://medium.com/dartlang/future-void-vs-future-null-whats-the-difference-84a42d616e7d).
 
 `main()`
 :   The special, *required*, top-level function where app execution


### PR DESCRIPTION
Fixes #2699.
Added brief description about `void`.
Is this enough? Or I should add more detailed info?
Please review @kwalrath .