### PR TITLE
Fix some null safety errors in "Effective Dart" example code context.

### DIFF
--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -19,7 +19,7 @@ void miscDeclAnalyzedButNotTested() {
     monsters.filter((monster) => monster.hasClaws);
     // #enddocregion code-like-prose
 
-    Iterable theCollectionOfErrors;
+    Iterable theCollectionOfErrors = [];
     // #docregion code-like-prose-overdone
     if (theCollectionOfErrors.isEmpty) {/*-...-*/}
 
@@ -126,7 +126,7 @@ typedef bool TestNumber(num);
 //----------------------------------------------------------------------------
 
 class StringBuffer0 {
-  StringBuffer0 write(dynamic _) => null;
+  StringBuffer0 write(dynamic _) => this;
 }
 
 //----------------------------------------------------------------------------

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -10,12 +10,12 @@ import 'package:examples_util/ellipsis.dart';
 typedef Func1<S, T> = S Function(T _);
 
 dynamic element, key, value;
-ByteBuffer bytes;
-DateTime dateTime;
-List list;
-Map map;
-String string;
-StreamSubscription subscription;
+ByteBuffer bytes = Int8List(0).buffer;
+DateTime dateTime = DateTime.now();
+List list = [];
+Map map = {};
+String string = '';
+StreamSubscription subscription = Stream.empty().listen((_) {});
 
 void miscDeclAnalyzedButNotTested() {
   (Iterable errors, Iterable<Monster> monsters) {
@@ -317,11 +317,11 @@ typedef Comparison2<T> = int Function(T a, T b);
 class AstNode {}
 
 class Constructor extends AstNode {
-  List<AstNode> get signature => null;
+  List<AstNode> get signature => [];
 }
 
 class Method extends AstNode {
-  List<AstNode> get parameters => null;
+  List<AstNode> get parameters => [];
 }
 
 class Socket {
@@ -333,14 +333,14 @@ class Socket {
 class Database {
   bool get hasData => false;
   bool get isEmpty => false;
-  String read() => null;
+  String read() => '';
 }
 
 class Monster {
-  bool hasClaws;
+  bool hasClaws = false;
 }
 
-List<Person> people;
+List<Person> people = [];
 
 class ListBox {
   ListBox({bool scroll, bool showScrollbars});
@@ -359,7 +359,7 @@ class Task {
 
 class Ingredient {}
 
-final List<List<Ingredient>> cookbook = null;
+final List<List<Ingredient>> cookbook = [];
 
 //----------------------------------------------------------------------------
 

--- a/examples/misc/lib/effective_dart/docs_bad.dart
+++ b/examples/misc/lib/effective_dart/docs_bad.dart
@@ -63,7 +63,7 @@ class C<ChunkBuilder, Flag, LineWriter> {
 }
 
 class Component {
-  const Component({String selector});
+  const Component({String selector = ''});
 }
 
 // #docregion doc-before-meta

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -178,6 +178,8 @@ class C0 {
 //----------------------------------------------------------------------------
 
 class C1 {
+  C1(this.weekday);
+
 // #docregion noun-phrases-for-var-etc
   /// The current day of the week, where `0` is Sunday.
   int weekday;
@@ -199,7 +201,7 @@ class Chunk {/* ... */}
 //----------------------------------------------------------------------------
 
 class Component {
-  const Component({String selector});
+  const Component({String selector = ''});
 }
 
 // #docregion doc-before-meta

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -9,7 +9,8 @@ typedef Func1<S, T> = S Function(T _);
 Func0<Future> longRunningCalculation = () => Future.value();
 Func0 somethingRisky = () {};
 Func1 raiseAlarm = (_) {}, handle = (_) {};
-Func1<bool, dynamic> canHandle = (_) => false, verifyResult = (_) => false;
+Func1<bool, dynamic> canHandle = (_) => false,
+    verifyResult = (_) => false;
 
 void miscDeclAnalyzedButNotTested() {
   {
@@ -333,7 +334,11 @@ class Treasure {
 }
 
 class C {
-  double left = 0.0, right = 0.0, top = 0.0, bottom = 0.0, minTime = 0.0;
+  double left = 0.0,
+      right = 0.0,
+      top = 0.0,
+      bottom = 0.0,
+      minTime = 0.0;
   Point center = Point(0.0, 0.0);
   Map<Chest, Treasure> _opened = {};
 

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -6,10 +6,10 @@ import 'dart:math';
 typedef Func0<T> = T Function();
 typedef Func1<S, T> = S Function(T _);
 
-Func0<Future> longRunningCalculation;
-Func0 somethingRisky;
-Func1 raiseAlarm, handle;
-Func1<bool, dynamic> canHandle, verifyResult;
+Func0<Future> longRunningCalculation = () => Future.value();
+Func0 somethingRisky = () {};
+Func1 raiseAlarm = (_) {}, handle = (_) {};
+Func1<bool, dynamic> canHandle = (_) => false, verifyResult = (_) => false;
 
 void miscDeclAnalyzedButNotTested() {
   {
@@ -235,12 +235,12 @@ void miscDeclAnalyzedButNotTested() {
 class Address {}
 
 class Animal {
-  String name;
-  bool isAquatic;
+  String name = '';
+  bool isAquatic = false;
 }
 
 class Person {
-  int zip;
+  int zip = 12345;
 }
 
 class Color {
@@ -254,8 +254,8 @@ class Player {
 }
 
 class Team {
-  Future<List<Player>> get roster => null;
-  Future<Team> downloadTeam(String name) => null;
+  Future<List<Player>> get roster => Future.value([]);
+  Future<Team> downloadTeam(String name) => Future.value(Team());
   dynamic get log => null;
 
   // #docregion async-await
@@ -323,7 +323,7 @@ class Box1 {
 //----------------------------------------------------------------------------
 
 class Chest {
-  List<String> get contents => null;
+  List<String> get contents => [];
 }
 
 class Treasure {
@@ -333,9 +333,9 @@ class Treasure {
 }
 
 class C {
-  double left, right, top, bottom, minTime;
-  Point center;
-  Map<Chest, Treasure> _opened;
+  double left = 0.0, right = 0.0, top = 0.0, bottom = 0.0, minTime = 0.0;
+  Point center = Point(0.0, 0.0);
+  Map<Chest, Treasure> _opened = {};
 
   // #docregion use-arrow
   double get area => (right - left) * (bottom - top);


### PR DESCRIPTION
I wanted to get a sense of how many of the examples would be affected
by null safety, so I temporarily enabled that and went through the
errors. The good news is that it's not bad. Probably half a dozen with
trivial fixes.

The bad news is that those fixes do require using null safety feature
syntax in the examples themselves ("?", "required", etc.). So I'm not
going to make those changes yet.

But, while I was at it, I went ahead and fixed a bunch of null safety
errors in the surrounding context code. These changes are entirely
backwards compatible and fine to land now on master so I figured I'd
send them out first.