### PR TITLE
Improve navbar font size

### DIFF
--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -61,7 +61,7 @@ $site-color-header: $site-color-dark-background;
 $site-color-header-text: #f8f9fa;
 $site-color-card-text: #f8f9fa;
 $site-color-card-link: #40C4FF;
-$site-font-size-header: 14px;
+$site-font-size-header: 16px;
 $site-color-primary: $brand-primary;
 $site-color-sidebar-active: #1389FD;
 

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -333,7 +333,7 @@ img {
       }
       &.searchfield {
         position: relative;
-        top: -3px;
+        top: -2px;
       }
     }
   }


### PR DESCRIPTION
The base font size was increased to 16px, but the navbar list elements, which are important click targets, were left at 14px. To me they seem a little small and even blurry.

Previously:
![image](https://user-images.githubusercontent.com/18372958/102772642-7b977b80-434d-11eb-8c95-16369e8a8faf.png)


After:
![image](https://user-images.githubusercontent.com/18372958/102772617-70445000-434d-11eb-9f43-66d5c4345387.png)

