### PR TITLE
Remove runtimeType comparison in lab

### DIFF
--- a/src/codelabs/iterables.md
+++ b/src/codelabs/iterables.md
@@ -1024,7 +1024,6 @@ class EmailAddress {
   bool operator ==(Object other) =>
       identical(this, other) ||
           other is EmailAddress &&
-              runtimeType == other.runtimeType &&
               address == other.address;
 
   @override


### PR DESCRIPTION
Fixes #2241 
Removes this comparison which isn't necessary based on @lrhn 's comments.