### PR TITLE
Forward /go/null-safety-migration to draft doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -128,7 +128,7 @@
       { "source": "/flutter", "destination": "https://flutter.io", "type": 301 },
 
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
-      { "source": "/go/null-safety-migration", "destination": "https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration", "type": 301 },
+      { "source": "/go/null-safety-migration", "destination": "https://kw-www-dartlang-1.firebaseapp.com/null-safety/migration-guide", "type": 302 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },


### PR DESCRIPTION
I think we're ready to get input from more people on this doc (https://kw-www-dartlang-1.firebaseapp.com/null-safety/migration-guide). If you'd still like people to have access to https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration, I can add a link to the draft doc.