### PR TITLE
Recommend `=>` for functions containing a single *return* statement.

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1442,7 +1442,7 @@ src="{{site.dartpad-embed-inline}}?id=5d70bc1889d055c7a18d35d77874af88&split=60&
     style="border: 1px solid #ccc;">
 </iframe>
 
-If the function contains only one statement, you can shorten it using arrow
+If the function contains only one return statement, you can shorten it using arrow
 notation. Paste the following line into DartPad and click **Run** to verify that
 it is functionally equivalent.
 

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -106,7 +106,7 @@ var result = fibonacci(20);
 {% endprettify %}
 
 A shorthand `=>` (_arrow_) syntax is handy for functions that
-contain a single statement.
+contain a single return statement.
 This syntax is especially useful when passing anonymous functions as arguments:
 
 <?code-excerpt "misc/test/samples_test.dart (arrow)"?>


### PR DESCRIPTION
See https://stackoverflow.com/questions/65802253/dart-function-arrow-syntax-confliction for background.