### PR TITLE
Migrated language_tour code to null safety

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/async.dart
+++ b/null_safety_examples/misc/lib/language_tour/async.dart
@@ -1,0 +1,87 @@
+// ignore_for_file: unused_element, unused_local_variable, unawaited_futures
+typedef Async0 = Future Function();
+typedef Async1 = Future Function(dynamic);
+typedef Async2 = Future Function(dynamic, dynamic);
+
+Future miscDeclAnalyzedButNotTested() async {
+  // #docregion async-lookUpVersion
+  Future<String> lookUpVersion() async => '1.0.0';
+  // #enddocregion async-lookUpVersion
+
+  {
+    // #docregion await-lookUpVersion
+    await lookUpVersion();
+    // #enddocregion await-lookUpVersion
+  }
+
+  {
+    // #docregion checkVersion
+    Future checkVersion() async {
+      var version = await lookUpVersion();
+      // Do something with version
+    }
+    // #enddocregion checkVersion
+  }
+
+  {
+    var version;
+    // #docregion try-catch
+    try {
+      version = await lookUpVersion();
+    } catch (e) {
+      // React to inability to look up the version
+    }
+    // #enddocregion try-catch
+  }
+
+  {
+    // #docregion sync-lookUpVersion
+    String lookUpVersion() => '1.0.0';
+    // #enddocregion sync-lookUpVersion
+  }
+
+  {
+    Async0 findEntrypoint;
+    Async1 flushThenExit;
+    Async2 runExecutable;
+    var args;
+    // #docregion repeated-await
+    var entrypoint = await findEntrypoint();
+    var exitCode = await runExecutable(entrypoint, args);
+    await flushThenExit(exitCode);
+    // #enddocregion repeated-await
+  }
+
+  {
+    Future checkVersion() async {}
+    // #docregion main
+    Future main() async {
+      checkVersion();
+      print('In main: version is ${await lookUpVersion()}');
+    }
+    // #enddocregion main
+  }
+
+  {
+    // Excerpt from dart-tutorials-samples/httpserver/number_thinker.dart
+    Stream requestServer;
+    Async1 handleRequest;
+    // #docregion number_thinker
+    Future main() async {
+      // ...
+      await for (var request in requestServer) {
+        handleRequest(request);
+      }
+      // ...
+    }
+    // #enddocregion number_thinker
+  }
+
+  <varOrType>(Stream<varOrType> expression) async {
+    // #docregion await-for
+    await for (varOrType identifier in expression) {
+      // Executes each time the stream emits a value.
+    }
+    // #enddocregion await-for
+  };
+}

--- a/null_safety_examples/misc/lib/language_tour/async.dart
+++ b/null_safety_examples/misc/lib/language_tour/async.dart
@@ -41,9 +41,9 @@ Future miscDeclAnalyzedButNotTested() async {
   }
 
   {
-    Async0 findEntrypoint;
-    Async1 flushThenExit;
-    Async2 runExecutable;
+    Async0 findEntrypoint = () async => Never;
+    Async1 flushThenExit = (_) async => Never;
+    Async2 runExecutable = (_, __) async => Never;
     var args;
     // #docregion repeated-await
     var entrypoint = await findEntrypoint();
@@ -64,8 +64,8 @@ Future miscDeclAnalyzedButNotTested() async {
 
   {
     // Excerpt from dart-tutorials-samples/httpserver/number_thinker.dart
-    Stream requestServer;
-    Async1 handleRequest;
+    Stream requestServer = Stream.empty();
+    Async1 handleRequest = (_) async => Never;
     // #docregion number_thinker
     Future main() async {
       // ...

--- a/null_safety_examples/misc/lib/language_tour/built_in_types.dart
+++ b/null_safety_examples/misc/lib/language_tour/built_in_types.dart
@@ -1,0 +1,214 @@
+// ignore_for_file: unused_local_variable, type_annotate_public_apis
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    // #docregion integer-literals
+    var x = 1;
+    var hex = 0xDEADBEEF;
+    // #enddocregion integer-literals
+  }
+
+  {
+    // #docregion double-literals
+    var y = 1.1;
+    var exponents = 1.42e5;
+    // #enddocregion double-literals
+  }
+
+  {
+    // #docregion int-to-double
+    double z = 1; // Equivalent to double z = 1.0.
+    // #enddocregion int-to-double
+  }
+
+  {
+    // #docregion const-num
+    const msPerSecond = 1000;
+    const secondsUntilRetry = 5;
+    const msUntilRetry = secondsUntilRetry * msPerSecond;
+    // #enddocregion const-num
+  }
+
+  {
+    // #docregion quoting
+    var s1 = 'Single quotes work well for string literals.';
+    var s2 = "Double quotes work just as well.";
+    var s3 = 'It\'s easy to escape the string delimiter.';
+    var s4 = "It's even easier to use the other delimiter.";
+    // #enddocregion quoting
+  }
+
+  {
+    // #docregion raw-strings
+    var s = r'In a raw string, not even \n gets special treatment.';
+    // #enddocregion raw-strings
+  }
+
+  {
+    // #docregion string-literals
+    // These work in a const string.
+    const aConstNum = 0;
+    const aConstBool = true;
+    const aConstString = 'a constant string';
+
+    // These do NOT work in a const string.
+    var aNum = 0;
+    var aBool = true;
+    var aString = 'a string';
+    const aConstList = [1, 2, 3];
+
+    const validConstString = '$aConstNum $aConstBool $aConstString';
+    // const invalidConstString = '$aNum $aBool $aString $aConstList';
+    // #enddocregion string-literals
+  }
+
+  {
+    var c = true;
+    /*
+    // #docregion if-one
+    if (1) {
+    // #enddocregion if-one
+    */
+    if (c) {
+      // #docregion if-one
+      print('JS prints this line.');
+    } else {
+      print('Dart in production mode prints this line.');
+      // However, in checked mode, if (1) throws an
+      // exception because 1 is not boolean.
+    }
+    // #enddocregion if-one
+  }
+
+  {
+    // #docregion list-literal
+    var list = [1, 2, 3];
+    // #enddocregion list-literal
+  }
+
+  {
+    // #docregion trailing-commas
+    var list = [
+      'Car',
+      'Boat',
+      'Plane',
+    ];
+    // #enddocregion trailing-commas
+  }
+
+  {
+    // #docregion const-list
+    var constantList = const [1, 2, 3];
+    // constantList[1] = 1; // This line will cause an error.
+    // #enddocregion const-list
+  }
+
+  {
+    // #docregion set-literal
+    var halogens = {'fluorine', 'chlorine', 'bromine', 'iodine', 'astatine'};
+    // #enddocregion set-literal
+
+    // #docregion set-vs-map
+    var names = <String>{};
+    // Set<String> names = {}; // This works, too.
+    // var names = {}; // Creates a map, not a set.
+    // #enddocregion set-vs-map
+
+    // #docregion set-add-items
+    var elements = <String>{};
+    elements.add('fluorine');
+    elements.addAll(halogens);
+    // #enddocregion set-add-items
+  }
+
+  {
+    // #docregion const-set
+    final constantSet = const {
+      'fluorine',
+      'chlorine',
+      'bromine',
+      'iodine',
+      'astatine',
+    };
+    // constantSet.add('helium'); // This line will cause an error.
+    // #enddocregion const-set
+  }
+
+  {
+    // #docregion map-literal
+    var gifts = {
+      // Key:    Value
+      'first': 'partridge',
+      'second': 'turtledoves',
+      'fifth': 'golden rings'
+    };
+
+    var nobleGases = {
+      2: 'helium',
+      10: 'neon',
+      18: 'argon',
+    };
+    // #enddocregion map-literal
+  }
+
+  {
+    // #docregion map-constructor
+    var gifts = Map();
+    gifts['first'] = 'partridge';
+    gifts['second'] = 'turtledoves';
+    gifts['fifth'] = 'golden rings';
+
+    var nobleGases = Map();
+    nobleGases[2] = 'helium';
+    nobleGases[10] = 'neon';
+    nobleGases[18] = 'argon';
+    // #enddocregion map-constructor
+  }
+
+  {
+    // #docregion map-add-item
+    var gifts = {'first': 'partridge'};
+    gifts['fourth'] = 'calling birds'; // Add a key-value pair
+    // #enddocregion map-add-item
+  }
+
+  {
+    // #docregion const-map
+    final constantMap = const {
+      2: 'helium',
+      10: 'neon',
+      18: 'argon',
+    };
+
+    // constantMap[2] = 'Helium'; // This line will cause an error.
+    // #enddocregion const-map
+  }
+}
+
+// #docregion triple-quotes
+var s1 = '''
+You can create
+multi-line strings like this one.
+''';
+
+var s2 = """This is also a
+multi-line string.""";
+// #enddocregion triple-quotes
+
+class SymbolExampleNotUsedYet {
+  // #docregion symbols
+  // MOVE TO library tour?
+
+  void main() {
+    print(Function.apply(int.parse, ['11']));
+    print(Function.apply(int.parse, ['11'], {#radix: 16}));
+    print(Function.apply(int.parse, ['11a'], {#onError: handleError}));
+    print(Function.apply(
+        int.parse, ['11a'], {#radix: 16, #onError: handleError}));
+  }
+
+  int handleError(String source) {
+    return 0;
+  }
+// #enddocregion symbols
+}

--- a/null_safety_examples/misc/lib/language_tour/callable_classes.dart
+++ b/null_safety_examples/misc/lib/language_tour/callable_classes.dart
@@ -1,0 +1,10 @@
+// ignore_for_file: type_annotate_public_apis
+// #docregion
+class WannabeFunction {
+  String call(String a, String b, String c) => '$a $b $c!';
+}
+
+var wf = WannabeFunction();
+var out = wf('Hi', 'there,', 'gang');
+
+main() => print(out);

--- a/null_safety_examples/misc/lib/language_tour/classes/doer.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/doer.dart
@@ -1,0 +1,13 @@
+// ignore_for_file: one_member_abstracts, annotate_overrides
+// #docregion
+abstract class Doer {
+  // Define instance variables and methods...
+
+  void doSomething(); // Define an abstract method.
+}
+
+class EffectiveDoer extends Doer {
+  void doSomething() {
+    // Provide an implementation, so the method is not abstract here...
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/employee.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/employee.dart
@@ -1,0 +1,44 @@
+// ignore_for_file: unnecessary_cast, sort_constructors_first
+
+Map get defaultData => {}; // stub
+
+// #docregion
+class Person {
+  String firstName;
+
+  Person.fromJson(Map data) {
+    print('in Person');
+  }
+}
+
+// #docregion method-then-constructor
+class Employee extends Person {
+  // #enddocregion ''
+  Employee() : super.fromJson(defaultData);
+  // #enddocregion method-then-constructor
+  // #docregion
+  // Person does not have a default constructor;
+  // you must call super.fromJson(data).
+  Employee.fromJson(Map data) : super.fromJson(data) {
+    print('in Employee');
+  }
+// #docregion method-then-constructor
+}
+// #enddocregion method-then-constructor
+
+void main() {
+  var emp = Employee.fromJson({});
+  // Prints:
+  // in Person
+  // in Employee
+
+  // #docregion emp-is-Person
+  if (emp is Person) {
+    // Type check
+    emp.firstName = 'Bob';
+  }
+  // #enddocregion emp-is-Person
+  // #docregion emp-as-Person
+  (emp as Person).firstName = 'Bob';
+  // #enddocregion emp-as-Person
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/employee.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/employee.dart
@@ -2,9 +2,10 @@
 
 Map get defaultData => {}; // stub
 
+// TODO(miquelbeltran) what would be better here, null, default value or late?
 // #docregion
 class Person {
-  String firstName;
+  String? firstName;
 
   Person.fromJson(Map data) {
     print('in Person');

--- a/null_safety_examples/misc/lib/language_tour/classes/enum.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/enum.dart
@@ -1,0 +1,32 @@
+// #docregion enum
+enum Color { red, green, blue }
+// #enddocregion enum
+
+void main() {
+  // #docregion index
+  assert(Color.red.index == 0);
+  assert(Color.green.index == 1);
+  assert(Color.blue.index == 2);
+  // #enddocregion index
+  assert(Color.blue.toString() == 'Color.blue');
+
+  // #docregion values
+  List<Color> colors = Color.values;
+  assert(colors[2] == Color.blue);
+  // #enddocregion values
+
+  // #docregion switch
+  var aColor = Color.blue;
+
+  switch (aColor) {
+    case Color.red:
+      print('Red as roses!');
+      break;
+    case Color.green:
+      print('Green as grass!');
+      break;
+    default: // Without this, you see a WARNING.
+      print(aColor); // 'Color.blue'
+  }
+  // #enddocregion switch
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/extends.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/extends.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: annotate_overrides
+// #docregion
+class Television {
+  void turnOn() {
+    _illuminateDisplay();
+    _activateIrSensor();
+  }
+  // #enddocregion
+
+  void _illuminateDisplay() {}
+  void _activateIrSensor() {}
+  // #docregion
+}
+
+class SmartTelevision extends Television {
+  void turnOn() {
+    super.turnOn();
+    _bootNetworkInterface();
+    _initializeMemory();
+    _upgradeApps();
+  }
+  // #enddocregion
+
+  void _bootNetworkInterface() {}
+  void _initializeMemory() {}
+  void _upgradeApps() {}
+  // #docregion
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/immutable_point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/immutable_point.dart
@@ -1,0 +1,9 @@
+// ignore_for_file: sort_constructors_first
+class ImmutablePoint {
+  static final ImmutablePoint origin =
+      const ImmutablePoint(0, 0);
+
+  final double x, y;
+
+  const ImmutablePoint(this.x, this.y);
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/impostor.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/impostor.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: sort_constructors_first, annotate_overrides
+// A person. The implicit interface contains greet().
+class Person {
+  // In the interface, but visible only in this library.
+  final _name;
+
+  // Not in the interface, since this is a constructor.
+  Person(this._name);
+
+  // In the interface.
+  String greet(String who) => 'Hello, $who. I am $_name.';
+}
+
+// An implementation of the Person interface.
+class Impostor implements Person {
+  get _name => '';
+
+  String greet(String who) => 'Hi $who. Do you know who I am?';
+}
+
+String greetBob(Person person) => person.greet('Bob');
+
+void main() {
+  print(greetBob(Person('Kathy')));
+  print(greetBob(Impostor()));
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/logger.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/logger.dart
@@ -1,0 +1,50 @@
+// ignore_for_file: sort_constructors_first
+// #docregion
+class Logger {
+  final String name;
+  bool mute = false;
+
+  // _cache is library-private, thanks to
+  // the _ in front of its name.
+  static final Map<String, Logger> _cache =
+      <String, Logger>{};
+
+  factory Logger(String name) {
+    return _cache.putIfAbsent(
+        name, () => Logger._internal(name));
+  }
+
+  factory Logger.fromJson(Map<String, Object> json) {
+    return Logger(json['name'].toString());
+  }
+
+  Logger._internal(this.name);
+
+  void log(String msg) {
+    if (!mute) print(msg);
+  }
+}
+// #enddocregion
+
+void main() {
+  // #docregion logger
+  var logger = Logger('UI');
+  logger.log('Button clicked');
+
+  var logMap = {'name': 'UI'};
+  var loggerJson = Logger.fromJson(logMap);
+  // #enddocregion logger
+
+  var l1 = Logger('log1');
+  var l2 = Logger('log1');
+  var l3 = Logger('log2');
+
+  assert(identical(l1, l2));
+  assert(l1 != l3);
+
+  l1.log('${l1.name}: This is l1.');
+  l2.log('${l2.name}: This is l1_2.');
+  l3.log('${l3.name}: This is l2.');
+  logger.log('${logger.name}: This is logger.');
+  loggerJson.log('${loggerJson.name}: This is loggerJson.');
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/misc.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/misc.dart
@@ -1,0 +1,30 @@
+// ignore_for_file: annotate_overrides, one_member_abstracts
+// #docregion abstract
+// This class is declared abstract and thus
+// can't be instantiated.
+abstract class AbstractContainer {
+  // Define constructors, fields, methods...
+
+  void updateChildren(); // Abstract method.
+}
+// #enddocregion abstract
+
+class Comparable {}
+
+class Location {}
+
+// #docregion point_interfaces
+class Point implements Comparable, Location {/*...*/}
+// #enddocregion point_interfaces
+
+// #docregion static-field
+class Queue {
+  static const initialCapacity = 16; // ignore: type_annotate_public_apis
+  // #enddocregion static-field
+  // #docregion static-field
+}
+
+void main() {
+  assert(Queue.initialCapacity == 16);
+}
+// #enddocregion static-field

--- a/null_safety_examples/misc/lib/language_tour/classes/no_such_method.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/no_such_method.dart
@@ -1,0 +1,15 @@
+void main() {
+  dynamic a = A();
+  a.foo();
+}
+
+// #docregion
+class A {
+  // Unless you override noSuchMethod, using a
+  // non-existent member results in a NoSuchMethodError.
+  @override
+  void noSuchMethod(Invocation invocation) {
+    print('You tried to use a non-existent member: ' +
+        '${invocation.memberName}');
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/orchestra.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/orchestra.dart
@@ -1,0 +1,106 @@
+// ignore_for_file: sort_constructors_first
+// #docregion Musical
+mixin Musical {
+  bool canPlayPiano = false;
+  bool canCompose = false;
+  bool canConduct = false;
+
+  void entertainMe() {
+    if (canPlayPiano) {
+      print('Playing piano');
+    } else if (canConduct) {
+      print('Waving hands');
+    } else {
+      print('Humming to self');
+    }
+  }
+}
+// #enddocregion Musical
+
+abstract class Aggressive {
+  bool passive = false;
+}
+
+abstract class Demented {
+  bool dangerous = false;
+}
+
+class Person {
+  String name;
+  Person();
+  Person.withName(this.name);
+}
+
+abstract class Performer {
+  Performer(String name);
+  String name;
+}
+
+// #docregion Musician-and-Maestro
+class Musician extends Performer with Musical {
+  // #enddocregion Musician-and-Maestro
+  Musician(String name) : super(name);
+  // #docregion Musician-and-Maestro
+}
+
+class Maestro extends Person
+    with Musical, Aggressive, Demented {
+  Maestro(String maestroName) {
+    name = maestroName;
+    canConduct = true;
+  }
+}
+// #enddocregion Musician-and-Maestro
+
+// Musician2 was a workaround for https://github.com/dart-lang/sdk/issues/35011,
+// which has been marked as fixed.
+
+class Musician2 extends Performer with Musical {
+  Musician2() : super('Anonymous');
+  Musician2.withName(String name) : super(name);
+}
+
+// Simple version of Musician for the mixin example.
+/*
+// #docregion mixin-on
+class Musician {
+  // ...
+}
+// #enddocregion mixin-on
+*/
+
+// #docregion mixin-on
+mixin MusicalPerformer on Musician2 {
+  // ...
+  // #enddocregion mixin-on
+  bool canDance = true;
+
+  @override
+  void entertainMe() =>
+      canDance ? dance() : super.entertainMe();
+
+  void dance() => print('Dancing');
+  // #docregion mixin-on
+}
+// #enddocregion mixin-on
+
+// #docregion mixin-on
+class SingerDancer extends Musician2 with MusicalPerformer {
+  // ...
+  // #enddocregion mixin-on
+  SingerDancer(String name) : super.withName(name);
+// #docregion mixin-on
+}
+// #enddocregion mixin-on
+
+void main() {
+  var director = Maestro('Allen');
+  director.entertainMe(); // Waving hands
+
+  var musician = Musician('Kathy');
+  musician.canPlayPiano = true;
+  musician.entertainMe(); // Playing piano
+
+  var singerDancer = SingerDancer('Todd');
+  singerDancer.entertainMe(); // Dancing
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/orchestra.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/orchestra.dart
@@ -26,14 +26,14 @@ abstract class Demented {
 }
 
 class Person {
-  String name;
+  String? name;
   Person();
   Person.withName(this.name);
 }
 
 abstract class Performer {
   Performer(String name);
-  String name;
+  String? name;
 }
 
 // #docregion Musician-and-Maestro

--- a/null_safety_examples/misc/lib/language_tour/classes/point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: sort_constructors_first
+// #docregion class-with-distanceTo
+import 'dart:math';
+
+// #docregion constructor-initializer, named-constructor
+class Point {
+  double x, y;
+
+  // #enddocregion class-with-distanceTo, named-constructor
+  // Syntactic sugar for setting x and y
+  // before the constructor body runs.
+  // #docregion class-with-distanceTo, named-constructor
+  Point(this.x, this.y);
+  // #enddocregion class-with-distanceTo, constructor-initializer
+
+  // Named constructor
+  Point.origin() {
+    x = 0;
+    y = 0;
+  }
+  // #enddocregion named-constructor
+
+  // Initializer list sets instance variables before
+  // the constructor body runs.
+  Point.fromJson(Map<String, double> json)
+      : x = json['x'],
+        y = json['y'];
+  // #docregion class-with-distanceTo
+
+  double distanceTo(Point other) {
+    var dx = x - other.x;
+    var dy = y - other.y;
+    return sqrt(dx * dx + dy * dy);
+  }
+  // #docregion constructor-initializer, named-constructor
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point.dart
@@ -2,9 +2,10 @@
 // #docregion class-with-distanceTo
 import 'dart:math';
 
+// TODO(miquelbeltran) maybe default value to 0 is better here
 // #docregion constructor-initializer, named-constructor
 class Point {
-  double x, y;
+  late double x, y;
 
   // #enddocregion class-with-distanceTo, named-constructor
   // Syntactic sugar for setting x and y
@@ -23,8 +24,8 @@ class Point {
   // Initializer list sets instance variables before
   // the constructor body runs.
   Point.fromJson(Map<String, double> json)
-      : x = json['x'],
-        y = json['y'];
+      : x = json['x']!,
+        y = json['y']!;
   // #docregion class-with-distanceTo
 
   double distanceTo(Point other) {

--- a/null_safety_examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_alt.dart
@@ -1,0 +1,35 @@
+// ignore_for_file: sort_constructors_first
+/// Example of:
+///
+/// - A constructor initializing fields in the body "the long way"
+/// - A named constructor with initializers, and a print statement in the body.
+///
+// #docregion constructor-long-way
+class Point {
+  double x, y;
+
+  Point(double x, double y) {
+    // There's a better way to do this, stay tuned.
+    this.x = x;
+    this.y = y;
+  }
+  // #enddocregion constructor-long-way
+
+  // #docregion initializer-list
+  // Initializer list sets instance variables before
+  // the constructor body runs.
+  Point.fromJson(Map<String, double> json)
+      : x = json['x'],
+        y = json['y'] {
+    print('In Point.fromJson(): ($x, $y)');
+  }
+  // #enddocregion initializer-list
+
+  // #docregion initializer-list-with-assert
+  Point.withAssert(this.x, this.y) : assert(x >= 0) {
+    print('In Point.withAssert(): ($x, $y)');
+  }
+  // #enddocregion initializer-list-with-assert
+
+// #docregion constructor-long-way
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_alt.dart
@@ -6,7 +6,7 @@
 ///
 // #docregion constructor-long-way
 class Point {
-  double x, y;
+  late double x, y;
 
   Point(double x, double y) {
     // There's a better way to do this, stay tuned.
@@ -19,8 +19,8 @@ class Point {
   // Initializer list sets instance variables before
   // the constructor body runs.
   Point.fromJson(Map<String, double> json)
-      : x = json['x'],
-        y = json['y'] {
+      : x = json['x']!,
+        y = json['y']! {
     print('In Point.fromJson(): ($x, $y)');
   }
   // #enddocregion initializer-list

--- a/null_safety_examples/misc/lib/language_tour/classes/point_redirecting.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_redirecting.dart
@@ -1,0 +1,10 @@
+// ignore_for_file: sort_constructors_first
+class Point {
+  double x, y;
+
+  // The main constructor for this class.
+  Point(this.x, this.y);
+
+  // Delegates to the main constructor.
+  Point.alongXAxis(double x) : this(x, 0);
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point_with_distance_field.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_with_distance_field.dart
@@ -1,0 +1,18 @@
+// ignore_for_file: sort_constructors_first
+import 'dart:math';
+
+class Point {
+  final double x;
+  final double y;
+  final double distanceFromOrigin;
+
+  Point(double x, double y)
+      : x = x,
+        y = y,
+        distanceFromOrigin = sqrt(x * x + y * y);
+}
+
+void main() {
+  var p = Point(2, 3);
+  print(p.distanceFromOrigin);
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point_with_distance_method.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_with_distance_method.dart
@@ -1,0 +1,21 @@
+// ignore_for_file: sort_constructors_first
+import 'dart:math';
+
+class Point {
+  double x, y;
+  Point(this.x, this.y);
+
+  static double distanceBetween(Point a, Point b) {
+    var dx = a.x - b.x;
+    var dy = a.y - b.y;
+    return sqrt(dx * dx + dy * dy);
+  }
+}
+
+void main() {
+  var a = Point(2, 2);
+  var b = Point(4, 4);
+  var distance = Point.distanceBetween(a, b);
+  assert(2.8 < distance && distance < 2.9);
+  print(distance);
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point_with_main.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_with_main.dart
@@ -1,0 +1,16 @@
+// #docregion class, class-main
+class Point {
+  double x; // Declare instance variable x, initially null.
+  double y; // Declare y, initially null.
+  // #enddocregion class-main
+  double z = 0; // Declare z, initially 0.
+// #docregion class-main
+}
+// #enddocregion class
+
+void main() {
+  var point = Point();
+  point.x = 4; // Use the setter method for x.
+  assert(point.x == 4); // Use the getter method for x.
+  assert(point.y == null); // Values default to null.
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/point_with_main.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point_with_main.dart
@@ -1,7 +1,7 @@
 // #docregion class, class-main
 class Point {
-  double x; // Declare instance variable x, initially null.
-  double y; // Declare y, initially null.
+  double? x; // Declare instance variable x, initially null.
+  double? y; // Declare y, initially null.
   // #enddocregion class-main
   double z = 0; // Declare z, initially 0.
 // #docregion class-main

--- a/null_safety_examples/misc/lib/language_tour/classes/rectangle.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/rectangle.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: sort_constructors_first
+class Rectangle {
+  double left, top, width, height;
+
+  Rectangle(this.left, this.top, this.width, this.height);
+
+  // Define two calculated properties: right and bottom.
+  double get right => left + width;
+  set right(double value) => left = value - width;
+  double get bottom => top + height;
+  set bottom(double value) => top = value - height;
+}
+
+void main() {
+  var rect = Rectangle(3, 4, 20, 15);
+  assert(rect.left == 3);
+  rect.right = 12;
+  assert(rect.left == -8);
+}

--- a/null_safety_examples/misc/lib/language_tour/classes/vector.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/vector.dart
@@ -1,0 +1,30 @@
+// ignore_for_file: sort_constructors_first
+// #docregion ''
+class Vector {
+  final int x, y;
+
+  Vector(this.x, this.y);
+
+  Vector operator +(Vector v) => Vector(x + v.x, y + v.y);
+  Vector operator -(Vector v) => Vector(x - v.x, y - v.y);
+
+  // Operator == and hashCode not shown.
+  // #enddocregion ''
+  @override
+  bool operator ==(Object o) => o is Vector && x == o.x && y == o.y;
+
+  @override
+  int get hashCode => 37 * (629 + x.hashCode) + y.hashCode;
+
+  @override
+  String toString() => '($x, $y)';
+  // #docregion ''
+}
+
+void main() {
+  final v = Vector(2, 3);
+  final w = Vector(2, 2);
+
+  assert(v + w == Vector(4, 5));
+  assert(v - w == Vector(0, 1));
+}

--- a/null_safety_examples/misc/lib/language_tour/comments.dart
+++ b/null_safety_examples/misc/lib/language_tour/comments.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: unused_element
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    // #docregion single-line-comments
+    void main() {
+      // TODO: refactor into an AbstractLlamaGreetingFactory?
+      print('Welcome to my Llama farm!');
+    }
+    // #enddocregion single-line-comments
+  }
+
+  {
+    // #docregion multi-line-comments
+    void main() {
+      /*
+       * This is a lot of work. Consider raising chickens.
+
+      Llama larry = Llama();
+      larry.feed();
+      larry.exercise();
+      larry.clean();
+       */
+    }
+    // #enddocregion multi-line-comments
+  }
+}
+
+class Food {}
+
+class Activity {}
+
+// #docregion doc-comments
+/// A domesticated South American camelid (Lama glama).
+///
+/// Andean cultures have used llamas as meat and pack
+/// animals since pre-Hispanic times.
+class Llama {
+  String name;
+
+  /// Feeds your llama [Food].
+  ///
+  /// The typical llama eats one bale of hay per week.
+  void feed(Food food) {
+    // ...
+  }
+
+  /// Exercises your llama with an [activity] for
+  /// [timeLimit] minutes.
+  void exercise(Activity activity, int timeLimit) {
+    // ...
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/comments.dart
+++ b/null_safety_examples/misc/lib/language_tour/comments.dart
@@ -36,7 +36,7 @@ class Activity {}
 /// Andean cultures have used llamas as meat and pack
 /// animals since pre-Hispanic times.
 class Llama {
-  String name;
+  String? name;
 
   /// Feeds your llama [Food].
   ///

--- a/null_safety_examples/misc/lib/language_tour/control_flow.dart
+++ b/null_safety_examples/misc/lib/language_tour/control_flow.dart
@@ -1,0 +1,177 @@
+typedef Pred0 = bool Function();
+typedef Void0 = void Function();
+
+class Candidate {
+  int yearsExperience;
+  void interview() {}
+}
+
+void miscDeclAnalyzedButNotTested() {
+  final candidates = <Candidate>[];
+
+  {
+    Pred0 isRaining, isSnowing;
+    dynamic car, you;
+    // #docregion if-else
+    if (isRaining()) {
+      you.bringRainCoat();
+    } else if (isSnowing()) {
+      you.wearJacket();
+    } else {
+      car.putTopDown();
+    }
+    // #enddocregion if-else
+  }
+
+  {
+    // #docregion forEach
+    candidates.forEach((candidate) => candidate.interview());
+    // #enddocregion forEach
+  }
+
+  {
+    Pred0 isDone, doSomething;
+    // #docregion while
+    while (!isDone()) {
+      doSomething();
+    }
+    // #enddocregion while
+  }
+
+  {
+    Pred0 atEndOfPage, printLine;
+    // #docregion do-while
+    do {
+      printLine();
+    } while (!atEndOfPage());
+    // #enddocregion do-while
+  }
+
+  {
+    Pred0 shutDownRequested, processIncomingRequests;
+    // #docregion while-break
+    while (true) {
+      if (shutDownRequested()) break;
+      processIncomingRequests();
+    }
+    // #enddocregion while-break
+  }
+
+  {
+    // #docregion for-continue
+    for (int i = 0; i < candidates.length; i++) {
+      var candidate = candidates[i];
+      if (candidate.yearsExperience < 5) {
+        continue;
+      }
+      candidate.interview();
+    }
+    // #enddocregion for-continue
+  }
+
+  {
+    // #docregion where
+    candidates
+        .where((c) => c.yearsExperience >= 5)
+        .forEach((c) => c.interview());
+    // #enddocregion where
+  }
+
+  Void0 executeClosed,
+      executePending,
+      executeApproved,
+      executeDenied,
+      executeOpen,
+      executeUnknown,
+      executeNowClosed;
+
+  {
+    // #docregion switch
+    var command = 'OPEN';
+    switch (command) {
+      case 'CLOSED':
+        executeClosed();
+        break;
+      case 'PENDING':
+        executePending();
+        break;
+      case 'APPROVED':
+        executeApproved();
+        break;
+      case 'DENIED':
+        executeDenied();
+        break;
+      case 'OPEN':
+        executeOpen();
+        break;
+      default:
+        executeUnknown();
+    }
+    // #enddocregion switch
+  }
+
+  {
+    // #docregion switch-break-omitted
+    var command = 'OPEN';
+    switch (command) {
+      case 'OPEN':
+        executeOpen();
+        // ERROR: Missing break
+        // #enddocregion switch-break-omitted
+        break;
+      // #docregion switch-break-omitted
+
+      case 'CLOSED':
+        executeClosed();
+        break;
+    }
+    // #enddocregion switch-break-omitted
+  }
+
+  {
+    // #docregion switch-empty-case
+    var command = 'CLOSED';
+    switch (command) {
+      case 'CLOSED': // Empty case falls through.
+      case 'NOW_CLOSED':
+        // Runs for both CLOSED and NOW_CLOSED.
+        executeNowClosed();
+        break;
+    }
+    // #enddocregion switch-empty-case
+  }
+
+  {
+    // #docregion switch-continue
+    var command = 'CLOSED';
+    switch (command) {
+      case 'CLOSED':
+        executeClosed();
+        continue nowClosed;
+      // Continues executing at the nowClosed label.
+
+      nowClosed:
+      case 'NOW_CLOSED':
+        // Runs for both CLOSED and NOW_CLOSED.
+        executeNowClosed();
+        break;
+    }
+    // #enddocregion switch-continue
+  }
+
+  {
+    int number;
+    String urlString;
+    var text;
+    // #docregion assert
+    // Make sure the variable has a non-null value.
+    assert(text != null);
+
+    // Make sure the value is less than 100.
+    assert(number < 100);
+
+    // Make sure this is an https URL.
+    assert(urlString.startsWith('https'));
+    // #enddocregion assert
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/control_flow.dart
+++ b/null_safety_examples/misc/lib/language_tour/control_flow.dart
@@ -2,7 +2,8 @@ typedef Pred0 = bool Function();
 typedef Void0 = void Function();
 
 class Candidate {
-  int yearsExperience;
+  int yearsExperience = 0;
+
   void interview() {}
 }
 
@@ -10,7 +11,8 @@ void miscDeclAnalyzedButNotTested() {
   final candidates = <Candidate>[];
 
   {
-    Pred0 isRaining, isSnowing;
+    Pred0 isRaining = () => true;
+    Pred0 isSnowing = () => true;
     dynamic car, you;
     // #docregion if-else
     if (isRaining()) {
@@ -30,7 +32,8 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    Pred0 isDone, doSomething;
+    Pred0 isDone = () => true;
+    Pred0 doSomething = () => true;
     // #docregion while
     while (!isDone()) {
       doSomething();
@@ -39,7 +42,8 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    Pred0 atEndOfPage, printLine;
+    Pred0 atEndOfPage = () => true;
+    Pred0 printLine = () => true;
     // #docregion do-while
     do {
       printLine();
@@ -48,7 +52,8 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    Pred0 shutDownRequested, processIncomingRequests;
+    Pred0 shutDownRequested = () => true;
+    Pred0 processIncomingRequests = () => true;
     // #docregion while-break
     while (true) {
       if (shutDownRequested()) break;
@@ -77,13 +82,13 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion where
   }
 
-  Void0 executeClosed,
-      executePending,
-      executeApproved,
-      executeDenied,
-      executeOpen,
-      executeUnknown,
-      executeNowClosed;
+  Void0 executeClosed = () {},
+      executePending = () {},
+      executeApproved = () {},
+      executeDenied = () {},
+      executeOpen = () {},
+      executeUnknown = () {},
+      executeNowClosed = () {};
 
   {
     // #docregion switch
@@ -160,8 +165,8 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    int number;
-    String urlString;
+    int number = 0;
+    String urlString = '';
     var text;
     // #docregion assert
     // Make sure the variable has a non-null value.

--- a/null_safety_examples/misc/lib/language_tour/exceptions.dart
+++ b/null_safety_examples/misc/lib/language_tour/exceptions.dart
@@ -1,0 +1,93 @@
+// ignore_for_file: only_throw_errors, unused_element
+
+class OutOfLlamasException /*extends Exception*/ {}
+
+class Point {}
+
+void breedMoreLlamas() {}
+void buyMoreLlamas() {}
+void cleanLlamaStalls() {}
+
+void miscDeclAnalyzedButNotTested(bool c) {
+  if (c) {
+    // #docregion throw-FormatException
+    throw FormatException('Expected at least 1 section');
+    // #enddocregion throw-FormatException
+  }
+
+  if (c) {
+    // #docregion out-of-llamas
+    throw 'Out of llamas!';
+    // #enddocregion out-of-llamas
+  }
+
+  {
+    // #docregion throw-is-an-expression
+    void distanceTo(Point other) => throw UnimplementedError();
+    // #enddocregion throw-is-an-expression
+  }
+
+  {
+    // #docregion try
+    try {
+      breedMoreLlamas();
+    } on OutOfLlamasException {
+      buyMoreLlamas();
+    }
+    // #enddocregion try
+  }
+
+  {
+    // #docregion try-catch
+    try {
+      breedMoreLlamas();
+    } on OutOfLlamasException {
+      // A specific exception
+      buyMoreLlamas();
+    } on Exception catch (e) {
+      // Anything else that is an exception
+      print('Unknown exception: $e');
+    } catch (e) {
+      // No specified type, handles all
+      print('Something really unknown: $e');
+    }
+    // #enddocregion try-catch
+  }
+
+  {
+    // #docregion try-catch-2
+    try {
+      // #enddocregion try-catch-2
+      // #docregion try-catch-2
+    } on Exception catch (e) {
+      print('Exception details:\n $e');
+    } catch (e, s) {
+      print('Exception details:\n $e');
+      print('Stack trace:\n $s');
+    }
+    // #enddocregion try-catch-2
+  }
+
+  {
+    // #docregion finally
+    try {
+      breedMoreLlamas();
+    } finally {
+      // Always clean up, even if an exception is thrown.
+      cleanLlamaStalls();
+    }
+    // #enddocregion finally
+  }
+
+  {
+    // #docregion try-catch-finally
+    try {
+      breedMoreLlamas();
+    } catch (e) {
+      print('Error: $e'); // Handle the exception first.
+    } finally {
+      cleanLlamaStalls(); // Then clean up.
+    }
+    // #enddocregion try-catch-finally
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/function_equality.dart
+++ b/null_safety_examples/misc/lib/language_tour/function_equality.dart
@@ -1,0 +1,32 @@
+void foo() {} // A top-level function
+
+class A {
+  static void bar() {} // A static method
+  void baz() {} // An instance method
+}
+
+void main() {
+  var x;
+
+  // Comparing top-level functions.
+  x = foo;
+  assert(foo == x);
+
+  // Comparing static methods.
+  x = A.bar;
+  assert(A.bar == x);
+
+  // Comparing instance methods.
+  var v = A(); // Instance #1 of A
+  var w = A(); // Instance #2 of A
+  var y = w;
+  x = w.baz;
+
+  // These closures refer to the same instance (#2),
+  // so they're equal.
+  assert(y.baz == x);
+
+  // These closures refer to different instances,
+  // so they're unequal.
+  assert(v.baz != w.baz);
+}

--- a/null_safety_examples/misc/lib/language_tour/functions.dart
+++ b/null_safety_examples/misc/lib/language_tour/functions.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: unused_element, type_annotate_public_apis
+
+import 'package:meta/meta.dart';
+
+void miscDeclAnalyzedButNotTested() {
+  var _nobleGases = {};
+
+  {
+    // #docregion function
+    bool isNoble(int atomicNumber) {
+      return _nobleGases[atomicNumber] != null;
+    }
+    // #enddocregion function
+  }
+
+  {
+    // #docregion function-omitting-types
+    isNoble(atomicNumber) {
+      return _nobleGases[atomicNumber] != null;
+    }
+    // #enddocregion function-omitting-types
+  }
+
+  {
+    // #docregion function-shorthand
+    bool isNoble(int atomicNumber) => _nobleGases[atomicNumber] != null;
+    // #enddocregion function-shorthand
+  }
+
+  {
+    // #docregion specify-named-parameters
+    /// Sets the [bold] and [hidden] flags ...
+    void enableFlags({bool bold, bool hidden}) {/*...*/}
+    // #enddocregion specify-named-parameters
+
+    // #docregion use-named-parameters
+    enableFlags(bold: true, hidden: false);
+    // #enddocregion use-named-parameters
+  }
+
+  {
+    // #docregion named-parameter-default-values
+    /// Sets the [bold] and [hidden] flags ...
+    void enableFlags({bool bold = false, bool hidden = false}) {/*...*/}
+
+    // bold will be true; hidden will be false.
+    enableFlags(bold: true);
+    // #enddocregion named-parameter-default-values
+  }
+
+  {
+    // #docregion list-map-default-function-param
+    void doStuff(
+        {List<int> list = const [1, 2, 3],
+        Map<String, String> gifts = const {
+          'first': 'paper',
+          'second': 'cotton',
+          'third': 'leather'
+        }}) {
+      print('list:  $list');
+      print('gifts: $gifts');
+    }
+    // #enddocregion list-map-default-function-param
+  }
+
+  {
+    // #docregion function-as-param
+    void printElement(int element) {
+      print(element);
+    }
+
+    var list = [1, 2, 3];
+
+    // Pass printElement as a parameter.
+    list.forEach(printElement);
+    // #enddocregion function-as-param
+  }
+}
+
+class Key {}
+
+abstract class Widget {
+  const Widget({Key key});
+}
+
+class Scrollbar extends Widget {
+  // #docregion required-named-parameters
+  const Scrollbar({Key key, @required Widget child})
+      // #enddocregion required-named-parameters
+      : super(key: key);
+}

--- a/null_safety_examples/misc/lib/language_tour/functions.dart
+++ b/null_safety_examples/misc/lib/language_tour/functions.dart
@@ -28,9 +28,10 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
+    // TODO(miquelbeltran) language-tour.md should explain that non-required params can be null
     // #docregion specify-named-parameters
     /// Sets the [bold] and [hidden] flags ...
-    void enableFlags({bool bold, bool hidden}) {/*...*/}
+    void enableFlags({bool? bold, bool? hidden}) {/*...*/}
     // #enddocregion specify-named-parameters
 
     // #docregion use-named-parameters
@@ -80,12 +81,12 @@ void miscDeclAnalyzedButNotTested() {
 class Key {}
 
 abstract class Widget {
-  const Widget({Key key});
+  const Widget({Key? key});
 }
 
 class Scrollbar extends Widget {
   // #docregion required-named-parameters
-  const Scrollbar({Key key, @required Widget child})
+  const Scrollbar({Key? key, required Widget child})
       // #enddocregion required-named-parameters
       : super(key: key);
 }

--- a/null_safety_examples/misc/lib/language_tour/functions.dart
+++ b/null_safety_examples/misc/lib/language_tour/functions.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: unused_element, type_annotate_public_apis
 
-import 'package:meta/meta.dart';
-
 void miscDeclAnalyzedButNotTested() {
   var _nobleGases = {};
 

--- a/null_safety_examples/misc/lib/language_tour/generics/base_class.dart
+++ b/null_safety_examples/misc/lib/language_tour/generics/base_class.dart
@@ -1,0 +1,9 @@
+class SomeBaseClass {}
+
+// #docregion
+class Foo<T extends SomeBaseClass> {
+  // Implementation goes here...
+  String toString() => "Instance of 'Foo<$T>'"; // ignore: annotate_overrides
+}
+
+class Extender extends SomeBaseClass {/*...*/}

--- a/null_safety_examples/misc/lib/language_tour/generics/cache.dart
+++ b/null_safety_examples/misc/lib/language_tour/generics/cache.dart
@@ -1,0 +1,20 @@
+// #docregion ObjectCache
+abstract class ObjectCache {
+  Object getByKey(String key);
+  void setByKey(String key, Object value);
+}
+// #enddocregion ObjectCache
+
+// #docregion StringCache
+abstract class StringCache {
+  String getByKey(String key);
+  void setByKey(String key, String value);
+}
+// #enddocregion StringCache
+
+// #docregion Cache
+abstract class Cache<T> {
+  T getByKey(String key);
+  void setByKey(String key, T value);
+}
+// #enddocregion Cache

--- a/null_safety_examples/misc/lib/language_tour/generics/misc.dart
+++ b/null_safety_examples/misc/lib/language_tour/generics/misc.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: unused_local_variable
+void miscDeclAnalyzedButNotTested() {
+  {
+    // #docregion collection-literals
+    var names = <String>['Seth', 'Kathy', 'Lars'];
+    var uniqueNames = <String>{'Seth', 'Kathy', 'Lars'};
+    var pages = <String, String>{
+      'index.html': 'Homepage',
+      'robots.txt': 'Hints for web robots',
+      'humans.txt': 'We are people, not machines'
+    };
+    // #enddocregion collection-literals
+  }
+}

--- a/null_safety_examples/misc/lib/language_tour/libraries/greeter.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/greeter.dart
@@ -1,0 +1,9 @@
+// #docregion import
+import 'hello.dart' deferred as hello;
+// #enddocregion import
+
+// #docregion loadLibrary
+Future greet() async {
+  await hello.loadLibrary();
+  hello.printGreeting();
+}

--- a/null_safety_examples/misc/lib/language_tour/libraries/hello.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/hello.dart
@@ -1,0 +1,1 @@
+void printGreeting() {}

--- a/null_safety_examples/misc/lib/language_tour/libraries/import_as.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/import_as.dart
@@ -1,0 +1,8 @@
+import 'lib1.dart';
+import 'lib2.dart' as lib2;
+
+// Uses Element from lib1.
+Element element1 = Element();
+
+// Uses Element from lib2.
+lib2.Element element2 = lib2.Element();

--- a/null_safety_examples/misc/lib/language_tour/libraries/lib1.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/lib1.dart
@@ -1,0 +1,3 @@
+void foo() {}
+
+class Element {}

--- a/null_safety_examples/misc/lib/language_tour/libraries/lib2.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/lib2.dart
@@ -1,0 +1,3 @@
+void foo() {}
+
+class Element {}

--- a/null_safety_examples/misc/lib/language_tour/libraries/show_hide.dart
+++ b/null_safety_examples/misc/lib/language_tour/libraries/show_hide.dart
@@ -1,0 +1,10 @@
+// #docregion
+// Import only foo.
+import 'lib1.dart' show foo;
+
+// Import all names EXCEPT foo.
+import 'lib2.dart' hide foo;
+// #enddocregion
+
+Element e = Element();
+dynamic bar = foo;

--- a/null_safety_examples/misc/lib/language_tour/metadata/misc.dart
+++ b/null_safety_examples/misc/lib/language_tour/metadata/misc.dart
@@ -1,0 +1,6 @@
+import 'todo.dart';
+
+@Todo('seth', 'make this do something')
+void doSomething() {
+  print('do something');
+}

--- a/null_safety_examples/misc/lib/language_tour/metadata/television.dart
+++ b/null_safety_examples/misc/lib/language_tour/metadata/television.dart
@@ -1,0 +1,20 @@
+// #docregion deprecated
+class Television {
+  /// _Deprecated: Use [turnOn] instead._
+  @deprecated
+  void activate() {
+    turnOn();
+  }
+
+  /// Turns the TV's power on.
+  void turnOn() {/*...*/}
+}
+// #enddocregion deprecated
+
+// #docregion override
+class SmartTelevision extends Television {
+  @override
+  void turnOn() {/*...*/}
+  // #enddocregion override
+  // #docregion override
+}

--- a/null_safety_examples/misc/lib/language_tour/metadata/todo.dart
+++ b/null_safety_examples/misc/lib/language_tour/metadata/todo.dart
@@ -1,0 +1,9 @@
+// ignore_for_file: sort_constructors_first
+library todo;
+
+class Todo {
+  final String who;
+  final String what;
+
+  const Todo(this.who, this.what);
+}

--- a/null_safety_examples/misc/lib/language_tour/operators.dart
+++ b/null_safety_examples/misc/lib/language_tour/operators.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: unused_local_variable, one_member_abstracts
+
+void miscDeclAnalyzedButNotTested() {
+  (bool done, int col) {
+    // #docregion op-logical
+    if (!done && (col == 0 || col == 3)) {
+      // ...Do something...
+    }
+    // #enddocregion op-logical
+  };
+
+  {
+    bool isPublic = true;
+    // #docregion if-then-else-operator
+    var visibility = isPublic ? 'public' : 'private';
+    // #enddocregion if-then-else-operator
+  }
+
+  {
+    // #docregion nested-cascades
+    final addressBook = (AddressBookBuilder()
+          ..name = 'jenny'
+          ..email = 'jenny@example.com'
+          ..phone = (PhoneNumberBuilder()
+                ..number = '415-555-0100'
+                ..label = 'home')
+              .build())
+        .build();
+    // #enddocregion nested-cascades
+  }
+
+  {
+    // #docregion cannot-cascade-on-void
+    var sb = StringBuffer();
+    sb.write('foo')
+        // #enddocregion cannot-cascade-on-void
+        /*
+      // #docregion cannot-cascade-on-void
+      ..write('bar'); // Error: method 'write' isn't defined for 'void'.
+      // #enddocregion cannot-cascade-on-void
+      */
+        ;
+  }
+}
+
+// Minimal class definitions in support of nested-cascades
+
+abstract class Builder<T> {
+  T build();
+}
+
+class PhoneNumber {
+  String number, label;
+}
+
+class PhoneNumberBuilder extends PhoneNumber with Builder<PhoneNumber> {
+  @override
+  PhoneNumber build() => null;
+}
+
+class AddressBook {
+  String name, email;
+  PhoneNumber phone;
+}
+
+class AddressBookBuilder extends AddressBook with Builder<AddressBook> {
+  @override
+  AddressBook build() => null;
+}

--- a/null_safety_examples/misc/lib/language_tour/operators.dart
+++ b/null_safety_examples/misc/lib/language_tour/operators.dart
@@ -50,20 +50,20 @@ abstract class Builder<T> {
 }
 
 class PhoneNumber {
-  String number, label;
+  String number = '', label = '';
 }
 
 class PhoneNumberBuilder extends PhoneNumber with Builder<PhoneNumber> {
   @override
-  PhoneNumber build() => null;
+  PhoneNumber build() => PhoneNumber();
 }
 
 class AddressBook {
-  String name, email;
-  PhoneNumber phone;
+  String name = '', email = '';
+  PhoneNumber phone = PhoneNumber();
 }
 
 class AddressBookBuilder extends AddressBook with Builder<AddressBook> {
   @override
-  AddressBook build() => null;
+  AddressBook build() => AddressBook();
 }

--- a/null_safety_examples/misc/lib/language_tour/typedefs/misc.dart
+++ b/null_safety_examples/misc/lib/language_tour/typedefs/misc.dart
@@ -1,0 +1,12 @@
+// #docregion Function
+typedef F = List<T> Function<T>(T);
+// #enddocregion Function
+
+// #docregion compare
+typedef Compare<T> = int Function(T a, T b);
+
+int sort(int a, int b) => a - b;
+
+void main() {
+  assert(sort is Compare<int>); // True!
+}

--- a/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_1.dart
+++ b/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_1.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: sort_constructors_first
+class SortedCollection {
+  Function compare;
+
+  SortedCollection(int f(Object a, Object b)) {
+    compare = f;
+  }
+}
+
+// Initial, broken implementation.
+int sort(Object a, Object b) => 0;
+
+void main() {
+  SortedCollection coll = SortedCollection(sort);
+
+  // All we know is that compare is a function,
+  // but what type of function?
+  assert(coll.compare is Function);
+}

--- a/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_1.dart
+++ b/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_1.dart
@@ -2,9 +2,7 @@
 class SortedCollection {
   Function compare;
 
-  SortedCollection(int f(Object a, Object b)) {
-    compare = f;
-  }
+  SortedCollection(int f(Object a, Object b)) : compare = f;
 }
 
 // Initial, broken implementation.

--- a/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
+++ b/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: sort_constructors_first
+typedef Compare = int Function(Object a, Object b);
+
+class SortedCollection {
+  Compare compare;
+
+  SortedCollection(this.compare);
+}
+
+// Initial, broken implementation.
+int sort(Object a, Object b) => 0;
+
+void main() {
+  SortedCollection coll = SortedCollection(sort);
+  assert(coll.compare is Function);
+  assert(coll.compare is Compare);
+}

--- a/null_safety_examples/misc/lib/language_tour/variables.dart
+++ b/null_safety_examples/misc/lib/language_tour/variables.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: unused_local_variable
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    // #docregion var-decl
+    var name = 'Bob';
+    // #enddocregion var-decl
+  }
+
+  {
+    // #docregion type-decl
+    dynamic name = 'Bob';
+    // #enddocregion type-decl
+  }
+
+  {
+    // #docregion static-types
+    String name = 'Bob';
+    // #enddocregion static-types
+  }
+
+  {
+    // #docregion final
+    final name = 'Bob'; // Without a type annotation
+    final String nickname = 'Bobby';
+    // #enddocregion final
+  }
+
+  {
+    // #docregion const
+    const bar = 1000000; // Unit of pressure (dynes/cm2)
+    const double atm = 1.01325 * bar; // Standard atmosphere
+    // #enddocregion const
+  }
+
+  {
+    // #docregion const-vs-final
+    var foo = const [];
+    final bar = const [];
+    const baz = []; // Equivalent to `const []`
+    // #enddocregion const-vs-final
+
+    // #docregion reassign-to-non-final
+    foo = [1, 2, 3]; // Was const []
+    // #enddocregion reassign-to-non-final
+  }
+
+  {
+    var bar, baz, name;
+    // #docregion cant-assign-to-final
+    name = 'Alice'; // Error: a final variable can only be set once.
+    // #enddocregion cant-assign-to-final
+    // #docregion cant-assign-to-const
+    baz = [42]; // Error: Constant variables can't be assigned a value.
+    // #enddocregion cant-assign-to-const
+  }
+
+  {
+    // #docregion const-dart-25
+    const Object i = 3; // Where i is a const Object with an int value...
+    const list = [i as int]; // Use a typecast.
+    const map = {if (i is int) i: "int"}; // Use is and collection if.
+    const set = {if (list is List<int>) ...list}; // ...and a spread.
+    // #enddocregion const-dart-25
+  }
+}

--- a/null_safety_examples/misc/test/language_tour/async_test.dart
+++ b/null_safety_examples/misc/test/language_tour/async_test.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: type_annotate_public_apis, curly_braces_in_flow_control_structures
+import 'package:test/test.dart';
+
+void main() {
+  test('syncGenerator', () {
+    // #docregion sync-generator
+    Iterable<int> naturalsTo(int n) sync* {
+      int k = 0;
+      while (k < n) yield k++;
+    }
+    // #enddocregion sync-generator
+
+    expect(naturalsTo(3), [0, 1, 2]);
+  });
+
+  test('asyncGenerator', () async {
+    // #docregion async-generator
+    Stream<int> asynchronousNaturalsTo(int n) async* {
+      int k = 0;
+      while (k < n) yield k++;
+    }
+    // #enddocregion async-generator
+
+    expect(await asynchronousNaturalsTo(3).toList(), [0, 1, 2]);
+  });
+
+  test('recursiveGenerator', () {
+    // #docregion recursive-generator
+    Iterable<int> naturalsDownFrom(int n) sync* {
+      if (n > 0) {
+        yield n;
+        yield* naturalsDownFrom(n - 1);
+      }
+    }
+    // #enddocregion recursive-generator
+
+    expect(naturalsDownFrom(3), [3, 2, 1]);
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/basic_test.dart
+++ b/null_safety_examples/misc/test/language_tour/basic_test.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: type_annotate_public_apis
+import 'package:test/test.dart';
+import 'package:examples_util/print_matcher.dart' as m;
+
+void main() {
+  test('basic', () {
+    // #docregion
+    // Define a function.
+    void printInteger(int aNumber) {
+      print('The number is $aNumber.'); // Print to console.
+    }
+
+    // This is where the app starts executing.
+    void main() {
+      var number = 42; // Declare and initialize a variable.
+      printInteger(number); // Call a function.
+    }
+
+    // #enddocregion
+    expect(main, m.prints('The number is 42.'));
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/browser_test.dart
+++ b/null_safety_examples/misc/test/language_tour/browser_test.dart
@@ -1,0 +1,55 @@
+@Tags(['browser'])
+@TestOn('browser')
+// #docregion dart-html-import
+import 'dart:html';
+// #enddocregion dart-html-import
+// #docregion package-import
+import 'package:test/test.dart';
+// #enddocregion package-import
+
+void main() {
+  test('simple-web-main-function', () {
+    final div = '<div id="sample_text_id"></div>';
+    document.body.appendHtml(div);
+    void reverseText(MouseEvent e) {}
+
+    // #docregion simple-web-main-function
+    void main() {
+      querySelector('#sample_text_id')
+        ..text = 'Click me!'
+        ..onClick.listen(reverseText);
+    }
+    // #enddocregion simple-web-main-function
+
+    main();
+    expect(document.querySelector('#sample_text_id').text, 'Click me!');
+  });
+
+  test('cascade-operator', () {
+    final div = '<button id="confirm"></button>';
+    document.body.appendHtml(div);
+
+    // #docregion cascade-operator
+    querySelector('#confirm') // Get an object.
+      ..text = 'Confirm' // Use its members.
+      ..classes.add('important')
+      ..onClick.listen((e) => window.alert('Confirmed!'));
+    // #enddocregion cascade-operator
+
+    expect(document.querySelector('#confirm').text, 'Confirm');
+  });
+
+  test('cascade-operator-example-expanded', () {
+    final div = '<button id="confirm"></button>';
+    document.body.appendHtml(div);
+
+    // #docregion cascade-operator-example-expanded
+    var button = querySelector('#confirm');
+    button.text = 'Confirm';
+    button.classes.add('important');
+    button.onClick.listen((e) => window.alert('Confirmed!'));
+    // #enddocregion cascade-operator-example-expanded
+
+    expect(document.querySelector('#confirm').text, 'Confirm');
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/browser_test.dart
+++ b/null_safety_examples/misc/test/language_tour/browser_test.dart
@@ -10,46 +10,47 @@ import 'package:test/test.dart';
 void main() {
   test('simple-web-main-function', () {
     final div = '<div id="sample_text_id"></div>';
-    document.body.appendHtml(div);
+    document.body?.appendHtml(div);
     void reverseText(MouseEvent e) {}
 
+    // TODO(miquelbeltran) Maybe ! would be better here
     // #docregion simple-web-main-function
     void main() {
       querySelector('#sample_text_id')
-        ..text = 'Click me!'
+        ?..text = 'Click me!'
         ..onClick.listen(reverseText);
     }
     // #enddocregion simple-web-main-function
 
     main();
-    expect(document.querySelector('#sample_text_id').text, 'Click me!');
+    expect(document.querySelector('#sample_text_id')?.text, 'Click me!');
   });
 
   test('cascade-operator', () {
     final div = '<button id="confirm"></button>';
-    document.body.appendHtml(div);
+    document.body?.appendHtml(div);
 
     // #docregion cascade-operator
     querySelector('#confirm') // Get an object.
-      ..text = 'Confirm' // Use its members.
+      ?..text = 'Confirm' // Use its members.
       ..classes.add('important')
       ..onClick.listen((e) => window.alert('Confirmed!'));
     // #enddocregion cascade-operator
 
-    expect(document.querySelector('#confirm').text, 'Confirm');
+    expect(document.querySelector('#confirm')?.text, 'Confirm');
   });
 
   test('cascade-operator-example-expanded', () {
     final div = '<button id="confirm"></button>';
-    document.body.appendHtml(div);
+    document.body?.appendHtml(div);
 
     // #docregion cascade-operator-example-expanded
     var button = querySelector('#confirm');
-    button.text = 'Confirm';
-    button.classes.add('important');
-    button.onClick.listen((e) => window.alert('Confirmed!'));
+    button?.text = 'Confirm';
+    button?.classes.add('important');
+    button?.onClick.listen((e) => window.alert('Confirmed!'));
     // #enddocregion cascade-operator-example-expanded
 
-    expect(document.querySelector('#confirm').text, 'Confirm');
+    expect(document.querySelector('#confirm')?.text, 'Confirm');
   });
 }

--- a/null_safety_examples/misc/test/language_tour/built_in_types_test.dart
+++ b/null_safety_examples/misc/test/language_tour/built_in_types_test.dart
@@ -1,0 +1,169 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('number-conversion', () {
+    // #docregion number-conversion
+    // String -> int
+    var one = int.parse('1');
+    assert(one == 1);
+
+    // String -> double
+    var onePointOne = double.parse('1.1');
+    assert(onePointOne == 1.1);
+
+    // int -> String
+    String oneAsString = 1.toString();
+    assert(oneAsString == '1');
+
+    // double -> String
+    String piAsString = 3.14159.toStringAsFixed(2);
+    assert(piAsString == '3.14');
+    // #enddocregion number-conversion
+  });
+
+  test('bit-shifting', () {
+    // #docregion bit-shifting
+    assert((3 << 1) == 6); // 0011 << 1 == 0110
+    assert((3 >> 1) == 1); // 0011 >> 1 == 0001
+    assert((3 | 4) == 7); // 0011 | 0100 == 0111
+    // #enddocregion bit-shifting
+  });
+
+  test('string-interpolation', () {
+    // #docregion string-interpolation
+    var s = 'string interpolation';
+
+    assert('Dart has $s, which is very handy.' ==
+        'Dart has string interpolation, ' +
+            'which is very handy.');
+    assert('That deserves all caps. ' +
+            '${s.toUpperCase()} is very handy!' ==
+        'That deserves all caps. ' +
+            'STRING INTERPOLATION is very handy!');
+    // #enddocregion string-interpolation
+  });
+
+  test('adjacent-string-literals', () {
+    // #docregion adjacent-string-literals
+    var s1 = 'String '
+        'concatenation'
+        " works even over line breaks.";
+    assert(s1 ==
+        'String concatenation works even over '
+            'line breaks.');
+
+    var s2 = 'The + operator ' + 'works, as well.';
+    assert(s2 == 'The + operator works, as well.');
+    // #enddocregion adjacent-string-literals
+  });
+
+  test('no-truthy', () {
+    // #docregion no-truthy
+    // Check for an empty string.
+    var fullName = '';
+    assert(fullName.isEmpty);
+
+    // Check for zero.
+    var hitPoints = 0;
+    assert(hitPoints <= 0);
+
+    // Check for null.
+    var unicorn;
+    assert(unicorn == null);
+
+    // Check for NaN.
+    var iMeantToDoThis = 0 / 0;
+    assert(iMeantToDoThis.isNaN);
+    // #enddocregion no-truthy
+  });
+
+  test('list-indexing', () {
+    // #docregion list-indexing
+    var list = [1, 2, 3];
+    assert(list.length == 3);
+    assert(list[1] == 2);
+
+    list[1] = 1;
+    assert(list[1] == 1);
+    // #enddocregion list-indexing
+  });
+
+  test('list-spread', () {
+    // #docregion list-spread
+    var list = [1, 2, 3];
+    var list2 = [0, ...list];
+    assert(list2.length == 4);
+    // #enddocregion list-spread
+  });
+
+  test('list-null-spread', () {
+    // #docregion list-null-spread
+    var list;
+    var list2 = [0, ...?list];
+    assert(list2.length == 1);
+    // #enddocregion list-null-spread
+  });
+
+  test('list-if', () {
+    var promoActive = false;
+    // #docregion list-if
+    var nav = [
+      'Home',
+      'Furniture',
+      'Plants',
+      if (promoActive) 'Outlet'
+    ];
+    // #enddocregion list-if
+    assert(nav.length == 3);
+  });
+
+  test('list-for', () {
+    // #docregion list-for
+    var listOfInts = [1, 2, 3];
+    var listOfStrings = [
+      '#0',
+      for (var i in listOfInts) '#$i'
+    ];
+    assert(listOfStrings[1] == '#1');
+    // #enddocregion list-for
+  });
+
+  test('set-length', () {
+    var halogens = {
+      'fluorine',
+      'chlorine',
+      'bromine',
+      'iodine',
+      'astatine'
+    };
+
+    // #docregion set-length
+    var elements = <String>{};
+    elements.add('fluorine');
+    elements.addAll(halogens);
+    assert(elements.length == 5);
+    // #enddocregion set-length
+  });
+
+  test('map-retrieve-item', () {
+    // #docregion map-retrieve-item
+    var gifts = {'first': 'partridge'};
+    assert(gifts['first'] == 'partridge');
+    // #enddocregion map-retrieve-item
+  });
+
+  test('map-missing-key', () {
+    // #docregion map-missing-key
+    var gifts = {'first': 'partridge'};
+    assert(gifts['fifth'] == null);
+    // #enddocregion map-missing-key
+  });
+
+  test('map-length', () {
+    // #docregion map-length
+    var gifts = {'first': 'partridge'};
+    gifts['fourth'] = 'calling birds';
+    assert(gifts.length == 2);
+    // #enddocregion map-length
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/callable_classes_test.dart
+++ b/null_safety_examples/misc/test/language_tour/callable_classes_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+import 'package:examples/language_tour/callable_classes.dart'
+    as callable_classes;
+
+void main() {
+  test('sorted_collection_1', () {
+    expect(callable_classes.out, 'Hi there, gang!');
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/classes_test.dart
+++ b/null_safety_examples/misc/test/language_tour/classes_test.dart
@@ -50,7 +50,12 @@ void main() {
     // Invoke distanceTo() on p.
     double distance = p.distanceTo(Point(4, 4));
     // #enddocregion object-members
+  });
 
+  test('safe-member-access', () {
+    // Trick to make p nullable
+    Point? Function() f = () => Point(2, 2);
+    Point? p = f();
     // #docregion safe-member-access
     // If p is non-null, set a variable equal to its y value.
     var a = p?.y;

--- a/null_safety_examples/misc/test/language_tour/classes_test.dart
+++ b/null_safety_examples/misc/test/language_tour/classes_test.dart
@@ -1,0 +1,182 @@
+// ignore_for_file: unused_local_variable
+import 'package:test/test.dart';
+import 'package:examples/language_tour/classes/employee.dart' as employee;
+import 'package:examples/language_tour/classes/enum.dart' as enum_with_main;
+import 'package:examples/language_tour/classes/immutable_point.dart';
+import 'package:examples/language_tour/classes/impostor.dart' as impostor;
+import 'package:examples/language_tour/classes/logger.dart' as logger_with_main;
+import 'package:examples/language_tour/classes/misc.dart' as misc;
+import 'package:examples/language_tour/classes/no_such_method.dart'
+    as no_such_method;
+import 'package:examples/language_tour/classes/orchestra.dart' as orchestra;
+import 'package:examples/language_tour/classes/point.dart';
+import 'package:examples/language_tour/classes/point_redirecting.dart'
+    as point_redirecting;
+import 'package:examples/language_tour/classes/point_with_distance_field.dart'
+    as point_with_distance_field;
+import 'package:examples/language_tour/classes/point_with_distance_method.dart'
+    as point_with_distance_method;
+import 'package:examples/language_tour/classes/point_with_main.dart'
+    as point_with_main;
+import 'package:examples/language_tour/classes/rectangle.dart'
+    as rectangle_with_main;
+import 'package:examples/language_tour/classes/vector.dart' as vector_with_main;
+import 'package:examples_util/print_matcher.dart' as m;
+
+void main() {
+  test('object-creation', () {
+    // #docregion object-creation
+    var p1 = Point(2, 2);
+    var p2 = Point.fromJson({'x': 1, 'y': 2});
+    // #enddocregion object-creation
+    expect(p1.y, p2.y);
+  });
+
+  test('object-creation-new', () {
+    // #docregion object-creation-new
+    var p1 = new Point(2, 2); // ignore: unnecessary_new
+    var p2 = new Point.fromJson({'x': 1, 'y': 2}); // ignore: unnecessary_new
+    // #enddocregion object-creation-new
+    expect(p1.y, p2.y);
+  });
+
+  test('object-members', () {
+    // #docregion object-members
+    var p = Point(2, 2);
+
+    // Get the value of y.
+    assert(p.y == 2);
+
+    // Invoke distanceTo() on p.
+    double distance = p.distanceTo(Point(4, 4));
+    // #enddocregion object-members
+
+    // #docregion safe-member-access
+    // If p is non-null, set a variable equal to its y value.
+    var a = p?.y;
+    // #enddocregion safe-member-access
+    expect(a, 2);
+  });
+
+  test('const, identical, runtimeType', () {
+    _test() {
+      // #docregion const
+      var p = const ImmutablePoint(2, 2);
+      // #enddocregion const
+
+      // #docregion identical
+      var a = const ImmutablePoint(1, 1);
+      var b = const ImmutablePoint(1, 1);
+
+      assert(identical(a, b)); // They are the same instance!
+      // #enddocregion identical
+
+      // #docregion runtimeType
+      print('The type of a is ${a.runtimeType}');
+      // #enddocregion runtimeType
+    }
+
+    expect(_test, m.prints('The type of a is ImmutablePoint'));
+  });
+
+  test('point_with_main', () {
+    point_with_main.main(); // contains assertions
+  });
+
+  test('employee', () {
+    expect(employee.main, m.prints(['in Person', 'in Employee']));
+  });
+
+  test('point_with_distance', () {
+    expect(point_with_distance_field.main, prints(startsWith('3.6')));
+  });
+
+  test('point_redirecting', () {
+    final p = point_redirecting.Point.alongXAxis(42);
+    expect(p.y, 0);
+  });
+
+  test('logger', () {
+    expect(
+        logger_with_main.main,
+        m.prints([
+          'Button clicked',
+          'log1: This is l1.',
+          'log1: This is l1_2.',
+          'log2: This is l2.',
+          'UI: This is logger.',
+          'UI: This is loggerJson.'
+        ]));
+  });
+
+  test('rectangle_with_main', () {
+    rectangle_with_main.main(); // contains assertions
+  });
+
+  test('vector_with_main', () {
+    vector_with_main.main(); // contains assertions
+  });
+
+  test('imposter', () {
+    expect(
+        impostor.main,
+        m.prints([
+          'Hello, Bob. I am Kathy.',
+          'Hi Bob. Do you know who I am?',
+        ]));
+  });
+
+  test('no_such_method', () {
+    expect(no_such_method.main,
+        m.prints('You tried to use a non-existent member: Symbol("foo")'));
+  });
+
+  test('enum_with_main', () {
+    expect(enum_with_main.main, m.prints('Color.blue'));
+  });
+
+  test('orchestra', () {
+    expect(
+        orchestra.main, m.prints(['Waving hands', 'Playing piano', 'Dancing']));
+  });
+
+  test('static-field', () {
+    misc.main(); // contains assertions
+  });
+
+  test('point_with_distance_method', () {
+    expect(point_with_distance_method.main, prints(startsWith('2.82')));
+  });
+
+  // ignore_for_file: unnecessary_const
+  test('const_context', () {
+    // #docregion const-context-withconst
+    // Lots of const keywords here.
+    const pointAndLine1 = const {
+      'point': const [const ImmutablePoint(0, 0)],
+      'line': const [const ImmutablePoint(1, 10), const ImmutablePoint(-2, 11)],
+    };
+    // #enddocregion const-context-withconst
+
+    // #docregion const-context-noconst
+    // Only one const, which establishes the constant context.
+    const pointAndLine2 = {
+      'point': [ImmutablePoint(0, 0)],
+      'line': [ImmutablePoint(1, 10), ImmutablePoint(-2, 11)],
+    };
+    // #enddocregion const-context-noconst
+
+    expect(pointAndLine1 == pointAndLine2, isTrue);
+  });
+
+  test('nonconst_const_constructor', () {
+    // #docregion nonconst-const-constructor
+    var a = const ImmutablePoint(1, 1); // Creates a constant
+    var b = ImmutablePoint(1, 1); // Does NOT create a constant
+
+    assert(!identical(a, b)); // NOT the same instance!
+    // #enddocregion nonconst-const-constructor
+
+    expect(a == b, isFalse);
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/control_flow_test.dart
+++ b/null_safety_examples/misc/test/language_tour/control_flow_test.dart
@@ -40,7 +40,10 @@ void main() {
   });
 
   test('assert', () {
-    var text = '', number = 0, urlString = 'https';
+    // trick to make text nullable
+    String? Function() _text = () => '';
+    String? text = _text();
+    var number = 0, urlString = 'https';
     // #docregion assert
     // Make sure the variable has a non-null value.
     assert(text != null);

--- a/null_safety_examples/misc/test/language_tour/control_flow_test.dart
+++ b/null_safety_examples/misc/test/language_tour/control_flow_test.dart
@@ -1,0 +1,60 @@
+import 'package:test/test.dart';
+import 'package:examples_util/print_matcher.dart' as m;
+
+void main() {
+  test('for', () {
+    // #docregion for
+    var message = StringBuffer('Dart is fun');
+    for (var i = 0; i < 5; i++) {
+      message.write('!');
+    }
+    // #enddocregion for
+    expect(message.toString(), 'Dart is fun!!!!!');
+  });
+
+  test('for-and-closures', () {
+    _test() {
+      // #docregion for-and-closures
+      var callbacks = [];
+      for (var i = 0; i < 2; i++) {
+        callbacks.add(() => print(i));
+      }
+      callbacks.forEach((c) => c());
+      // #enddocregion for-and-closures
+    }
+
+    expect(_test, m.prints(['0', '1']));
+  });
+
+  test('collection', () {
+    _test() {
+      // #docregion collection
+      var collection = [1, 2, 3];
+      for (var x in collection) {
+        print(x); // 1 2 3
+      }
+      // #enddocregion collection
+    }
+
+    expect(_test, m.prints([1, 2, 3]));
+  });
+
+  test('assert', () {
+    var text = '', number = 0, urlString = 'https';
+    // #docregion assert
+    // Make sure the variable has a non-null value.
+    assert(text != null);
+
+    // Make sure the value is less than 100.
+    assert(number < 100);
+
+    // Make sure this is an https URL.
+    assert(urlString.startsWith('https'));
+    // #enddocregion assert
+
+    // #docregion assert-with-message
+    assert(urlString.startsWith('https'),
+        'URL ($urlString) should start with "https".');
+    // #enddocregion assert-with-message
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/exceptions_test.dart
+++ b/null_safety_examples/misc/test/language_tour/exceptions_test.dart
@@ -1,0 +1,35 @@
+// ignore_for_file: assignment_to_final, unused_local_variable
+// Dart 2 only:
+// ignore_for_file: assignment_to_final_local
+import 'package:test/test.dart';
+
+void main() {
+  test('rethrow', () {
+    // #docregion rethrow
+    void misbehave() {
+      try {
+        dynamic foo = true;
+        print(foo++); // Runtime error
+      } catch (e) {
+        print('misbehave() partially handled ${e.runtimeType}.');
+        rethrow; // Allow callers to see the exception.
+      }
+    }
+
+    void main() {
+      try {
+        misbehave();
+      } catch (e) {
+        print('main() finished handling ${e.runtimeType}.');
+      }
+    }
+    // #enddocregion rethrow
+
+    expect(
+        main,
+        prints(allOf([
+          contains('misbehave() partially handled'),
+          contains('main() finished handling')
+        ])));
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/functions_test.dart
+++ b/null_safety_examples/misc/test/language_tour/functions_test.dart
@@ -1,0 +1,149 @@
+// ignore_for_file: unused_element, type_annotate_public_apis
+import 'package:examples/language_tour/function_equality.dart'
+    as function_equality;
+import 'package:test/test.dart';
+import 'package:examples_util/print_matcher.dart' as m;
+
+void main() {
+  test('optional-positional-parameters', () {
+    // #docregion optional-positional-parameters
+    String say(String from, String msg, [String device]) {
+      var result = '$from says $msg';
+      if (device != null) {
+        result = '$result with a $device';
+      }
+      return result;
+    }
+
+    // #enddocregion optional-positional-parameters
+    // #docregion call-without-optional-param
+    assert(say('Bob', 'Howdy') == 'Bob says Howdy');
+    // #enddocregion call-without-optional-param
+    // #docregion call-with-optional-param
+    assert(say('Bob', 'Howdy', 'smoke signal') ==
+        'Bob says Howdy with a smoke signal');
+    // #enddocregion call-with-optional-param
+  });
+
+  test('optional-positional-param-default', () {
+    // #docregion optional-positional-param-default
+    String say(String from, String msg,
+        [String device = 'carrier pigeon']) {
+      var result = '$from says $msg with a $device';
+      return result;
+    }
+
+    assert(say('Bob', 'Howdy') ==
+        'Bob says Howdy with a carrier pigeon');
+    // #enddocregion optional-positional-param-default
+  });
+
+  test('main-args', () {
+    // #docregion main-args
+    // Run the app like this: dart args.dart 1 test
+    void main(List<String> arguments) {
+      print(arguments);
+
+      assert(arguments.length == 2);
+      assert(int.parse(arguments[0]) == 1);
+      assert(arguments[1] == 'test');
+    }
+
+    // #enddocregion main-args
+    final args = ['1', 'test'];
+    expect(() => main(args), m.prints('[1, test]'));
+  });
+
+  test('function-as-var', () {
+    // #docregion function-as-var
+    var loudify = (msg) => '!!! ${msg.toUpperCase()} !!!';
+    assert(loudify('hello') == '!!! HELLO !!!');
+    // #enddocregion function-as-var
+  });
+
+  final indexedFruit = '''0: apples
+1: bananas
+2: oranges
+''';
+
+  test('anonymous-function', () {
+    _test() {
+      // #docregion anonymous-function
+      var list = ['apples', 'bananas', 'oranges'];
+      list.forEach((item) {
+        print('${list.indexOf(item)}: $item');
+      });
+      // #enddocregion anonymous-function
+    }
+
+    expect(_test, prints(indexedFruit));
+  });
+
+  test('anon-func', () {
+    _test() {
+      var list = ['apples', 'bananas', 'oranges'];
+      // #docregion anon-func
+      list.forEach(
+          (item) => print('${list.indexOf(item)}: $item'));
+      // #enddocregion anon-func
+    }
+
+    expect(_test, prints(indexedFruit));
+  });
+
+  test('nested-functions', () {
+    // #docregion nested-functions
+    bool topLevel = true;
+
+    void main() {
+      var insideMain = true;
+
+      void myFunction() {
+        var insideFunction = true;
+
+        void nestedFunction() {
+          var insideNestedFunction = true;
+
+          assert(topLevel);
+          assert(insideMain);
+          assert(insideFunction);
+          assert(insideNestedFunction);
+        }
+      }
+    }
+    // #enddocregion nested-functions
+  });
+
+  test('function-closure', () {
+    // #docregion function-closure
+    /// Returns a function that adds [addBy] to the
+    /// function's argument.
+    Function makeAdder(int addBy) {
+      return (int i) => addBy + i;
+    }
+
+    void main() {
+      // Create a function that adds 2.
+      var add2 = makeAdder(2);
+
+      // Create a function that adds 4.
+      var add4 = makeAdder(4);
+
+      assert(add2(3) == 5);
+      assert(add4(3) == 7);
+    }
+
+    // #enddocregion function-closure
+    main();
+  });
+
+  test('function-equality', () => function_equality.main());
+
+  test('implicit-return-null', () {
+    // #docregion implicit-return-null
+    foo() {}
+
+    assert(foo() == null);
+    // #enddocregion implicit-return-null
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/functions_test.dart
+++ b/null_safety_examples/misc/test/language_tour/functions_test.dart
@@ -7,7 +7,7 @@ import 'package:examples_util/print_matcher.dart' as m;
 void main() {
   test('optional-positional-parameters', () {
     // #docregion optional-positional-parameters
-    String say(String from, String msg, [String device]) {
+    String say(String from, String msg, [String? device]) {
       var result = '$from says $msg';
       if (device != null) {
         result = '$result with a $device';

--- a/null_safety_examples/misc/test/language_tour/generics_test.dart
+++ b/null_safety_examples/misc/test/language_tour/generics_test.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: argument_type_not_assignable
+import 'package:examples/language_tour/generics/base_class.dart';
+import 'package:test/test.dart';
+
+final Matcher throwsATypeError = throwsA(TypeMatcher<TypeError>());
+
+void main() {
+  test('constructor-1', () {
+    var names = List<String>();
+    names.addAll(['Seth', 'Kathy', 'Lars']);
+    // #docregion constructor-1
+    var nameSet = Set<String>.from(names);
+    // #enddocregion constructor-1
+    expect(nameSet.length, 3);
+  });
+
+  test('constructor-2', () {
+    // #docregion constructor-2
+    var views = Map<int, View>();
+    // #enddocregion constructor-2
+    expect(views.length, 0);
+  });
+
+  test('generic-collections', () {
+    _test() {
+      // #docregion generic-collections
+      var names = List<String>();
+      names.addAll(['Seth', 'Kathy', 'Lars']);
+      print(names is List<String>); // true
+      // #enddocregion generic-collections
+    }
+
+    expect(_test, prints('true\n'));
+  });
+
+  test('method', () {
+    // #docregion method, method-with-main
+    T first<T>(List<T> ts) {
+      // Do some initial work or error checking, then...
+      T tmp = ts[0];
+      // Do some additional checking or processing...
+      return tmp;
+    }
+    // #enddocregion method
+
+    void main() => print('first: ${first<int>([1, 2, 3])}');
+    // #enddocregion method-with-main
+    expect(main, prints('first: 1\n'));
+  });
+
+  test('base_class', () {
+    // #docregion SomeBaseClass-ok
+    var someBaseClassFoo = Foo<SomeBaseClass>();
+    var extenderFoo = Foo<Extender>();
+    // #enddocregion SomeBaseClass-ok
+    expect(someBaseClassFoo.toString(), "Instance of 'Foo<SomeBaseClass>'");
+    expect(extenderFoo.toString(), "Instance of 'Foo<Extender>'");
+
+    // #docregion no-generic-arg-ok
+    var foo = Foo();
+    expect(foo.toString(), "Instance of 'Foo<SomeBaseClass>'");
+    // #enddocregion no-generic-arg-ok
+  });
+}
+
+class View {}

--- a/null_safety_examples/misc/test/language_tour/generics_test.dart
+++ b/null_safety_examples/misc/test/language_tour/generics_test.dart
@@ -6,7 +6,7 @@ final Matcher throwsATypeError = throwsA(TypeMatcher<TypeError>());
 
 void main() {
   test('constructor-1', () {
-    var names = List<String>();
+    var names = <String>[];
     names.addAll(['Seth', 'Kathy', 'Lars']);
     // #docregion constructor-1
     var nameSet = Set<String>.from(names);
@@ -23,8 +23,9 @@ void main() {
 
   test('generic-collections', () {
     _test() {
+      // TODO(miquelbeltran) language-tour.md should be updated, List<String> cannot be used with null-safety
       // #docregion generic-collections
-      var names = List<String>();
+      var names = <String>[];
       names.addAll(['Seth', 'Kathy', 'Lars']);
       print(names is List<String>); // true
       // #enddocregion generic-collections

--- a/null_safety_examples/misc/test/language_tour/operators_test.dart
+++ b/null_safety_examples/misc/test/language_tour/operators_test.dart
@@ -1,0 +1,186 @@
+import 'package:test/test.dart';
+import 'package:examples/language_tour/classes/employee.dart' as employee;
+import 'package:examples_util/print_matcher.dart' as m;
+
+class T {}
+
+void main() {
+  test('expressions', () {
+    var a = 1, b = 2, c = true;
+    final expressions = [
+      // #docregion expressions
+      a++,
+      a + b,
+      a = b,
+      a == b,
+      c ? a : b,
+      a is T,
+      // #enddocregion expressions
+    ];
+    expect(expressions, [1, 4, 2, true, 2, false]);
+  });
+
+  test('precedence', () {
+    int d = 1, i = 1, n = 1;
+    // #docregion precedence
+    // Parentheses improve readability.
+    if ((n % i == 0) && (d % i == 0)) {/*-...-*/}
+
+    // Harder to read, but equivalent.
+    if (n % i == 0 && d % i == 0) {/*-...-*/}
+    // #enddocregion precedence
+  });
+
+  test('arithmetic', () {
+    // #docregion arithmetic
+    assert(2 + 3 == 5);
+    assert(2 - 3 == -1);
+    assert(2 * 3 == 6);
+    assert(5 / 2 == 2.5); // Result is a double
+    assert(5 ~/ 2 == 2); // Result is an int
+    assert(5 % 2 == 1); // Remainder
+
+    assert('5/2 = ${5 ~/ 2} r ${5 % 2}' == '5/2 = 2 r 1');
+    // #enddocregion arithmetic
+  });
+
+  test('increment-decrement', () {
+    // #docregion increment-decrement
+    var a, b;
+
+    a = 0;
+    b = ++a; // Increment a before b gets its value.
+    assert(a == b); // 1 == 1
+
+    a = 0;
+    b = a++; // Increment a AFTER b gets its value.
+    assert(a != b); // 1 != 0
+
+    a = 0;
+    b = --a; // Decrement a before b gets its value.
+    assert(a == b); // -1 == -1
+
+    a = 0;
+    b = a--; // Decrement a AFTER b gets its value.
+    assert(a != b); // -1 != 0
+    // #enddocregion increment-decrement
+  });
+
+  test('relational', () {
+    // #docregion relational
+    assert(2 == 2);
+    assert(2 != 3);
+    assert(3 > 2);
+    assert(2 < 3);
+    assert(3 >= 3);
+    assert(2 <= 3);
+    // #enddocregion relational
+  });
+
+  test('is-vs-as', () {
+    expect(employee.main, m.prints(['in Person', 'in Employee']));
+  });
+
+  group('`=` vs `??=`:', () {
+    // #docregion assignment-gist-main-body
+    void assignValues(int a, int b, int value) {
+      print('Initially: a == $a, b == $b');
+      // #docregion assignment
+      // Assign value to a
+      a = value;
+      // Assign value to b if b is null; otherwise, b stays the same
+      b ??= value;
+      // #enddocregion assignment
+      print('After: a == $a, b == $b');
+    }
+
+    // #enddocregion assignment-gist-main-body
+    /*
+    // #docregion assignment-gist-main-body
+    main() {
+    // #enddocregion assignment-gist-main-body
+    */
+
+    _test001() {
+      // #docregion assignment-gist-main-body
+      assignValues(0, 0, 1);
+      // #enddocregion assignment-gist-main-body
+    }
+
+    _testNull() {
+      // #docregion assignment-gist-main-body
+      assignValues(null, null, 1);
+      // #enddocregion assignment-gist-main-body
+    }
+
+    test('var initially non-null', () {
+      expect(
+          _test001,
+          m.prints([
+            'Initially: a == 0, b == 0',
+            'After: a == 1, b == 0',
+          ]));
+    });
+
+    test('var initially non-null', () {
+      expect(
+          _testNull,
+          m.prints([
+            'Initially: a == null, b == null',
+            'After: a == 1, b == 1',
+          ]));
+    });
+
+    /*
+    // #docregion assignment-gist-main-body
+    }
+    // #enddocregion assignment-gist-main-body
+    */
+  });
+
+  test('op-assign', () {
+    // #docregion op-assign
+    var a = 2; // Assign using =
+    a *= 3; // Assign and multiply: a = a * 3
+    assert(a == 6);
+    // #enddocregion op-assign
+  });
+
+  test('op-bitwise', () {
+    // #docregion op-bitwise
+    final value = 0x22;
+    final bitmask = 0x0f;
+
+    assert((value & bitmask) == 0x02); // AND
+    assert((value & ~bitmask) == 0x20); // AND NOT
+    assert((value | bitmask) == 0x2f); // OR
+    assert((value ^ bitmask) == 0x2d); // XOR
+    assert((value << 4) == 0x220); // Shift left
+    assert((value >> 4) == 0x02); // Shift right
+    // #enddocregion op-bitwise
+  });
+
+  test('if-null', () {
+    // #docregion if-null
+    String playerName1(String name) => name ?? 'Guest';
+    // #enddocregion if-null
+
+    // #docregion if-null-alt
+    // Slightly longer version uses ?: operator.
+    String playerName2(String name) => name != null ? name : 'Guest';
+
+    // Very long version uses if-else statement.
+    String playerName3(String name) {
+      if (name != null) {
+        return name;
+      } else {
+        return 'Guest';
+      }
+    }
+
+    // #enddocregion if-null-alt
+    final funcs = [playerName1, playerName2, playerName3];
+    expect(funcs.map((f) => f(null)), List.filled(3, 'Guest'));
+    expect(funcs.map((f) => f('Alice')), List.filled(3, 'Alice'));
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/operators_test.dart
+++ b/null_safety_examples/misc/test/language_tour/operators_test.dart
@@ -83,7 +83,7 @@ void main() {
 
   group('`=` vs `??=`:', () {
     // #docregion assignment-gist-main-body
-    void assignValues(int a, int b, int value) {
+    void assignValues(int? a, int? b, int value) {
       print('Initially: a == $a, b == $b');
       // #docregion assignment
       // Assign value to a
@@ -162,15 +162,15 @@ void main() {
 
   test('if-null', () {
     // #docregion if-null
-    String playerName1(String name) => name ?? 'Guest';
+    String playerName1(String? name) => name ?? 'Guest';
     // #enddocregion if-null
 
     // #docregion if-null-alt
     // Slightly longer version uses ?: operator.
-    String playerName2(String name) => name != null ? name : 'Guest';
+    String playerName2(String? name) => name != null ? name : 'Guest';
 
     // Very long version uses if-else statement.
-    String playerName3(String name) {
+    String playerName3(String? name) {
       if (name != null) {
         return name;
       } else {

--- a/null_safety_examples/misc/test/language_tour/typedefs_test.dart
+++ b/null_safety_examples/misc/test/language_tour/typedefs_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+
+import 'package:examples/language_tour/typedefs/misc.dart' as misc;
+import 'package:examples/language_tour/typedefs/sorted_collection_1.dart'
+    as sorted_collection_1;
+import 'package:examples/language_tour/typedefs/sorted_collection_2.dart'
+    as sorted_collection_2;
+
+void main() {
+  test('sorted_collection_1', () {
+    sorted_collection_1.main(); // contains assertions
+  });
+
+  test('sorted_collection_2', () {
+    sorted_collection_2.main(); // contains assertions
+  });
+
+  test('compare', () {
+    misc.main(); // contains assertions
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/variables_test.dart
+++ b/null_safety_examples/misc/test/language_tour/variables_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('var-null-init', () {
+    // #docregion var-null-init
+    int lineCount;
+    assert(lineCount == null);
+    // #enddocregion var-null-init
+  });
+}

--- a/null_safety_examples/misc/test/language_tour/variables_test.dart
+++ b/null_safety_examples/misc/test/language_tour/variables_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 void main() {
   test('var-null-init', () {
     // #docregion var-null-init
-    int lineCount;
+    int? lineCount;
     assert(lineCount == null);
     // #enddocregion var-null-init
   });


### PR DESCRIPTION
As requested by @kwalrath.

In most cases the changes are transparent to the Language Tour guide and happen outside the code excerpts that get imported.

The most complex cases to solve is what to do with simple classes with one or more members. I went case by case and made them nullable, gave them a default value or marked them as `late` depending on what made more sense.

I also left some comments pointing to changes that should be done in the markdown file as well.