### PR TITLE
Add guideline for naming unused parameters "_".

### DIFF
--- a/deploy/effective-dart-rules/pubspec.yaml
+++ b/deploy/effective-dart-rules/pubspec.yaml
@@ -1,6 +1,8 @@
 name: effective_dart_rules
 version: 0.0.2
 description: Builds a file with all the rules in the different sections of Effective Dart.
+environment:
+  sdk: '>=2.10.0 <3.0.0'
 dependencies:
   html_unescape: ^1.0.0
   markdown: ^2.0.0

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -109,7 +109,7 @@ unusedCallbackParams() {
   var futureOfVoid = Future<void>.value();
   // #docregion unused-callback-params
   futureOfVoid.then((_) {
-    print("Operation complete.");
+    print('Operation complete.');
   });
   // #enddocregion unused-callback-params
 }

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -105,6 +105,17 @@ class Dice {
 
 //----------------------------------------------------------------------------
 
+unusedCallbackParams() {
+  var futureOfVoid = Future<void>.value();
+  // #docregion unused-callback-params
+  futureOfVoid.then((_) {
+    print("Operation complete.");
+  });
+  // #enddocregion unused-callback-params
+}
+
+//----------------------------------------------------------------------------
+
 // #docregion extension-names
 extension MyFancyList<T> on List<T> {/* ... */}
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -275,9 +275,10 @@ ID iD;
 
 ### PREFER using `_`, `__`, etc. for unused callback parameters.
 
-Sometimes a callback you give to an API is passed an argument that you don't use
-in the body of the function. In that case, it is idiomatic to name the unused
-parameter `_`. If there are multiple unused parameters, use additional
+Sometimes the type signature of a callback function requires a parameter,
+but the callback implementation doesn't _use_ the parameter.
+In this case, it's idiomatic to name the unused parameter `_`.
+If the function has multiple unused parameters, use additional
 underscores to avoid name collisions: `__`, `___`, etc.
 
 {:.good}

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -284,7 +284,7 @@ underscores to avoid name collisions: `__`, `___`, etc.
 <?code-excerpt "misc/lib/effective_dart/style_good.dart (unused-callback-params)"?>
 {% prettify dart tag=pre+code %}
 futureOfVoid.then((_) {
-  print("Operation complete.");
+  print('Operation complete.');
 });
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -288,12 +288,12 @@ futureOfVoid.then((_) {
 });
 {% endprettify %}
 
-This guideline is only for *anonymous and local functions* since those are
-usually immediately passed to some other API whose expected function type makes
-it clear what the unused parameter represents. Top-level functions and method
-declarations don't have that context, so should name their parameters. This way,
-someone reading the code knows what that parameter is for, even if not actually
-used.
+This guideline is only for functions that are both *anonymous and local*.
+These functions are usually used immediately in a context where it's
+clear what the unused parameter represents.
+In contrast, top-level functions and method declarations don't have that context,
+so their parameters must be named so that it's clear what each parameter is for,
+even if it isn't used.
 
 
 ### DON'T use a leading underscore for identifiers that aren't private.

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -244,8 +244,8 @@ to tell if it's referring to HTTPS FTP or HTTP SFTP.
 
 To avoid this, acronyms and abbreviations are capitalized like regular words.
 
-**Exception:** Two-letter *acronyms* like IO (input/output) are fully 
-capitalized: `IO`. On the other hand, two-letter *abbreviations* like 
+**Exception:** Two-letter *acronyms* like IO (input/output) are fully
+capitalized: `IO`. On the other hand, two-letter *abbreviations* like
 ID (identification) are still capitalized like regular words: `Id`.
 
 {:.good}
@@ -273,6 +273,29 @@ ID iD;
 {% endprettify %}
 
 
+### PREFER using `_`, `__`, etc. for unused callback parameters.
+
+Sometimes a callback you give to an API is passed an argument that you don't use
+in the body of the function. In that case, it is idiomatic to name the unused
+parameter `_`. If there are multiple unused parameters, use additional
+underscores to avoid name collisions: `__`, `___`, etc.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (unused-callback-params)"?>
+{% prettify dart tag=pre+code %}
+futureOfVoid.then((_) {
+  print("Operation complete.");
+});
+{% endprettify %}
+
+This guideline is only for *anonymous and local functions* since those are
+usually immediately passed to some other API whose expected function type makes
+it clear what the unused parameter represents. Top-level functions and method
+declarations don't have that context, so should name their parameters. This way,
+someone reading the code knows what that parameter is for, even if not actually
+used.
+
+
 ### DON'T use a leading underscore for identifiers that aren't private.
 
 Dart uses a leading underscore in an identifier to mark members and top-level
@@ -283,11 +306,6 @@ There is no concept of "private" for local variables, parameters, or library
 prefixes. When one of those has a name that starts with an underscore, it sends
 a confusing signal to the reader. To avoid that, don't use leading underscores
 in those names.
-
-**Exception:** An unused parameter can be named `_`, `__`, `___`, etc. This
-happens in things like callbacks where you are passed a value but you don't need
-to use it. Giving it a name that consists *solely* of underscores is the
-idiomatic way to indicate the value isn't used.
 
 
 ### DON'T use prefix letters.

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -24,6 +24,7 @@
 * <a href='/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase'>DO name other identifiers using <code>lowerCamelCase</code>.</a>
 * <a href='/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names'>PREFER using <code>lowerCamelCase</code> for constant names.</a>
 * <a href='/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words'>DO capitalize acronyms and abbreviations longer than two letters like words.</a>
+* <a href='/guides/language/effective-dart/style#prefer-using-_-__-etc-for-unused-callback-parameters'>PREFER using <code>_</code>, <code>__</code>, etc. for unused callback parameters.</a>
 * <a href='/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private'>DON'T use a leading underscore for identifiers that aren't private.</a>
 * <a href='/guides/language/effective-dart/style#dont-use-prefix-letters'>DON'T use prefix letters.</a>
 


### PR DESCRIPTION
Fix #1101.