### PR TITLE
Removed outdated line about dart:convert

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1481,7 +1481,6 @@ structured objects and collections. [UTF-8][] is a common variable-width
 encoding that can represent every character in the Unicode character
 set.
 
-The dart:convert library works in both web apps and command-line apps.
 To use it, import dart:convert.
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (import)"?>

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1481,7 +1481,7 @@ structured objects and collections. [UTF-8][] is a common variable-width
 encoding that can represent every character in the Unicode character
 set.
 
-To use it, import dart:convert.
+To use this library, import dart:convert.
 
 <?code-excerpt "misc/test/library_tour/convert_test.dart (import)"?>
 ```dart


### PR DESCRIPTION
Fixes #1272
Removes a line that is outdated. Since Dart now works on many different platforms, the line is no longer fully accurate, and the section would be less confusing without it. 