### PR TITLE
Iterables codelab example migration to Null Safety

### DIFF
--- a/null_safety_examples/analysis_options.yaml
+++ b/null_safety_examples/analysis_options.yaml
@@ -1,0 +1,39 @@
+include: package:pedantic/analysis_options.1.8.0.yaml
+
+analyzer:
+  exclude: [build/**]
+  strong-mode:
+    implicit-casts: false
+
+linter:
+  # Rules and documentation: http://dart-lang.github.io/linter/lints
+  rules:
+    - annotate_overrides
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    - close_sinks
+    - comment_references
+    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - non_constant_identifier_names
+    - one_member_abstracts
+    - only_throw_errors
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    - type_annotate_public_apis
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_getters_setters
+    - unnecessary_new

--- a/null_safety_examples/iterables/analysis_options.yaml
+++ b/null_safety_examples/iterables/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../../examples/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/null_safety_examples/iterables/analysis_options.yaml
+++ b/null_safety_examples/iterables/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../examples/analysis_options.yaml

--- a/null_safety_examples/iterables/pubspec.yaml
+++ b/null_safety_examples/iterables/pubspec.yaml
@@ -1,0 +1,10 @@
+name: iterables
+description: dart.dev example code.
+
+environment:
+  sdk: ">=2.12.0-0 <3.0.0"
+
+dev_dependencies:
+  examples_util: {path: ../util}
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.13

--- a/null_safety_examples/iterables/test/iterables_test.dart
+++ b/null_safety_examples/iterables/test/iterables_test.dart
@@ -1,0 +1,107 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('iterables codelab', () {
+    test('any_example', () {
+      void any(Iterable<String> items, Function(String) print) {
+        // #docregion any-false
+        if (items.any((element) => element.contains('Z'))) {
+          print('At least one element contains "Z"');
+        } else {
+          print('No element contains "Z"');
+        }
+        // #enddocregion any-false
+      }
+
+      var items = ['Zoo', 'Home'];
+      any(items, (output) {
+        expect(output, 'At least one element contains "Z"');
+      });
+
+      items = ['Home'];
+      any(items, (output) {
+        expect(output, 'No element contains "Z"');
+      });
+    });
+
+    test('every_example', () {
+      bool bad(Iterable<String> items) {
+        // #docregion every-bad
+        for (var item in items) {
+          if (item.length < 5) {
+            return false;
+          }
+        }
+        return true;
+        // #enddocregion every-bad
+      }
+
+      bool good(Iterable<String> items) {
+        // #docregion every-good
+        return items.every((element) => element.length >= 5);
+        // #enddocregion every-good
+      }
+
+      expect(bad(['12345']), true);
+      expect(bad(['1234']), false);
+      expect(good(['12345']), true);
+      expect(good(['1234']), false);
+    });
+
+    test('firstWhere_example', () {
+      final iterable = ['a', '123456', 'abcdef'];
+      // #docregion firstwhere
+      String element = iterable.firstWhere((element) => element.length > 5);
+      // #enddocregion firstwhere
+      expect(element, '123456');
+    });
+
+    test('iterable_example', () {
+      // #docregion iterable
+      // #docregion iterable-elementat
+      Iterable<int> iterable = [1, 2, 3];
+      // #enddocregion iterable
+      int value = iterable.elementAt(1);
+      // #enddocregion iterable-elementat
+      expect(value, 2);
+    });
+
+    test('map_int_example', () {
+      final numbers = [1, 2, 3];
+      // #docregion map-int
+      Iterable<int> output = numbers.map((number) => number * 10);
+      // #enddocregion map-int
+      expect(output, [10, 20, 30]);
+    });
+
+    test('map_string_example', () {
+      final numbers = [1, 2, 3];
+      // #docregion map-string
+      Iterable<String> output = numbers.map((number) => number.toString());
+      // #enddocregion map-string
+      expect(output, ['1', '2', '3']);
+    });
+
+    test('takeWhile_example', () {
+      final numbers = [1, 2, 3, -1, 4, 5];
+      // #docregion takewhile
+      var numbersUntilNegative =
+          numbers.takeWhile((number) => !number.isNegative);
+      // #enddocregion takewhile
+      expect(numbersUntilNegative, [1, 2, 3]);
+    });
+
+    test('where_example', () {
+      final numbers = [1, 2, 3, 4];
+      // #docregion where
+      // #docregion where-for
+      var evenNumbers = numbers.where((number) => number.isEven);
+      // #enddocregion where
+      for (var number in evenNumbers) {
+        print('$number is even');
+      }
+      // #enddocregion where-for
+      expect(evenNumbers, [2, 4]);
+    });
+  });
+}

--- a/null_safety_examples/util/analysis_options.yaml
+++ b/null_safety_examples/util/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../../examples/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/null_safety_examples/util/analysis_options.yaml
+++ b/null_safety_examples/util/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../examples/analysis_options.yaml

--- a/null_safety_examples/util/lib/dart_version.dart
+++ b/null_safety_examples/util/lib/dart_version.dart
@@ -1,0 +1,6 @@
+import 'dart:io';
+
+final _majorVersNum = RegExp(r'(\d+)\.');
+
+final int dartMajorVers =
+    int.parse(_majorVersNum.firstMatch(Platform.version)![1]!);

--- a/null_safety_examples/util/lib/ellipsis.dart
+++ b/null_safety_examples/util/lib/ellipsis.dart
@@ -1,0 +1,2 @@
+dynamic blockEllipsis; // Use as replace="/=. blockEllipsis;/{ ... }/g"
+T? ellipsis<T>() => null; // Use as replace="/ellipsis;?/.../g"

--- a/null_safety_examples/util/lib/logger.dart
+++ b/null_safety_examples/util/lib/logger.dart
@@ -1,0 +1,11 @@
+/// A simple logger
+class Logger {
+  final List<String> _log = [];
+
+  List<String> get log => List.from(_log);
+  void clear() => _log.clear();
+  void print(Object o) => _log.add(o.toString());
+
+  @override
+  String toString() => _log.join('\n');
+}

--- a/null_safety_examples/util/lib/print_matcher.dart
+++ b/null_safety_examples/util/lib/print_matcher.dart
@@ -1,0 +1,19 @@
+import 'package:test/test.dart' as test;
+
+/// Like the [test.prints] matcher, but accepts non-String arguments. If [any]
+/// is an [Iterable], this matches the equivalent of `any.forEach(print)`;
+/// otherwise this matches `'$any'`.
+test.Matcher prints(dynamic any) {
+  Iterable args = any is Iterable ? any : [any];
+  return test.prints(args.map((arg) => '$arg').join('\n') + '\n');
+}
+
+/// Cleans up [lines] by trimming off leading whitespace and adding a trailing
+/// newline before passing the result to the test package [prints] matcher.
+test.Matcher printsLines(String lines) {
+  lines = _trim(lines);
+  if (!lines.endsWith('\n')) lines += '\n';
+  return test.prints(lines);
+}
+
+String _trim(String s) => s.trimLeft().replaceAll(RegExp(r'\n\s*'), '\n');

--- a/null_safety_examples/util/pubspec.yaml
+++ b/null_safety_examples/util/pubspec.yaml
@@ -1,0 +1,10 @@
+name: examples_util
+description: dart.dev example utilities.
+version: 0.0.2
+
+environment:
+  sdk: ">=2.12.0-0 <3.0.0"
+
+dev_dependencies:
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.13


### PR DESCRIPTION
Hi! :wave: I am working with @RedBrogdon on migrating documentation to null safety, first focusing on codelabs.

In this PR, I have copied the `iterables` example code into the `null_safety_examples` folder.
I had to copy as well the `util` code to it, because `iterables` depends on it.
Migrating the codelab and updating the `code-excerpts` will come in a separated PR.

I also applied the following changes:

- sdk version set to `">=2.12.0-0 <3.0.0"`
- `dev_dependencies` point to the `nullsafety` versions of pedantic and test packages.
- in `util` I had to fix the `dartMajorVers` and the `ellipsis` code snippets to support null safety.
- the code in `iterables` was already null safe after applying the sdk change.
- I did not copy the `analysis_options.yaml`, and instead I pointed to the one in `examples`.

Let me know if you would like to do anything differently.

cc. @kwalrath 