### PR TITLE
Add a bit of flutter info to unsound-null-safety page

### DIFF
--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -151,8 +151,7 @@ you need to disable sound null safety.
 You can do this in two ways:
 
 * Disable sound null safety using the `--no-sound-null-safety` flag
-  to the `dart` or `flutter` command, at the command line or in your IDE.
-  Example:
+  to the `dart` or `flutter` command:
 
   ```terminal
   $ dart --no-sound-null-safety run

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -150,11 +150,13 @@ To test or run mixed-version code,
 you need to disable sound null safety.
 You can do this in two ways:
 
-* Disable sound null safety using the `--no-sound-null-safety` flag.
+* Disable sound null safety using the `--no-sound-null-safety` flag
+  to the `dart` or `flutter` command, at the command line or in your IDE.
   Example:
 
   ```terminal
   $ dart --no-sound-null-safety run
+  $ flutter run --no-sound-null-safety
   ```
 
 * Alternatively, set the language version in the entrypoint —


### PR DESCRIPTION
We might also want to update other pages on dart.dev or the flutter.dev/docs/null-safety page.

Fixes #2797