### PR TITLE
Make /go/flutter-upper-bound-deprecation redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -128,6 +128,7 @@
       { "source": "/flutter", "destination": "https://flutter.io", "type": 301 },
 
       { "source": "/go/analysis-server-protocol", "destination": "https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/doc/api.html", "type": 301 },
+      { "source": "/go/flutter-upper-bound-deprecation", "destination": "https://github.com/flutter/flutter/issues/68143", "type": 301 },
       { "source": "/go/dart-fix", "destination": "https://github.com/dart-lang/sdk/blob/master/pkg/dartdev/doc/dart-fix.md", "type": 301 },
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },


### PR DESCRIPTION
For use in pub warnings. See https://github.com/dart-lang/pub/pull/2780