### PR TITLE
Remove link to unsoundness from note

### DIFF
--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -52,7 +52,6 @@ then passing a nullable argument becomes a compile error.
   don't use null safety yet.
   For example, the Dart and Flutter core libraries are null safe,
   and they're still usable by apps that haven't migrated to null safety.
-  For more information, see [Unsound null safety][].
 {{ site.alert.end }}
 
 This section tells you how to


### PR DESCRIPTION
I find it a bit confusing to link to the unsound page -- which really is mostly about the exception flow -- from the note that is meant to reassure developers that it's totally great to migrate before the packages/apps that depend on them.