### PR TITLE
Add documentation alert about brew switch being disabled

### DIFF
--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -25,10 +25,9 @@ To switch between locally installed Dart releases, use
 $ brew switch dart 2.10.1
 ```
 
-{{site.alert.important}}
-  The `brew switch` command was removed after the `2.6.0` release of Homebrew.
-  
-  To continue using it, you need to explicitly downgrade Homebrew to the `2.6.0` version by running:
+{{site.alert.version-note}}
+  The `brew switch` command was removed after the 2.6 release of Homebrew.  
+  To continue using it, you need to explicitly downgrade Homebrew to a 2.6 version:
 
   ```terminal
   $ cd /usr/local/Homebrew && git checkout 2.6.2

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -26,9 +26,10 @@ $ brew switch dart 2.10.1
 ```
 
 {{site.alert.version-note}}
-  The `brew switch` command was removed after the 2.6 release of Homebrew.  
-  To continue using it, you need to explicitly downgrade Homebrew to a 2.6 version:
-
+  The `brew switch` command was removed
+  after the 2.6 release of Homebrew.
+  To continue using `brew switch`,
+  downgrade Homebrew to a 2.6 version:
   ```terminal
   $ cd /usr/local/Homebrew && git checkout 2.6.2
   ```

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -25,6 +25,16 @@ To switch between locally installed Dart releases, use
 $ brew switch dart 2.10.1
 ```
 
+{{site.alert.important}}
+  The `brew switch` command was removed after the `2.6.0` release of Homebrew.
+  
+  To continue using it, you need to explicitly downgrade Homebrew to the `2.6.0` version by running:
+
+  ```terminal
+  $ cd /usr/local/Homebrew && git checkout 2.6.2
+  ```
+{{site.alert.end}}
+
 To see which versions of Dart you've installed:
 
 ```terminal


### PR DESCRIPTION
The `brew switch` command is advertised as being the supported method of switching between Dart SDK installs on a Mac. However, versions of Homebrew beyond `2.6.0` no longer support it.

This documentation alert explains how to work around that.

> More context: https://github.com/Homebrew/discussions/discussions/339