### PR TITLE
Clean up ImmutablePoint.origin

### DIFF
--- a/examples/misc/lib/language_tour/classes/immutable_point.dart
+++ b/examples/misc/lib/language_tour/classes/immutable_point.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: sort_constructors_first
 class ImmutablePoint {
-  static final ImmutablePoint origin =
-      const ImmutablePoint(0, 0);
+  static const ImmutablePoint origin = ImmutablePoint(0, 0);
 
   final double x, y;
 

--- a/null_safety_examples/misc/lib/language_tour/classes/immutable_point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/immutable_point.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: sort_constructors_first
 class ImmutablePoint {
-  static final ImmutablePoint origin =
-      const ImmutablePoint(0, 0);
+  static const ImmutablePoint origin = ImmutablePoint(0, 0);
 
   final double x, y;
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2941,8 +2941,7 @@ and make sure that all instance variables are `final`.
 <?code-excerpt "misc/lib/language_tour/classes/immutable_point.dart"?>
 ```dart
 class ImmutablePoint {
-  static final ImmutablePoint origin =
-      const ImmutablePoint(0, 0);
+  static const ImmutablePoint origin = ImmutablePoint(0, 0);
 
   final double x, y;
 


### PR DESCRIPTION
Since the field is static, we can specify a single `const` instead of `final` in the declaration.