### PR TITLE
[DONT MERGE] Create unsound-null-safety.md

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -130,7 +130,7 @@
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "https://kw-www-dartlang-1.firebaseapp.com/null-safety/migration-guide", "type": 302 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
-      { "source": "/go/unsound-null-safety", "destination": "https://github.com/flutter/flutter/wiki/Experimenting-with-null-safety-in-Flutter#unsound-null-safety", "type": 301 },
+      { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -1,0 +1,186 @@
+---
+title: Unsound null safety
+description: Mixing language versions lets you migrate to null safety at your own pace, with some of the benefits of null safety.
+---
+
+An app can use some libraries that
+are [null safe][] and some that aren't.
+These apps — called **mixed-version programs** —
+execute with **unsound null safety**.
+
+[null safe]: /null-safety
+
+Mixing language versions lets you migrate to null safety at your own pace.
+It also frees package maintainers to migrate their code,
+with the knowledge that even legacy users can get new
+bug fixes and other improvements.
+However, mixed-version programs don't get all the advantages
+that null safety can bring.
+
+This page describes the differences between sound and unsound null safety,
+to help you decide whether to migrate before
+all your dependencies support null safety.
+After the conceptual discussion are instructions for migrating incrementally,
+followed by details on analyzing, testing, and running mixed-version programs.
+
+{{ site.alert.note }}
+  We recommend that, if possible, you wait for dependencies to migrate
+  before you migrate your app.
+  For details, see the [migration guide][].
+{{ site.alert.end }}
+
+[migration guide]: /null-safety/migration-guide
+
+
+## Sound and unsound null safety
+
+Dart provides sound null safety through a combination of
+static and runtime checks.
+Each Dart library that opts in to null safety gets
+all the _static_ checks, with stricter compile-time errors.
+This is true even in a mixed-version program that contains
+null-unsafe libraries.
+You start getting these benefits
+as soon as you start migrating some of your code to null safety.
+
+However, a mixed-version program can't have the
+_runtime_ soundness guarantees that a fully null-safe app has.
+It's possible for `null` to leak out of the null-unsafe libraries
+into the null-safe code, because
+preventing that would break the existing behavior of the unmigrated code.
+
+To maintain runtime compatibility with legacy libraries
+while offering soundness to completely null-safe programs,
+Dart tools support two modes:
+
+* When you run a mixed-version program,
+  it runs with **unsound null safety**.
+  It's possible for `null` reference errors to occur at runtime,
+  but only because a `null` or nullable type escaped from
+  some null-unsafe library and got into your null-safe code.
+
+* When your program is fully migrated and _all_ libraries are null safe,
+  then your program automatically runs with **sound null safety**.
+  That mode gives you the full null safety experience with
+  all of the guarantees and compiler optimizations that soundness enables.
+
+Sound null safety is what you want if possible.
+Dart tools automatically run your program in sound mode if
+the main entrypoint library of your program has opted into null safety.
+If you import a null-unsafe library,
+the tools print a warning to let you know that
+they can only [run with unsound null safety](#analyzing-and-testing).
+
+{{ site.alert.info }}
+  Except for a few edge cases,
+  a mixed-version program should do exactly what you expect.
+  One example of an edge case is an `is` test
+  on an instance of a generic type from a closure
+  that crosses the boundary between null-safe and null-unsafe libraries.
+{{ site.alert.end }}
+
+
+## Migrating incrementally
+
+The [migration tool][] is aimed at migrating a whole package at once.
+If you want to migrate your package piecemeal,
+the migration tool can still help,
+but you'll need to do more by hand.
+
+[migration tool]: /null-safety/migration-guide#step2-migrate
+
+Because Dart supports mixed-version programs,
+you can migrate one library (generally one Dart file) at a time,
+while still being able to run your app and its tests.
+
+We recommend that you **first migrate leaf libraries** —
+libraries that don't import other files from the package.
+Then migrate libraries that directly depend on the leaf libraries.
+End by migrating the libraries that have the most
+intra-package dependencies.
+
+For example, say you have a `lib/src/util.dart` file
+that imports other (null-safe) packages and core libraries,
+but that doesn't have any `import '<local_path>'` directives.
+Consider migrating `util.dart` first,
+and then migrating simple files that depend only on `util.dart`.
+If any libraries have cyclic imports
+(for example, A imports B which imports C, and C imports A),
+consider migrating those libraries together.
+
+To migrate a package by hand, follow these steps:
+
+1. Modify the SDK constraints in the package's `pubspec.yaml` file,
+   setting the language version to 2.12 beta or later:
+   ```yaml
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+```
+
+2. Update dependencies: <br>
+   ```terminal
+$ dart pub get
+```
+
+   Running `dart pub get` with a lower constraint of 2.12.0
+   sets the default language version of
+   every library in your package to 2.12,
+   opting them all in to null safety.
+
+
+3. Open the package in your IDE. <br>
+   You're likely to see a lot of analysis errors.
+   That's OK.
+
+4. _Optional:_ Add a [language version comment][] to the top of
+   any Dart files that you don't want to consider during your current migration:
+   ```dart
+// @dart=2.9
+```
+
+   Using language version 2.9 for a library that's in a 2.12 package
+   can reduce analysis errors (red squiggles) if you disable sound null safety.
+   However, **unsound null safety reduces the
+   information the analyzer can use.**
+   For example, the analyzer might assume a
+   parameter type is non-nullable,
+   even though a 2.9 file might pass in a null value.
+
+5. Migrate the code of each Dart file,
+   using the analyzer to identify static errors. <br>
+   Eliminate static errors by adding `?`, `!`, `required`, and `late`,
+   as needed.
+   Consider refactoring your code, as needed.
+
+
+## Analyzing, testing, and running mixed-version code
+
+To analyze, test, or run mixed-version code,
+you need to disable sound null safety.
+You can do this in two ways:
+
+* Disable sound null safety using the `--no-sound-null-safety` flag.
+  Example:
+
+  ```terminal
+  $ dart run --no-sound-null-safety
+  ```
+
+* Alternatively, set the language version in the entrypoint —
+  the file that contains `main()` function — to 2.9.
+  In Flutter apps, this file is often named `lib/main.dart`.
+  In command-line apps, this file is often named `bin/<packageName>.dart`.
+  Example:
+
+  ```dart
+  // @dart=2.9
+  import 'src/my_app.dart';
+
+  main() {
+    //...
+  }
+  ```
+
+[language version comment]: /guides/language/evolution#per-library-language-version-selection
+[package config]: https://pub.dev/packages/package_config
+

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -5,17 +5,19 @@ description: Mixing language versions lets you migrate to null safety at your ow
 
 An app can use some libraries that
 are [null safe][] and some that aren't.
-These apps — called **mixed-version programs** —
-execute with **unsound null safety**.
+Such an app — called a **mixed-version program** —
+executes with **unsound null safety**.
 
 [null safe]: /null-safety
 
-Mixing language versions lets you migrate to null safety at your own pace.
+Mixing [language versions][] lets you migrate to null safety at your own pace.
 It also frees package maintainers to migrate their code,
 with the knowledge that even legacy users can get new
 bug fixes and other improvements.
 However, mixed-version programs don't get all the advantages
 that null safety can bring.
+
+[language versions]: /guides/language/evolution#language-versioning
 
 This page describes the differences between sound and unsound null safety,
 to help you decide whether to migrate before
@@ -71,27 +73,18 @@ If you import a null-unsafe library,
 the tools print a warning to let you know that
 they can only [run with unsound null safety](#analyzing-and-testing).
 
-{{ site.alert.info }}
-  Except for a few edge cases,
-  a mixed-version program should do exactly what you expect.
-  One example of an edge case is an `is` test
-  on an instance of a generic type from a closure
-  that crosses the boundary between null-safe and null-unsafe libraries.
-{{ site.alert.end }}
-
 
 ## Migrating incrementally
-
-The [migration tool][] is aimed at migrating a whole package at once.
-If you want to migrate your package piecemeal,
-the migration tool can still help,
-but you'll need to do more by hand.
-
-[migration tool]: /null-safety/migration-guide#step2-migrate
 
 Because Dart supports mixed-version programs,
 you can migrate one library (generally one Dart file) at a time,
 while still being able to run your app and its tests.
+If you want to migrate your package file by file,
+the [migration tool][] can help,
+but you'll need to do more by hand.
+
+[migration tool]: /null-safety/migration-guide#step2-migrate
+
 
 We recommend that you **first migrate leaf libraries** —
 libraries that don't import other files from the package.
@@ -103,7 +96,7 @@ For example, say you have a `lib/src/util.dart` file
 that imports other (null-safe) packages and core libraries,
 but that doesn't have any `import '<local_path>'` directives.
 Consider migrating `util.dart` first,
-and then migrating simple files that depend only on `util.dart`.
+and then migrating files that depend only on `util.dart`.
 If any libraries have cyclic imports
 (for example, A imports B which imports C, and C imports A),
 consider migrating those libraries together.
@@ -122,7 +115,7 @@ environment:
 $ dart pub get
 ```
 
-   Running `dart pub get` with a lower constraint of 2.12.0
+   Running `dart pub get` with a lower constraint of 2.12.0-0
    sets the default language version of
    every library in your package to 2.12,
    opting them all in to null safety.
@@ -132,14 +125,14 @@ $ dart pub get
    You're likely to see a lot of analysis errors.
    That's OK.
 
-4. _Optional:_ Add a [language version comment][] to the top of
+4. Add a [language version comment][] to the top of
    any Dart files that you don't want to consider during your current migration:
    ```dart
 // @dart=2.9
 ```
 
    Using language version 2.9 for a library that's in a 2.12 package
-   can reduce analysis errors (red squiggles) if you disable sound null safety.
+   can reduce analysis errors (red squiggles).
    However, **unsound null safety reduces the
    information the analyzer can use.**
    For example, the analyzer might assume a
@@ -150,10 +143,9 @@ $ dart pub get
    using the analyzer to identify static errors. <br>
    Eliminate static errors by adding `?`, `!`, `required`, and `late`,
    as needed.
-   Consider refactoring your code, as needed.
 
 
-## Analyzing, testing, and running mixed-version code
+## Analyzing, testing, and running mixed-version programs
 
 To analyze, test, or run mixed-version code,
 you need to disable sound null safety.
@@ -163,7 +155,7 @@ You can do this in two ways:
   Example:
 
   ```terminal
-  $ dart run --no-sound-null-safety
+  $ dart --no-sound-null-safety run
   ```
 
 * Alternatively, set the language version in the entrypoint —

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -3,15 +3,15 @@ title: Unsound null safety
 description: Mixing language versions lets you migrate to null safety at your own pace, with some of the benefits of null safety.
 ---
 
-An app can use some libraries that
+A Dart program can contain some libraries that
 are [null safe][] and some that aren't.
-Such an app — called a **mixed-version program** —
-executes with **unsound null safety**.
+These **mixed-version programs**
+execute with **unsound null safety**.
 
 [null safe]: /null-safety
 
-Mixing [language versions][] lets you migrate to null safety at your own pace.
-It also frees package maintainers to migrate their code,
+The ability to mix [language versions][]
+frees package maintainers to migrate their code,
 with the knowledge that even legacy users can get new
 bug fixes and other improvements.
 However, mixed-version programs don't get all the advantages
@@ -20,14 +20,13 @@ that null safety can bring.
 [language versions]: /guides/language/evolution#language-versioning
 
 This page describes the differences between sound and unsound null safety,
-to help you decide whether to migrate before
-all your dependencies support null safety.
+with the goal of helping you decide when to migrate to null safety.
 After the conceptual discussion are instructions for migrating incrementally,
-followed by details on analyzing, testing, and running mixed-version programs.
+followed by details on testing and running mixed-version programs.
 
 {{ site.alert.note }}
   We recommend that, if possible, you wait for dependencies to migrate
-  before you migrate your app.
+  before you migrate your package.
   For details, see the [migration guide][].
 {{ site.alert.end }}
 
@@ -55,15 +54,13 @@ To maintain runtime compatibility with legacy libraries
 while offering soundness to completely null-safe programs,
 Dart tools support two modes:
 
-* When you run a mixed-version program,
-  it runs with **unsound null safety**.
+* Mixed-version programs run with **unsound null safety**.
   It's possible for `null` reference errors to occur at runtime,
   but only because a `null` or nullable type escaped from
-  some null-unsafe library and got into your null-safe code.
+  some null-unsafe library and got into null-safe code.
 
-* When your program is fully migrated and _all_ libraries are null safe,
-  then your program automatically runs with **sound null safety**.
-  That mode gives you the full null safety experience with
+* When a program is fully migrated and _all_ its libraries are null safe,
+  then it runs with **sound null safety**, with
   all of the guarantees and compiler optimizations that soundness enables.
 
 Sound null safety is what you want if possible.
@@ -78,7 +75,7 @@ they can only [run with unsound null safety](#analyzing-and-testing).
 
 Because Dart supports mixed-version programs,
 you can migrate one library (generally one Dart file) at a time,
-while still being able to run your app and its tests.
+while still being able to run your program and its tests.
 If you want to migrate your package file by file,
 the [migration tool][] can help,
 but you'll need to do more by hand.
@@ -103,23 +100,25 @@ consider migrating those libraries together.
 
 To migrate a package by hand, follow these steps:
 
-1. Modify the SDK constraints in the package's `pubspec.yaml` file,
-   setting the language version to 2.12 beta or later:
+1. Edit the package's `pubspec.yaml` file,
+   setting the minimum SDK constraint to `2.12.0-0`:
    ```yaml
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 ```
 
-2. Update dependencies: <br>
+2. Regenerate the [package configuration file][]:
+
    ```terminal
-$ dart pub get
-```
+   $ dart pub get
+   ```
 
-   Running `dart pub get` with a lower constraint of 2.12.0-0
+   [package configuration file]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/package-config-file-v2.md
+
+   Running `dart pub get` with a lower SDK constraint of `2.12.0-0`
    sets the default language version of
-   every library in your package to 2.12,
+   every library in the package to 2.12,
    opting them all in to null safety.
-
 
 3. Open the package in your IDE. <br>
    You're likely to see a lot of analysis errors.
@@ -132,7 +131,7 @@ $ dart pub get
 ```
 
    Using language version 2.9 for a library that's in a 2.12 package
-   can reduce analysis errors (red squiggles).
+   can reduce analysis errors (red squiggles) coming from unmigrated code.
    However, **unsound null safety reduces the
    information the analyzer can use.**
    For example, the analyzer might assume a
@@ -145,9 +144,9 @@ $ dart pub get
    as needed.
 
 
-## Analyzing, testing, and running mixed-version programs
+## Testing or running mixed-version programs
 
-To analyze, test, or run mixed-version code,
+To test or run mixed-version code,
 you need to disable sound null safety.
 You can do this in two ways:
 
@@ -162,6 +161,8 @@ You can do this in two ways:
   the file that contains `main()` function — to 2.9.
   In Flutter apps, this file is often named `lib/main.dart`.
   In command-line apps, this file is often named `bin/<packageName>.dart`.
+  You can also opt out files under `test`,
+  because they are also entrypoints.
   Example:
 
   ```dart


### PR DESCRIPTION
Staged: https://kw-dartlang-3.firebaseapp.com/null-safety/unsound-null-safety

I wasn't able to satisfactorily test the `--no-sound-null-safety` instructions (at the bottom) — in particular, `dart test` didn't seem to accept that flag — so I'd appreciate special attention to that section.

We should probably add this to the sidenav... but that can happen later.