### PR TITLE
Use the latest null safety terminology

### DIFF
--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -175,17 +175,17 @@ An explicit runtime null check, for example `if (arg == null) throw
 ArgumentError(...)`, will be flagged as an unnecessary comparison if you make
 `arg` non-nullable.
 
-But, the check *is* still needed when running in mixed mode. Until everything is
-fully migrated and the code switches to running in sound mode, it will be
+But, the check *is* still needed when running with mixed versions. Until everything is
+fully migrated and the code switches to running with sound null safety, it will be
 possible for `arg` to be null.
 
 The simplest way to preserve behavior is change the check into
 [`ArgumentError.checkNotNull`](https://api.dart.dev/stable/dart-core/ArgumentError/checkNotNull.html).
 
-The same applies to some runtime type checks. In legacy or mixed mode, if arg
+The same applies to some runtime type checks. With mixed versions, if `arg`
 has static type `String`, then `if (arg is! String)` is actually checking
 whether `arg` is `null`. It might look like migrating to null safety means `arg`
-can never be `null`, but it could be `null` in mixed mode. So, to preserve
+can never be `null`, but it could be `null` in unsound null safety. So, to preserve
 behavior, the null check should remain.
 
 ## I'm using `package:ffi` and get a failure with `Dart_CObject_kUnsupported` when I migrate. What happened?

--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -175,14 +175,14 @@ An explicit runtime null check, for example `if (arg == null) throw
 ArgumentError(...)`, will be flagged as an unnecessary comparison if you make
 `arg` non-nullable.
 
-But, the check *is* still needed when running with mixed versions. Until everything is
-fully migrated and the code switches to running with sound null safety, it will be
-possible for `arg` to be null.
+But, the check *is* still needed if the program is a mixed-version one.  Until
+everything is fully migrated and the code switches to running with sound null
+safety, it will be possible for `arg` to be null.
 
 The simplest way to preserve behavior is change the check into
 [`ArgumentError.checkNotNull`](https://api.dart.dev/stable/dart-core/ArgumentError/checkNotNull.html).
 
-The same applies to some runtime type checks. With mixed versions, if `arg`
+The same applies to some runtime type checks. If `arg`
 has static type `String`, then `if (arg is! String)` is actually checking
 whether `arg` is `null`. It might look like migrating to null safety means `arg`
 can never be `null`, but it could be `null` in unsound null safety. So, to preserve

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -96,8 +96,8 @@ pros and cons. These principles guided the choices we made:
 
     One caveat: We only guarantee soundness in Dart programs that are fully null
     safe. Dart supports programs that contain a mixture of newer null safe code
-    and older legacy code. In these "mixed-mode" programs, null reference errors
-    may still occur. In a mixed-mode program, you get all of the *static* safety
+    and older legacy code. In these mixed-version programs, null reference errors
+    may still occur. In a mixed-version program, you get all of the *static* safety
     benefits in the portions that are null safe, but you don't get full runtime
     soundness until the entire application is null safe.
 


### PR DESCRIPTION
Contributes to #2748

Staged:
https://kw-staging-dartlang-2.firebaseapp.com/null-safety/understanding-null-safety
https://kw-staging-dartlang-2.firebaseapp.com/null-safety/faq

It wasn't as straightforward as I thought it'd be. In particular, the FAQ still contains some references to _mode_ that I'm not sure how to handle. What do you think, @munificent?