### PR TITLE
Update language-tour.md

### DIFF
--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -57,7 +57,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion const-dart-25
-    // Valid compile-time constants as of Dart 2.5.
+    // Some examples of valid compile-time constants
     const Object i = 3; // Where i is a const Object with an int value...
     const list = [i as int]; // Use a typecast.
     const map = {if (i is int) i: "int"}; // Use is and collection if.

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -57,7 +57,6 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion const-dart-25
-    // Some examples of valid compile-time constants
     const Object i = 3; // Where i is a const Object with an int value...
     const list = [i as int]; // Use a typecast.
     const map = {if (i is int) i: "int"}; // Use is and collection if.

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -949,7 +949,7 @@ nobleGases[18] = 'argon';
 ```
 
 {{site.alert.note}}
-  If you come from a language like C# or Java, You might expect to see `new Map()` 
+  If you come from a language like C# or Java, you might expect to see `new Map()` 
   instead of just `Map()`. In Dart, the `new` keyword is optional.
   For details, see [Using constructors](#using-constructors).
 {{site.alert.end}}

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -259,9 +259,8 @@ However, if necessary, the keywords marked with superscripts can be identifiers:
   these keywords are valid identifiers in most places,
   but they can't be used as class or type names, or as import prefixes.
 
-* Words with the superscript **3** are newer, limited reserved words related to
-  the [asynchrony support](#asynchrony-support) that was added
-  after Dart's 1.0 release.
+* Words with the superscript **3** are limited reserved words related to
+  [asynchrony support](#asynchrony-support).
   You can't use `await` or `yield` as an identifier
   in any function body marked with `async`, `async*`, or `sync*`.
 
@@ -403,14 +402,13 @@ You can't change the value of a `const` variable:
 baz = [42]; // Error: Constant variables can't be assigned a value.
 ```
 
-As of Dart 2.5, you can define constants that use
+You can define constants that use
 [type checks and casts](#type-test-operators) (`is` and `as`),
 [collection if](#collection-operators),
 and [spread operators](#spread-operator) (`...` and `...?`):
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (const-dart-25)"?>
 ```dart
-// Valid compile-time constants as of Dart 2.5.
 const Object i = 3; // Where i is a const Object with an int value...
 const list = [i as int]; // Use a typecast.
 const map = {if (i is int) i: "int"}; // Use is and collection if.
@@ -507,18 +505,12 @@ var y = 1.1;
 var exponents = 1.42e5;
 ```
 
-As of Dart 2.1, integer literals are automatically converted to doubles
-when necessary:
+Integer literals are automatically converted to doubles when necessary:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (int-to-double)"?>
 ```dart
 double z = 1; // Equivalent to double z = 1.0.
 ```
-
-{{site.alert.version-note}}
-  Before Dart 2.1, it was an error to use an integer literal in a double
-  context.
-{{site.alert.end}}
 
 Here’s how you turn a string into a number, or vice versa:
 
@@ -785,7 +777,7 @@ For more details and examples of using the spread operator, see the
 [spread operator proposal.][spread proposal]
 
 <a id="collection-operators"> </a>
-Dart 2.3 also introduced **collection if** and **collection for**,
+Dart also offers **collection if** and **collection for**,
 which you can use to build collections using conditionals (`if`)
 and repetition (`for`).
 
@@ -832,11 +824,6 @@ information about lists, see [Generics](#generics) and
 
 A set in Dart is an unordered collection of unique items.
 Dart support for sets is provided by set literals and the [Set][Set class] type.
-
-{{site.alert.version-note}}
-  Although the Set _type_ has always been a core part of Dart, set _literals_
-  were introduced in Dart 2.2.
-{{site.alert.end}}
 
 Here is a simple Dart set, created using a set literal:
 
@@ -903,7 +890,7 @@ final constantSet = const {
 // constantSet.add('helium'); // This line will cause an error.
 ```
 
-As of Dart 2.3, sets support spread operators (`...` and `...?`)
+Sets support spread operators (`...` and `...?`)
 and collection ifs and fors,
 just like lists do.
 For more information, see the
@@ -962,8 +949,8 @@ nobleGases[18] = 'argon';
 ```
 
 {{site.alert.note}}
-  You might expect to see `new Map()` instead of just `Map()`.
-  As of Dart 2, the `new` keyword is optional.
+  If you come from a language like C# or Java, You might expect to see `new Map()` 
+  instead of just `Map()`. In Dart, the `new` keyword is optional.
   For details, see [Using constructors](#using-constructors).
 {{site.alert.end}}
 
@@ -1015,7 +1002,7 @@ final constantMap = const {
 // constantMap[2] = 'Helium'; // This line will cause an error.
 ```
 
-As of Dart 2.3, maps support spread operators (`...` and `...?`)
+Maps support spread operators (`...` and `...?`)
 and collection if and for, just like lists do.
 For details and examples, see the
 [spread operator proposal][spread proposal] and the
@@ -1029,7 +1016,7 @@ For more information about maps, see
 ### Runes and grapheme clusters
 
 In Dart, [runes][] expose the Unicode code points of a string.
-As of Dart 2.6, use the [characters package][]
+You can use the [characters package][]
 to view or manipulate user-perceived characters,
 also known as
 [Unicode (extended) grapheme clusters.][grapheme clusters]
@@ -3336,8 +3323,7 @@ For more information, see the informal
 
 ### Extension methods
 
-Extension methods, introduced in Dart 2.7,
-are a way to add functionality to existing libraries.
+Extension methods are a way to add functionality to existing libraries.
 You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
@@ -3494,16 +3480,6 @@ only classes that extend or implement the `Musician` class
 can use the mixin `MusicalPerformer`.
 Because `SingerDancer` extends `Musician`,
 `SingerDancer` can mix in `MusicalPerformer`.
-
-{{site.alert.version-note}}
-  Support for the `mixin` keyword was introduced in Dart 2.1. Code in earlier
-  releases usually used `abstract class` instead. For more information on 2.1
-  mixin changes, see the [Dart SDK changelog][] and [2.1 mixin specification.][]
-{{site.alert.end}}
-
-[Dart SDK changelog]: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md
-[2.1 mixin specification.]: https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/feature-specification.md#dart-2-mixin-declarations
-
 
 ### Class variables and methods
 


### PR DESCRIPTION
Remove references to long-dead language versions. At this point, there's no need to document features added in 2.3 or call out that async keywords aren't supported in Dart 1.x :)