### PR TITLE
Update C Interop Tutorial to use new dart tool

### DIFF
--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -42,7 +42,7 @@ The hello_world example has the following files:
 
 | **Source file** | **Description** |
 | [hello.dart]({{ page.hw}}/hello.dart) | A Dart file that uses the `hello_world()` function from a C library. |
-| [pubspec.yaml]({{ page.hw}}/pubspec.yaml) | The usual Dart [pubspec](/tools/pub/pubspec), with a lower bounds on the SDK that's at least 2.5. |
+| [pubspec.yaml]({{ page.hw}}/pubspec.yaml) | The usual Dart [pubspec](/tools/pub/pubspec), with a lower bounds on the SDK that's at least 2.6. |
 | [hello_library/hello.h]({{ page.hw}}/hello_library/hello.h) | Declares the `hello_world()` function. |
 | [hello_library/hello.c]({{ page.hw}}/hello_library/hello.c) | A C file that imports `hello.h` and defines the `hello_world()` function. |
 | [hello_library/CMakeLists.txt]({{ page.hw}}/hello_library/CMakeLists.txt) | A CMake build file for compiling the C code into a dynamic library. |
@@ -71,7 +71,7 @@ $ cmake .
 $ make
 ...
 $ cd ..
-$ dart hello.dart
+$ dart run hello.dart
 Hello World
 ```
 


### PR DESCRIPTION
Fixes part of #2617 
## Description
Update the C Interop Tutorial (`src/_guides/libraries/c-interop.md`) to use the new dart tool. Also, I noticed the SDK version in the `hello_world` example had a lower bound of 2.6, but the lower bound in the tutorial was 2.5, so I updated it.

@kwalrath, please review the changes.