### PR TITLE
Update firebase.json to create a go/dart-fix redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -127,6 +127,7 @@
       { "source": "/events{,/**}", "destination": "https://events.dartlang.org", "type": 301 },
       { "source": "/flutter", "destination": "https://flutter.io", "type": 301 },
 
+      { "source": "/go/dart-fix", "destination": "https://github.com/dart-lang/sdk/blob/master/pkg/dartdev/doc/dart-fix.md", "type": 301 },
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "https://kw-www-dartlang-1.firebaseapp.com/null-safety/migration-guide", "type": 302 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },


### PR DESCRIPTION
- update firebase.json to create a `dart.dev/go/dart-fix` redirect

@kwalrath for review

@pq @bwilkerson - this depends on having a placeholder `pkg/dartdev/doc/dart-fix.md` file to point to; we can update this re-direct when there's something more official to use