### PR TITLE
Migrate Async-Await Codelab to Null Safety

### DIFF
--- a/null_safety_examples/async_await/analysis_options.yaml
+++ b/null_safety_examples/async_await/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../analysis_options.yaml

--- a/null_safety_examples/async_await/bin/async_example.dart
+++ b/null_safety_examples/async_await/bin/async_example.dart
@@ -1,0 +1,25 @@
+Future<void> printOrderMessage() async {
+  print('Awaiting user order...');
+  // #docregion swap-stmts
+  var order = await fetchUserOrder();
+  // print('Awaiting user order...');
+  // #enddocregion swap-stmts
+  print('Your order is: $order');
+}
+
+Future<String> fetchUserOrder() {
+  // Imagine that this function is more complex and slow.
+  return Future.delayed(Duration(seconds: 4), () => 'Large Latte');
+}
+
+Future<void> main() async {
+  countSeconds(4);
+  await printOrderMessage();
+}
+
+// You can ignore this function - it's here to visualize delay time in this example.
+void countSeconds(int s) {
+  for (var i = 1; i <= s; i++) {
+    Future.delayed(Duration(seconds: i), () => print(i));
+  }
+}

--- a/null_safety_examples/async_await/bin/futures_intro.dart
+++ b/null_safety_examples/async_await/bin/futures_intro.dart
@@ -1,0 +1,19 @@
+// #docregion ''
+Future<void> fetchUserOrder() {
+  // Imagine that this function is fetching user info from another service or database.
+  return Future.delayed(Duration(seconds: 2), () => print('Large Latte'));
+}
+// #enddocregion ''
+
+// #docregion error
+Future<void> fetchUserOrderError() {
+// Imagine that this function is fetching user info but encounters a bug
+  return Future.delayed(Duration(seconds: 2),
+      () => throw Exception('Logout failed: user ID is invalid'));
+}
+// #docregion ''
+
+void main() {
+  fetchUserOrder();
+  print('Fetching user order...');
+}

--- a/null_safety_examples/async_await/bin/get_order.dart
+++ b/null_safety_examples/async_await/bin/get_order.dart
@@ -1,0 +1,20 @@
+Future<String> createOrderMessage() async {
+  var order = await fetchUserOrder();
+  return 'Your order is: $order';
+}
+
+Future<String> fetchUserOrder() =>
+    // Imagine that this function is more complex and slow.
+    Future.delayed(
+      Duration(seconds: 2),
+      () => 'Large Latte',
+    );
+
+// #docregion main-sig
+Future<void> main() async {
+  // #enddocregion main-sig
+  print('Fetching user order...');
+  // #docregion print-order
+  print(await createOrderMessage());
+  // #enddocregion print-order
+}

--- a/null_safety_examples/async_await/bin/get_order_sync_bad.dart
+++ b/null_safety_examples/async_await/bin/get_order_sync_bad.dart
@@ -1,0 +1,21 @@
+// This example shows how *not* to write asynchronous Dart code.
+
+// #docregion no-warning
+String createOrderMessage() {
+  var order = fetchUserOrder();
+  return 'Your order is: $order';
+}
+
+Future<String> fetchUserOrder() =>
+    // Imagine that this function is more complex and slow.
+    Future.delayed(
+      Duration(seconds: 2),
+      () => 'Large Latte',
+    );
+
+// #docregion main-sig
+void main() {
+  // #enddocregion main-sig
+  print('Fetching user order...');
+  print(createOrderMessage());
+}

--- a/null_safety_examples/async_await/bin/try_catch.dart
+++ b/null_safety_examples/async_await/bin/try_catch.dart
@@ -1,0 +1,24 @@
+Future<void> printOrderMessage() async {
+  // #docregion try-catch
+  try {
+    var order = await fetchUserOrder();
+    print('Awaiting user order...');
+    print(order);
+  } catch (err) {
+    print('Caught error: $err');
+  }
+  // #enddocregion try-catch
+}
+
+Future<String> fetchUserOrder() {
+  // Imagine that this function is more complex.
+  var str = Future.delayed(
+      Duration(seconds: 4),
+      // ignore: only_throw_errors
+      () => throw 'Cannot locate user order');
+  return str;
+}
+
+Future<void> main() async {
+  await printOrderMessage();
+}

--- a/null_safety_examples/async_await/dart_test.yaml
+++ b/null_safety_examples/async_await/dart_test.yaml
@@ -1,0 +1,1 @@
+include: ../dart_test_base_browser.yaml

--- a/null_safety_examples/async_await/pubspec.yaml
+++ b/null_safety_examples/async_await/pubspec.yaml
@@ -1,0 +1,10 @@
+name: async_await
+description: dart.dev example code.
+
+environment:
+  sdk: '>=2.5.0 <3.0.0'
+
+dev_dependencies:
+  examples_util: {path: ../util}
+  pedantic: ^1.8.0
+  test: ^1.6.0

--- a/null_safety_examples/async_await/pubspec.yaml
+++ b/null_safety_examples/async_await/pubspec.yaml
@@ -2,9 +2,9 @@ name: async_await
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}
-  pedantic: ^1.8.0
-  test: ^1.6.0
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.13

--- a/null_safety_examples/async_await/test/async_await_test.dart
+++ b/null_safety_examples/async_await/test/async_await_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+import 'package:examples_util/print_matcher.dart' as m;
+
+import '../bin/async_example.dart' as async_example;
+import '../bin/futures_intro.dart' as futures_intro;
+import '../bin/get_order_sync_bad.dart' as get_order_sync_bad;
+import '../bin/get_order.dart' as get_order;
+import '../bin/try_catch.dart' as try_catch;
+
+void main() {
+  test('async_example', () {
+    final output = '''
+      Awaiting user order...
+      1
+      2
+      3
+      4
+      Your order is: Large Latte
+    ''';
+    expect(async_example.main, m.printsLines(output));
+  });
+
+  test('futures_intro', () {
+    final output = '''
+      Fetching user order...
+      Large Latte
+    ''';
+    expect(
+        () => Future.wait([
+              Future.delayed(Duration(seconds: 4)),
+              Future.sync(futures_intro.main),
+            ]),
+        m.printsLines(output));
+  });
+
+  test('get_order_sync_bad', () {
+    final output = '''
+      Fetching user order...
+      Your order is: Instance of 'Future<String>'
+    ''';
+    expect(get_order_sync_bad.main, m.printsLines(output));
+  });
+
+  test('get_order', () {
+    final output = '''
+      Fetching user order...
+      Your order is: Large Latte
+    ''';
+    expect(get_order.main, m.printsLines(output));
+  });
+
+  test('try_catch', () {
+    expect(try_catch.main, m.prints('Caught error: Cannot locate user order'));
+  });
+}

--- a/null_safety_examples/dart_test_base.yaml
+++ b/null_safety_examples/dart_test_base.yaml
@@ -1,0 +1,2 @@
+# When analyzing build/test logs, the expanded reporter is better:
+reporter: expanded

--- a/null_safety_examples/dart_test_base_browser.yaml
+++ b/null_safety_examples/dart_test_base_browser.yaml
@@ -1,0 +1,13 @@
+include: dart_test_base.yaml
+
+tags:
+  browser:
+
+# Chrome option required because Travis is't running under sudo
+# https://docs.travis-ci.com/user/chrome#Sandboxing
+define_platforms:
+  travischrome:
+    name: Chrome for Travis w/o sudo
+    extends: chrome
+    settings:
+      arguments: --no-sandbox

--- a/src/codelabs/async-await_migrated.md
+++ b/src/codelabs/async-await_migrated.md
@@ -1,0 +1,1138 @@
+---
+title: "Asynchronous programming: futures, async, await"
+description: Learn about and practice writing asynchronous code in DartPad!
+js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
+---
+{% assign useIframe = false -%}
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
+<?code-excerpt plaster="none"?>
+<style>
+{% comment %}
+TODO(chalin): move this into one of our SCSS files
+{% endcomment -%}
+iframe[src^="https://dartpad"] {
+  border: 1px solid #ccc;
+  margin-bottom: 1rem;
+  min-height: 150px;
+  resize: vertical;
+  width: 100%;
+}
+</style>
+
+This codelab teaches you how to write asynchronous code using
+futures and the `async` and `await` keywords. Using embedded DartPad
+editors, you can test your knowledge by running example code and completing
+exercises.
+
+To get the most out of this codelab, you should have the following:
+
+* Knowledge of [basic Dart syntax](/samples).
+* Some experience writing asynchronous code in another language.
+
+This codelab covers the following material:
+
+* How and when to use the `async` and `await` keywords.
+* How using `async` and `await` affects execution order.
+* How to handle errors from an asynchronous call using `try-catch` expressions
+  in `async` functions.
+
+Estimated time to complete this codelab: 40-60 minutes.
+
+{{site.alert.note}}
+  This page uses embedded DartPads to display examples and exercises.
+  {% include dartpads-embedded-troubleshooting.md %}
+{{site.alert.end}}
+
+## Why asynchronous code matters
+
+Asynchronous operations let your program complete work while waiting for
+another operation to finish. Here are some common asynchronous operations:
+
+* Fetching data over a network.
+* Writing to a database.
+* Reading data from a file.
+
+To perform asynchronous operations in Dart, you can use the `Future` class
+and the `async` and `await` keywords.
+
+### Example: Incorrectly using an asynchronous function
+The following example shows the wrong way to use an asynchronous function
+(`fetchUserOrder()`). Later you'll fix the example using `async` and `await`.
+Before running this example, try to spot the issue -- what do you think the
+output will be?
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=5c8c7716b6b4284842f15fe079f61e47&ga_id=incorrect_usage"
+  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
+  frameborder="no"
+  height="420"
+  width="100%" >
+</iframe>
+{% else -%}
+
+<?code-excerpt "async_await/bin/get_order_sync_bad.dart" remove="Fetching"?>
+```dart:run-dartpad:height-380px:ga_id-incorrect_usage
+// This example shows how *not* to write asynchronous Dart code.
+
+String createOrderMessage() {
+  var order = fetchUserOrder();
+  return 'Your order is: $order';
+}
+
+Future<String> fetchUserOrder() =>
+    // Imagine that this function is more complex and slow.
+    Future.delayed(
+      Duration(seconds: 2),
+      () => 'Large Latte',
+    );
+
+void main() {
+  print(createOrderMessage());
+}
+```
+{% endif -%}
+
+Here's why the example fails to print the value that `fetchUserOrder()` eventually
+produces:
+
+* `fetchUserOrder()` is an asynchronous function that, after a delay,
+  provides a string that describes the user's order: a "Large Latte".
+* To get the user's order, `createOrderMessage()` should call `fetchUserOrder()`
+  and wait for it to finish. Because `createOrderMessage()` does *not* wait
+  for `fetchUserOrder()` to finish, `createOrderMessage()` fails to get the string
+  value that `fetchUserOrder()` eventually provides.
+* Instead, `createOrderMessage()` gets a representation of pending work to be
+  done: an uncompleted future. You'll learn more about futures in the next section.
+* Because `createOrderMessage()` fails to get the value describing the user's
+  order, the example fails to print "Large Latte" to the console, and instead
+  prints "Your order is: Instance of '_Future<String>'".
+
+In the next sections you'll learn about futures and about working with futures
+(using `async` and `await`)
+so that you'll be able to write the code necessary to make `fetchUserOrder()`
+print the desired value ("Large Latte") to the console.
+
+{{site.alert.secondary}}
+  **Key terms:**
+
+  * **synchronous operation**: A synchronous operation blocks other operations
+    from executing until it completes.
+  * **synchronous function**: A synchronous function only performs synchronous
+    operations.
+  * **asynchronous operation**: Once initiated, an asynchronous operation allows
+    other operations to execute before it completes.
+  * **asynchronous function**: An asynchronous function performs at least one
+    asynchronous operation and can also perform _synchronous_ operations.
+{{site.alert.end}}
+
+
+## What is a future?
+
+A future (lower case "f") is an instance of the [Future][]
+(capitalized "F") class. A future represents the result of an asynchronous
+operation, and can have two states: uncompleted or completed.
+
+{{site.alert.note}}
+  _Uncompleted_ is a Dart term referring to the state of a future
+  before it has produced a value.
+{{site.alert.end}}
+
+### Uncompleted
+
+When you call an asynchronous function, it returns an uncompleted future.
+That future is waiting for the function's asynchronous operation to finish or to
+throw an error.
+
+### Completed
+
+If the asynchronous operation succeeds, the future completes with a
+value. Otherwise it completes with an error.
+
+#### Completing with a value
+
+A future of type `Future<T>` completes with a value of type `T`.
+For example, a future with type `Future<String>` produces a string value.
+If a future doesn't produce a usable value, then the future's type is
+`Future<void>`.
+
+#### Completing with an error
+
+If the asynchronous operation performed by the function fails for any reason, the
+future completes with an error.
+
+### Example: Introducing futures
+
+In the following example, `fetchUserOrder()` returns a future that completes after
+printing to the console. Because it doesn't return a usable value,
+`fetchUserOrder()` has the type `Future<void>`. Before you run the example,
+try to predict which will print first: "Large Latte" or "Fetching user order...".
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=57e6085344cbd1719ed42b32f8ad1bce&ga_id=introducting_futures"
+  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
+  frameborder="no"
+  height="300"
+  width="100%" >
+</iframe>
+{% else -%}
+
+<?code-excerpt "async_await/bin/futures_intro.dart"?>
+```dart:run-dartpad:height-300px:ga_id-introducting_futures
+Future<void> fetchUserOrder() {
+  // Imagine that this function is fetching user info from another service or database.
+  return Future.delayed(Duration(seconds: 2), () => print('Large Latte'));
+}
+
+void main() {
+  fetchUserOrder();
+  print('Fetching user order...');
+}
+```
+{% endif -%}
+
+In the preceding example, even though `fetchUserOrder()` executes before
+the `print()` call on line 8, the console shows the output from line 8
+("Fetching user order...") before the output from `fetchUserOrder()` ("Large Latte").
+This is because `fetchUserOrder()` delays before it prints "Large Latte".
+
+### Example: Completing with an error
+
+Run the following example to see how a future completes with an error.
+A bit later you'll learn how to handle the error.
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=d843061bbd9388b837c57613dc6d5125&ga_id=completing_with_error"
+  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
+  frameborder="no"
+  height="275"
+  width="100%" >
+</iframe>
+{% else -%}
+
+<?code-excerpt "async_await/bin/futures_intro.dart (error)" replace="/Error//g"?>
+```dart:run-dartpad:height-300px:ga_id-completing_with_error
+Future<void> fetchUserOrder() {
+// Imagine that this function is fetching user info but encounters a bug
+  return Future.delayed(Duration(seconds: 2),
+      () => throw Exception('Logout failed: user ID is invalid'));
+}
+
+void main() {
+  fetchUserOrder();
+  print('Fetching user order...');
+}
+```
+{% endif -%}
+
+In this example, `fetchUserOrder()` completes with an error indicating that the
+user ID is invalid.
+
+You've learned about futures and how they complete, but how do you use the
+results of asynchronous functions? In the next section you'll learn how to get
+results with the `async` and `await` keywords.
+
+{{site.alert.secondary}}
+  **Quick review:**
+
+  * A [Future\<T\>][Future] instance produces a value of type `T`.
+  * If a future doesn't produce a usable value, then the future's type is
+    `Future<void>`.
+  * A future can be in one of two states: uncompleted or completed.
+  * When you call a function that returns a future, the function queues up
+    work to be done and returns an uncompleted future.
+  * When a future's operation finishes, the future completes with a value or
+    with an error.
+
+  **Key terms:**
+
+  * **Future**: the Dart [Future][] class.
+  * **future**: an instance of the Dart `Future` class.
+{{site.alert.end}}
+
+## Working with futures: async and await
+
+The `async` and `await` keywords provide a declarative way to define
+asynchronous functions and use their results. Remember these two basic guidelines
+when using `async` and `await`:
+
+* __To define an async function, add `async` before the function body:__
+* __The `await` keyword works only in `async` functions.__
+
+Here's an example  that converts `main()` from a synchronous to asynchronous
+function.
+
+First, add the `async` keyword before the function body:
+
+<?code-excerpt "async_await/bin/get_order_sync_bad.dart (main-sig)" replace="/main\(\)/$& async/g; /async/[!$&!]/g; /$/ ··· }/g"?>
+{% prettify dart tag=pre+code %}
+void main() [!async!] { ··· }
+{% endprettify %}
+
+If the function has a declared return type, then update the type to be
+`Future<T>`, where `T` is the type of the value that the function returns.
+If the function doesn't explicitly return a value, then the return type is
+`Future<void>`:
+
+<?code-excerpt "async_await/bin/get_order.dart (main-sig)" replace="/Future<\w+\W/[!$&!]/g;  /$/ ··· }/g"?>
+{% prettify dart tag=pre+code %}
+[!Future<void>!] main() async { ··· }
+{% endprettify %}
+
+Now that you have an `async` function, you can use the `await` keyword to wait
+for a future to complete:
+
+<?code-excerpt "async_await/bin/get_order.dart (print-order)" replace="/await/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+print([!await!] createOrderMessage());
+{% endprettify %}
+
+As the following two examples show, the `async` and `await` keywords result in
+asynchronous code that looks a lot like synchronous code.
+The only differences are highlighted in the asynchronous example, which — if
+your window is wide enough — is to the right of the synchronous example.
+
+<div class="container">
+<div class="row">
+<div class="col-sm" markdown="1">
+#### Example: synchronous functions
+
+<?code-excerpt "async_await/bin/get_order_sync_bad.dart (no-warning)" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g"?>
+```dart
+String createOrderMessage() {
+  var order = fetchUserOrder();
+  return 'Your order is: $order';
+}
+
+Future<String> fetchUserOrder() =>
+    // Imagine that this function is
+    // more complex and slow.
+    Future.delayed(
+      Duration(seconds: 2),
+      () => 'Large Latte',
+    );
+
+void main() {
+  print('Fetching user order...');
+  print(createOrderMessage());
+}
+```
+
+{:.console-output}
+```nocode
+Fetching user order...
+Your order is: Instance of _Future<String>
+```
+</div>
+<div class="col-sm" markdown="1">
+#### Example: asynchronous functions
+
+<?code-excerpt "async_await/bin/get_order.dart" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g; /async|await/[!$&!]/g; /(Future<\w+\W)( [^f])/[!$1!]$2/g; /4/2/g"?>
+{% prettify dart tag=pre+code %}
+[!Future<String>!] createOrderMessage() [!async!] {
+  var order = [!await!] fetchUserOrder();
+  return 'Your order is: $order';
+}
+
+Future<String> fetchUserOrder() =>
+    // Imagine that this function is
+    // more complex and slow.
+    Future.delayed(
+      Duration(seconds: 2),
+      () => 'Large Latte',
+    );
+
+[!Future<void>!] main() [!async!] {
+  print('Fetching user order...');
+  print([!await!] createOrderMessage());
+}
+{% endprettify %}
+
+{:.console-output}
+```nocode
+Fetching user order...
+Your order is: Large Latte
+```
+</div>
+</div>
+</div>
+
+The asynchronous example is different in three ways:
+
+* The return type for `createOrderMessage()` changes from `String` to
+  `Future<String>`.
+* The **`async`** keyword appears before the function bodies for
+  `createOrderMessage()` and `main()`.
+* The **`await`** keyword appears before calling the asynchronous functions
+  `fetchUserOrder()` and `createOrderMessage()`.
+
+{{site.alert.secondary}}
+  **Key terms:**
+  * **async**: You can use the `async` keyword before a function's body to mark it as
+    asynchronous.
+  * **async function**:  An `async` function is a function labeled with the `async`
+    keyword.
+  * **await**: You can use the `await` keyword to get the completed result of an
+    asynchronous expression. The `await` keyword only works within an `async` function.
+{{site.alert.end}}
+
+### Execution flow with async and await
+
+An `async` function runs synchronously until the first
+`await` keyword. This means that within an `async` function body, all
+synchronous code before the first `await` keyword executes immediately.
+
+{{site.alert.version-note}}
+  Before Dart 2.0, an `async` function returned immediately, without executing
+  any code within the `async` function body.
+{{site.alert.end}}
+
+### Example: Execution within async functions
+Run the following example to see how execution proceeds within an `async`
+function body. What do you think the output will be?
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=d7abfdea1ae5596e96c7c0203d975dba&ga_id=execution_within_async_function"
+  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 40px"
+  frameborder="no"
+  height="600"
+  width="100%">
+</iframe>
+{% else -%}
+
+<?code-excerpt "async_await/bin/async_example.dart" remove="/\/\/ print/"?>
+```dart:run-dartpad:height-530px:ga_id-execution_within_async_function
+Future<void> printOrderMessage() async {
+  print('Awaiting user order...');
+  var order = await fetchUserOrder();
+  print('Your order is: $order');
+}
+
+Future<String> fetchUserOrder() {
+  // Imagine that this function is more complex and slow.
+  return Future.delayed(Duration(seconds: 4), () => 'Large Latte');
+}
+
+Future<void> main() async {
+  countSeconds(4);
+  await printOrderMessage();
+}
+
+// You can ignore this function - it's here to visualize delay time in this example.
+void countSeconds(int s) {
+  for (var i = 1; i <= s; i++) {
+    Future.delayed(Duration(seconds: i), () => print(i));
+  }
+}
+```
+{% endif -%}
+
+After running the code in the preceding example, try reversing lines 2 and 3:
+
+<?code-excerpt "async_await/bin/async_example.dart (swap-stmts)" replace="/\/\/ (print)/$1/g"?>
+```dart
+var order = await fetchUserOrder();
+print('Awaiting user order...');
+```
+
+Notice that timing of the output shifts, now that `print('Awaiting user order')`
+appears after the first `await` keyword in `printOrderMessage()`.
+
+### Exercise: Practice using async and await
+
+The following exercise is a failing unit test that contains partially completed
+code snippets. Your task is to complete the exercise by writing code to make the
+tests pass.
+You don't need to implement `main()`.
+
+To simulate asynchronous operations, call the following functions, which are
+provided for you:
+
+|------------------+--------------------------------+-------------|
+| Function         | Type signature                 | Description |
+|------------------|--------------------------------|-------------|
+| fetchRole()        | `Future<String> fetchRole()`     | Gets a short description of the user's role. |
+| fetchLoginAmount() | `Future<int> fetchLoginAmount()` | Gets the number of times a user has logged in. |
+{:.table .table-striped}
+
+
+#### Part 1: `reportUserRole()`
+
+Add code to the `reportUserRole()` function so that it does the following:
+{% comment %}
+  Some bulleted items are intentionally lacking punctuation to avoid
+  confusing the users about characters in string values
+{% endcomment -%}
+
+* Returns a future that completes with the following
+  string: `"User role: <user role>"`
+  * Note: You must use the actual value returned by `fetchRole()`; copying and
+    pasting the example return value won't make the test pass.
+  * Example return value: `"User role: tester"`
+* Gets the user role by calling the provided function `fetchRole()`.
+
+####  Part 2: `reportLogins()`
+
+Implement an `async` function `reportLogins()` so that it does the following:
+
+* Returns the string `"Total number of logins: <# of logins>"`.
+  * Note: You must use the actual value returned by `fetchLoginAmount()`; copying
+    and pasting the example return value won't make the test pass.
+  * Example return value from `reportLogins()`: `"Total number of logins: 57"`
+* Gets the number of logins by calling the provided function `fetchLoginAmount()`.
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=f751b692502c4ee43d932f745860b056&theme=dark&ga_id=practice_using"
+  frameborder="no"
+  height="550"
+  width="100%">
+</iframe>
+
+{% else -%}
+
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_using
+{$ begin main.dart $}
+// Part 1
+// You can call the provided async function fetchRole()
+// to return the user role.
+Future<String> reportUserRole() async {
+  // TO DO: Your implementation goes here.
+}
+
+// Part 2
+// Implement reportLogins here
+// You can call the provided async function fetchLoginAmount()
+// to return the number of times that the user has logged in.
+reportLogins(){}
+{$ end main.dart $}
+{$ begin solution.dart $}
+Future<String> reportUserRole() async {
+  var username = await fetchRole();
+  return 'User role: $username';
+}
+
+Future<String> reportLogins() async {
+  var logins = await fetchLoginAmount();
+  return 'Total number of logins: $logins';
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+const role = 'administrator';
+const logins = 42;
+const passed = 'PASSED';
+const testFailedMessage = 'Test failed for the function:';
+const typoMessage = 'Test failed! Check for typos in your return value';
+const didNotImplement = 'Test failed! Did you forget to implement or return from ';
+const oneSecond = Duration(seconds: 1);
+List<String> messages = [];
+Future<String> fetchRole() => Future.delayed(oneSecond, () => role);
+Future<int> fetchLoginAmount() => Future.delayed(oneSecond, () => logins);
+
+main() async {
+  try {
+    messages
+      ..add(makeReadable(
+
+        testLabel: 'Part 1',
+        testResult: await asyncEquals(
+          expected: 'User role: administrator',
+          actual: await reportUserRole(),
+          typoKeyword: role
+        ),
+        readableErrors: {
+          typoMessage: typoMessage,
+          'null': '$didNotImplement reportUserRole?',
+          'User role: Instance of \'Future<String>\'': '$testFailedMessage reportUserRole. Did you use the await keyword?',
+          'User role: Instance of \'_Future<String>\'': '$testFailedMessage reportUserRole. Did you use the await keyword?',
+          'User role:' : '$testFailedMessage reportUserRole. Did you return a user role?',
+          'User role: ' : '$testFailedMessage reportUserRole. Did you return a user role?',
+          'User role: tester' : '$testFailedMessage reportUserRole. Did you invoke fetchRole to fetch the user\'s role?',
+        }))
+
+      ..add(makeReadable(
+
+        testLabel: 'Part 2',
+        testResult: await asyncEquals(
+          expected: 'Total number of logins: 42',
+          actual: await reportLogins(),
+          typoKeyword: logins.toString()
+        ),
+        readableErrors: {
+          typoMessage: typoMessage,
+          'null': '$didNotImplement reportLogins?',
+          'Total number of logins: Instance of \'Future<int>\'': '$testFailedMessage reportLogins. Did you use the await keyword?',
+          'Total number of logins: Instance of \'_Future<int>\'': '$testFailedMessage reportLogins. Did you use the await keyword?',
+          'Total number of logins: ': '$testFailedMessage reportLogins. Did you return the number of logins?',
+          'Total number of logins:': '$testFailedMessage reportLogins. Did you return the number of logins?',
+          'Total number of logins: 57': '$testFailedMessage reportLogins. Did you invoke fetchLoginAmount to fetch the number of user logins?',
+        }))
+      ..removeWhere((m) => m.contains(passed))
+      ..toList();
+
+    if (messages.isEmpty) {
+      _result(true);
+    } else {
+      _result(false, messages);
+    }
+  } catch (e) {
+    _result(false, ['Tried to run solution, but received an exception: $e']);
+  }
+}
+
+////////////////////////////////////////
+///////////// Test Helpers /////////////
+////////////////////////////////////////
+String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
+  if (readableErrors.containsKey(testResult)) {
+    var readable = readableErrors[testResult];
+    return '$testLabel $readable';
+  } else {
+    return '$testLabel $testResult';
+  }
+}
+
+///////////////////////////////////////
+//////////// Assertions ///////////////
+///////////////////////////////////////
+Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
+  var strActual = actual is String ? actual : actual.toString();
+  try {
+    if (expected == actual) {
+      return passed;
+    } else if (strActual.contains(typoKeyword)) {
+      return typoMessage;
+    } else {
+      return strActual;
+    }
+  } catch(e) {
+    return e;
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Did you remember to add the async keyword to the reportUserRole() function?
+
+Did you remember to use the await keyword before invoking fetchRole()?
+
+Remember: reportUserRole() needs to return a future!
+{$ end hint.txt $}
+```
+{% endif -%}
+
+{{site.alert.note}}
+  If your code passes the tests, you can ignore
+  [info-level messages.](/guides/language/analysis-options#customizing-analysis-rules)
+{{site.alert.end}}
+
+## Handling errors
+To handle errors in an `async` function, use try-catch:
+
+<?code-excerpt "async_await/bin/try_catch.dart (try-catch)" remove="print(order)"?>
+```dart
+try {
+  var order = await fetchUserOrder();
+  print('Awaiting user order...');
+} catch (err) {
+  print('Caught error: $err');
+}
+```
+
+Within an `async` function, you can write [try-catch clauses](/guides/language/language-tour#catch)
+the same way you would in synchronous code.
+
+### Example: async and await with try-catch
+
+Run the following example to see how to handle an error from an
+asynchronous function. What do you think the output will be?
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=25ade03f0632878a9169209e3cd7bef2&ga_id=try_catch"
+  style="border: 1px solid lightgrey;"
+  frameborder="no"
+  height="525"
+  width="100%">
+</iframe>
+{% else -%}
+
+<?code-excerpt "async_await/bin/try_catch.dart"?>
+```dart:run-dartpad:height-530px:ga_id-try_catch
+Future<void> printOrderMessage() async {
+  try {
+    var order = await fetchUserOrder();
+    print('Awaiting user order...');
+    print(order);
+  } catch (err) {
+    print('Caught error: $err');
+  }
+}
+
+Future<String> fetchUserOrder() {
+  // Imagine that this function is more complex.
+  var str = Future.delayed(
+      Duration(seconds: 4),
+      () => throw 'Cannot locate user order');
+  return str;
+}
+
+Future<void> main() async {
+  await printOrderMessage();
+}
+```
+{% endif -%}
+
+### Exercise: Practice handling errors
+
+The following exercise provides practice handling errors with asynchronous code,
+using the approach described in the previous section. To simulate asynchronous
+operations, your code will call the following function, which is provided for you:
+
+|------------------+-----------------------------------+-------------|
+| Function         | Type signature                    | Description |
+|------------------|-----------------------------------|-------------|
+| fetchNewUsername() | `Future<String> fetchNewUsername()` | Returns the new username that you can use to replace an old one.|
+{:.table .table-striped}
+
+Use `async` and `await` to implement an asynchronous `changeUsername()` function
+that does the following:
+
+* Calls the provided asynchronous function `fetchNewUsername()` and returns its result.
+  * Example return value from `changeUsername()`: `"jane_smith_92"`
+* Catches any error that occurs and returns the string value of the error.
+  * You can use the
+    [toString()]({{site.dart_api}}/stable/dart-core/ArgumentError/toString.html)
+    method to stringify both
+    [Exceptions]({{site.dart_api}}/stable/dart-core/Exception-class.html) and
+    [Errors.]({{site.dart_api}}/stable/dart-core/Error-class.html)
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=858f71f0ad0e70051999bcafa41806a3&theme=dark&ga_id=practice_errors"
+  frameborder="no"
+  height="525"
+  width="100%">
+</iframe>
+
+{% else -%}
+{% comment %}
+PENDING: Any way to auto-include this code?
+{% endcomment %}
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_errors
+{$ begin main.dart $}
+// Implement changeUsername here
+{$ end main.dart $}
+{$ begin solution.dart $}
+Future<String> changeUsername () async {
+  try {
+    return await fetchNewUsername();
+  } catch (err) {
+    return err.toString();
+  }
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+List<String> messages = [];
+bool logoutSucceeds = false;
+const passed = 'PASSED';
+const noCatch = 'NO_CATCH';
+const typoMessage = 'Test failed! Check for typos in your return value';
+const oneSecond = Duration(seconds: 1);
+
+class UserError implements Exception {
+  String errMsg() => 'New username is invalid';
+}
+
+Future fetchNewUsername() {
+  var str = Future.delayed(oneSecond, () => throw UserError());
+  return str;
+}
+
+main() async {
+  try {
+    // ignore: cascade_invocations
+    messages
+      ..add(makeReadable(
+          testLabel: '',
+          testResult: await asyncDidCatchException(changeUsername),
+          readableErrors: {
+            typoMessage: typoMessage,
+            noCatch: 'Did you remember to call fetchNewUsername within a try/catch block?',
+          }
+      ))
+      ..add(makeReadable(
+          testLabel: '',
+          testResult: await asyncErrorEquals(changeUsername),
+          readableErrors: {
+            typoMessage: typoMessage,
+            noCatch: 'Did you remember to call fetchNewUsername within a try/catch block?',
+          }
+      ))
+      ..removeWhere((m) => m.contains(passed))
+      ..toList();
+
+    if (messages.isEmpty) {
+      _result(true);
+    } else {
+      _result(false, messages);
+    }
+  } catch (e) {
+    _result(false, ['Tried to run solution, but received an exception: $e']);
+  }
+}
+
+////////////////////////////////////////
+///////////// Test Helpers /////////////
+////////////////////////////////////////
+String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
+  if (readableErrors.containsKey(testResult)) {
+    var readable = readableErrors[testResult];
+    return '$testLabel $readable';
+  } else {
+    return '$testLabel $testResult';
+  }
+}
+
+void passIfNoMessages(List<String> messages, Map<String, String> readable){
+  if (messages.isEmpty) {
+    _result(true);
+  } else {
+
+    // ignore: omit_local_variable_types
+    List<String> userMessages = messages
+        .where((message) => readable.containsKey(message))
+        .map((message) => readable[message])
+        .toList();
+    print(messages);
+
+    _result(false, userMessages);
+  }
+}
+///////////////////////////////////////
+//////////// Assertions ///////////////
+///////////////////////////////////////
+Future<String> asyncErrorEquals(Function fn) async {
+  var result = await fn();
+  if (result == UserError().toString()) {
+    return passed;
+  } else {
+    return 'Test failed! Did you stringify and return the caught error?';
+  }
+}
+
+Future<String> asyncDidCatchException(Function fn) async {
+  var caught = true;
+  try {
+    await fn();
+  } on UserError catch(_) {
+    caught = false;
+  }
+
+  if (caught == false) {
+    return noCatch;
+  } else {
+    return passed;
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Implement changeUsername() to return the string from fetchNewUsername() or
+(if that fails) the string value of any error that occurs.
+You'll need a try-catch statement to catch and handle errors.
+{$ end hint.txt $}
+```
+{% endif -%}
+
+{% comment %}
+TODO: Consider summary section before final exercise
+TODO: Consider adding new content to final section (not repeating same stuff)
+{% endcomment -%}
+
+![Someone's looking at you!](/codelabs/images/mortarboard.png)<br>
+_You've found [something special!](https://goo.gle/FlutterDay-Puzzle)_
+
+
+## Exercise: Putting it all together
+
+It's time to practice what you've learned in one final exercise.
+To simulate asynchronous operations, this exercise provides the asynchronous
+functions `fetchUsername()` and `logoutUser()`:
+
+|------------------+-----------------------------------+-------------|
+| Function         | Type signature                    | Description |
+|------------------|-----------------------------------|-------------|
+| fetchUsername()    | `Future<String> fetchUsername()`    | Returns the name associated with the current user.|
+| logoutUser()     | `Future<String> logoutUser()`     | Performs logout of current user and returns the username that was logged out.|
+{:.table .table-striped}
+
+Write the following:
+
+####  Part 1: `addHello()`
+
+* Write a function `addHello()` that takes a single String argument.
+* `addHello()` returns its String argument preceded by 'Hello '.<br>
+  Example: `addHello('Jon')` returns `'Hello Jon'`.
+
+####  Part 2: `greetUser()`
+
+* Write a function `greetUser()` that takes no arguments.
+* To get the username, `greetUser()` calls the provided asynchronous
+  function `fetchUsername()`.
+* `greetUser()` creates a greeting for the user by calling `addHello()`,
+  passing it the username, and returning the result.<br>
+  Example: If `fetchUsername()` returns `'Jenny'`, then
+  `greetUser()` returns `'Hello Jenny'`.
+
+####  Part 3: `sayGoodbye()`
+
+* Write a function `sayGoodbye()` that does the following:
+  * Takes no arguments.
+  * Catches any errors.
+  * Calls the provided asynchronous function `logoutUser()`.
+* If `logoutUser()` fails, `sayGoodbye()` returns any string you like.
+* If `logoutUser()` succeeds, `sayGoodbye()` returns the string
+  `'<result> Thanks, see you next time'`, where `<result>` is
+  the String value returned by calling `logoutUser()`.
+
+{% if useIframe -%}
+<iframe
+  src="{{site.dartpad-embed}}?id=f601d25bc2833c957186e3c6bf71effc&theme=dark&ga_id=putting_it_all_together"
+  frameborder="no"
+  height="550"
+  width="100%">
+</iframe>
+
+{% else -%}
+
+{% comment %}
+PENDING: Any way to auto-include this code?
+{% endcomment %}
+```dart:run-dartpad:theme-dark:height-380px:ga_id-putting_it_all_together
+{$ begin main.dart $}
+// Part 1
+addHello(){}
+
+// Part 2
+// You can call the provided async function fetchUsername()
+// to return the username.
+greetUser(){}
+
+// Part 3
+// You can call the provided async function logoutUser()
+// to log out the user.
+sayGoodbye(){}
+{$ end main.dart $}
+{$ begin solution.dart $}
+String addHello(user) => 'Hello $user';
+
+Future<String> greetUser() async {
+  var username = await fetchUsername();
+  return addHello(username);
+}
+
+Future<String> sayGoodbye() async {
+  try {
+    var result = await logoutUser();
+    return '$result Thanks, see you next time';
+  } catch (e) {
+    return 'Failed to logout user: $e';
+  }
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+List<String> messages = [];
+bool logoutSucceeds = false;
+const passed = 'PASSED';
+const noCatch = 'NO_CATCH';
+const typoMessage = 'Test failed! Check for typos in your return value';
+const didNotImplement = 'Test failed! Did you forget to implement or return from ';
+const oneSecond = Duration(seconds: 1);
+
+Future<String> fetchUsername() => Future.delayed(oneSecond, () => 'Jean');
+String failOnce () {
+  if (logoutSucceeds) {
+    return 'Success!';
+  } else {
+    logoutSucceeds = true;
+    throw Exception('Logout failed');
+  }
+}
+
+logoutUser() => Future.delayed(oneSecond, failOnce);
+
+main() async {
+  try {
+    // ignore: cascade_invocations
+    messages
+      ..add(makeReadable(
+
+        testLabel: 'Part 1',
+        testResult: await asyncEquals(
+          expected: 'Hello Jerry',
+          actual: addHello('Jerry'),
+          typoKeyword: 'Jerry'
+        ),
+        readableErrors: {
+          typoMessage: typoMessage,
+          'null': '$didNotImplement addHello?',
+          'Hello Instance of \'Future<String>\'': 'Looks like you forgot to use the \'await\' keyword!',
+          'Hello Instance of \'_Future<String>\'': 'Looks like you forgot to use the \'await\' keyword!',
+        }))
+      ..add(makeReadable(
+
+        testLabel: 'Part 2',
+        testResult: await asyncEquals(
+          expected: 'Hello Jean',
+          actual: await greetUser(),
+          typoKeyword: 'Jean'
+        ),
+        readableErrors: {
+          typoMessage: typoMessage,
+          'null': '$didNotImplement greetUser?',
+          'HelloJean' : 'Looks like you forgot the space between \'Hello\' and \'Jean\'',
+          'Hello Instance of \'Future<String>\'': 'Looks like you forgot to use the \'await\' keyword!',
+          'Hello Instance of \'_Future<String>\'': 'Looks like you forgot to use the \'await\' keyword!',
+          '{Closure: (String) => dynamic from Function \'addHello\': static.(await fetchUsername())}': 'Did you place the \'\$\' character correctly?',
+          '{Closure \'addHello\'(await fetchUsername())}': 'Did you place the \'\$\' character correctly?', 
+        }))
+      ..add(makeReadable(
+        testLabel: 'Part 3',
+        testResult: await asyncDidCatchException(sayGoodbye),
+        readableErrors: {
+          typoMessage: '$typoMessage. Did you add the text \'Thanks, see you next time\'?',
+          'null': '$didNotImplement sayGoodbye?',
+          noCatch: 'Did you remember to call logoutUser within a try/catch block?',
+          'Instance of \'Future<String>\' Thanks, see you next time':'Did you remember to use the \'await\' keyword in the sayGoodbye function?',
+          'Instance of \'_Future<String>\' Thanks, see you next time':'Did you remember to use the \'await\' keyword in the sayGoodbye function?',
+        }
+      ))
+      ..add(makeReadable(
+        testLabel: 'Part 3',
+        testResult: await asyncEquals(
+          expected: 'Success! Thanks, see you next time',
+          actual: await sayGoodbye(),
+          typoKeyword: 'Success'
+        ),
+        readableErrors: {
+          typoMessage: '$typoMessage. Did you add the text \'Thanks, see you next time\'?',
+          'null': '$didNotImplement sayGoodbye?',
+          noCatch: 'Did you remember to call logoutUser within a try/catch block?',
+          'Instance of \'Future<String>\' Thanks, see you next time':'Did you remember to use the \'await\' keyword in the sayGoodbye function?',
+          'Instance of \'_Future<String>\' Thanks, see you next time':'Did you remember to use the \'await\' keyword in the sayGoodbye function?',
+          'Instance of \'_Exception\'': 'CAUGHT Did you remember to return a string?',
+          }
+      ))
+    ..removeWhere((m) => m.contains(passed))
+    ..toList();
+
+    if (messages.isEmpty) {
+      _result(true);
+    } else {
+      _result(false, messages);
+    }
+  } catch (e) {
+    _result(false, ['Tried to run solution, but received an exception: $e']);
+  }
+}
+
+////////////////////////////////////////
+///////////// Test Helpers /////////////
+////////////////////////////////////////
+String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
+  String readable;
+  if (readableErrors.containsKey(testResult)) {
+    readable = readableErrors[testResult];
+    return '$testLabel $readable';
+  } else if ((testResult != passed) && (testResult.length < 18)) {
+    readable = typoMessage;
+    return '$testLabel $readable';
+  } else {
+    return '$testLabel $testResult';
+  }
+}
+
+void passIfNoMessages(List<String> messages, Map<String, String> readable){
+  if (messages.isEmpty) {
+    _result(true);
+  } else {
+
+    // ignore: omit_local_variable_types
+    List<String> userMessages = messages
+        .where((message) => readable.containsKey(message))
+        .map((message) => readable[message])
+        .toList();
+    print(messages);
+
+    _result(false, userMessages);
+  }
+}
+///////////////////////////////////////
+//////////// Assertions ///////////////
+///////////////////////////////////////
+Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
+  var strActual = actual is String ? actual : actual.toString();
+  try {
+    if (expected == actual) {
+      return passed;
+    } else if (strActual.contains(typoKeyword)) {
+      return typoMessage;
+    } else {
+      return strActual;
+    }
+  } catch(e) {
+    return e;
+  }
+}
+
+Future<String> asyncDidCatchException(Function fn) async {
+  var caught = true;
+  try {
+    await fn();
+  } on Exception catch(_) {
+    caught = false;
+  }
+
+  if (caught == true) {
+    return passed;
+  } else {
+    return noCatch;
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+The greetUser() and sayGoodbye() functions are asynchronous;
+addHello() isn't.
+{$ end hint.txt $}
+```
+{% endif -%}
+
+## What's next?
+
+Congratulations, you've finished the codelab! If you'd like to learn more, here
+are some suggestions for where to go next:
+
+- Play with [DartPad.]({{site.dartpad}})
+- Try another [codelab](/codelabs).
+- Learn more about futures and asynchrony:
+  - [Streams tutorial](/tutorials/language/streams):
+    Learn how to work with a sequence of asynchronous events.
+  - [Dart videos from Google:][Dart videos]
+    Watch one or more of the videos about asynchronous coding.
+    Or, if you prefer, read the articles that are based on these videos.
+    (Start with [isolates and event loops.][article])
+- [Get the Dart SDK.](/get-dart)
+
+If you're interested in using embedded DartPads, like this codelab does, see
+[best practices for using DartPad in tutorials][].
+
+[best practices for using DartPad in tutorials]: /resources/dartpad-best-practices
+[Dart videos]: https://www.youtube.com/playlist?list=PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J
+[article]: https://medium.com/dartlang/dart-asynchronous-programming-isolates-and-event-loops-bffc3e296a6a
+[Future]: {{site.dart_api}}/stable/dart-async/Future-class.html
+[style guide]: /guides/language/effective-dart/style
+[documentation guide]: /guides/language/effective-dart/documentation
+[usage guide]: /guides/language/effective-dart/usage
+[design guide]: /guides/language/effective-dart/design

--- a/src/codelabs/async-await_migrated.md
+++ b/src/codelabs/async-await_migrated.md
@@ -3,7 +3,6 @@ title: "Asynchronous programming: futures, async, await"
 description: Learn about and practice writing asynchronous code in DartPad!
 js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
 ---
-{% assign useIframe = false -%}
 <?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
 <?code-excerpt plaster="none"?>
 <style>
@@ -61,18 +60,8 @@ The following example shows the wrong way to use an asynchronous function
 Before running this example, try to spot the issue -- what do you think the
 output will be?
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=5c8c7716b6b4284842f15fe079f61e47&ga_id=incorrect_usage"
-  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
-  frameborder="no"
-  height="420"
-  width="100%" >
-</iframe>
-{% else -%}
-
-<?code-excerpt "async_await/bin/get_order_sync_bad.dart" remove="Fetching"?>
-```dart:run-dartpad:height-380px:ga_id-incorrect_usage
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order_sync_bad.dart" remove="Fetching"?>
+```dart:run-dartpad:height-380px:ga_id-incorrect_usage:null_safety-true
 // This example shows how *not* to write asynchronous Dart code.
 
 String createOrderMessage() {
@@ -91,7 +80,6 @@ void main() {
   print(createOrderMessage());
 }
 ```
-{% endif -%}
 
 Here's why the example fails to print the value that `fetchUserOrder()` eventually
 produces:
@@ -168,18 +156,8 @@ printing to the console. Because it doesn't return a usable value,
 `fetchUserOrder()` has the type `Future<void>`. Before you run the example,
 try to predict which will print first: "Large Latte" or "Fetching user order...".
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=57e6085344cbd1719ed42b32f8ad1bce&ga_id=introducting_futures"
-  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
-  frameborder="no"
-  height="300"
-  width="100%" >
-</iframe>
-{% else -%}
-
-<?code-excerpt "async_await/bin/futures_intro.dart"?>
-```dart:run-dartpad:height-300px:ga_id-introducting_futures
+<?code-excerpt "../null_safety_examples/async_await/bin/futures_intro.dart"?>
+```dart:run-dartpad:height-300px:ga_id-introducting_futures:null_safety-true
 Future<void> fetchUserOrder() {
   // Imagine that this function is fetching user info from another service or database.
   return Future.delayed(Duration(seconds: 2), () => print('Large Latte'));
@@ -190,7 +168,6 @@ void main() {
   print('Fetching user order...');
 }
 ```
-{% endif -%}
 
 In the preceding example, even though `fetchUserOrder()` executes before
 the `print()` call on line 8, the console shows the output from line 8
@@ -202,18 +179,8 @@ This is because `fetchUserOrder()` delays before it prints "Large Latte".
 Run the following example to see how a future completes with an error.
 A bit later you'll learn how to handle the error.
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=d843061bbd9388b837c57613dc6d5125&ga_id=completing_with_error"
-  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 25px"
-  frameborder="no"
-  height="275"
-  width="100%" >
-</iframe>
-{% else -%}
-
-<?code-excerpt "async_await/bin/futures_intro.dart (error)" replace="/Error//g"?>
-```dart:run-dartpad:height-300px:ga_id-completing_with_error
+<?code-excerpt "../null_safety_examples/async_await/bin/futures_intro.dart (error)" replace="/Error//g"?>
+```dart:run-dartpad:height-300px:ga_id-completing_with_error:null_safety-true
 Future<void> fetchUserOrder() {
 // Imagine that this function is fetching user info but encounters a bug
   return Future.delayed(Duration(seconds: 2),
@@ -225,7 +192,6 @@ void main() {
   print('Fetching user order...');
 }
 ```
-{% endif -%}
 
 In this example, `fetchUserOrder()` completes with an error indicating that the
 user ID is invalid.
@@ -266,7 +232,7 @@ function.
 
 First, add the `async` keyword before the function body:
 
-<?code-excerpt "async_await/bin/get_order_sync_bad.dart (main-sig)" replace="/main\(\)/$& async/g; /async/[!$&!]/g; /$/ ··· }/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order_sync_bad.dart (main-sig)" replace="/main\(\)/$& async/g; /async/[!$&!]/g; /$/ ··· }/g"?>
 {% prettify dart tag=pre+code %}
 void main() [!async!] { ··· }
 {% endprettify %}
@@ -276,7 +242,7 @@ If the function has a declared return type, then update the type to be
 If the function doesn't explicitly return a value, then the return type is
 `Future<void>`:
 
-<?code-excerpt "async_await/bin/get_order.dart (main-sig)" replace="/Future<\w+\W/[!$&!]/g;  /$/ ··· }/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order.dart (main-sig)" replace="/Future<\w+\W/[!$&!]/g;  /$/ ··· }/g"?>
 {% prettify dart tag=pre+code %}
 [!Future<void>!] main() async { ··· }
 {% endprettify %}
@@ -284,7 +250,7 @@ If the function doesn't explicitly return a value, then the return type is
 Now that you have an `async` function, you can use the `await` keyword to wait
 for a future to complete:
 
-<?code-excerpt "async_await/bin/get_order.dart (print-order)" replace="/await/[!$&!]/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order.dart (print-order)" replace="/await/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 print([!await!] createOrderMessage());
 {% endprettify %}
@@ -299,7 +265,7 @@ your window is wide enough — is to the right of the synchronous example.
 <div class="col-sm" markdown="1">
 #### Example: synchronous functions
 
-<?code-excerpt "async_await/bin/get_order_sync_bad.dart (no-warning)" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order_sync_bad.dart (no-warning)" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g"?>
 ```dart
 String createOrderMessage() {
   var order = fetchUserOrder();
@@ -329,7 +295,7 @@ Your order is: Instance of _Future<String>
 <div class="col-sm" markdown="1">
 #### Example: asynchronous functions
 
-<?code-excerpt "async_await/bin/get_order.dart" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g; /async|await/[!$&!]/g; /(Future<\w+\W)( [^f])/[!$1!]$2/g; /4/2/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/get_order.dart" replace="/(\s+\/\/ )(Imagine.*? is )(.*)/$1$2$1$3/g; /async|await/[!$&!]/g; /(Future<\w+\W)( [^f])/[!$1!]$2/g; /4/2/g"?>
 {% prettify dart tag=pre+code %}
 [!Future<String>!] createOrderMessage() [!async!] {
   var order = [!await!] fetchUserOrder();
@@ -393,18 +359,8 @@ synchronous code before the first `await` keyword executes immediately.
 Run the following example to see how execution proceeds within an `async`
 function body. What do you think the output will be?
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=d7abfdea1ae5596e96c7c0203d975dba&ga_id=execution_within_async_function"
-  style="border: 1px solid lightgrey; margin-top: 10px; margin-bottom: 40px"
-  frameborder="no"
-  height="600"
-  width="100%">
-</iframe>
-{% else -%}
-
-<?code-excerpt "async_await/bin/async_example.dart" remove="/\/\/ print/"?>
-```dart:run-dartpad:height-530px:ga_id-execution_within_async_function
+<?code-excerpt "../null_safety_examples/async_await/bin/async_example.dart" remove="/\/\/ print/"?>
+```dart:run-dartpad:height-530px:ga_id-execution_within_async_function:null_safety-true
 Future<void> printOrderMessage() async {
   print('Awaiting user order...');
   var order = await fetchUserOrder();
@@ -428,11 +384,10 @@ void countSeconds(int s) {
   }
 }
 ```
-{% endif -%}
 
 After running the code in the preceding example, try reversing lines 2 and 3:
 
-<?code-excerpt "async_await/bin/async_example.dart (swap-stmts)" replace="/\/\/ (print)/$1/g"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/async_example.dart (swap-stmts)" replace="/\/\/ (print)/$1/g"?>
 ```dart
 var order = await fetchUserOrder();
 print('Awaiting user order...');
@@ -484,23 +439,13 @@ Implement an `async` function `reportLogins()` so that it does the following:
   * Example return value from `reportLogins()`: `"Total number of logins: 57"`
 * Gets the number of logins by calling the provided function `fetchLoginAmount()`.
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=f751b692502c4ee43d932f745860b056&theme=dark&ga_id=practice_using"
-  frameborder="no"
-  height="550"
-  width="100%">
-</iframe>
-
-{% else -%}
-
-```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_using
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_using:null_safety-true
 {$ begin main.dart $}
 // Part 1
 // You can call the provided async function fetchRole()
 // to return the user role.
 Future<String> reportUserRole() async {
-  // TO DO: Your implementation goes here.
+  TODO('Your implementation goes here.');
 }
 
 // Part 2
@@ -554,7 +499,6 @@ main() async {
         }))
 
       ..add(makeReadable(
-
         testLabel: 'Part 2',
         testResult: await asyncEquals(
           expected: 'Total number of logins: 42',
@@ -578,6 +522,10 @@ main() async {
     } else {
       _result(false, messages);
     }
+  } on UnimplementedError {
+    _result(false, [
+      '$didNotImplement reportUserRole?',
+    ]);
   } catch (e) {
     _result(false, ['Tried to run solution, but received an exception: $e']);
   }
@@ -586,7 +534,11 @@ main() async {
 ////////////////////////////////////////
 ///////////// Test Helpers /////////////
 ////////////////////////////////////////
-String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
+String makeReadable({
+  required String testResult,
+  required Map readableErrors,
+  required String testLabel,
+}) {
   if (readableErrors.containsKey(testResult)) {
     var readable = readableErrors[testResult];
     return '$testLabel $readable';
@@ -598,7 +550,11 @@ String makeReadable({ String testResult, Map readableErrors, String testLabel })
 ///////////////////////////////////////
 //////////// Assertions ///////////////
 ///////////////////////////////////////
-Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
+Future<String> asyncEquals({
+  expected,
+  actual,
+  required String typoKeyword,
+}) async {
   var strActual = actual is String ? actual : actual.toString();
   try {
     if (expected == actual) {
@@ -609,7 +565,7 @@ Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
       return strActual;
     }
   } catch(e) {
-    return e;
+    return e.toString();
   }
 }
 {$ end test.dart $}
@@ -621,7 +577,6 @@ Did you remember to use the await keyword before invoking fetchRole()?
 Remember: reportUserRole() needs to return a future!
 {$ end hint.txt $}
 ```
-{% endif -%}
 
 {{site.alert.note}}
   If your code passes the tests, you can ignore
@@ -631,7 +586,7 @@ Remember: reportUserRole() needs to return a future!
 ## Handling errors
 To handle errors in an `async` function, use try-catch:
 
-<?code-excerpt "async_await/bin/try_catch.dart (try-catch)" remove="print(order)"?>
+<?code-excerpt "../null_safety_examples/async_await/bin/try_catch.dart (try-catch)" remove="print(order)"?>
 ```dart
 try {
   var order = await fetchUserOrder();
@@ -649,18 +604,8 @@ the same way you would in synchronous code.
 Run the following example to see how to handle an error from an
 asynchronous function. What do you think the output will be?
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=25ade03f0632878a9169209e3cd7bef2&ga_id=try_catch"
-  style="border: 1px solid lightgrey;"
-  frameborder="no"
-  height="525"
-  width="100%">
-</iframe>
-{% else -%}
-
-<?code-excerpt "async_await/bin/try_catch.dart"?>
-```dart:run-dartpad:height-530px:ga_id-try_catch
+<?code-excerpt "../null_safety_examples/async_await/bin/try_catch.dart"?>
+```dart:run-dartpad:height-530px:ga_id-try_catch:null_safety-true
 Future<void> printOrderMessage() async {
   try {
     var order = await fetchUserOrder();
@@ -683,7 +628,6 @@ Future<void> main() async {
   await printOrderMessage();
 }
 ```
-{% endif -%}
 
 ### Exercise: Practice handling errors
 
@@ -709,21 +653,13 @@ that does the following:
     [Exceptions]({{site.dart_api}}/stable/dart-core/Exception-class.html) and
     [Errors.]({{site.dart_api}}/stable/dart-core/Error-class.html)
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=858f71f0ad0e70051999bcafa41806a3&theme=dark&ga_id=practice_errors"
-  frameborder="no"
-  height="525"
-  width="100%">
-</iframe>
-
-{% else -%}
 {% comment %}
 PENDING: Any way to auto-include this code?
 {% endcomment %}
-```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_errors
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_errors:null_safety-true
 {$ begin main.dart $}
 // Implement changeUsername here
+changeUsername() {}
 {$ end main.dart $}
 {$ begin solution.dart $}
 Future<String> changeUsername () async {
@@ -787,7 +723,11 @@ main() async {
 ////////////////////////////////////////
 ///////////// Test Helpers /////////////
 ////////////////////////////////////////
-String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
+String makeReadable({
+  required String testResult,
+  required Map readableErrors,
+  required String testLabel,
+}) {
   if (readableErrors.containsKey(testResult)) {
     var readable = readableErrors[testResult];
     return '$testLabel $readable';
@@ -804,7 +744,7 @@ void passIfNoMessages(List<String> messages, Map<String, String> readable){
     // ignore: omit_local_variable_types
     List<String> userMessages = messages
         .where((message) => readable.containsKey(message))
-        .map((message) => readable[message])
+        .map((message) => readable[message]!)
         .toList();
     print(messages);
 
@@ -844,7 +784,6 @@ Implement changeUsername() to return the string from fetchNewUsername() or
 You'll need a try-catch statement to catch and handle errors.
 {$ end hint.txt $}
 ```
-{% endif -%}
 
 {% comment %}
 TODO: Consider summary section before final exercise
@@ -897,23 +836,13 @@ Write the following:
   `'<result> Thanks, see you next time'`, where `<result>` is
   the String value returned by calling `logoutUser()`.
 
-{% if useIframe -%}
-<iframe
-  src="{{site.dartpad-embed}}?id=f601d25bc2833c957186e3c6bf71effc&theme=dark&ga_id=putting_it_all_together"
-  frameborder="no"
-  height="550"
-  width="100%">
-</iframe>
-
-{% else -%}
-
 {% comment %}
 PENDING: Any way to auto-include this code?
 {% endcomment %}
-```dart:run-dartpad:theme-dark:height-380px:ga_id-putting_it_all_together
+```dart:run-dartpad:theme-dark:height-380px:ga_id-putting_it_all_together:null_safety-true
 {$ begin main.dart $}
 // Part 1
-addHello(){}
+addHello(user){}
 
 // Part 2
 // You can call the provided async function fetchUsername()
@@ -1041,8 +970,12 @@ main() async {
 ////////////////////////////////////////
 ///////////// Test Helpers /////////////
 ////////////////////////////////////////
-String makeReadable({ String testResult, Map readableErrors, String testLabel }) {
-  String readable;
+String makeReadable({
+  required String testResult,
+  required Map<String, String> readableErrors,
+  required String testLabel,
+}) {
+  String? readable;
   if (readableErrors.containsKey(testResult)) {
     readable = readableErrors[testResult];
     return '$testLabel $readable';
@@ -1062,7 +995,7 @@ void passIfNoMessages(List<String> messages, Map<String, String> readable){
     // ignore: omit_local_variable_types
     List<String> userMessages = messages
         .where((message) => readable.containsKey(message))
-        .map((message) => readable[message])
+        .map((message) => readable[message]!)
         .toList();
     print(messages);
 
@@ -1072,7 +1005,11 @@ void passIfNoMessages(List<String> messages, Map<String, String> readable){
 ///////////////////////////////////////
 //////////// Assertions ///////////////
 ///////////////////////////////////////
-Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
+Future<String> asyncEquals({
+  expected,
+  actual,
+  required String typoKeyword,
+}) async {
   var strActual = actual is String ? actual : actual.toString();
   try {
     if (expected == actual) {
@@ -1083,7 +1020,7 @@ Future<String> asyncEquals({expected, actual, String typoKeyword}) async {
       return strActual;
     }
   } catch(e) {
-    return e;
+    return e.toString();
   }
 }
 
@@ -1107,7 +1044,6 @@ The greetUser() and sayGoodbye() functions are asynchronous;
 addHello() isn't.
 {$ end hint.txt $}
 ```
-{% endif -%}
 
 ## What's next?
 


### PR DESCRIPTION
Continuing the work from the #2805 PR.

This PR adds the migrated version of the Async-Await Collections codelab in the `async-await_migrated.md`, following the migration guide.

This PR is split in different commits:

1. the original copy of the codelab and the examples folder.
2. contains the modification of the example code (no code was changed in the dart files, but the pubspec changed)
3. contains the modification of the codelab markdown and code.

I removed the references to the iframes hosted as gists, because I cannot update them and I assume they are not deprecated.

Live preview: https://mb-dart-dev-2.firebaseapp.com/codelabs/async-await_migrated

cc. @kwalrath @RedBrogdon 