### PR TITLE
removed deprecated pub publish

### DIFF
--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -1,13 +1,13 @@
 ---
-title: dart publish
-description: Use dart publish to publish your Dart package to the pub.dev site.
+title: dart pub publish
+description: Use dart pub publish to publish your Dart package to the pub.dev site.
 toc: false
 ---
 
 _Publish_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify nocode tag=pre+code %}
-$ dart publish [--dry-run] [--force]
+$ dart pub publish [--dry-run] [--force]
 {% endprettify %}
 
 This command publishes your package on the

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -1,13 +1,13 @@
 ---
-title: pub publish
-description: Use pub publish to publish your Dart package to the pub.dev site.
+title: dart publish
+description: Use dart publish to publish your Dart package to the pub.dev site.
 toc: false
 ---
 
 _Publish_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify nocode tag=pre+code %}
-$ pub publish [--dry-run] [--force]
+$ dart publish [--dry-run] [--force]
 {% endprettify %}
 
 This command publishes your package on the

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -5,7 +5,7 @@ description: Learn how to publish a Dart package to pub.dev.
 
 [The pub package manager][pub] isn't just for using other people's packages.
 It also allows you to share your packages with the world. If you have a useful
-project and you want others to be able to use it, use the `dart publish`
+project and you want others to be able to use it, use the `dart pub publish`
 command.
 
 {{site.alert.note}}
@@ -120,16 +120,16 @@ To create a verified publisher, follow these steps:
 
 ## Publishing your package
 
-Use the [dart publish][] command to publish your package for the first time,
+Use the [dart pub publish][] command to publish your package for the first time,
 or to update it to a new version.
 
 
 ### Performing a dry run
 
-To test how `dart publish` will work, you can perform a dry run:
+To test how `dart pub publish` will work, you can perform a dry run:
 
 ```terminal
-$ dart publish --dry-run
+$ dart pub publish --dry-run
 ```
 
 Pub makes sure that your package follows the
@@ -162,7 +162,7 @@ Package has 0 warnings.
 When you're ready to publish your package, remove the `--dry-run` argument:
 
 ```terminal
-$ dart publish
+$ dart pub publish
 ```
 
 {{site.alert.note}}
@@ -171,7 +171,7 @@ $ dart publish
   and then [transfer the package to a publisher](#transferring-a-package-to-a-verified-publisher).
 
   Once a package has been transferred to a publisher,
-  you can update the package using `dart publish`.
+  you can update the package using `dart pub publish`.
 {{site.alert.end}}
 
 After your package has been successfully uploaded to pub.dev, any pub user can
@@ -221,7 +221,7 @@ PENDING: Here only to make it easy to find the packages discussion: packages-dir
 {% endcomment %}
 
 Be sure to delete any files you don't want to include (or add them to
-`.gitignore`). `dart publish` lists all files that it's going to publish
+`.gitignore`). `dart pub publish` lists all files that it's going to publish
 before uploading your package,
 so examine the list carefully before completing your upload.
 
@@ -288,7 +288,7 @@ If you change your mind, you can remove the discontinued mark at any time.
 
 For more information, see the reference pages for the following `pub` commands:
 
-* [dart publish][]
+* [dart pub publish][]
 * [pub uploader][]
 
 [BSD license]: https://opensource.org/licenses/BSD-3-Clause
@@ -298,7 +298,7 @@ For more information, see the reference pages for the following `pub` commands:
 [package layout conventions]: /tools/pub/package-layout
 [policy]: https://pub.dev/policy
 [pub]: /guides/packages
-[dart publish]: /tools/pub/cmd/pub-lish
+[dart pub publish]: /tools/pub/cmd/pub-lish
 [pub uploader]: /tools/pub/cmd/pub-uploader
 [pubspec]: /tools/pub/pubspec
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -5,7 +5,7 @@ description: Learn how to publish a Dart package to pub.dev.
 
 [The pub package manager][pub] isn't just for using other people's packages.
 It also allows you to share your packages with the world. If you have a useful
-project and you want others to be able to use it, use the `pub publish`
+project and you want others to be able to use it, use the `dart publish`
 command.
 
 {{site.alert.note}}
@@ -120,16 +120,16 @@ To create a verified publisher, follow these steps:
 
 ## Publishing your package
 
-Use the [pub publish][] command to publish your package for the first time,
+Use the [dart publish][] command to publish your package for the first time,
 or to update it to a new version.
 
 
 ### Performing a dry run
 
-To test how `pub publish` will work, you can perform a dry run:
+To test how `dart publish` will work, you can perform a dry run:
 
 ```terminal
-$ pub publish --dry-run
+$ dart publish --dry-run
 ```
 
 Pub makes sure that your package follows the
@@ -162,7 +162,7 @@ Package has 0 warnings.
 When you're ready to publish your package, remove the `--dry-run` argument:
 
 ```terminal
-$ pub publish
+$ dart publish
 ```
 
 {{site.alert.note}}
@@ -171,7 +171,7 @@ $ pub publish
   and then [transfer the package to a publisher](#transferring-a-package-to-a-verified-publisher).
 
   Once a package has been transferred to a publisher,
-  you can update the package using `pub publish`.
+  you can update the package using `dart publish`.
 {{site.alert.end}}
 
 After your package has been successfully uploaded to pub.dev, any pub user can
@@ -221,7 +221,7 @@ PENDING: Here only to make it easy to find the packages discussion: packages-dir
 {% endcomment %}
 
 Be sure to delete any files you don't want to include (or add them to
-`.gitignore`). `pub publish` lists all files that it's going to publish
+`.gitignore`). `dart publish` lists all files that it's going to publish
 before uploading your package,
 so examine the list carefully before completing your upload.
 
@@ -288,7 +288,7 @@ If you change your mind, you can remove the discontinued mark at any time.
 
 For more information, see the reference pages for the following `pub` commands:
 
-* [pub publish][]
+* [dart publish][]
 * [pub uploader][]
 
 [BSD license]: https://opensource.org/licenses/BSD-3-Clause
@@ -298,7 +298,7 @@ For more information, see the reference pages for the following `pub` commands:
 [package layout conventions]: /tools/pub/package-layout
 [policy]: https://pub.dev/policy
 [pub]: /guides/packages
-[pub publish]: /tools/pub/cmd/pub-lish
+[dart publish]: /tools/pub/cmd/pub-lish
 [pub uploader]: /tools/pub/cmd/pub-uploader
 [pubspec]: /tools/pub/pubspec
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html


### PR DESCRIPTION
I have changed `dart` in the place of `pub` in src/tools/pub/publishing.md as mention in https://github.com/dart-lang/site-www/issues/2617 issue.