### PR TITLE
Add clarification for null-safe prereleases

### DIFF
--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -494,6 +494,11 @@ increment the prerelease suffix.
 For example, if the first null-safe version is `3.0.0-nullsafety.0`,
 then the next one is `3.0.0-nullsafety.1`.
 
+If you have published a stable release (`1.0.0`) along with a prerelease
+(`2.0.0-nullsafety.0`), you can still publish new versions of the stable release
+(`1.0.1`) and null-safe release (`2.0.0-nullsafety.1`). This allows you to
+maintain a stable release and null-safe prerelease at the same time.
+
 Once null safety is available in a stable release of the Dart SDK,
 we encourage you to publish a stable version of your null-safe package.
 

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -494,10 +494,11 @@ increment the prerelease suffix.
 For example, if the first null-safe version is `3.0.0-nullsafety.0`,
 then the next one is `3.0.0-nullsafety.1`.
 
-If you have published a stable release (`1.0.0`) along with a prerelease
-(`2.0.0-nullsafety.0`), you can still publish new versions of the stable release
-(`1.0.1`) and null-safe release (`2.0.0-nullsafety.1`). This allows you to
-maintain a stable release and null-safe prerelease at the same time.
+You can maintain a stable release and null-safe prerelease at the same time.
+For example, if you have a stable release that's `1.0.0` and
+a prerelease that's `2.0.0-nullsafety.0`,
+you can still publish new versions of the stable release
+(`1.0.1`) and null-safe prerelease (`2.0.0-nullsafety.1`).
 
 Once null safety is available in a stable release of the Dart SDK,
 we encourage you to publish a stable version of your null-safe package.


### PR DESCRIPTION
This resolves a question where it was incorrectly assumed that Pub requires that you publish a semantic version higher than the highest published version.

cc: @kevmoo 