### PR TITLE
Update and fix old pub link

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4473,7 +4473,7 @@ To learn more about Dart's core libraries, see
 [AssertionError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
 [`Characters`]: {{site.pub-api}}/characters/latest/characters/Characters-class.html
 [characters API]: {{site.pub-api}}/characters
-[characters example]: {{site.pub-pkg}}/characters#-example-tab-
+[characters example]: {{site.pub-pkg}}/characters/example
 [characters package]: {{site.pub-pkg}}/characters
 [dart2js]: /tools/dart2js
 [dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html


### PR DESCRIPTION
It seems the new format of links are used by default, even when navigating between tabs. In fact, it appears this old link didn't even navigate to the example tab. This was the only link I identified which navigated to a tab with the old fashion.

Fixes #2377