### PR TITLE
Clarify how dartdoc handles getters and setters with doc comments.

### DIFF
--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -260,7 +260,7 @@ int get checkedCount => ...
 If a property has both a getter and a setter, then create a doc comment for
 only one of them. Dartdoc treats the getter and setter like a single field,
 and if both the getter and the setter have doc comments, then
-dartdoc discards the setter's doc comments.
+dartdoc discards the setter's doc comment.
 
 ### PREFER starting library or type comments with noun phrases.
 

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -257,10 +257,10 @@ int weekday;
 int get checkedCount => ...
 {% endprettify %}
 
-When you have a corresponding getter and setter with the same name, document
-only one of them. Dartdoc will merge them together and document them as if they
-are a single field. When it does that, if both the getter and setter have doc
-comments, it discards the setter's.
+If a property has both a getter and a setter, then create a doc comment for
+only one of them. Dartdoc treats the getter and setter like a single field,
+and if both the getter and the setter have doc comments, then
+dartdoc discards the setter's doc comments.
 
 ### PREFER starting library or type comments with noun phrases.
 
@@ -521,4 +521,3 @@ class Box {
   bool get hasValue => _value != null;
 }
 {% endprettify %}
-

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -166,7 +166,7 @@ paragraph. If more than a single sentence of explanation is useful, put the
 rest in later paragraphs.
 
 This helps you write a tight first sentence that summarizes the documentation.
-Also, tools like Dartdoc use the first paragraph as a short summary in places
+Also, tools like dartdoc use the first paragraph as a short summary in places
 like lists of classes and members.
 
 {:.good}
@@ -257,8 +257,10 @@ int weekday;
 int get checkedCount => ...
 {% endprettify %}
 
-Avoid having a doc comment on both the setter and the getter, as DartDoc will show
-only one (the one on the getter.)
+When you have a corresponding getter and setter with the same name, document
+only one of them. Dartdoc will merge them together and document them as if they
+are a single field. When it does that, if both the getter and setter have doc
+comments, it discards the setter's.
 
 ### PREFER starting library or type comments with noun phrases.
 


### PR DESCRIPTION
Fix #1078.