### PR TITLE
Change reference from "encode" to "jsonEncode"

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1537,7 +1537,7 @@ string keys) are directly encodable into JSON. List and Map objects are
 encoded recursively.
 
 You have two options for encoding objects that aren't directly
-encodable. The first is to invoke `encode()` with a second argument: a
+encodable. The first is to invoke `jsonEncode()` with a second argument: a
 function that returns an object that is directly encodable. Your second
 option is to omit the second argument, in which case the encoder calls
 the object's `toJson()` method.


### PR DESCRIPTION
Fixes #1273
Fixes a point where the code references `encode()` despite using `jsonEncode()` throughout the section. 
I don't think it's necessary to explain how `jsonEncode()` is short for `json.encode()`, unless someone thinks that is useful information for this section. 