### PR TITLE
Fixes 'What’s new' page issue 

### DIFF
--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -1,7 +1,6 @@
 ---
 title: What’s new
 description: A list of what’s new on dart.dev and related sites.
-toc: false
 ---
 
 {% comment %}

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -17,6 +17,11 @@ join the [Dart announcements Google group.][dart-announce]
 [flutter-whats-new]: {{site.flutter}}/docs/whats-new
 [dart-announce]: https://groups.google.com/a/dartlang.org/d/forum/announce
 
+## Changes after 2.10
+
+Added [Dart team packages][dart-team-packages].
+
+[dart-team-packages]: https://dart.dev/dart-team-packages
 
 ## October 1, 2020: 2.10 release
 


### PR DESCRIPTION
Fixes #2814 .

Not quite sure what text to put in the new section yet.

Was also thinking about 'We added a [dart team packages][dart-team-packages] site to dart.dev.'.

What do you think @kwalrath ? Not quite sure what change was actually made after 2.10 (sorry :D).