### PR TITLE
Update package:args dependency to 2.0.0, so that dart migrate works

### DIFF
--- a/null_safety_examples/misc/pubspec.yaml
+++ b/null_safety_examples/misc/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
-  args: ^1.5.0
+  args: ^2.0.0
   examples_util:
     path: ../util
   pedantic: ^1.10.0-nullsafety.3


### PR DESCRIPTION
this allows any future code added to `null_safety_examples/` to use the `dart migrate` tool.