### PR TITLE
[NOT READY FOR MERGING] Mark `dart:ffi` as stable

### DIFF
--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -12,13 +12,8 @@ _FFI_ stands for [_foreign function interface._][FFI]
 Other terms for similar functionality include _native interface_
 and _language bindings._
 
-{{site.alert.info}}
-  As of Dart 2.10, [dart:ffi is in beta,][ffi issue]
-  and breaking API changes might still happen.
-{{site.alert.end}}
-
-API documentation is available from the dev channel:
-[dart:ffi API reference.]({{site.dart_api}}/dev/dart-ffi/dart-ffi-library.html)
+API documentation is available in the
+[dart:ffi API reference.]({{site.dart_api}}/dart-ffi/dart-ffi-library.html)
 
 ## Examples
 

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -12,6 +12,12 @@ _FFI_ stands for [_foreign function interface._][FFI]
 Other terms for similar functionality include _native interface_
 and _language bindings._
 
+{{ site.alert.version-note }}
+  As of Dart 2.12 beta, FFi has been marked as 1.0,
+  and will be fully stable once a 2.12 stable SDK is
+  released.
+{{ site.alert.end }}
+
 API documentation is available in the
 [dart:ffi API reference.]({{site.dart_api}}/dart-ffi/dart-ffi-library.html)
 

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -13,7 +13,7 @@ Other terms for similar functionality include _native interface_
 and _language bindings._
 
 {{ site.alert.version-note }}
-  As of Dart 2.12 beta, FFi has been marked as 1.0,
+  As of Dart 2.12 beta, FFI has been marked as 1.0,
   and will be fully stable once a 2.12 stable SDK is
   released.
 {{ site.alert.end }}


### PR DESCRIPTION
Should be merged when https://dart-review.googlesource.com/c/sdk/+/179765 is merged.