### PR TITLE
Fixed typo

### DIFF
--- a/src/_guides/libraries/_dart-html-tour.md
+++ b/src/_guides/libraries/_dart-html-tour.md
@@ -103,7 +103,7 @@ Consider this example of specifying an anchor element in HTML:
 
 This \<a\> tag specifies an element with an `href` attribute and a text
 node (accessible via a `text` property) that contains the string
-“linktext”. To change the URL that the link goes to, you can use
+“link text”. To change the URL that the link goes to, you can use
 AnchorElement’s `href` property:
 
 <?code-excerpt "html/test/html_test.dart (href)" plaster="none"?>


### PR DESCRIPTION
Added missing space to make it "link text" rather than "linktext"