### PR TITLE
Use Class Members Language Tour Fix

### DIFF
--- a/examples/misc/test/language_tour/classes_test.dart
+++ b/examples/misc/test/language_tour/classes_test.dart
@@ -43,7 +43,7 @@ void main() {
   test('object-members', () {
     // #docregion object-members
     var p = Point(2, 2);
-      
+
     // Get the value of y.
     assert(p.y == 2);
 

--- a/examples/misc/test/language_tour/classes_test.dart
+++ b/examples/misc/test/language_tour/classes_test.dart
@@ -43,22 +43,19 @@ void main() {
   test('object-members', () {
     // #docregion object-members
     var p = Point(2, 2);
-
-    // Set the value of the instance variable y.
-    p.y = 3;
-
+      
     // Get the value of y.
-    assert(p.y == 3);
+    assert(p.y == 2);
 
     // Invoke distanceTo() on p.
     double distance = p.distanceTo(Point(4, 4));
     // #enddocregion object-members
 
     // #docregion safe-member-access
-    // If p is non-null, set its y value to 4.
-    p?.y = 4;
+    // If p is non-null, set a variable equal to its y value.
+    var a = p?.y;
     // #enddocregion safe-member-access
-    expect(p.y, 4);
+    expect(a, 2);
   });
 
   test('const, identical, runtimeType', () {

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2528,7 +2528,7 @@ Use a dot (`.`) to refer to an instance variable or method:
 <?code-excerpt "misc/test/language_tour/classes_test.dart (object-members)"?>
 ```dart
 var p = Point(2, 2);
-      
+
 // Get the value of y.
 assert(p.y == 2);
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2528,12 +2528,9 @@ Use a dot (`.`) to refer to an instance variable or method:
 <?code-excerpt "misc/test/language_tour/classes_test.dart (object-members)"?>
 ```dart
 var p = Point(2, 2);
-
-// Set the value of the instance variable y.
-p.y = 3;
-
+      
 // Get the value of y.
-assert(p.y == 3);
+assert(p.y == 2);
 
 // Invoke distanceTo() on p.
 double distance = p.distanceTo(Point(4, 4));
@@ -2549,8 +2546,8 @@ https://gist.github.com/0cb25997742ed5382e4a
 
 <?code-excerpt "misc/test/language_tour/classes_test.dart (safe-member-access)"?>
 ```dart
-// If p is non-null, set its y value to 4.
-p?.y = 4;
+// If p is non-null, set a variable equal to its y value.
+var a = p?.y;
 ```
 
 


### PR DESCRIPTION
Fixes #2627
Changes a section in the Language Tour so the example no longer tries to change the value of a final variable. 