### PR TITLE
Migrate Dart Cheat-Sheet Codelab to Null Safety

### DIFF
--- a/null_safety_examples/misc/analysis_options.yaml
+++ b/null_safety_examples/misc/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../analysis_options.yaml

--- a/null_safety_examples/misc/analysis_options.yaml
+++ b/null_safety_examples/misc/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../analysis_options.yaml
+include: ../../examples/analysis_options.yaml

--- a/null_safety_examples/misc/bin/collection_literals.dart
+++ b/null_safety_examples/misc/bin/collection_literals.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: unused_local_variable
+
+void main() {
+// #docregion collection-literals
+  final aListOfStrings = ['one', 'two', 'three'];
+  final aSetOfStrings = {'one', 'two', 'three'};
+  final aMapOfStringsToInts = {
+    'one': 1,
+    'two': 2,
+    'three': 3,
+  };
+// #enddocregion collection-literals
+
+// #docregion collection-literals-2
+  final aListOfInts = <int>[];
+  final aSetOfInts = <int>{};
+  final aMapOfIntToDouble = <int, double>{};
+// #enddocregion collection-literals-2
+}

--- a/null_safety_examples/misc/bin/exceptions.dart
+++ b/null_safety_examples/misc/bin/exceptions.dart
@@ -1,0 +1,20 @@
+void breedMoreLlamas() {
+  print('Breed more Llamas');
+}
+
+void cleanLlamaStalls() {
+  print('clean Llama stalls');
+}
+
+void main() {
+// #docregion
+  try {
+    breedMoreLlamas();
+  } catch (e) {
+    // ... handle exception ...
+  } finally {
+    // Always clean up, even if an exception is thrown.
+    cleanLlamaStalls();
+  }
+// #enddocregion
+}

--- a/null_safety_examples/misc/bin/factory_constructors.dart
+++ b/null_safety_examples/misc/bin/factory_constructors.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: unused_local_variable
+
+// #docregion
+class Square extends Shape {}
+
+class Circle extends Shape {}
+
+class Shape {
+  Shape();
+
+  factory Shape.fromTypeName(String typeName) {
+    if (typeName == 'square') return Square();
+    if (typeName == 'circle') return Circle();
+
+    print('I don\'t recognize $typeName');
+    return null;
+  }
+}
+// #enddocregion
+
+void main() {
+  final shape = Shape();
+}

--- a/null_safety_examples/misc/bin/factory_constructors.dart
+++ b/null_safety_examples/misc/bin/factory_constructors.dart
@@ -13,7 +13,7 @@ class Shape {
     if (typeName == 'circle') return Circle();
 
     print('I don\'t recognize $typeName');
-    return null;
+    throw Error();
   }
 }
 // #enddocregion

--- a/null_safety_examples/misc/bin/getter_compute.dart
+++ b/null_safety_examples/misc/bin/getter_compute.dart
@@ -1,0 +1,21 @@
+// #docregion
+class MyClass {
+  List<int> _values = [];
+
+  void addValue(int value) {
+    _values.add(value);
+  }
+
+  // A computed property.
+  int get count {
+    return _values.length;
+  }
+}
+// #enddocregion
+
+void main() {
+  MyClass _class = MyClass();
+  _class.addValue(5);
+  _class.addValue(7);
+  print(_class.count.toString());
+}

--- a/null_safety_examples/misc/bin/getters_setters.dart
+++ b/null_safety_examples/misc/bin/getters_setters.dart
@@ -1,0 +1,19 @@
+// #docregion
+class MyClass {
+  int _aProperty = 0;
+
+  int get aProperty => _aProperty;
+
+  set aProperty(int value) {
+    if (value >= 0) {
+      _aProperty = value;
+    }
+  }
+}
+// #enddocregion
+
+void main() {
+  MyClass _class = MyClass();
+  _class.aProperty = 5;
+  print(_class.aProperty);
+}

--- a/null_safety_examples/misc/bin/named_constructor.dart
+++ b/null_safety_examples/misc/bin/named_constructor.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: sort_constructors_first
+
+// #docregion
+class Point {
+  double x, y;
+
+  Point(this.x, this.y);
+
+  Point.origin() {
+    x = 0;
+    y = 0;
+  }
+}
+// #enddocregion
+
+void main() {
+  final myPoint = Point.origin();
+  print(myPoint.x);
+  print(myPoint.y);
+}

--- a/null_safety_examples/misc/bin/named_constructor.dart
+++ b/null_safety_examples/misc/bin/named_constructor.dart
@@ -2,7 +2,7 @@
 
 // #docregion
 class Point {
-  double x, y;
+  late double x, y;
 
   Point(this.x, this.y);
 

--- a/null_safety_examples/misc/bin/null_aware_operators.dart
+++ b/null_safety_examples/misc/bin/null_aware_operators.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: unnecessary_null_in_if_null_operators
+
+void main() {
+// #docregion null-aware-operators
+  int a; // The initial value of a is null.
+  a ??= 3;
+  print(a); // <-- Prints 3.
+
+  a ??= 5;
+  print(a); // <-- Still prints 3.
+// #enddocregion null-aware-operators
+
+// #docregion null-aware-operators-2
+  print(1 ?? 3); // <-- Prints 1.
+  print(null ?? 12); // <-- Prints 12.
+// #enddocregion null-aware-operators-2
+}

--- a/null_safety_examples/misc/bin/null_aware_operators.dart
+++ b/null_safety_examples/misc/bin/null_aware_operators.dart
@@ -2,7 +2,7 @@
 
 void main() {
 // #docregion null-aware-operators
-  int a; // The initial value of a is null.
+  int? a; // The initial value of a is null.
   a ??= 3;
   print(a); // <-- Prints 3.
 

--- a/null_safety_examples/misc/bin/null_aware_operators.dart
+++ b/null_safety_examples/misc/bin/null_aware_operators.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unnecessary_null_in_if_null_operators
+// ignore_for_file: unnecessary_null_in_if_null_operators, dead_null_aware_expression
 
 void main() {
 // #docregion null-aware-operators

--- a/null_safety_examples/misc/bin/null_aware_operators.dart
+++ b/null_safety_examples/misc/bin/null_aware_operators.dart
@@ -2,7 +2,7 @@
 
 void main() {
 // #docregion null-aware-operators
-  int? a; // The initial value of a is null.
+  int? a; // = null
   a ??= 3;
   print(a); // <-- Prints 3.
 

--- a/null_safety_examples/misc/bin/optional_named_params.dart
+++ b/null_safety_examples/misc/bin/optional_named_params.dart
@@ -1,0 +1,12 @@
+// #docregion
+void printName(String firstName, String lastName, {String suffix}) {
+  print('$firstName $lastName ${suffix ?? ''}');
+}
+// #enddocregion
+
+void main() {
+  // #docregion
+  printName('Avinash', 'Gupta');
+  printName('Poshmeister', 'Moneybuckets', suffix: 'IV');
+  // #enddocregion
+}

--- a/null_safety_examples/misc/bin/optional_named_params.dart
+++ b/null_safety_examples/misc/bin/optional_named_params.dart
@@ -1,5 +1,5 @@
 // #docregion
-void printName(String firstName, String lastName, {String suffix}) {
+void printName(String firstName, String lastName, {String? suffix}) {
   print('$firstName $lastName ${suffix ?? ''}');
 }
 // #enddocregion

--- a/null_safety_examples/misc/bin/optional_positional_args.dart
+++ b/null_safety_examples/misc/bin/optional_positional_args.dart
@@ -1,0 +1,29 @@
+// #docregion optional-positional-args-2
+int sumUpToFive(int a, [int b, int c, int d, int e]) {
+  int sum = a;
+  if (b != null) sum += b;
+  if (c != null) sum += c;
+  if (d != null) sum += d;
+  if (e != null) sum += e;
+  return sum;
+}
+// #enddocregion optional-positional-args-2
+
+// #docregion optional-positional-args
+int sumUp(int a, int b, int c) {
+  return a + b + c;
+}
+// #enddocregion optional-positional-args
+
+void main() {
+  // #docregion optional-positional-args
+  int total = sumUp(1, 2, 3);
+  // #enddocregion optional-positional-args
+  // #docregion optional-positional-args-2
+  int total2 = sumUpToFive(1, 2);
+  int otherTotal = sumUpToFive(1, 2, 3, 4, 5);
+  // #enddocregion optional-positional-args-2
+  print(total);
+  print(total2);
+  print(otherTotal);
+}

--- a/null_safety_examples/misc/bin/optional_positional_args.dart
+++ b/null_safety_examples/misc/bin/optional_positional_args.dart
@@ -1,5 +1,5 @@
 // #docregion optional-positional-args-2
-int sumUpToFive(int a, [int b, int c, int d, int e]) {
+int sumUpToFive(int a, [int? b, int? c, int? d, int? e]) {
   int sum = a;
   if (b != null) sum += b;
   if (c != null) sum += c;

--- a/null_safety_examples/misc/bin/optional_positional_args2.dart
+++ b/null_safety_examples/misc/bin/optional_positional_args2.dart
@@ -1,0 +1,14 @@
+// #docregion
+int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
+// #enddocregion
+  return a + b + c + d + e;
+// #docregion
+}
+// #enddocregion
+
+void main() {
+  // #docregion
+  int newTotal = sumUpToFive(1);
+  print(newTotal); // <-- prints 15
+  // #enddocregion
+}

--- a/null_safety_examples/misc/bin/redirecting_const_constructors.dart
+++ b/null_safety_examples/misc/bin/redirecting_const_constructors.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: sort_constructors_first
+
+// #docregion redirecting-constructors
+class Automobile {
+  String make;
+  String model;
+  int mpg;
+
+  // The main constructor for this class.
+  Automobile(this.make, this.model, this.mpg);
+
+  // Delegates to the main constructor.
+  Automobile.hybrid(String make, String model) : this(make, model, 60);
+
+  // Delegates to a named constructor
+  Automobile.fancyHybrid() : this.hybrid('Futurecar', 'Mark 2');
+}
+// #enddocregion redirecting-constructors
+
+// #docregion const-constructors
+class ImmutablePoint {
+  const ImmutablePoint(this.x, this.y);
+
+  final int x;
+  final int y;
+
+  static const ImmutablePoint origin = ImmutablePoint(0, 0);
+}
+// #enddocregion const-constructors

--- a/null_safety_examples/misc/bin/this_constructor.dart
+++ b/null_safety_examples/misc/bin/this_constructor.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: sort_constructors_first, type_annotate_public_apis
+
+// #docregion
+class MyColor {
+  int red;
+  int green;
+  int blue;
+
+  MyColor(this.red, this.green, this.blue);
+}
+
+final color = MyColor(80, 80, 128);
+// #enddocregion
+
+void main() {
+  print(color.blue.toString());
+}

--- a/null_safety_examples/misc/pubspec.yaml
+++ b/null_safety_examples/misc/pubspec.yaml
@@ -1,0 +1,12 @@
+name: examples
+description: dart.dev example code.
+
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+
+dev_dependencies:
+  args: ^1.5.0
+  examples_util:
+    path: ../util
+  pedantic: ^1.0.0
+  test: ^1.0.0

--- a/null_safety_examples/misc/pubspec.yaml
+++ b/null_safety_examples/misc/pubspec.yaml
@@ -2,11 +2,11 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   args: ^1.5.0
   examples_util:
     path: ../util
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.13

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -99,36 +99,47 @@ reference them inside single quotes, with a space in between.
 
 ## Nullable variables
 
-In Dart, types in your code are non-nullable by default, meaning that values can’t be null
-unless you say they can be.
+Dart 2.12 introduced sound null safety,
+meaning that (when you [enable null safety][])
+values can’t be null unless you say they can be.
+In other words, types are non-nullable by default.
 
-For example, consider the following code, which is **invalid**, because `null` cannot be assigned to `a`.
-
-{% prettify dart tag=pre+code %}
-int a = [!null!];
-{% endprettify %}
-
-When creating a variable, you can use ? to inform Dart of the variable’s nullability.
+For example, consider the following code,
+which is **invalid** because (with null safety)
+a variable of type `int` can't have the value `null`:
 
 {% prettify dart tag=pre+code %}
-int? a = null;
+int a = [!null!]; // INVALID in null-safe Dart.
 {% endprettify %}
 
-However, nullable variables are null by default, so it is not necessary to assign null to it.
+When creating a variable in Dart 2.12 or higher,
+you can add `?` to the type to indicate
+that the variable can be null:
 
 {% prettify dart tag=pre+code %}
-int? a; // The initial value of a is null
+[!int?!] a = null; // Valid in null-safe Dart.
 {% endprettify %}
 
-Read the [Sound null safety guide](/null-safety) for more information about null safety on Dart.
+You can simplify that code a bit because, in all versions of Dart,
+`null` is the default value for uninitialized variables:
+
+{% prettify dart tag=pre+code %}
+int? a; // The initial value of a is null.
+{% endprettify %}
+
+For more information about null safety in Dart,
+read the [sound null safety guide](/null-safety).
+
+[enable null safety]: https://dart.dev/null-safety#enable-null-safety
+
 
 ### Code example
 
 Try to declare two variables below:
-- A nullable `String` named `name` with the value `Jane`.
-- A nullable `String` named `address` with the value of null.
+- A nullable `String` named `name` with the value `'Jane'`.
+- A nullable `String` named `address` with the value `null`.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 {% comment %}
 TODO: Add new ga_id tag.
@@ -177,7 +188,7 @@ TBD: Make this and all non-trivial snippets testable.
 
 <?code-excerpt "../null_safety_examples/misc/bin/null_aware_operators.dart (null-aware-operators)"?>
 ```dart
-int? a; // The initial value of a is null.
+int? a; // = null
 a ??= 3;
 print(a); // <-- Prints 3.
 
@@ -186,7 +197,8 @@ print(a); // <-- Still prints 3.
 ```
 
 Another null-aware operator is `??`,
-which returns the expression on its left unless that expression's value is null,
+which returns the expression on its left unless
+that expression's value is null,
 in which case it evaluates and returns the expression on its right:
 
 <?code-excerpt "../null_safety_examples/misc/bin/null_aware_operators.dart (null-aware-operators-2)"?>
@@ -199,12 +211,12 @@ print(null ?? 12); // <-- Prints 12.
 
 Try putting the `??=` and `??` operators to work below.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:height-255px:ga_id-null_aware:null_safety-true
 {$ begin main.dart $}
 String? foo = 'a string';
-String? bar; // Unassigned objects are null by default.
+String? bar; // = null
 
 // Substitute an operator that makes 'a string' be assigned to baz.
 String? baz = foo /* TODO */ bar;
@@ -216,7 +228,7 @@ void updateSomeVars() {
 {$ end main.dart $}
 {$ begin solution.dart $}
 String? foo = 'a string';
-String? bar; // Unassigned objects are null by default.
+String? bar; // = null
 
 // Substitute an operator that makes 'a string' be assigned to baz.
 String? baz = foo ?? bar;
@@ -801,7 +813,7 @@ Add the following:
   as long as the new list doesn't contain any negative prices
   (in which case the setter should throw an `InvalidPriceException`).
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:height-240px:ga_id-getters_setters:null_safety-true
 {$ begin main.dart $}
@@ -937,7 +949,7 @@ Their default value is null unless you provide another default value:
 <?code-excerpt "../null_safety_examples/misc/bin/optional_positional_args2.dart"?>
 ```dart
 int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
-// ···
+  // ···
 }
 // ···
   int newTotal = sumUpToFive(1);
@@ -1050,14 +1062,22 @@ void printName(String firstName, String lastName, {String? suffix}) {
   printName('Poshmeister', 'Moneybuckets', suffix: 'IV');
 ```
 
-As you might expect, the value of these parameters is null by default,
-but you can provide default values to make them not nullable:
+As you might expect,
+the default value of an optional named parameter is `null`,
+but you can provide a default value.
 
-```dart
-void printName(String firstName, String lastName, {String suffix = ''}) {
+If the type of a parameter is non-nullable,
+then you must either provide a default value
+(as shown in the following code)
+or mark the parameter as `required`
+(as shown in the
+[constructor section](#using-this-in-a-constructor)).
+
+{% prettify dart tag=pre+code %}
+void printName(String firstName, String lastName, {String suffix[! = ''!]}) {
   print('$firstName $lastName $suffix');
 }
-```
+{% endprettify %}
 
 A function can't have both optional positional and optional named parameters.
 
@@ -1065,22 +1085,20 @@ A function can't have both optional positional and optional named parameters.
 ### Code example
 
 Add a `copyWith()` instance method to the `MyDataObject`
-class. It should take three named parameters:
+class. It should take three named, nullable parameters:
 
 * `int? newInt`
 * `String? newString`
 * `double? newDouble`
 
-Note that the parameters should be nullable.
-
-When called, `copyWith()` should return a new `MyDataObject`
+Your`copyWith()` method should return a new `MyDataObject`
 based on the current instance,
 with data from the preceding parameters (if any)
 copied into the object's properties.
 For example, if `newInt` is non-null,
 then copy its value into `anInt`.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:height-310px:ga_id-optional_named_parameters:null_safety-true
 {$ begin main.dart $}
@@ -1221,7 +1239,7 @@ to propagate the exception:
 try {
   breedMoreLlamas();
 } catch (e) {
-  print('I was just trying to breed llamas!.');
+  print('I was just trying to breed llamas!');
   rethrow;
 }
 ```
@@ -1439,9 +1457,9 @@ class MyColor {
 final color = MyColor(red: 80, green: 80, blue: 80);
 ```
 
-In this case,`red`, `green` and `blue` are marked as `required` because they are not nullable.
-
-For optional parameters, default values work as expected:
+In the preceding code, `red`, `green`, and `blue` are marked as `required`
+because these `int` values can't be null.
+If you add default values, you can omit `required`:
 
 ```dart
 MyColor([this.red = 0, this.green = 0, this.blue = 0]);
@@ -1449,15 +1467,13 @@ MyColor([this.red = 0, this.green = 0, this.blue = 0]);
 MyColor({this.red = 0, this.green = 0, this.blue = 0});
 ```
 
-With default values it is no longer necessary to mark the parameters as `required`.
-
 ### Code example
 
 Add a one-line constructor to `MyClass` that uses
 `this.` syntax to receive and assign values for
 all three properties of the class.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:ga_id-this_constructor:null_safety-true
 {$ begin main.dart $}
@@ -1558,7 +1574,7 @@ Use an initializer list to assign the first two characters in `word` to
 the `letterOne` and `LetterTwo` properties.
 For extra credit, add an `assert` to catch words of less than two characters.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 {% comment %}
 Is the assert even executed? I can't see any effect on the test,
@@ -1664,8 +1680,8 @@ class Point {
 }
 ```
 
-This example uses the `late` annotation to indicate that `x` and `y` will
-be initalized later in the named constructor.
+This example uses the `late` annotation to indicate that `x` and `y` are
+initialized before they're used.
 
 To use a named constructor, invoke it using its full name:
 
@@ -1675,10 +1691,10 @@ final myPoint = Point.origin();
 
 ### Code example
 
-Give the Color class a constructor named `Color.black`
+Give the `Color` class a constructor named `Color.black`
 that sets all three properties to zero.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:height-240px:ga_id-named_constructors:null_safety-true
 {$ begin main.dart $}
@@ -1783,7 +1799,7 @@ making it do the following:
   create an `IntegerDouble` with the values in order.
 * If the list has **three** values,
   create an `IntegerTriple` with the values in order.
-* Otherwise, throw Error.
+* Otherwise, throw an `Error`.
 
 ```dart:run-dartpad:height-415px:ga_id-factory_constructors:null_safety-true
 {$ begin main.dart $}
@@ -1973,7 +1989,7 @@ Remember the `Color` class from above? Create a named constructor called
 `black`, but rather than manually assigning the properties, redirect it to the
 default constructor with zeros as the arguments.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:height-255px:ga_id-redirecting_constructors:null_safety-true
 {$ begin main.dart $}
@@ -2065,7 +2081,7 @@ and create a constant constructor that does the following:
 * Is constant, with the `const` keyword just before
   `Recipe` in the constructor declaration.
 
-Ignore all initial errors in the dartpad.
+Ignore all initial errors in the DartPad.
 
 ```dart:run-dartpad:ga_id-const_constructors:null_safety-true
 {$ begin main.dart $}

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -108,9 +108,9 @@ variable is currently null:
 TBD: Make this and all non-trivial snippets testable.
 {% endcomment %}
 
-<?code-excerpt "misc/bin/null_aware_operators.dart (null-aware-operators)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/null_aware_operators.dart (null-aware-operators)"?>
 ```dart
-int a; // The initial value of a is null.
+int? a; // The initial value of a is null.
 a ??= 3;
 print(a); // <-- Prints 3.
 
@@ -122,7 +122,7 @@ Another null-aware operator is `??`,
 which returns the expression on its left unless that expression's value is null,
 in which case it evaluates and returns the expression on its right:
 
-<?code-excerpt "misc/bin/null_aware_operators.dart (null-aware-operators-2)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/null_aware_operators.dart (null-aware-operators-2)"?>
 ```dart
 print(1 ?? 3); // <-- Prints 1.
 print(null ?? 12); // <-- Prints 12.
@@ -281,7 +281,7 @@ you could do it like this: str?.toLowerCase()
 Dart has built-in support for lists, maps, and sets.
 You can create them using literals:
 
-<?code-excerpt "misc/bin/collection_literals.dart (collection-literals)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/collection_literals.dart (collection-literals)"?>
 ```dart
 final aListOfStrings = ['one', 'two', 'three'];
 final aSetOfStrings = {'one', 'two', 'three'};
@@ -298,7 +298,7 @@ In this case, the inferred types are `List<String>`,
 
 Or you can specify the type yourself:
 
-<?code-excerpt "misc/bin/collection_literals.dart (collection-literals-2)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/collection_literals.dart (collection-literals-2)"?>
 ```dart
 final aListOfInts = <int>[];
 final aSetOfInts = <int>{};
@@ -684,7 +684,7 @@ than a simple field allows.
 
 For example, you can make sure a property's value is valid:
 
-<?code-excerpt "misc/bin/getters_setters.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/getters_setters.dart"?>
 ```dart
 class MyClass {
   int _aProperty = 0;
@@ -701,7 +701,7 @@ class MyClass {
 
 You can also use a getter to define a computed property:
 
-<?code-excerpt "misc/bin/getter_compute.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/getter_compute.dart"?>
 ```dart
 class MyClass {
   List<int> _values = [];
@@ -834,7 +834,7 @@ with a function you give it
 Dart has two kinds of function parameters: positional and named. Positional parameters are the kind
 you're likely familiar with:
 
-<?code-excerpt "misc/bin/optional_positional_args.dart (optional-positional-args)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/optional_positional_args.dart (optional-positional-args)"?>
 ```dart
 int sumUp(int a, int b, int c) {
   return a + b + c;
@@ -845,9 +845,9 @@ int sumUp(int a, int b, int c) {
 
 With Dart, you can make these positional parameters optional by wrapping them in brackets:
 
-<?code-excerpt "misc/bin/optional_positional_args.dart (optional-positional-args-2)" replace="/total2/total/g"?>
+<?code-excerpt "../null_safety_examples/misc/bin/optional_positional_args.dart (optional-positional-args-2)" replace="/total2/total/g"?>
 ```dart
-int sumUpToFive(int a, [int b, int c, int d, int e]) {
+int sumUpToFive(int a, [int? b, int? c, int? d, int? e]) {
   int sum = a;
   if (b != null) sum += b;
   if (c != null) sum += c;
@@ -864,7 +864,7 @@ Optional positional parameters are always last
 in a function's parameter list.
 Their default value is null unless you provide another default value:
 
-<?code-excerpt "misc/bin/optional_positional_args2.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/optional_positional_args2.dart"?>
 ```dart
 int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
 // ···
@@ -961,9 +961,9 @@ before you add them to the final string.
 Using a curly brace syntax,
 you can define optional parameters that have names.
 
-<?code-excerpt "misc/bin/optional_named_params.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/optional_named_params.dart"?>
 ```dart
-void printName(String firstName, String lastName, {String suffix}) {
+void printName(String firstName, String lastName, {String? suffix}) {
   print('$firstName $lastName ${suffix ?? ''}');
 }
 // ···
@@ -1154,7 +1154,7 @@ try {
 To execute code whether or not an exception is thrown,
 use `finally`:
 
-<?code-excerpt "misc/bin/exceptions.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/exceptions.dart"?>
 ```dart
 try {
   breedMoreLlamas();
@@ -1338,7 +1338,7 @@ Dart provides a handy shortcut for assigning
 values to properties in a constructor:
 use `this.propertyName` when declaring the constructor:
 
-<?code-excerpt "misc/bin/this_constructor.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/this_constructor.dart"?>
 ```dart
 class MyColor {
   int red;
@@ -1575,10 +1575,10 @@ so I deleted that. We can add it back if we can word it better.]
 To allow classes to have multiple constructors,
 Dart supports named constructors:
 
-<?code-excerpt "misc/bin/named_constructor.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/named_constructor.dart"?>
 ```dart
 class Point {
-  double x, y;
+  late double x, y;
 
   Point(this.x, this.y);
 
@@ -1674,7 +1674,7 @@ Dart supports factory constructors,
 which can return subtypes or even null.
 To create a factory constructor, use the `factory` keyword:
 
-<?code-excerpt "misc/bin/factory_constructors.dart"?>
+<?code-excerpt "../null_safety_examples/misc/bin/factory_constructors.dart"?>
 ```dart
 class Square extends Shape {}
 
@@ -1688,7 +1688,7 @@ class Shape {
     if (typeName == 'circle') return Circle();
 
     print('I don\'t recognize $typeName');
-    return null;
+    throw Error();
   }
 }
 ```
@@ -1869,7 +1869,7 @@ another constructor in the same class.
 A redirecting constructor’s body is empty,
 with the constructor call appearing after a colon (`:`).
 
-<?code-excerpt "misc/bin/redirecting_const_constructors.dart (redirecting-constructors)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/redirecting_const_constructors.dart (redirecting-constructors)"?>
 ```dart
 class Automobile {
   String make;
@@ -1963,7 +1963,7 @@ If your class produces objects that never change, you can make these objects com
 do this, define a `const` constructor and make sure that all instance variables
 are final.
 
-<?code-excerpt "misc/bin/redirecting_const_constructors.dart (const-constructors)"?>
+<?code-excerpt "../null_safety_examples/misc/bin/redirecting_const_constructors.dart (const-constructors)"?>
 ```dart
 class ImmutablePoint {
   const ImmutablePoint(this.x, this.y);

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -1,4 +1,4 @@
----
+c--
 title: Dart cheatsheet codelab
 description: Interactively learn (or relearn) some of Dart's unique features.
 js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -57,10 +57,10 @@ The following function takes two integers as parameters.
 Make it return a string containing both integers separated by a space.
 For example, `stringify(2, 3)` should return `'2 3'`.
 
-```dart:run-dartpad:ga_id-string_interpolation
+```dart:run-dartpad:ga_id-string_interpolation:null_safety-true
 {$ begin main.dart $}
 String stringify(int x, int y) {
-  // Return a formatted string here
+  TODO('Return a formatted string here');
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
@@ -69,6 +69,7 @@ String stringify(int x, int y) {
 }
 {$ end solution.dart $}
 {$ begin test.dart $}
+
 void main() {
   try {
     final str = stringify(2, 3); 
@@ -77,11 +78,11 @@ void main() {
       _result(true);
     } else if (str == '23') {
       _result(false, ['Test failed. It looks like you forgot the space!']);
-    } else if (str == null) {
-      _result(false, ['Test failed. Did you forget to return a value?']);
     } else {
       _result(false, ['That\'s not quite right. Keep trying!']);
     }
+  } on UnimplementedError {
+    _result(false, ['Test failed. Did you implement the method?']);
   } catch (e) {
     _result(false, ['Tried calling stringify(2, 3), but received an exception: ${e.runtimeType}']);
   }
@@ -96,9 +97,75 @@ reference them inside single quotes, with a space in between.
 {$ end hint.txt $}
 ```
 
+## Nullable variables
+
+In Dart, types in your code are non-nullable by default, meaning that values can’t be null
+unless you say they can be.
+
+For example, consider the following code, which is **invalid**, because `null` cannot be assigned to `a`.
+
+{% prettify dart tag=pre+code %}
+int a = [!null!];
+{% endprettify %}
+
+When creating a variable, you can use ? to inform Dart of the variable’s nullability.
+
+{% prettify dart tag=pre+code %}
+int? a = null;
+{% endprettify %}
+
+However, nullable variables are null by default, so it is not necessary to assign null to it.
+
+{% prettify dart tag=pre+code %}
+int? a; // The initial value of a is null
+{% endprettify %}
+
+Read the [Sound null safety guide](/null-safety) for more information about null safety on Dart.
+
+### Code example
+
+Try to declare two variables below:
+- A nullable `String` named `name` with the value `Jane`.
+- A nullable `String` named `address` with the value of null.
+
+Ignore all initial errors in the dartpad.
+
+{% comment %}
+TODO: Add new ga_id tag.
+{% endcomment -%}
+```dart:run-dartpad:null_safety-true
+{$ begin main.dart $}
+// Declare the two variables here
+{$ end main.dart $}
+{$ begin solution.dart $}
+String? name = 'Jane';
+String? address;
+{$ end solution.dart $}
+{$ begin test.dart $}
+
+void main() {
+  try {
+    if (name == 'Jane' && address == null) {
+      // verify that "name" is nullable
+      name = null;
+      _result(true);
+    } else {
+      _result(false, ['That\'s not quite right. Keep trying!']);
+    }
+  } catch (e) {
+    _result(false, ['Tried calling stringify(2, 3), but received an exception: ${e.runtimeType}']);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Declare the two variables as "String" followed by "?".
+Then, assign "Jane" to "name"
+and leave "address" uninitalized.
+{$ end hint.txt $}
+```
+
 
 ## Null-aware operators
-
 
 Dart offers some handy operators for dealing with values that might be null. One is the
 `??=` assignment operator, which assigns a value to a variable only if that
@@ -132,13 +199,15 @@ print(null ?? 12); // <-- Prints 12.
 
 Try putting the `??=` and `??` operators to work below.
 
-```dart:run-dartpad:height-255px:ga_id-null_aware
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:height-255px:ga_id-null_aware:null_safety-true
 {$ begin main.dart $}
-String foo = 'a string';
-String bar; // Unassigned objects are null by default.
+String? foo = 'a string';
+String? bar; // Unassigned objects are null by default.
 
 // Substitute an operator that makes 'a string' be assigned to baz.
-String baz = foo /* TODO */ bar;
+String? baz = foo /* TODO */ bar;
 
 void updateSomeVars() {
   // Substitute an operator that makes 'a string' be assigned to bar.
@@ -146,11 +215,11 @@ void updateSomeVars() {
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
-String foo = 'a string';
-String bar; // Unassigned objects are null by default.
+String? foo = 'a string';
+String? bar; // Unassigned objects are null by default.
 
 // Substitute an operator that makes 'a string' be assigned to baz.
-String baz = foo ?? bar;
+String? baz = foo ?? bar;
 
 void updateSomeVars() {
   // Substitute an operator that makes 'a string' be assigned to bar.
@@ -221,18 +290,18 @@ null.
 
 Try using conditional property access to finish the code snippet below.
 
-```dart:run-dartpad:ga_id-conditional-property_access
+```dart:run-dartpad:ga_id-conditional-property_access:null_safety-true
 {$ begin main.dart $}
 // This method should return the uppercase version of `str`
 // or null if `str` is null.
-String upperCaseIt(String str) {
+String? upperCaseIt(String? str) {
   // Try conditionally accessing the `toUpperCase` method here.
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
 // This method should return the uppercase version of `str`
 // or null if `str` is null.
-String upperCaseIt(String str) {
+String? upperCaseIt(String? str) {
   return str?.toUpperCase();
 }
 {$ end solution.dart $}
@@ -241,7 +310,7 @@ void main() {
   final errs = <String>[];
   
   try {
-    String one = upperCaseIt(null);
+    String? one = upperCaseIt(null);
 
     if (one != null) {
       errs.add('Looks like you\'re not returning null for null inputs.');
@@ -251,7 +320,7 @@ void main() {
   }
   
   try {
-    String two = upperCaseIt('asdf');
+    String? two = upperCaseIt('asdf');
 
     if (two == null) {
       errs.add('Looks like you\'re returning null even when str has a value.');
@@ -314,27 +383,27 @@ final aListOfBaseType = <BaseType>[SubType(), SubType()];
 
 ### Code example
 
-Try setting the following variables to the indicated values.
+Try setting the following variables to the indicated values. Replace the existing null values.
 
-```dart:run-dartpad:height-400px:ga_id-collection_literals
+```dart:run-dartpad:height-400px:ga_id-collection_literals:null_safety-true
 {$ begin main.dart $}
 // Assign this a list containing 'a', 'b', and 'c' in that order:
-final aListOfStrings = 
+final aListOfStrings = null;
 
 // Assign this a set containing 3, 4, and 5:
-final aSetOfInts = 
+final aSetOfInts = null;
 
 // Assign this a map of String to int so that aMapOfStringsToInts['myKey'] returns 12:
-final aMapOfStringsToInts = 
+final aMapOfStringsToInts = null;
 
 // Assign this an empty List<double>:
-final anEmptyListOfDouble = 
+final anEmptyListOfDouble = null;
 
 // Assign this an empty Set<String>:
-final anEmptySetOfString = 
+final anEmptySetOfString = null;
 
 // Assign this an empty Map of double to int:
-final anEmptyMapOfDoublesToInts = 
+final anEmptyMapOfDoublesToInts = null;
 {$ end main.dart $}
 {$ begin solution.dart $}
 // Assign this a list containing 'a', 'b', and 'c' in that order:
@@ -439,35 +508,35 @@ bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
 
 Try finishing the following statements, which use arrow syntax.
 
-```dart:run-dartpad:height-345px:ga_id-arrow_syntax
+```dart:run-dartpad:height-345px:ga_id-arrow_syntax:null_safety-true
 {$ begin main.dart $}
 class MyClass {
-  int _value1 = 2;
-  int _value2 = 3;
-  int _value3 = 5;
+  int value1 = 2;
+  int value2 = 3;
+  int value3 = 5;
   
   // Returns the product of the above values:
-  int get product =>
+  int get product => TODO();
   
-  // Adds 1 to _value1:
-  void incrementValue1() => 
+  // Adds 1 to value1:
+  void incrementValue1() => TODO();
   
   // Returns a string containing each item in the
   // list, separated by commas (e.g. 'a,b,c'): 
-  String joinWithCommas(List<String> strings) =>
+  String joinWithCommas(List<String> strings) => TODO();
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
 class MyClass {
-  int _value1 = 2;
-  int _value2 = 3;
-  int _value3 = 5;
+  int value1 = 2;
+  int value2 = 3;
+  int value3 = 5;
 
   // Returns the product of the above values:
-  int get product => _value1 * _value2 * _value3;
+  int get product => value1 * value2 * value3;
   
-  // Adds 1 to _value1:
-  void incrementValue1() => _value1++; 
+  // Adds 1 to value1:
+  void incrementValue1() => value1++; 
   
   // Returns a string containing each item in the
   // list, separated by commas (e.g. 'a,b,c'): 
@@ -485,6 +554,9 @@ void main() {
     if (product != 30) {
       errs.add('The product property returned $product instead of the expected value (30).'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to use MyClass.product but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried to use MyClass.product, but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -493,9 +565,12 @@ void main() {
   try {
     obj.incrementValue1();
     
-    if (obj._value1 != 3) {
-      errs.add('After calling incrementValue, value1 was ${obj._value1} instead of the expected value (3).'); 
+    if (obj.value1 != 3) {
+      errs.add('After calling incrementValue, value1 was ${obj.value1} instead of the expected value (3).'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to use MyClass.incrementValue1 but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried to use MyClass.incrementValue1, but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -507,6 +582,9 @@ void main() {
     if (joined != 'one,two,three') {
       errs.add('Tried calling joinWithCommas([\'one\', \'two\', \'three\']) and received $joined instead of the expected value (\'one,two,three\').'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to use MyClass.joinWithCommas but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried to use MyClass.joinWithCommas, but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -575,7 +653,7 @@ sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
 to `1`, `'String!'`, and `[3.0]` (respectively)
 and then calls `allDone()`.
 
-```dart:run-dartpad:height-345px:ga_id-cascades
+```dart:run-dartpad:height-345px:ga_id-cascades:null_safety-true
 {$ begin main.dart $}
 class BigObject {
   int anInt = 0;
@@ -590,7 +668,7 @@ class BigObject {
 
 BigObject fillBigObject(BigObject obj) {
   // Create a single statement that will update and return obj:
-  return obj..
+  return TODO('obj..');
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
@@ -619,6 +697,9 @@ void main() {
 
   try {
     obj = fillBigObject(BigObject());
+  } on UnimplementedError {
+    _result(false, ['Tried to call fillBigObject but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, [
       'Caught an exception of type ${e.runtimeType} while running fillBigObject'
@@ -626,44 +707,36 @@ void main() {
     return;
   }
 
-  if (obj == null) {
-    _result(false, ['It looks like fillBigObject returned a null!']);
+  final errs = <String>[];
+
+  if (obj.anInt != 1) {
+    errs.add(
+        'The value of anInt was ${obj.anInt} rather than the expected (1).');
+  }
+
+  if (obj.aString != 'String!') {
+    errs.add(
+        'The value of aString was \'${obj.aString}\' rather than the expected (\'String!\').');
+  }
+
+  if (obj.aList.length != 1) {
+    errs.add(
+        'The length of aList was ${obj.aList.length} rather than the expected value (1).');
   } else {
-    final errs = <String>[];
-
-    if (obj.anInt != 1) {
+    if (obj.aList[0] != 3.0) {
       errs.add(
-          'The value of anInt was ${obj.anInt} rather than the expected (1).');
+          'The value found in aList was ${obj.aList[0]} rather than the expected (3.0).');
     }
+  }
+  
+  if (!obj._done) {
+    errs.add('It looks like allDone() wasn\'t called.');
+  }
 
-    if (obj.aString != 'String!') {
-      errs.add(
-          'The value of aString was \'${obj.aString}\' rather than the expected (\'String!\').');
-    }
-
-    if (obj.aList == null) {
-      errs.add('The value of aList was null.');
-    }
-
-    if (obj.aList.length != 1) {
-      errs.add(
-          'The length of aList was ${obj.aList.length} rather than the expected value (1).');
-    } else {
-      if (obj.aList[0] != 3.0) {
-        errs.add(
-            'The value found in aList was ${obj.aList[0]} rather than the expected (3.0).');
-      }
-    }
-    
-    if (!obj._done) {
-      errs.add('It looks like allDone() wasn\'t called.');
-    }
-
-    if (errs.isEmpty) {
-      _result(true);
-    } else {
-      _result(false, errs);
-    }
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
   }
 }
 {$ end test.dart $}
@@ -728,7 +801,9 @@ Add the following:
   as long as the new list doesn't contain any negative prices
   (in which case the setter should throw an `InvalidPriceException`).
 
-```dart:run-dartpad:height-240px:ga_id-getters_setters
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:height-240px:ga_id-getters_setters:null_safety-true
 {$ begin main.dart $}
 class InvalidPriceException {}
 
@@ -764,7 +839,7 @@ void main() {
   try {
     final cart = ShoppingCart();
     cart.prices = [12.0, 12.0, -23.0];
-  } on InvalidPriceException{
+  } on InvalidPriceException {
     foundException = true;
   } catch (e) {
     _result(false, ['Tried setting a negative price and received a ${e.runtimeType} instead of an InvalidPriceException.']);
@@ -782,11 +857,6 @@ void main() {
     secondCart.prices = [1.0, 2.0, 3.0];
   } catch(e) {
     _result(false, ['Tried setting prices with a valid list, but received an exception: ${e.runtimeType}.']);
-    return;
-  }
-  
-  if (secondCart._prices == null) {
-    _result(false, ['Tried setting prices with a list of three values, but _prices ended up being null.']);
     return;
   }
   
@@ -888,14 +958,14 @@ Here are some examples of function calls and returned values:
 
 <br>
 
-```dart:run-dartpad:ga_id-optional_positional_parameters
+```dart:run-dartpad:ga_id-optional_positional_parameters:null_safety-true
 {$ begin main.dart $}
-String joinWithCommas(int a, [int b, int c, int d, int e]) {
-
+String joinWithCommas(int a, [int? b, int? c, int? d, int? e]) {
+  return TODO();
 }
 {$ end main.dart $}
 {$ begin solution.dart $}
-String joinWithCommas(int a, [int b, int c, int d, int e]) {
+String joinWithCommas(int a, [int? b, int? c, int? d, int? e]) {
   var total = '$a';
   if (b != null) total = '$total,$b';
   if (c != null) total = '$total,$c';
@@ -914,6 +984,9 @@ void main() {
     if (value != '1') {
       errs.add('Tried calling joinWithCommas(1) and got $value instead of the expected (\'1\').'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to call joinWithCommas but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried calling joinWithCommas(1), but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -925,6 +998,9 @@ void main() {
     if (value != '1,2,3') {
       errs.add('Tried calling joinWithCommas(1, 2, 3) and got $value instead of the expected (\'1,2,3\').'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to call joinWithCommas but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried calling joinWithCommas(1, 2 ,3), but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -936,6 +1012,9 @@ void main() {
     if (value != '1,2,3,4,5') {
       errs.add('Tried calling joinWithCommas(1, 2, 3, 4, 5) and got $value instead of the expected (\'1,2,3,4,5\').'); 
     } 
+  } on UnimplementedError {
+    _result(false, ['Tried to call joinWithCommas but failed. Did you implement the method?']);
+    return;
   } catch (e) {
     _result(false, ['Tried calling stringify(1, 2, 3, 4 ,5), but encountered an exception: ${e.runtimeType}.']);
     return;
@@ -972,7 +1051,7 @@ void printName(String firstName, String lastName, {String? suffix}) {
 ```
 
 As you might expect, the value of these parameters is null by default,
-but you can provide default values:
+but you can provide default values to make them not nullable:
 
 ```dart
 void printName(String firstName, String lastName, {String suffix = ''}) {
@@ -988,9 +1067,11 @@ A function can't have both optional positional and optional named parameters.
 Add a `copyWith()` instance method to the `MyDataObject`
 class. It should take three named parameters:
 
-* `int newInt`
-* `String newString`
-* `double newDouble`
+* `int? newInt`
+* `String? newString`
+* `double? newDouble`
+
+Note that the parameters should be nullable.
 
 When called, `copyWith()` should return a new `MyDataObject`
 based on the current instance,
@@ -999,7 +1080,9 @@ copied into the object's properties.
 For example, if `newInt` is non-null,
 then copy its value into `anInt`.
 
-```dart:run-dartpad:height-310px:ga_id-optional_named_parameters
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:height-310px:ga_id-optional_named_parameters:null_safety-true
 {$ begin main.dart $}
 class MyDataObject {
   final int anInt;
@@ -1027,7 +1110,7 @@ class MyDataObject {
      this.aDouble = 2.0,
   });
 
-  MyDataObject copyWith({int newInt, String newString, double newDouble}) {
+  MyDataObject copyWith({int? newInt, String? newString, double? newDouble}) {
     return MyDataObject(
       anInt: newInt ?? this.anInt,
       aString: newString ?? this.aString,
@@ -1044,20 +1127,16 @@ void main() {
   try {
     final copy = source.copyWith(newInt: 12, newString: 'New!', newDouble: 3.0);
     
-    if (copy == null) {
-      errs.add('Tried copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0) and it returned null');
-    } else {
-      if (copy.anInt != 12) {
-        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s anInt was ${copy.anInt} rather than the expected value (12).');
-      }
-      
-      if (copy.aString != 'New!') {
-        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aString was ${copy.aString} rather than the expected value (\'New!\').');
-      }
-      
-      if (copy.aDouble != 3) {
-        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (3).');
-      }
+    if (copy.anInt != 12) {
+      errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s anInt was ${copy.anInt} rather than the expected value (12).');
+    }
+    
+    if (copy.aString != 'New!') {
+      errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aString was ${copy.aString} rather than the expected value (\'New!\').');
+    }
+    
+    if (copy.aDouble != 3) {
+      errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (3).');
     }
   } catch (e) {
     _result(false, ['Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0) and got an exception: ${e.runtimeType}']);
@@ -1066,20 +1145,16 @@ void main() {
   try {
     final copy = source.copyWith();
     
-    if (copy == null) {
-      errs.add('Tried copyWith() and it returned null');
-    } else {
-      if (copy.anInt != 1) {
-        errs.add('Called copyWith(), and the new object\'s anInt was ${copy.anInt} rather than the expected value (1).');
-      }
-      
-      if (copy.aString != 'Old!') {
-        errs.add('Called copyWith(), and the new object\'s aString was ${copy.aString} rather than the expected value (\'Old!\').');
-      }
-      
-      if (copy.aDouble != 2) {
-        errs.add('Called copyWith(), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (2).');
-      }
+    if (copy.anInt != 1) {
+      errs.add('Called copyWith(), and the new object\'s anInt was ${copy.anInt} rather than the expected value (1).');
+    }
+    
+    if (copy.aString != 'Old!') {
+      errs.add('Called copyWith(), and the new object\'s aString was ${copy.aString} rather than the expected value (\'Old!\').');
+    }
+    
+    if (copy.aDouble != 2) {
+      errs.add('Called copyWith(), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (2).');
     }
   } catch (e) {
     _result(false, ['Called copyWith() and got an exception: ${e.runtimeType}']);
@@ -1181,7 +1256,7 @@ then do the following:
 * After everything's caught and handled, call `logger.doneLogging`
   (try using `finally`).
 
-```dart:run-dartpad:height-420px:ga_id-exceptions
+```dart:run-dartpad:height-420px:ga_id-exceptions:null_safety-true
 {$ begin main.dart $}
 typedef VoidFunction = void Function();
 
@@ -1192,7 +1267,7 @@ class ExceptionWithMessage {
 
 // Call logException to log an exception, and doneLogging when finished.
 abstract class Logger {
-  void logException(Type t, [String msg]);
+  void logException(Type t, [String? msg]);
   void doneLogging();
 }
 
@@ -1211,7 +1286,7 @@ class ExceptionWithMessage {
 }
 
 abstract class Logger {
-  void logException(Type t, [String msg]);
+  void logException(Type t, [String? msg]);
   void doneLogging();
 }
 
@@ -1229,11 +1304,11 @@ void tryFunction(VoidFunction untrustworthy, Logger logger) {
 {$ end solution.dart $}
 {$ begin test.dart $}
 class MyLogger extends Logger {
-  Type lastType;
+  Type? lastType;
   String lastMessage = '';
   bool done = false;
   
-  void logException(Type t, [String message]) {
+  void logException(Type t, [String? message]) {
     lastType = t;
     lastMessage = message ?? lastMessage;
   }
@@ -1358,11 +1433,13 @@ Property names become the names of the parameters:
 class MyColor {
   ...
 
-  MyColor({this.red, this.green, this.blue});
+  MyColor({required this.red, required this.green, required this.blue});
 }
 
 final color = MyColor(red: 80, green: 80, blue: 80);
 ```
+
+In this case,`red`, `green` and `blue` are marked as `required` because they are not nullable.
 
 For optional parameters, default values work as expected:
 
@@ -1372,13 +1449,17 @@ MyColor([this.red = 0, this.green = 0, this.blue = 0]);
 MyColor({this.red = 0, this.green = 0, this.blue = 0});
 ```
 
+With default values it is no longer necessary to mark the parameters as `required`.
+
 ### Code example
 
 Add a one-line constructor to `MyClass` that uses
 `this.` syntax to receive and assign values for
 all three properties of the class.
 
-```dart:run-dartpad:ga_id-this_constructor
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:ga_id-this_constructor:null_safety-true
 {$ begin main.dart $}
 class MyClass {
   final int anInt;
@@ -1404,20 +1485,16 @@ void main() {
   try {
     final obj = MyClass(1, 'two', 3);
     
-    if (obj == null) {
-      errs.add('Called MyClass(1, \'two\', 3) and got a null in response.');
-    } else {
-      if (obj.anInt != 1) {
-        errs.add('Called MyClass(1, \'two\', 3) and got an object with anInt of ${obj.anInt} instead of the expected value (1).');
-      }
+    if (obj.anInt != 1) {
+      errs.add('Called MyClass(1, \'two\', 3) and got an object with anInt of ${obj.anInt} instead of the expected value (1).');
+    }
 
-      if (obj.anInt != 1) {
-        errs.add('Called MyClass(1, \'two\', 3) and got an object with aString of \'${obj.aString}\' instead of the expected value (\'two\').');
-      }
+    if (obj.anInt != 1) {
+      errs.add('Called MyClass(1, \'two\', 3) and got an object with aString of \'${obj.aString}\' instead of the expected value (\'two\').');
+    }
 
-      if (obj.anInt != 1) {
-        errs.add('Called MyClass(1, \'two\', 3) and got an object with aDouble of ${obj.aDouble} instead of the expected value (3).');
-      }
+    if (obj.anInt != 1) {
+      errs.add('Called MyClass(1, \'two\', 3) and got an object with aDouble of ${obj.aDouble} instead of the expected value (3).');
     }
   } catch (e) {
     _result(false, ['Called MyClass(1, \'two\', 3) and got an exception of type ${e.runtimeType}.']);
@@ -1481,6 +1558,8 @@ Use an initializer list to assign the first two characters in `word` to
 the `letterOne` and `LetterTwo` properties.
 For extra credit, add an `assert` to catch words of less than two characters.
 
+Ignore all initial errors in the dartpad.
+
 {% comment %}
 Is the assert even executed? I can't see any effect on the test,
 which makes me think asserts are ignored.
@@ -1495,7 +1574,7 @@ FINALLY: Suggest using https://pub.dev/packages/characters
 if this is a user-entered string.
 {% endcomment %}
 
-```dart:run-dartpad:ga_id-initializer_lists
+```dart:run-dartpad:ga_id-initializer_lists:null_safety-true
 {$ begin main.dart $}
 class FirstTwoLetters {
   final String letterOne;
@@ -1523,16 +1602,12 @@ void main() {
   try {
     final result = FirstTwoLetters('My String');
     
-    if (result == null) {
-      errs.add('Called FirstTwoLetters(\'My String\') and got a null in response.');
-    } else {
-      if (result.letterOne != 'M') {
-        errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterOne equal to \'${result.letterOne}\' instead of the expected value (\'M\').');
-      }
+    if (result.letterOne != 'M') {
+      errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterOne equal to \'${result.letterOne}\' instead of the expected value (\'M\').');
+    }
 
-      if (result.letterTwo != 'y') {
-        errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterTwo equal to \'${result.letterTwo}\' instead of the expected value (\'y\').');
-      }
+    if (result.letterTwo != 'y') {
+      errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterTwo equal to \'${result.letterTwo}\' instead of the expected value (\'y\').');
     }
   } catch (e) {
     errs.add('Called FirstTwoLetters(\'My String\') and got an exception of type ${e.runtimeType}.');
@@ -1589,6 +1664,9 @@ class Point {
 }
 ```
 
+This example uses the `late` annotation to indicate that `x` and `y` will
+be initalized later in the named constructor.
+
 To use a named constructor, invoke it using its full name:
 
 ```dart
@@ -1600,12 +1678,14 @@ final myPoint = Point.origin();
 Give the Color class a constructor named `Color.black`
 that sets all three properties to zero.
 
-```dart:run-dartpad:height-240px:ga_id-named_constructors
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:height-240px:ga_id-named_constructors:null_safety-true
 {$ begin main.dart $}
 class Color {
-  int red;
-  int green;
-  int blue;
+  late int red;
+  late int green;
+  late int blue;
   
   Color(this.red, this.green, this.blue);
 
@@ -1614,9 +1694,9 @@ class Color {
 {$ end main.dart $}
 {$ begin solution.dart $}
 class Color {
-  int red;
-  int green;
-  int blue;
+  late int red;
+  late int green;
+  late int blue;
   
   Color(this.red, this.green, this.blue);
 
@@ -1634,21 +1714,20 @@ void main() {
   try {
     final result = Color.black();
     
-    if (result == null) {
-      errs.add('Called Color.black() and got a null in response.');
-    } else {
-      if (result.red != 0) {
-        errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
-      }
-
-      if (result.green != 0) {
-        errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
-      }
-
-      if (result.blue != 0) {
-    errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
-      }
+    if (result.red != 0) {
+      errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
     }
+
+    if (result.green != 0) {
+      errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
+    }
+
+    if (result.blue != 0) {
+  errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
+    }
+  } on LateInitializationError {
+     _result(false, ['Called Color.black() and got an error. Did you forget to initalize a property?']);
+    return;
   } catch (e) {
     _result(false, ['Called Color.black() and got an exception of type ${e.runtimeType}.']);
     return;
@@ -1704,15 +1783,16 @@ making it do the following:
   create an `IntegerDouble` with the values in order.
 * If the list has **three** values,
   create an `IntegerTriple` with the values in order.
-* Otherwise, return null.
+* Otherwise, throw Error.
 
-```dart:run-dartpad:height-415px:ga_id-factory_constructors
+```dart:run-dartpad:height-415px:ga_id-factory_constructors:null_safety-true
 {$ begin main.dart $}
 class IntegerHolder {
   IntegerHolder();
   
   // Implement this factory constructor.
   factory IntegerHolder.fromList(List<int> list) {
+    TODO();
   }
 }
 
@@ -1739,14 +1819,14 @@ class IntegerHolder {
   IntegerHolder();
   
   factory IntegerHolder.fromList(List<int> list) {
-    if (list?.length == 1) {
+    if (list.length == 1) {
       return IntegerSingle(list[0]);
-    } else if (list?.length == 2) {
+    } else if (list.length == 2) {
       return IntegerDouble(list[0], list[1]);
-    } else if (list?.length == 3) {
+    } else if (list.length == 3) {
       return IntegerTriple(list[0], list[1], list[2]);
     } else {
-      return null;
+      throw Error();
     } 
   }
 }
@@ -1773,27 +1853,31 @@ class IntegerTriple extends IntegerHolder {
 void main() {
   final errs = <String>[];
 
+  bool _throwed = false;
   try {
-    final obj = IntegerHolder.fromList([]);
-    
-    if (obj != null) {
-      errs.add('Called IntegerSingle.fromList([]) and didn\'t get a null.');
-    } 
+    IntegerHolder.fromList([]);
+  } on UnimplementedError {
+    _result(false, ['Test failed. Did you implement the method?']);
+    return;
+  } on Error {
+    _throwed = true;
   } catch (e) {
     _result(false, ['Called IntegerSingle.fromList([]) and got an exception of type ${e.runtimeType}.']);
     return;
   }
+  
+  if (!_throwed) {
+    errs.add('Called IntegerSingle.fromList([]) and didn\'t throw Error.');
+  } 
 
   try {
     final obj = IntegerHolder.fromList([1]);
     
-    if (obj == null) {
-      errs.add('Called IntegerHolder.fromList([1]) and got a null.');
-    } else if (obj is! IntegerSingle) {
+    if (obj is! IntegerSingle) {
       errs.add('Called IntegerHolder.fromList([1]) and got an object of type ${obj.runtimeType} instead of IntegerSingle.');
     } else {
-      if ((obj as IntegerSingle).a != 1) {
-        errs.add('Called IntegerHolder.fromList([1]) and got an IntegerSingle with an \'a\' value of ${(obj as IntegerSingle).a} instead of the expected (1).');
+      if (obj.a != 1) {
+        errs.add('Called IntegerHolder.fromList([1]) and got an IntegerSingle with an \'a\' value of ${obj.a} instead of the expected (1).');
       }
     }
   } catch (e) {
@@ -1804,17 +1888,15 @@ void main() {
   try {
     final obj = IntegerHolder.fromList([1, 2]);
     
-    if (obj == null) {
-      errs.add('Called IntegerHolder.fromList([1, 2]) and got a null.');
-    } else if (obj is! IntegerDouble) {
+    if (obj is! IntegerDouble) {
       errs.add('Called IntegerHolder.fromList([1, 2]) and got an object of type ${obj.runtimeType} instead of IntegerDouble.');
     } else {
-      if ((obj as IntegerDouble).a != 1) {
-        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'a\' value of ${(obj as IntegerDouble).a} instead of the expected (1).');
+      if (obj.a != 1) {
+        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'a\' value of ${obj.a} instead of the expected (1).');
       }
       
-      if ((obj as IntegerDouble).b != 2) {
-        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'b\' value of ${(obj as IntegerDouble).b} instead of the expected (2).');
+      if (obj.b != 2) {
+        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'b\' value of ${obj.b} instead of the expected (2).');
       }
     }
   } catch (e) {
@@ -1825,21 +1907,19 @@ void main() {
   try {
     final obj = IntegerHolder.fromList([1, 2, 3]);
     
-    if (obj == null) {
-      errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got a null.');
-    } else if (obj is! IntegerTriple) {
+    if (obj is! IntegerTriple) {
       errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an object of type ${obj.runtimeType} instead of IntegerTriple.');
     } else {
-      if ((obj as IntegerTriple).a != 1) {
-        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).a} instead of the expected (1).');
+      if (obj.a != 1) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${obj.a} instead of the expected (1).');
       }
       
-      if ((obj as IntegerTriple).b != 2) {
-        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).b} instead of the expected (2).');
+      if (obj.b != 2) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${obj.b} instead of the expected (2).');
       }
 
-      if ((obj as IntegerTriple).c != 3) {
-        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).b} instead of the expected (2).');
+      if (obj.c != 3) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${obj.b} instead of the expected (2).');
       }
     }
   } catch (e) {
@@ -1893,7 +1973,9 @@ Remember the `Color` class from above? Create a named constructor called
 `black`, but rather than manually assigning the properties, redirect it to the
 default constructor with zeros as the arguments.
 
-```dart:run-dartpad:height-255px:ga_id-redirecting_constructors
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:height-255px:ga_id-redirecting_constructors:null_safety-true
 {$ begin main.dart $}
 class Color {
   int red;
@@ -1924,20 +2006,16 @@ void main() {
   try {
     final result = Color.black();
     
-    if (result == null) {
-      errs.add('Called Color.black() and got a null in response.');
-    } else {
-      if (result.red != 0) {
-        errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
-      }
+    if (result.red != 0) {
+      errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
+    }
 
-      if (result.green != 0) {
-        errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
-      }
+    if (result.green != 0) {
+      errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
+    }
 
-      if (result.blue != 0) {
-    errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
-      }
+    if (result.blue != 0) {
+  errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
     }
   } catch (e) {
     _result(false, ['Called Color.black() and got an exception of type ${e.runtimeType}.']);
@@ -1987,7 +2065,9 @@ and create a constant constructor that does the following:
 * Is constant, with the `const` keyword just before
   `Recipe` in the constructor declaration.
 
-```dart:run-dartpad:ga_id-const_constructors
+Ignore all initial errors in the dartpad.
+
+```dart:run-dartpad:ga_id-const_constructors:null_safety-true
 {$ begin main.dart $}
 class Recipe {
   List<String> ingredients;
@@ -2011,20 +2091,16 @@ void main() {
   try {
     const obj = Recipe(['1 egg', 'Pat of butter', 'Pinch salt'], 120, 200);
     
-    if (obj == null) {
-      errs.add('Tried calling Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and received a null.');
-    } else {
-      if (obj.ingredients?.length != 3) {
-        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with ingredient list of length ${obj.ingredients?.length} rather than the expected length (3).');
-      }
-      
-      if (obj.calories != 120) {
-        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a calorie value of ${obj.calories} rather than the expected value (120).');
-      }
-      
-      if (obj.milligramsOfSodium != 200) {
-        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a milligramsOfSodium value of ${obj.milligramsOfSodium} rather than the expected value (200).');
-      }
+    if (obj.ingredients.length != 3) {
+      errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with ingredient list of length ${obj.ingredients.length} rather than the expected length (3).');
+    }
+    
+    if (obj.calories != 120) {
+      errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a calorie value of ${obj.calories} rather than the expected value (120).');
+    }
+    
+    if (obj.milligramsOfSodium != 200) {
+      errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a milligramsOfSodium value of ${obj.milligramsOfSodium} rather than the expected value (200).');
     }
   } catch (e) {
     _result(false, ['Tried calling Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and received a null.']);

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -1,4 +1,4 @@
-c--
+---
 title: Dart cheatsheet codelab
 description: Interactively learn (or relearn) some of Dart's unique features.
 js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -949,7 +949,7 @@ Their default value is null unless you provide another default value:
 <?code-excerpt "../null_safety_examples/misc/bin/optional_positional_args2.dart"?>
 ```dart
 int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
-  // ···
+// ···
 }
 // ···
   int newTotal = sumUpToFive(1);

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -1,0 +1,2054 @@
+---
+title: Dart cheatsheet codelab
+description: Interactively learn (or relearn) some of Dart's unique features.
+js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
+---
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
+<style>
+{% comment %}
+TODO(chalin): move this into one of our SCSS files
+{% endcomment -%}
+iframe[src^="https://dartpad"] {
+  border: 1px solid #ccc;
+  margin-bottom: 1rem;
+  min-height: 220px;
+  resize: vertical;
+  width: 100%;
+}
+</style>
+
+The Dart language is designed to be easy to learn for
+coders coming from other languages,
+but it has a few unique features.
+This codelab — which is based on a
+[Dart language cheatsheet](/guides/language/cheatsheet)
+written by and for Google engineers —
+walks you through the most important of these language features.
+
+The embedded editors in this codelab have partially completed code snippets.
+You can use these editors to test your knowledge by completing the code and
+clicking the **Run** button.
+If you need help, click the **Hint** button.
+To run the code formatter ([dartfmt](/tools/dartfmt)), click **Format**.
+The **Reset** button erases your work and
+restores the editor to its original state.
+
+{{site.alert.note}}
+  This page uses embedded DartPads to display runnable examples.
+  {% include dartpads-embedded-troubleshooting.md %}
+{{site.alert.end}}
+
+## String interpolation
+
+To put the value of an expression inside a string, use `${expression}`.
+If the expression is an identifier, you can omit the `{}`.
+
+Here are some examples of using string interpolation:
+
+| String                      | | Result |
+|-----------------------------+-+ -------|
+| `'${3 + 2}'`                | | `'5'` |
+| `'${"word".toUpperCase()}'` | | `'WORD'` |
+| `'$myObject'`               | | The value of `myObject.toString()` |
+
+### Code example
+
+The following function takes two integers as parameters.
+Make it return a string containing both integers separated by a space.
+For example, `stringify(2, 3)` should return `'2 3'`.
+
+```dart:run-dartpad:ga_id-string_interpolation
+{$ begin main.dart $}
+String stringify(int x, int y) {
+  // Return a formatted string here
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+String stringify(int x, int y) {
+  return '$x $y';
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  try {
+    final str = stringify(2, 3); 
+
+    if (str == '2 3') {
+      _result(true);
+    } else if (str == '23') {
+      _result(false, ['Test failed. It looks like you forgot the space!']);
+    } else if (str == null) {
+      _result(false, ['Test failed. Did you forget to return a value?']);
+    } else {
+      _result(false, ['That\'s not quite right. Keep trying!']);
+    }
+  } catch (e) {
+    _result(false, ['Tried calling stringify(2, 3), but received an exception: ${e.runtimeType}']);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Both x and y are simple values,
+and Dart's string interpolation will handle
+converting them to string representations.
+All you need to do is use the $ operator to
+reference them inside single quotes, with a space in between.
+{$ end hint.txt $}
+```
+
+
+## Null-aware operators
+
+
+Dart offers some handy operators for dealing with values that might be null. One is the
+`??=` assignment operator, which assigns a value to a variable only if that
+variable is currently null:
+
+{% comment %}
+TBD: Make this and all non-trivial snippets testable.
+{% endcomment %}
+
+<?code-excerpt "misc/bin/null_aware_operators.dart (null-aware-operators)"?>
+```dart
+int a; // The initial value of a is null.
+a ??= 3;
+print(a); // <-- Prints 3.
+
+a ??= 5;
+print(a); // <-- Still prints 3.
+```
+
+Another null-aware operator is `??`,
+which returns the expression on its left unless that expression's value is null,
+in which case it evaluates and returns the expression on its right:
+
+<?code-excerpt "misc/bin/null_aware_operators.dart (null-aware-operators-2)"?>
+```dart
+print(1 ?? 3); // <-- Prints 1.
+print(null ?? 12); // <-- Prints 12.
+```
+
+### Code example
+
+Try putting the `??=` and `??` operators to work below.
+
+```dart:run-dartpad:height-255px:ga_id-null_aware
+{$ begin main.dart $}
+String foo = 'a string';
+String bar; // Unassigned objects are null by default.
+
+// Substitute an operator that makes 'a string' be assigned to baz.
+String baz = foo /* TODO */ bar;
+
+void updateSomeVars() {
+  // Substitute an operator that makes 'a string' be assigned to bar.
+  bar /* TODO */ 'a string';
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+String foo = 'a string';
+String bar; // Unassigned objects are null by default.
+
+// Substitute an operator that makes 'a string' be assigned to baz.
+String baz = foo ?? bar;
+
+void updateSomeVars() {
+  // Substitute an operator that makes 'a string' be assigned to bar.
+  bar ??= 'a string';
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+  
+  try {
+    updateSomeVars();
+    
+    if (foo != 'a string') {
+      errs.add('Looks like foo somehow ended up with the wrong value.');
+    } else if (bar != 'a string') {
+      errs.add('Looks like bar ended up with the wrong value.');
+    } else if (baz != 'a string') {
+      errs.add('Looks like baz ended up with the wrong value.');
+    }
+  } catch (e) {
+    errs.add('Tried calling updateSomeVars and received an exception: ${e.runtimeType}.');
+  }
+  
+  if (errs.isEmpty) {
+   _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+All you need to do in this exercise is
+replace the TODO comments with either ?? or ??=.
+Read the codelab text to make sure you understand both,
+and then give it a try.
+{$ end hint.txt $}
+```
+
+
+## Conditional property access
+
+To guard access to a property or method of an object that might be null,
+put a question mark (`?`) before the dot (`.`):
+
+```dart
+myObject?.someProperty
+```
+
+The preceding code is equivalent to the following:
+
+```dart
+(myObject != null) ? myObject.someProperty : null
+```
+
+You can chain multiple uses of `?.` together in a single expression:
+
+```dart
+myObject?.someProperty?.someMethod()
+```
+
+The preceding code returns null (and never calls `someMethod()`) if either
+`myObject` or `myObject.someProperty` is
+null.
+
+
+### Code example
+
+Try using conditional property access to finish the code snippet below.
+
+```dart:run-dartpad:ga_id-conditional-property_access
+{$ begin main.dart $}
+// This method should return the uppercase version of `str`
+// or null if `str` is null.
+String upperCaseIt(String str) {
+  // Try conditionally accessing the `toUpperCase` method here.
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+// This method should return the uppercase version of `str`
+// or null if `str` is null.
+String upperCaseIt(String str) {
+  return str?.toUpperCase();
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+  
+  try {
+    String one = upperCaseIt(null);
+
+    if (one != null) {
+      errs.add('Looks like you\'re not returning null for null inputs.');
+    }
+  } catch (e) {
+    errs.add('Tried calling upperCaseIt(null) and got an exception: ${e.runtimeType}.');
+  }
+  
+  try {
+    String two = upperCaseIt('asdf');
+
+    if (two == null) {
+      errs.add('Looks like you\'re returning null even when str has a value.');
+    } else if (two != 'ASDF') {
+      errs.add('Tried upperCaseIt(\'asdf\'), but didn\'t get \'ASDF\' in response.');
+    }
+  } catch (e) {
+    errs.add('Tried calling upperCaseIt(\'asdf\') and got an exception: ${e.runtimeType}.');
+  }
+  
+  if (errs.isEmpty) {
+   _result(true);
+  } else {
+   _result(false, errs);
+  }  
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+If this exercise wanted you to conditionally lowercase a string,
+you could do it like this: str?.toLowerCase()
+{$ end hint.txt $}
+```
+
+
+## Collection literals
+
+Dart has built-in support for lists, maps, and sets.
+You can create them using literals:
+
+<?code-excerpt "misc/bin/collection_literals.dart (collection-literals)"?>
+```dart
+final aListOfStrings = ['one', 'two', 'three'];
+final aSetOfStrings = {'one', 'two', 'three'};
+final aMapOfStringsToInts = {
+  'one': 1,
+  'two': 2,
+  'three': 3,
+};
+```
+
+Dart's type inference can assign types to these variables for you.
+In this case, the inferred types are `List<String>`,
+`Set<String>`, and `Map<String, int>`.
+
+Or you can specify the type yourself:
+
+<?code-excerpt "misc/bin/collection_literals.dart (collection-literals-2)"?>
+```dart
+final aListOfInts = <int>[];
+final aSetOfInts = <int>{};
+final aMapOfIntToDouble = <int, double>{};
+```
+
+Specifying types is handy when you initialize a list with contents of a subtype,
+but still want the list to be `List<BaseType>`:
+
+```dart
+final aListOfBaseType = <BaseType>[SubType(), SubType()];
+```
+
+### Code example
+
+Try setting the following variables to the indicated values.
+
+```dart:run-dartpad:height-400px:ga_id-collection_literals
+{$ begin main.dart $}
+// Assign this a list containing 'a', 'b', and 'c' in that order:
+final aListOfStrings = 
+
+// Assign this a set containing 3, 4, and 5:
+final aSetOfInts = 
+
+// Assign this a map of String to int so that aMapOfStringsToInts['myKey'] returns 12:
+final aMapOfStringsToInts = 
+
+// Assign this an empty List<double>:
+final anEmptyListOfDouble = 
+
+// Assign this an empty Set<String>:
+final anEmptySetOfString = 
+
+// Assign this an empty Map of double to int:
+final anEmptyMapOfDoublesToInts = 
+{$ end main.dart $}
+{$ begin solution.dart $}
+// Assign this a list containing 'a', 'b', and 'c' in that order:
+final aListOfStrings = ['a', 'b', 'c'];
+
+// Assign this a set containing 3, 4, and 5:
+final aSetOfInts = {3, 4, 5};
+
+// Assign this a map of String to int so that aMapOfStringsToInts['myKey'] returns 12:
+final aMapOfStringsToInts = {'myKey': 12};
+
+// Assign this an empty List<double>:
+final anEmptyListOfDouble = <double>[];
+
+// Assign this an empty Set<String>:
+final anEmptySetOfString = <String>{};
+
+// Assign this an empty Map of double to int:
+final anEmptyMapOfDoublesToInts = <double, int>{};
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+  
+  if (aListOfStrings is! List<String>) {
+    errs.add('aListOfStrings should have the type List<String>.');
+  } else if (aListOfStrings.length != 3) {
+    errs.add('aListOfStrings has ${aListOfStrings.length} items in it, rather than the expected 3.');
+  } else if (aListOfStrings[0] != 'a' || aListOfStrings[1] != 'b' || aListOfStrings[2] != 'c') {
+    errs.add('aListOfStrings doesn\'t contain the correct values (\'a\', \'b\', \'c\').');
+  }
+
+  if (aSetOfInts is! Set<int>) {
+    errs.add('aSetOfInts should have the type Set<int>.');
+  } else if (aSetOfInts.length != 3) {
+    errs.add('aSetOfInts has ${aSetOfInts.length} items in it, rather than the expected 3.');
+  } else if (!aSetOfInts.contains(3) || !aSetOfInts.contains(4) || !aSetOfInts.contains(5)) {
+    errs.add('aSetOfInts doesn\'t contain the correct values (3, 4, 5).');
+  }
+
+  if (aMapOfStringsToInts is! Map<String, int>) {
+    errs.add('aMapOfStringsToInts should have the type Map<String, int>.');
+  } else if (aMapOfStringsToInts['myKey'] != 12) {
+    errs.add('aMapOfStringsToInts doesn\'t contain the correct values (\'myKey\': 12).');
+  }
+
+  if (anEmptyListOfDouble is! List<double>) {
+    errs.add('anEmptyListOfDouble should have the type List<double>.');
+  } else if (anEmptyListOfDouble.isNotEmpty) {
+    errs.add('anEmptyListOfDouble should be empty.');
+  }
+
+  if (anEmptySetOfString is! Set<String>) {
+    errs.add('anEmptySetOfString should have the type Set<String>.');
+  } else if (anEmptySetOfString.isNotEmpty) {
+    errs.add('anEmptySetOfString should be empty.');
+  }
+
+  if (anEmptyMapOfDoublesToInts is! Map<double, int>) {
+    errs.add('anEmptyMapOfDoublesToInts should have the type Map<double, int>.');
+  } else if (anEmptyMapOfDoublesToInts.isNotEmpty) {
+    errs.add('anEmptyMapOfDoublesToInts should be empty.');
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+This exercise is fairly straightforward.
+Just add a list, set, or map literal after each equals sign.
+See the codelab text for the correct syntax to use.
+{$ end hint.txt $}
+```
+
+
+## Arrow syntax
+
+You might have seen the `=>` symbol in Dart code.
+This arrow syntax is a way to define a function that executes the
+expression to its right and returns its value.
+
+For example, consider this call to the `List` class's
+`any()` method:
+
+```dart
+bool hasEmpty = aListOfStrings.any((s) {
+  return s.isEmpty;
+});
+```
+
+Here’s a simpler way to write that code:
+
+```dart
+bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
+```
+
+### Code example
+
+Try finishing the following statements, which use arrow syntax.
+
+```dart:run-dartpad:height-345px:ga_id-arrow_syntax
+{$ begin main.dart $}
+class MyClass {
+  int _value1 = 2;
+  int _value2 = 3;
+  int _value3 = 5;
+  
+  // Returns the product of the above values:
+  int get product =>
+  
+  // Adds 1 to _value1:
+  void incrementValue1() => 
+  
+  // Returns a string containing each item in the
+  // list, separated by commas (e.g. 'a,b,c'): 
+  String joinWithCommas(List<String> strings) =>
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class MyClass {
+  int _value1 = 2;
+  int _value2 = 3;
+  int _value3 = 5;
+
+  // Returns the product of the above values:
+  int get product => _value1 * _value2 * _value3;
+  
+  // Adds 1 to _value1:
+  void incrementValue1() => _value1++; 
+  
+  // Returns a string containing each item in the
+  // list, separated by commas (e.g. 'a,b,c'): 
+  String joinWithCommas(List<String> strings) => strings.join(',');
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final obj = MyClass();
+  final errs = <String>[];
+  
+  try {
+    final product = obj.product;
+    
+    if (product != 30) {
+      errs.add('The product property returned $product instead of the expected value (30).'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried to use MyClass.product, but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    obj.incrementValue1();
+    
+    if (obj._value1 != 3) {
+      errs.add('After calling incrementValue, value1 was ${obj._value1} instead of the expected value (3).'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried to use MyClass.incrementValue1, but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final joined = obj.joinWithCommas(['one', 'two', 'three']);
+    
+    if (joined != 'one,two,three') {
+      errs.add('Tried calling joinWithCommas([\'one\', \'two\', \'three\']) and received $joined instead of the expected value (\'one,two,three\').'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried to use MyClass.joinWithCommas, but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+For the product, you can just multiply the three values together.
+For incrementValue1, you can use the increment operator (++).
+For joinWithCommas, try using the join method found in the List class.
+{$ end hint.txt $}
+```
+
+
+## Cascades
+
+To perform a sequence of operations on the same object, use cascades (`..`).
+We've all seen an expression like this:
+
+```dart
+myObject.someMethod()
+```
+
+It invokes `someMethod()` on `myObject`, and the result of
+the expression is the return value of `someMethod()`.
+
+Here's the same expression with a cascade:
+
+```dart
+myObject..someMethod()
+```
+
+Although it still invokes `someMethod()` on `myObject`, the result
+of the expression **isn't** the return value — it's a reference to `myObject`!
+Using cascades, you can chain together operations that
+would otherwise require separate statements.
+For example, consider this code:
+
+```dart
+var button = querySelector('#confirm');
+button.text = 'Confirm';
+button.classes.add('important');
+button.onClick.listen((e) => window.alert('Confirmed!'));
+```
+
+With cascades, the code becomes much shorter,
+and you don’t need the `button` variable:
+
+```dart
+querySelector('#confirm')
+..text = 'Confirm'
+..classes.add('important')
+..onClick.listen((e) => window.alert('Confirmed!'));
+```
+
+### Code example
+
+Use cascades to create a single statement that
+sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
+to `1`, `'String!'`, and `[3.0]` (respectively)
+and then calls `allDone()`.
+
+```dart:run-dartpad:height-345px:ga_id-cascades
+{$ begin main.dart $}
+class BigObject {
+  int anInt = 0;
+  String aString = '';
+  List<double> aList = [];
+  bool _done = false;
+  
+  void allDone() {
+    _done = true;
+  }
+}
+
+BigObject fillBigObject(BigObject obj) {
+  // Create a single statement that will update and return obj:
+  return obj..
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class BigObject {
+  int anInt = 0;
+  String aString = '';
+  List<double> aList = [];
+  bool _done = false;
+  
+  void allDone() {
+    _done = true;
+  }
+}
+
+BigObject fillBigObject(BigObject obj) {
+  return obj
+    ..anInt = 1
+    ..aString = 'String!'
+    ..aList.add(3)
+    ..allDone();
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  BigObject obj;
+
+  try {
+    obj = fillBigObject(BigObject());
+  } catch (e) {
+    _result(false, [
+      'Caught an exception of type ${e.runtimeType} while running fillBigObject'
+    ]);
+    return;
+  }
+
+  if (obj == null) {
+    _result(false, ['It looks like fillBigObject returned a null!']);
+  } else {
+    final errs = <String>[];
+
+    if (obj.anInt != 1) {
+      errs.add(
+          'The value of anInt was ${obj.anInt} rather than the expected (1).');
+    }
+
+    if (obj.aString != 'String!') {
+      errs.add(
+          'The value of aString was \'${obj.aString}\' rather than the expected (\'String!\').');
+    }
+
+    if (obj.aList == null) {
+      errs.add('The value of aList was null.');
+    }
+
+    if (obj.aList.length != 1) {
+      errs.add(
+          'The length of aList was ${obj.aList.length} rather than the expected value (1).');
+    } else {
+      if (obj.aList[0] != 3.0) {
+        errs.add(
+            'The value found in aList was ${obj.aList[0]} rather than the expected (3.0).');
+      }
+    }
+    
+    if (!obj._done) {
+      errs.add('It looks like allDone() wasn\'t called.');
+    }
+
+    if (errs.isEmpty) {
+      _result(true);
+    } else {
+      _result(false, errs);
+    }
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+The best solution for this exercise starts with obj.. and
+has four assignment operations chained together.
+Try starting with `return obj..anInt = 1`,
+then add another cascade (..) and start the next assignment.
+{$ end hint.txt $}
+```
+
+
+## Getters and setters
+
+You can define getters and setters
+whenever you need more control over a property
+than a simple field allows.
+
+For example, you can make sure a property's value is valid:
+
+<?code-excerpt "misc/bin/getters_setters.dart"?>
+```dart
+class MyClass {
+  int _aProperty = 0;
+
+  int get aProperty => _aProperty;
+
+  set aProperty(int value) {
+    if (value >= 0) {
+      _aProperty = value;
+    }
+  }
+}
+```
+
+You can also use a getter to define a computed property:
+
+<?code-excerpt "misc/bin/getter_compute.dart"?>
+```dart
+class MyClass {
+  List<int> _values = [];
+
+  void addValue(int value) {
+    _values.add(value);
+  }
+
+  // A computed property.
+  int get count {
+    return _values.length;
+  }
+}
+```
+
+### Code example
+
+Imagine you have a shopping cart class that keeps a private `List<double>`
+of prices.
+Add the following:
+
+* A getter called `total` that returns the sum of the prices
+* A setter that replaces the list with a new one,
+  as long as the new list doesn't contain any negative prices
+  (in which case the setter should throw an `InvalidPriceException`).
+
+```dart:run-dartpad:height-240px:ga_id-getters_setters
+{$ begin main.dart $}
+class InvalidPriceException {}
+
+class ShoppingCart {
+  List<double> _prices = [];
+  
+  // Add a "total" getter here:
+
+  // Add a "prices" setter here:
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class InvalidPriceException {}
+
+class ShoppingCart {
+  List<double> _prices = [];
+  
+  double get total => _prices.fold(0, (e, t) => e + t);
+  
+  set prices(List<double> value) {
+    if (value.any((p) => p < 0)) {
+      throw InvalidPriceException();
+    }
+    
+    _prices = value;
+  }
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  var foundException = false;
+  
+  try {
+    final cart = ShoppingCart();
+    cart.prices = [12.0, 12.0, -23.0];
+  } on InvalidPriceException{
+    foundException = true;
+  } catch (e) {
+    _result(false, ['Tried setting a negative price and received a ${e.runtimeType} instead of an InvalidPriceException.']);
+    return;
+  }
+  
+  if (!foundException) {
+    _result(false, ['Tried setting a negative price and didn\'t get an InvalidPriceException.']);
+    return;
+  }
+  
+  final secondCart = ShoppingCart();
+  
+  try {
+    secondCart.prices = [1.0, 2.0, 3.0];
+  } catch(e) {
+    _result(false, ['Tried setting prices with a valid list, but received an exception: ${e.runtimeType}.']);
+    return;
+  }
+  
+  if (secondCart._prices == null) {
+    _result(false, ['Tried setting prices with a list of three values, but _prices ended up being null.']);
+    return;
+  }
+  
+  if (secondCart._prices.length != 3) {
+    _result(false, ['Tried setting prices with a list of three values, but _prices ended up having length ${secondCart._prices.length}.']);
+    return;
+  }
+
+  if (secondCart._prices[0] != 1.0 || secondCart._prices[1] != 2.0 || secondCart._prices[2] != 3.0) {
+    final vals = secondCart._prices.map((p) => p.toString()).join(', ');
+    _result(false, ['Tried setting prices with a list of three values (1, 2, 3), but incorrect ones ended up in the price list ($vals) .']);
+    return;
+  }
+  
+  var sum = 0.0;
+  
+  try {
+    sum = secondCart.total;
+  } catch (e) {
+    _result(false, ['Tried to get total, but received an exception: ${e.runtimeType}.']);
+    return;
+  }
+  
+  if (sum != 6.0) {
+    _result(false, ['After setting prices to (1, 2, 3), total returned $sum instead of 6.']);
+    return;
+  }
+  
+  _result(true);
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Two functions are handy for this exercise. 
+One is `fold`, which can reduce a list to a single value
+(try it to calculate the total).
+The other is `any`, which can check each item in a list
+with a function you give it
+(try using it to check if there are any negative prices in the prices setter).
+{$ end hint.txt $}
+```
+
+
+## Optional positional parameters
+
+Dart has two kinds of function parameters: positional and named. Positional parameters are the kind
+you're likely familiar with:
+
+<?code-excerpt "misc/bin/optional_positional_args.dart (optional-positional-args)"?>
+```dart
+int sumUp(int a, int b, int c) {
+  return a + b + c;
+}
+// ···
+  int total = sumUp(1, 2, 3);
+```
+
+With Dart, you can make these positional parameters optional by wrapping them in brackets:
+
+<?code-excerpt "misc/bin/optional_positional_args.dart (optional-positional-args-2)" replace="/total2/total/g"?>
+```dart
+int sumUpToFive(int a, [int b, int c, int d, int e]) {
+  int sum = a;
+  if (b != null) sum += b;
+  if (c != null) sum += c;
+  if (d != null) sum += d;
+  if (e != null) sum += e;
+  return sum;
+}
+// ···
+  int total = sumUpToFive(1, 2);
+  int otherTotal = sumUpToFive(1, 2, 3, 4, 5);
+```
+
+Optional positional parameters are always last
+in a function's parameter list.
+Their default value is null unless you provide another default value:
+
+<?code-excerpt "misc/bin/optional_positional_args2.dart"?>
+```dart
+int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
+// ···
+}
+// ···
+  int newTotal = sumUpToFive(1);
+  print(newTotal); // <-- prints 15
+```
+
+### Code example
+
+Implement a function called `joinWithCommas()` that accepts one to
+five integers, then returns a string of those numbers separated by commas.
+Here are some examples of function calls and returned values:
+
+| Function call                   | | Returned value |
+|---------------------------------+-+----------------|
+| `joinWithCommas(1)`             | | `'1'`          |
+| `joinWithCommas(1, 2, 3)`       | | `'1,2,3'`      |
+| `joinWithCommas(1, 1, 1, 1, 1)` | | `'1,1,1,1,1'`  |
+
+<br>
+
+```dart:run-dartpad:ga_id-optional_positional_parameters
+{$ begin main.dart $}
+String joinWithCommas(int a, [int b, int c, int d, int e]) {
+
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+String joinWithCommas(int a, [int b, int c, int d, int e]) {
+  var total = '$a';
+  if (b != null) total = '$total,$b';
+  if (c != null) total = '$total,$c';
+  if (d != null) total = '$total,$d';
+  if (e != null) total = '$total,$e';
+  return total;
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+  
+  try {
+    final value = joinWithCommas(1);
+    
+    if (value != '1') {
+      errs.add('Tried calling joinWithCommas(1) and got $value instead of the expected (\'1\').'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried calling joinWithCommas(1), but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final value = joinWithCommas(1, 2, 3);
+    
+    if (value != '1,2,3') {
+      errs.add('Tried calling joinWithCommas(1, 2, 3) and got $value instead of the expected (\'1,2,3\').'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried calling joinWithCommas(1, 2 ,3), but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final value = joinWithCommas(1, 2, 3, 4, 5);
+    
+    if (value != '1,2,3,4,5') {
+      errs.add('Tried calling joinWithCommas(1, 2, 3, 4, 5) and got $value instead of the expected (\'1,2,3,4,5\').'); 
+    } 
+  } catch (e) {
+    _result(false, ['Tried calling stringify(1, 2, 3, 4 ,5), but encountered an exception: ${e.runtimeType}.']);
+    return;
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+The b, c, d, and e paramters are null if they aren't provided by caller.
+The important thing, then, is to check whether those arguments are null
+before you add them to the final string.
+{$ end hint.txt $}
+```
+
+
+## Optional named parameters
+
+Using a curly brace syntax,
+you can define optional parameters that have names.
+
+<?code-excerpt "misc/bin/optional_named_params.dart"?>
+```dart
+void printName(String firstName, String lastName, {String suffix}) {
+  print('$firstName $lastName ${suffix ?? ''}');
+}
+// ···
+  printName('Avinash', 'Gupta');
+  printName('Poshmeister', 'Moneybuckets', suffix: 'IV');
+```
+
+As you might expect, the value of these parameters is null by default,
+but you can provide default values:
+
+```dart
+void printName(String firstName, String lastName, {String suffix = ''}) {
+  print('$firstName $lastName $suffix');
+}
+```
+
+A function can't have both optional positional and optional named parameters.
+
+
+### Code example
+
+Add a `copyWith()` instance method to the `MyDataObject`
+class. It should take three named parameters:
+
+* `int newInt`
+* `String newString`
+* `double newDouble`
+
+When called, `copyWith()` should return a new `MyDataObject`
+based on the current instance,
+with data from the preceding parameters (if any)
+copied into the object's properties.
+For example, if `newInt` is non-null,
+then copy its value into `anInt`.
+
+```dart:run-dartpad:height-310px:ga_id-optional_named_parameters
+{$ begin main.dart $}
+class MyDataObject {
+  final int anInt;
+  final String aString;
+  final double aDouble;
+
+  MyDataObject({
+     this.anInt = 1,
+     this.aString = 'Old!',
+     this.aDouble = 2.0,
+  });
+
+  // Add your copyWith method here:
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class MyDataObject {
+  final int anInt;
+  final String aString;
+  final double aDouble;
+
+  MyDataObject({
+     this.anInt = 1,
+     this.aString = 'Old!',
+     this.aDouble = 2.0,
+  });
+
+  MyDataObject copyWith({int newInt, String newString, double newDouble}) {
+    return MyDataObject(
+      anInt: newInt ?? this.anInt,
+      aString: newString ?? this.aString,
+      aDouble: newDouble ?? this.aDouble,
+    );
+  }
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final source = MyDataObject();
+  final errs = <String>[];
+  
+  try {
+    final copy = source.copyWith(newInt: 12, newString: 'New!', newDouble: 3.0);
+    
+    if (copy == null) {
+      errs.add('Tried copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0) and it returned null');
+    } else {
+      if (copy.anInt != 12) {
+        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s anInt was ${copy.anInt} rather than the expected value (12).');
+      }
+      
+      if (copy.aString != 'New!') {
+        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aString was ${copy.aString} rather than the expected value (\'New!\').');
+      }
+      
+      if (copy.aDouble != 3) {
+        errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (3).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0) and got an exception: ${e.runtimeType}']);
+  }
+  
+  try {
+    final copy = source.copyWith();
+    
+    if (copy == null) {
+      errs.add('Tried copyWith() and it returned null');
+    } else {
+      if (copy.anInt != 1) {
+        errs.add('Called copyWith(), and the new object\'s anInt was ${copy.anInt} rather than the expected value (1).');
+      }
+      
+      if (copy.aString != 'Old!') {
+        errs.add('Called copyWith(), and the new object\'s aString was ${copy.aString} rather than the expected value (\'Old!\').');
+      }
+      
+      if (copy.aDouble != 2) {
+        errs.add('Called copyWith(), and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (2).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called copyWith() and got an exception: ${e.runtimeType}']);
+  }
+  
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+The copyWith method shows up in a lot of classes and libraries.
+Yours should do a few things:
+use optional named parameters,
+create a new instance of MyDataObject,
+and use the data from the parameters to fill it
+(or the data from the current instance if the parameters are null).
+This is a chance to get more practice with the ?? operator!
+{$ end hint.txt $}
+```
+
+
+## Exceptions
+
+Dart code can throw and catch exceptions. In contrast to Java, all of Dart’s exceptions are unchecked
+exceptions. Methods don't declare which exceptions they might throw, and you aren't required to catch
+any exceptions.
+
+Dart provides `Exception` and `Error` types, but you're
+allowed to throw any non-null object:
+
+```dart
+throw Exception('Something bad happened.');
+throw 'Waaaaaaah!';
+```
+
+Use the `try`, `on`, and `catch` keywords when handling exceptions:
+
+```dart
+try {
+  breedMoreLlamas();
+} on OutOfLlamasException {
+  // A specific exception
+  buyMoreLlamas();
+} on Exception catch (e) {
+  // Anything else that is an exception
+  print('Unknown exception: $e');
+} catch (e) {
+  // No specified type, handles all
+  print('Something really unknown: $e');
+}
+```
+
+The `try` keyword works as it does in most other languages.
+Use the `on` keyword to filter for specific exceptions by type,
+and the `catch` keyword to get a reference to the exception object.
+
+If you can't completely handle the exception, use the `rethrow` keyword
+to propagate the exception:
+
+```dart
+try {
+  breedMoreLlamas();
+} catch (e) {
+  print('I was just trying to breed llamas!.');
+  rethrow;
+}
+```
+
+To execute code whether or not an exception is thrown,
+use `finally`:
+
+<?code-excerpt "misc/bin/exceptions.dart"?>
+```dart
+try {
+  breedMoreLlamas();
+} catch (e) {
+  // ... handle exception ...
+} finally {
+  // Always clean up, even if an exception is thrown.
+  cleanLlamaStalls();
+}
+```
+
+### Code example
+
+Implement `tryFunction()` below. It should execute an untrustworthy method and
+then do the following:
+
+* If `untrustworthy()` throws an `ExceptionWithMessage`,
+  call `logger.logException` with the exception type and message
+  (try using `on` and `catch`).
+* If `untrustworthy()` throws an `Exception`,
+  call `logger.logException` with the exception type
+  (try using `on` for this one).
+* If `untrustworthy()` throws any other object, don't catch the exception.
+* After everything's caught and handled, call `logger.doneLogging`
+  (try using `finally`).
+
+```dart:run-dartpad:height-420px:ga_id-exceptions
+{$ begin main.dart $}
+typedef VoidFunction = void Function();
+
+class ExceptionWithMessage {
+  final String message;
+  const ExceptionWithMessage(this.message);
+}
+
+// Call logException to log an exception, and doneLogging when finished.
+abstract class Logger {
+  void logException(Type t, [String msg]);
+  void doneLogging();
+}
+
+void tryFunction(VoidFunction untrustworthy, Logger logger) {
+  // Invoking this method might cause an exception. Catch and handle
+  // them using try-on-catch-finally.
+  untrustworthy();
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+typedef VoidFunction = void Function();
+
+class ExceptionWithMessage {
+  final String message;
+  const ExceptionWithMessage(this.message);
+}
+
+abstract class Logger {
+  void logException(Type t, [String msg]);
+  void doneLogging();
+}
+
+void tryFunction(VoidFunction untrustworthy, Logger logger) {
+  try {
+    untrustworthy();
+  } on ExceptionWithMessage catch (e) {
+    logger.logException(e.runtimeType, e.message);
+  } on Exception {
+    logger.logException(Exception);
+  } finally {
+    logger.doneLogging();
+  }
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+class MyLogger extends Logger {
+  Type lastType;
+  String lastMessage = '';
+  bool done = false;
+  
+  void logException(Type t, [String message]) {
+    lastType = t;
+    lastMessage = message ?? lastMessage;
+  }
+  
+  void doneLogging() => done = true;  
+}
+
+void main() {
+  final errs = <String>[];
+  var logger = MyLogger();
+  
+  try {
+    tryFunction(() => throw Exception(), logger);
+  
+    if ('${logger.lastType}' != 'Exception' && '${logger.lastType}' != '_Exception') {
+      errs.add('Untrustworthy threw an Exception, but a different type was logged: ${logger.lastType}.');
+    }
+    
+    if (logger.lastMessage != '') {
+      errs.add('Untrustworthy threw an Exception with no message, but a message was logged anyway: \'${logger.lastMessage}\'.');
+    }
+    
+    if (!logger.done) {
+      errs.add('Untrustworthy threw an Exception, and doneLogging() wasn\'t called afterward.');
+    }
+  } catch (e) {
+    _result(false, ['Untrustworthy threw an exception, and an exception of type ${e.runtimeType} was unhandled by tryFunction.']);
+  }
+  
+  logger = MyLogger();
+  
+  try {
+    tryFunction(() => throw ExceptionWithMessage('Hey!'), logger);
+  
+    if (logger.lastType != ExceptionWithMessage) {
+      errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), but a different type was logged: ${logger.lastType}.');
+    }
+    
+    if (logger.lastMessage != 'Hey!') {
+      errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), but a different message was logged: \'${logger.lastMessage}\'.');
+    }
+    
+    if (!logger.done) {
+      errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), and doneLogging() wasn\'t called afterward.');
+    }
+  } catch (e) {
+    _result(false, ['Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), and an exception of type ${e.runtimeType} was unhandled by tryFunction.']);
+  }
+  
+  logger = MyLogger();
+  bool caughtStringException = false;
+
+  try {
+    tryFunction(() => throw 'A String', logger);
+  } on String {
+    caughtStringException = true;
+  }
+
+  if (!caughtStringException) {
+    errs.add('Untrustworthy threw a string, and it was incorrectly handled inside tryFunction().');
+  }
+  
+  logger = MyLogger();
+  
+  try {
+    tryFunction(() {}, logger);
+  
+    if (logger.lastType != null) {
+      errs.add('Untrustworthy didn\'t throw an Exception, but one was logged anyway: ${logger.lastType}.');
+    }
+    
+    if (logger.lastMessage != '') {
+      errs.add('Untrustworthy didn\'t throw an Exception with no message, but a message was logged anyway: \'${logger.lastMessage}\'.');
+    }
+    
+    if (!logger.done) {
+      errs.add('Untrustworthy didn\'t throw an Exception, but doneLogging() wasn\'t called afterward.');
+    }
+  } catch (e) {
+    _result(false, ['Untrustworthy didn\'t throw an exception, but an exception of type ${e.runtimeType} was unhandled by tryFunction anyway.']);
+  }
+  
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+This exercise looks tricky, but it's really one big `try` statement.
+Just call `untrustworthy` inside the `try`, and
+then use `on`, `catch`, and `finally` to catch exceptions and
+call methods on the logger.
+{$ end hint.txt $}
+```
+
+
+## Using `this` in a constructor
+
+Dart provides a handy shortcut for assigning
+values to properties in a constructor:
+use `this.propertyName` when declaring the constructor:
+
+<?code-excerpt "misc/bin/this_constructor.dart"?>
+```dart
+class MyColor {
+  int red;
+  int green;
+  int blue;
+
+  MyColor(this.red, this.green, this.blue);
+}
+
+final color = MyColor(80, 80, 128);
+```
+
+This technique works for named parameters, too.
+Property names become the names of the parameters:
+
+```dart
+class MyColor {
+  ...
+
+  MyColor({this.red, this.green, this.blue});
+}
+
+final color = MyColor(red: 80, green: 80, blue: 80);
+```
+
+For optional parameters, default values work as expected:
+
+```dart
+MyColor([this.red = 0, this.green = 0, this.blue = 0]);
+// or
+MyColor({this.red = 0, this.green = 0, this.blue = 0});
+```
+
+### Code example
+
+Add a one-line constructor to `MyClass` that uses
+`this.` syntax to receive and assign values for
+all three properties of the class.
+
+```dart:run-dartpad:ga_id-this_constructor
+{$ begin main.dart $}
+class MyClass {
+  final int anInt;
+  final String aString;
+  final double aDouble;
+  
+  // Create a constructor here.
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class MyClass {
+  final int anInt;
+  final String aString;
+  final double aDouble;
+  
+  MyClass(this.anInt, this.aString, this.aDouble);
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+  
+  try {
+    final obj = MyClass(1, 'two', 3);
+    
+    if (obj == null) {
+      errs.add('Called MyClass(1, \'two\', 3) and got a null in response.');
+    } else {
+      if (obj.anInt != 1) {
+        errs.add('Called MyClass(1, \'two\', 3) and got an object with anInt of ${obj.anInt} instead of the expected value (1).');
+      }
+
+      if (obj.anInt != 1) {
+        errs.add('Called MyClass(1, \'two\', 3) and got an object with aString of \'${obj.aString}\' instead of the expected value (\'two\').');
+      }
+
+      if (obj.anInt != 1) {
+        errs.add('Called MyClass(1, \'two\', 3) and got an object with aDouble of ${obj.aDouble} instead of the expected value (3).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called MyClass(1, \'two\', 3) and got an exception of type ${e.runtimeType}.']);
+  }
+  
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+This exercise has a one-line solution.
+Just declare the constructor with
+`this.anInt`, `this.aString`, and `this.aDouble`
+as its parameters in that order.
+{$ end hint.txt $}
+```
+
+{% comment %}
+This one seems super easy compared to previous ones.
+We've already seen it in the Exceptions example,
+and I'd already used it in a previous example.
+Move it up higher? Or make it more challenging, somehow?
+Maybe require both positional and optional named parameters (with defaults)?
+{% endcomment %}
+
+## Initializer lists
+
+Sometimes when you implement a constructor,
+you need to do some setup before the constructor body executes.
+For example, final fields must have values
+before the constructor body executes.
+Do this work in an initializer list,
+which goes between the constructor's signature and its body:
+
+```dart
+Point.fromJson(Map<String, num> json)
+    : x = json['x'],
+      y = json['y'] {
+  print('In Point.fromJson(): ($x, $y)');
+}
+```
+
+The initializer list is also a handy place to put asserts,
+which run only during development:
+
+```dart
+NonNegativePoint(this.x, this.y)
+    : assert(x >= 0),
+      assert(y >= 0) {
+  print('I just made a NonNegativePoint: ($x, $y)');
+}
+```
+
+### Code example
+
+Complete the `FirstTwoLetters` constructor below.
+Use an initializer list to assign the first two characters in `word` to
+the `letterOne` and `LetterTwo` properties.
+For extra credit, add an `assert` to catch words of less than two characters.
+
+{% comment %}
+Is the assert even executed? I can't see any effect on the test,
+which makes me think asserts are ignored.
+Also, the test just checks for the presence of any exception, not for
+an AssertionError.
+
+Also, my print() wasn't visible in the Output until I fixed my code and/or
+the test. That was unexpected.
+It'd be cool if Output appeared only if you want it, like Solution does.
+
+FINALLY: Suggest using https://pub.dev/packages/characters
+if this is a user-entered string.
+{% endcomment %}
+
+```dart:run-dartpad:ga_id-initializer_lists
+{$ begin main.dart $}
+class FirstTwoLetters {
+  final String letterOne;
+  final String letterTwo;
+
+  // Create a constructor with an initializer list here:
+  FirstTwoLetters(String word)
+    ...
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class FirstTwoLetters {
+  final String letterOne;
+  final String letterTwo;
+
+  FirstTwoLetters(String word)
+      : letterOne = word[0],
+        letterTwo = word[1];
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+
+  try {
+    final result = FirstTwoLetters('My String');
+    
+    if (result == null) {
+      errs.add('Called FirstTwoLetters(\'My String\') and got a null in response.');
+    } else {
+      if (result.letterOne != 'M') {
+        errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterOne equal to \'${result.letterOne}\' instead of the expected value (\'M\').');
+      }
+
+      if (result.letterTwo != 'y') {
+        errs.add('Called FirstTwoLetters(\'My String\') and got an object with letterTwo equal to \'${result.letterTwo}\' instead of the expected value (\'y\').');
+      }
+    }
+  } catch (e) {
+    errs.add('Called FirstTwoLetters(\'My String\') and got an exception of type ${e.runtimeType}.');
+  }
+
+  bool caughtException = false;
+  
+  try {
+    FirstTwoLetters('');
+  } catch (e) {
+    caughtException = true;
+  }
+  
+  if (!caughtException) {
+    errs.add('Called FirstTwoLetters(\'\') and didn\'t get an exception from the failed assertion.');
+  }
+  
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Two assignments need to happen:
+letterOne should be word[0], and letterTwo should be word[1].
+{$ end hint.txt $}
+```
+
+
+## Named constructors
+
+{% comment %}
+Much like JavaScript, Dart doesn't support method overloads
+(two methods with the same name but different signatures).
+[ISSUE: methods & constructors aren't the same thing,
+so I deleted that. We can add it back if we can word it better.]
+{% endcomment %}
+To allow classes to have multiple constructors,
+Dart supports named constructors:
+
+<?code-excerpt "misc/bin/named_constructor.dart"?>
+```dart
+class Point {
+  double x, y;
+
+  Point(this.x, this.y);
+
+  Point.origin() {
+    x = 0;
+    y = 0;
+  }
+}
+```
+
+To use a named constructor, invoke it using its full name:
+
+```dart
+final myPoint = Point.origin();
+```
+
+### Code example
+
+Give the Color class a constructor named `Color.black`
+that sets all three properties to zero.
+
+```dart:run-dartpad:height-240px:ga_id-named_constructors
+{$ begin main.dart $}
+class Color {
+  int red;
+  int green;
+  int blue;
+  
+  Color(this.red, this.green, this.blue);
+
+  // Create a named constructor called "Color.black" here:
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class Color {
+  int red;
+  int green;
+  int blue;
+  
+  Color(this.red, this.green, this.blue);
+
+  Color.black() {
+    red = 0;
+    green = 0;
+    blue = 0;
+  } 
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+
+  try {
+    final result = Color.black();
+    
+    if (result == null) {
+      errs.add('Called Color.black() and got a null in response.');
+    } else {
+      if (result.red != 0) {
+        errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
+      }
+
+      if (result.green != 0) {
+        errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
+      }
+
+      if (result.blue != 0) {
+    errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called Color.black() and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+The declaration for your constructor should be `Color.black() {}`.
+Inside the braces, set red, green, and blue to zero.
+{$ end hint.txt $}
+```
+
+
+## Factory constructors
+
+Dart supports factory constructors,
+which can return subtypes or even null.
+To create a factory constructor, use the `factory` keyword:
+
+<?code-excerpt "misc/bin/factory_constructors.dart"?>
+```dart
+class Square extends Shape {}
+
+class Circle extends Shape {}
+
+class Shape {
+  Shape();
+
+  factory Shape.fromTypeName(String typeName) {
+    if (typeName == 'square') return Square();
+    if (typeName == 'circle') return Circle();
+
+    print('I don\'t recognize $typeName');
+    return null;
+  }
+}
+```
+
+### Code example
+
+Fill in the factory constructor named `IntegerHolder.fromList`,
+making it do the following:
+
+* If the list has **one** value,
+  create an `IntegerSingle` with that value.
+* If the list has **two** values,
+  create an `IntegerDouble` with the values in order.
+* If the list has **three** values,
+  create an `IntegerTriple` with the values in order.
+* Otherwise, return null.
+
+```dart:run-dartpad:height-415px:ga_id-factory_constructors
+{$ begin main.dart $}
+class IntegerHolder {
+  IntegerHolder();
+  
+  // Implement this factory constructor.
+  factory IntegerHolder.fromList(List<int> list) {
+  }
+}
+
+class IntegerSingle extends IntegerHolder {
+  final int a;
+  IntegerSingle(this.a); 
+}
+
+class IntegerDouble extends IntegerHolder {
+  final int a;
+  final int b;
+  IntegerDouble(this.a, this.b); 
+}
+
+class IntegerTriple extends IntegerHolder {
+  final int a;
+  final int b;
+  final int c;
+  IntegerTriple(this.a, this.b, this.c); 
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class IntegerHolder {
+  IntegerHolder();
+  
+  factory IntegerHolder.fromList(List<int> list) {
+    if (list?.length == 1) {
+      return IntegerSingle(list[0]);
+    } else if (list?.length == 2) {
+      return IntegerDouble(list[0], list[1]);
+    } else if (list?.length == 3) {
+      return IntegerTriple(list[0], list[1], list[2]);
+    } else {
+      return null;
+    } 
+  }
+}
+
+class IntegerSingle extends IntegerHolder {
+  final int a;
+  IntegerSingle(this.a); 
+}
+
+class IntegerDouble extends IntegerHolder {
+  final int a;
+  final int b;
+  IntegerDouble(this.a, this.b); 
+}
+
+class IntegerTriple extends IntegerHolder {
+  final int a;
+  final int b;
+  final int c;
+  IntegerTriple(this.a, this.b, this.c); 
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+
+  try {
+    final obj = IntegerHolder.fromList([]);
+    
+    if (obj != null) {
+      errs.add('Called IntegerSingle.fromList([]) and didn\'t get a null.');
+    } 
+  } catch (e) {
+    _result(false, ['Called IntegerSingle.fromList([]) and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final obj = IntegerHolder.fromList([1]);
+    
+    if (obj == null) {
+      errs.add('Called IntegerHolder.fromList([1]) and got a null.');
+    } else if (obj is! IntegerSingle) {
+      errs.add('Called IntegerHolder.fromList([1]) and got an object of type ${obj.runtimeType} instead of IntegerSingle.');
+    } else {
+      if ((obj as IntegerSingle).a != 1) {
+        errs.add('Called IntegerHolder.fromList([1]) and got an IntegerSingle with an \'a\' value of ${(obj as IntegerSingle).a} instead of the expected (1).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called IntegerHolder.fromList([]) and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final obj = IntegerHolder.fromList([1, 2]);
+    
+    if (obj == null) {
+      errs.add('Called IntegerHolder.fromList([1, 2]) and got a null.');
+    } else if (obj is! IntegerDouble) {
+      errs.add('Called IntegerHolder.fromList([1, 2]) and got an object of type ${obj.runtimeType} instead of IntegerDouble.');
+    } else {
+      if ((obj as IntegerDouble).a != 1) {
+        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'a\' value of ${(obj as IntegerDouble).a} instead of the expected (1).');
+      }
+      
+      if ((obj as IntegerDouble).b != 2) {
+        errs.add('Called IntegerHolder.fromList([1, 2]) and got an IntegerDouble with an \'b\' value of ${(obj as IntegerDouble).b} instead of the expected (2).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called IntegerHolder.fromList([1, 2]) and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  try {
+    final obj = IntegerHolder.fromList([1, 2, 3]);
+    
+    if (obj == null) {
+      errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got a null.');
+    } else if (obj is! IntegerTriple) {
+      errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an object of type ${obj.runtimeType} instead of IntegerTriple.');
+    } else {
+      if ((obj as IntegerTriple).a != 1) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).a} instead of the expected (1).');
+      }
+      
+      if ((obj as IntegerTriple).b != 2) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).b} instead of the expected (2).');
+      }
+
+      if ((obj as IntegerTriple).c != 3) {
+        errs.add('Called IntegerHolder.fromList([1, 2, 3]) and got an IntegerTriple with an \'a\' value of ${(obj as IntegerTriple).b} instead of the expected (2).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called IntegerHolder.fromList([1, 2, 3]) and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Inside the factory constructor,
+check the length of the list and create an
+IntegerSingle, IntegerDouble, or IntegerTriple as appropriate.
+{$ end hint.txt $}
+```
+
+
+## Redirecting constructors
+
+Sometimes a constructor’s only purpose is to redirect to
+another constructor in the same class.
+A redirecting constructor’s body is empty,
+with the constructor call appearing after a colon (`:`).
+
+<?code-excerpt "misc/bin/redirecting_const_constructors.dart (redirecting-constructors)"?>
+```dart
+class Automobile {
+  String make;
+  String model;
+  int mpg;
+
+  // The main constructor for this class.
+  Automobile(this.make, this.model, this.mpg);
+
+  // Delegates to the main constructor.
+  Automobile.hybrid(String make, String model) : this(make, model, 60);
+
+  // Delegates to a named constructor
+  Automobile.fancyHybrid() : this.hybrid('Futurecar', 'Mark 2');
+}
+```
+
+### Code example
+
+Remember the `Color` class from above? Create a named constructor called
+`black`, but rather than manually assigning the properties, redirect it to the
+default constructor with zeros as the arguments.
+
+```dart:run-dartpad:height-255px:ga_id-redirecting_constructors
+{$ begin main.dart $}
+class Color {
+  int red;
+  int green;
+  int blue;
+  
+  Color(this.red, this.green, this.blue);
+
+  // Create a named constructor called "black" here and redirect it
+  // to call the existing constructor
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class Color {
+  int red;
+  int green;
+  int blue;
+  
+  Color(this.red, this.green, this.blue);
+
+  Color.black() : this(0, 0, 0);
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+
+  try {
+    final result = Color.black();
+    
+    if (result == null) {
+      errs.add('Called Color.black() and got a null in response.');
+    } else {
+      if (result.red != 0) {
+        errs.add('Called Color.black() and got a Color with red equal to ${result.red} instead of the expected value (0).');
+      }
+
+      if (result.green != 0) {
+        errs.add('Called Color.black() and got a Color with green equal to ${result.green} instead of the expected value (0).');
+      }
+
+      if (result.blue != 0) {
+    errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Called Color.black() and got an exception of type ${e.runtimeType}.']);
+    return;
+  }
+
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+Your constructor should redirect to `this(0, 0, 0)`.
+{$ end hint.txt $}
+```
+
+
+## Const constructors
+
+If your class produces objects that never change, you can make these objects compile-time constants. To
+do this, define a `const` constructor and make sure that all instance variables
+are final.
+
+<?code-excerpt "misc/bin/redirecting_const_constructors.dart (const-constructors)"?>
+```dart
+class ImmutablePoint {
+  const ImmutablePoint(this.x, this.y);
+
+  final int x;
+  final int y;
+
+  static const ImmutablePoint origin = ImmutablePoint(0, 0);
+}
+```
+
+### Code example
+
+Modify the `Recipe` class so its instances can be constants,
+and create a constant constructor that does the following:
+
+* Has three parameters: `ingredients`, `calories`,
+  and `milligramsOfSodium` (in that order).
+* Uses `this.` syntax to automatically assign the parameter values to the
+  object properties of the same name.
+* Is constant, with the `const` keyword just before
+  `Recipe` in the constructor declaration.
+
+```dart:run-dartpad:ga_id-const_constructors
+{$ begin main.dart $}
+class Recipe {
+  List<String> ingredients;
+  int calories;
+  double milligramsOfSodium;
+}
+{$ end main.dart $}
+{$ begin solution.dart $}
+class Recipe {
+  final List<String> ingredients;
+  final int calories;
+  final double milligramsOfSodium;
+
+  const Recipe(this.ingredients, this.calories, this.milligramsOfSodium);
+}
+{$ end solution.dart $}
+{$ begin test.dart $}
+void main() {
+  final errs = <String>[];
+
+  try {
+    const obj = Recipe(['1 egg', 'Pat of butter', 'Pinch salt'], 120, 200);
+    
+    if (obj == null) {
+      errs.add('Tried calling Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and received a null.');
+    } else {
+      if (obj.ingredients?.length != 3) {
+        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with ingredient list of length ${obj.ingredients?.length} rather than the expected length (3).');
+      }
+      
+      if (obj.calories != 120) {
+        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a calorie value of ${obj.calories} rather than the expected value (120).');
+      }
+      
+      if (obj.milligramsOfSodium != 200) {
+        errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and got an object with a milligramsOfSodium value of ${obj.milligramsOfSodium} rather than the expected value (200).');
+      }
+    }
+  } catch (e) {
+    _result(false, ['Tried calling Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) and received a null.']);
+  }
+  
+  if (errs.isEmpty) {
+    _result(true);
+  } else {
+    _result(false, errs);
+  }
+}
+{$ end test.dart $}
+{$ begin hint.txt $}
+To make the constructor const, you'll need to make all the properties final.
+{$ end hint.txt $}
+```
+
+## What next?
+
+We hope you enjoyed using this codelab to learn or test your knowledge of
+some of the most interesting features of the Dart language.
+Here are some suggestions for what to do now:
+
+* Try [other Dart codelabs](/codelabs).
+* Read the [Dart language tour](/guides/language/language-tour).
+* Play with [DartPad.]({{site.dartpad}})
+* [Get the Dart SDK](/get-dart).


### PR DESCRIPTION
Continuing the work from the #2857 PR.

This PR adds the migrated version of the Dart cheat-sheet codelab, following the migration guide.

This PR is split in different commits, a larger commit (the last one) shows the changes in the codelab markdown.

This codelab has been modified a little bit to accommodate null safety better:

- Added a short introduction about null safe variable declaration, linking to the null safety docs.
- Some sections have extra explanations.
- Some dartpats show errors by default, this is intended because the learner must complete the dartpad for the errors to go away.

It is larger than the other two PRs, please feel free to edit the content!

Link preview: https://mb-dart-dev-1.firebaseapp.com/codelabs/dart-cheatsheet_migrated

cc. @kwalrath @RedBrogdon