### PR TITLE
Add font-weight 700 Roboto to improve bold text clarity

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -41,7 +41,7 @@
   <meta property="og:type" content="{{og_type}}" />
   {% endif -%}
 
-  <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500|Roboto+Mono:300,400,700|Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700|Material+Icons" rel="stylesheet">
   {% asset main.css %}
   {% for css in page.css -%}
     <link href="{{css}}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Since we use font-weight: 700 for some bold text, not including that weight causes some slight blurriness for bold text. It's hard to notice, but it's there.

It's hard to showcase in screenshots due to compression, but here I'll try. Refer to the `Note`: 

Previously:
![image](https://user-images.githubusercontent.com/18372958/102771521-a385df80-434b-11eb-827c-fcf7665abd68.png)

After:
![image](https://user-images.githubusercontent.com/18372958/102771556-b39dbf00-434b-11eb-91c5-528f8c65a8ad.png)
