### PR TITLE
Add a different color for the banner links on hover/focus

### DIFF
--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -333,6 +333,10 @@ $dash-dartpad-border: #293542;
 
     a {
       color: $site-color-card-link;
+
+      &:hover, &:focus, &:active {
+        color: darken($site-color-card-link, 20%);
+      }
     }
   }
 


### PR DESCRIPTION
Previously since the custom color for the banner links overrode all color styles, there was no hover/focus style change, making it hard to identify a difference.

With this change, a user can now properly identify which link they focused or hovered.

![image](https://user-images.githubusercontent.com/18372958/107455774-f6db0980-6b14-11eb-840e-f84d26bc9120.png)
