### PR TITLE
Change dartfmt to dart format

### DIFF
--- a/src/_guides/language/formatting.md
+++ b/src/_guides/language/formatting.md
@@ -1,6 +1,6 @@
 ---
 title: Formatting code
-description: Use dart format to format your code, and follow Effective Dart guidelines for what dart format doesn't cover.
+description: Use `dart format` to format your code, and follow Effective Dart guidelines for what `dart format` doesn't cover.
 toc: false
 ---
 
@@ -11,7 +11,7 @@ If two pieces of code look different it should be because
 they _are_ different in some meaningful way.
 When a bit of code stands out and catches your eye, it should do so for a useful reason.
 
-Fortunately, you can use the [dart format tool][dartfmt] —
+Fortunately, you can use the [`dart format` tool][dartfmt] —
 from the command line or in your favorite [Dart-savvy IDE][ide] —
 to perform most of the drudge work of formatting your code.
 For example, here's how to format all the Dart files
@@ -22,13 +22,13 @@ $ dart format -w bin lib test
 ```
 
 However, dart format can't do it all.
-To avoid making changes that might be unsafe, dart format affects only whitespace.
+To avoid making changes that might be unsafe, `dart format` affects only whitespace.
 For additional guidance, see the Effective Dart
 [style guidelines][], especially the [formatting guidelines][]. 
 
 More information:
 
-* [dart format][dartfmt]
+* [`dart format`][dartfmt]
 * [Effective Dart: Style][style guidelines]
 
 [dartfmt]: /tools/dartfmt

--- a/src/_guides/language/formatting.md
+++ b/src/_guides/language/formatting.md
@@ -1,6 +1,6 @@
 ---
 title: Formatting code
-description: Use dartfmt to format your code, and follow Effective Dart guidelines for what dartfmt doesn't cover.
+description: Use dart format to format your code, and follow Effective Dart guidelines for what dart format doesn't cover.
 toc: false
 ---
 
@@ -11,24 +11,24 @@ If two pieces of code look different it should be because
 they _are_ different in some meaningful way.
 When a bit of code stands out and catches your eye, it should do so for a useful reason.
 
-Fortunately, you can use the [dartfmt tool][dartfmt] —
+Fortunately, you can use the [dart format tool][dartfmt] —
 from the command line or in your favorite [Dart-savvy IDE][ide] —
 to perform most of the drudge work of formatting your code.
 For example, here's how to format all the Dart files
 under the current directory's `bin`, `lib`, and `test` directories:
 
 ```terminal
-$ dartfmt -w bin lib test
+$ dart format -w bin lib test
 ```
 
-However, dartfmt can't do it all.
-To avoid making changes that might be unsafe, dartfmt affects only whitespace.
+However, dart format can't do it all.
+To avoid making changes that might be unsafe, dart format affects only whitespace.
 For additional guidance, see the Effective Dart
 [style guidelines][], especially the [formatting guidelines][]. 
 
 More information:
 
-* [dartfmt][dartfmt]
+* [dart format][dartfmt]
 * [Effective Dart: Style][style guidelines]
 
 [dartfmt]: /tools/dartfmt


### PR DESCRIPTION
Change `dartfmt`  to `dart format`,  related to #2617, 
 

Have a doubt in line 14, 
should [dartfmt]: /tools/dartfmt be changed? 

will it be covered by #2719? 
 