### PR TITLE
Migrate effective dart

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/bar/bar.dart
+++ b/null_safety_examples/misc/lib/effective_dart/bar/bar.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/design_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_bad.dart
@@ -96,7 +96,7 @@ void miscDeclAnalyzedButNotTested() {
   // #docregion future-or
   FutureOr<int> triple(FutureOr<int> value) {
     if (value is int) return value * 3;
-    return (value as Future<int>).then((v) => v * 3);
+    return value.then((v) => v * 3);
   }
   // #enddocregion future-or
 
@@ -182,6 +182,7 @@ class Person1 {
   // #enddocregion eq-dont-check-for-null
   Person1(this.name);
   int get hashCode => ellipsis();
+  // ignore_for_file: unnecessary_null_comparison
   // #docregion eq-dont-check-for-null
   bool operator ==(other) => other != null && ellipsis();
 }

--- a/null_safety_examples/misc/lib/effective_dart/design_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_bad.dart
@@ -1,0 +1,188 @@
+// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable, avoid_types_as_parameter_names, sort_constructors_first, unused_field
+
+import 'dart:async';
+
+import 'package:examples_util/ellipsis.dart';
+
+import 'design_good.dart';
+
+void miscDeclAnalyzedButNotTested() {
+  (errors, monsters, subscription) {
+    // #docregion code-like-prose
+    // Telling errors to empty itself, or asking if it is?
+    if (errors.empty as bool) {/*-...-*/}
+
+    // Toggle what? To what?
+    subscription.toggle();
+
+    // Filter the monsters with claws *out* or include *only* those?
+    monsters.filter((monster) => monster.hasClaws);
+    // #enddocregion code-like-prose
+
+    Iterable theCollectionOfErrors = [];
+    // #docregion code-like-prose-overdone
+    if (theCollectionOfErrors.isEmpty) {/*-...-*/}
+
+    monsters.producesANewSequenceWhereEach((monster) => monster.hasClaws);
+    // #enddocregion code-like-prose-overdone
+  };
+
+  (Socket socket, Database database) {
+    // #docregion positive
+    if (!socket.isDisconnected && !database.isEmpty) {
+      socket.write(database.read());
+    }
+    // #enddocregion positive
+  };
+
+  {
+    // #docregion cascades
+    var buffer = StringBuffer0() //!<br>
+        .write('one')
+        .write('two')
+        .write('three');
+    // #enddocregion cascades
+  }
+
+  {
+    // #docregion type_annotate_public_apis
+    install(id, destination) => ellipsis();
+    // #enddocregion type_annotate_public_apis
+  }
+
+  {
+    // #docregion func-expr-no-param-type
+    var names = people.map((Person person) => person.name);
+    // #enddocregion func-expr-no-param-type
+  }
+
+  {
+    // #docregion omit-types-on-locals
+    List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
+      List<List<Ingredient>> desserts = <List<Ingredient>>[];
+      for (List<Ingredient> recipe in cookbook) {
+        if (pantry.containsAll(recipe)) {
+          desserts.add(recipe);
+        }
+      }
+
+      return desserts;
+    }
+    // #enddocregion omit-types-on-locals
+  }
+
+  {
+    // #docregion redundant
+    Set<String> things = Set<String>();
+    // #enddocregion redundant
+  }
+
+  {
+    // #docregion explicit
+    var things = Set();
+    // #enddocregion explicit
+  }
+
+  {
+    // #docregion prefer-dynamic
+    mergeJson(original, changes) => ellipsis();
+    // #enddocregion prefer-dynamic
+  }
+
+  // #docregion avoid-Function
+  bool isValid(String value, Function test) => ellipsis();
+  // #enddocregion avoid-Function
+
+  // #docregion future-or
+  FutureOr<int> triple(FutureOr<int> value) {
+    if (value is int) return value * 3;
+    return (value as Future<int>).then((v) => v * 3);
+  }
+  // #enddocregion future-or
+
+  (int start) {
+    // #docregion avoid-mandatory-param
+    var rest = string.substring(start, null);
+    // #enddocregion avoid-mandatory-param
+  };
+}
+
+class MyIterable<T> {
+  // #docregion function-type-param
+  Iterable<T> where(bool predicate(T element)) => ellipsis();
+  // #enddocregion function-type-param
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion old-typedef
+typedef int Comparison<T>(T a, T b);
+// #enddocregion old-typedef
+
+// #docregion typedef-param
+typedef bool TestNumber(num);
+// #enddocregion typedef-param
+
+//----------------------------------------------------------------------------
+
+class StringBuffer0 {
+  StringBuffer0 write(dynamic _) => this;
+}
+
+//----------------------------------------------------------------------------
+// ignore_for_file: one_member_abstracts
+
+// #docregion one-member-abstract-class
+abstract class Predicate<E> {
+  bool test(E element);
+}
+// #enddocregion one-member-abstract-class
+
+//----------------------------------------------------------------------------
+
+// #docregion class-only-static
+class DateUtils {
+  static DateTime mostRecent(List<DateTime> dates) {
+    return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+  }
+}
+
+class _Favorites {
+  static const mammal = 'weasel';
+}
+// #enddocregion class-only-static
+
+//----------------------------------------------------------------------------
+
+// #docregion class-only-static-exception
+class Color {
+  static const red = '#f00';
+  static const green = '#0f0';
+  static const blue = '#00f';
+  static const black = '#000';
+  static const white = '#fff';
+}
+// #enddocregion class-only-static-exception
+
+//----------------------------------------------------------------------------
+// ignore_for_file: avoid_return_types_on_setters
+
+class C<Foo> {
+  // #docregion avoid_return_types_on_setters
+  void set foo(Foo value) {/* ... */}
+  // #enddocregion avoid_return_types_on_setters
+}
+
+//----------------------------------------------------------------------------
+// ignore_for_file: annotate_overrides
+
+// #docregion eq-dont-check-for-null
+class Person1 {
+  final String name;
+  // #enddocregion eq-dont-check-for-null
+  Person1(this.name);
+  int get hashCode => ellipsis();
+  // #docregion eq-dont-check-for-null
+  bool operator ==(other) => other != null && ellipsis();
+}
+// #enddocregion eq-dont-check-for-null

--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -1,0 +1,499 @@
+// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable, sort_constructors_first
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:examples_util/ellipsis.dart';
+
+typedef Func1<S, T> = S Function(T _);
+
+dynamic element, key, value;
+ByteBuffer bytes = Int8List(0).buffer;
+DateTime dateTime = DateTime.now();
+List list = [];
+Map map = {};
+String string = '';
+StreamSubscription subscription = Stream.empty().listen((_) {});
+
+void miscDeclAnalyzedButNotTested() {
+  (Iterable errors, Iterable<Monster> monsters) {
+    // #docregion code-like-prose
+    // "If errors is empty..."
+    if (errors.isEmpty) {/*-...-*/}
+
+    // "Hey, subscription, cancel!"
+    subscription.cancel();
+
+    // "Get the monsters where the monster has claws."
+    monsters.where((monster) => monster.hasClaws);
+    // #enddocregion code-like-prose
+  };
+
+  (Func1 entryPoint, message, Iterable elements, String pattern) {
+    // #docregion omit-verb-for-bool-param
+    Isolate.spawn(entryPoint, message, paused: false);
+    var copy = List.from(elements, growable: true);
+    var regExp = RegExp(pattern, caseSensitive: false);
+    // #enddocregion omit-verb-for-bool-param
+  };
+
+  (Queue queue, window, connection) {
+    // #docregion verb-for-func-with-side-effect
+    list.add("element");
+    queue.removeFirst();
+    window.refresh();
+    // #enddocregion verb-for-func-with-side-effect
+  };
+
+  (bool Function(dynamic) test) {
+    // #docregion noun-for-func-returning-value
+    var element = list.elementAt(3);
+    var first = list.firstWhere(test);
+    var char = string.codeUnitAt(4);
+    // #enddocregion noun-for-func-returning-value
+  };
+
+  (database, packageGraph) {
+    // #docregion verb-for-func-with-work
+    var table = database.downloadData();
+    var packageVersions = packageGraph.solveConstraints();
+    // #enddocregion verb-for-func-with-work
+  };
+
+  (stackTrace) {
+    // #docregion to___
+    list.toSet();
+    stackTrace.toString();
+    dateTime.toLocal();
+    // #enddocregion to___
+  };
+
+  () {
+    dynamic table;
+    // #docregion as___
+    var map = table.asMap();
+    var list = bytes.asFloat32List();
+    var future = subscription.asFuture();
+    // #enddocregion as___
+  };
+
+  () {
+    // #docregion avoid-desc-param-in-func
+    list.add(element);
+    map.remove(key);
+    // #enddocregion avoid-desc-param-in-func
+  };
+
+  () {
+    // #docregion desc-param-in-func-ok
+    map.containsKey(key);
+    map.containsValue(value);
+    // #enddocregion desc-param-in-func-ok
+  };
+
+  () {
+    // #docregion class-only-static
+    DateTime mostRecent(List<DateTime> dates) {
+      return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+    }
+
+    const _favoriteMammal = 'weasel';
+    // #enddocregion class-only-static
+  };
+
+  (Socket socket, Database database) {
+    // #docregion positive
+    if (socket.isConnected && database.hasData) {
+      socket.write(database.read());
+    }
+    // #enddocregion positive
+  };
+
+  () {
+    // #docregion cascades
+    var buffer = StringBuffer() //!<br>
+      ..write('one')
+      ..write('two')
+      ..write('three');
+    // #enddocregion cascades
+  };
+
+  // #docregion annotate-declaration
+  bool isEmpty(String parameter) {
+    bool result = parameter.isEmpty;
+    return result;
+  }
+  // #enddocregion annotate-declaration
+
+  {
+    // #docregion annotate-invocation
+    var lists = <num>[1, 2];
+    lists.addAll(List<num>.filled(3, 4));
+    lists.cast<int>();
+    // #enddocregion annotate-invocation
+  }
+
+  {
+    // #docregion annotate-type-arg
+    List<int> ints = [1, 2];
+    // #enddocregion annotate-type-arg
+  }
+
+  <PackageId>() {
+    // #docregion type_annotate_public_apis
+    Future<bool> install(PackageId id, String destination) => ellipsis();
+    // #enddocregion type_annotate_public_apis
+
+    // #docregion inferred
+    const screenWidth = 640; // Inferred as int.
+    // #enddocregion inferred
+  };
+
+  {
+    // #docregion func-expr-no-param-type
+    var names = people.map((person) => person.name);
+    // #enddocregion func-expr-no-param-type
+  }
+
+  {
+    // #docregion omit-types-on-locals
+    List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
+      var desserts = <List<Ingredient>>[];
+      for (var recipe in cookbook) {
+        if (pantry.containsAll(recipe)) {
+          desserts.add(recipe);
+        }
+      }
+
+      return desserts;
+    }
+    // #enddocregion omit-types-on-locals
+  }
+
+  (AstNode node) {
+    // #docregion uninitialized-local
+    List<AstNode> parameters;
+    if (node is Constructor) {
+      parameters = node.signature;
+    } else if (node is Method) {
+      parameters = node.parameters;
+    }
+    // #enddocregion uninitialized-local
+  };
+
+  // #docregion inferred-wrong
+  num highScore(List<num> scores) {
+    num highest = 0;
+    for (var score in scores) {
+      if (score > highest) highest = score;
+    }
+    return highest;
+  }
+  // #enddocregion inferred-wrong
+
+  {
+    // #docregion redundant
+    Set<String> things = Set();
+    // #enddocregion redundant
+  }
+
+  {
+    // #docregion explicit
+    var things = Set<String>();
+    // #enddocregion explicit
+  }
+
+  {
+    // #docregion prefer-dynamic
+    dynamic mergeJson(dynamic original, dynamic changes) => ellipsis();
+    // #enddocregion prefer-dynamic
+  }
+
+  // #docregion avoid-Function
+  bool isValid(String value, bool Function(String) test) => ellipsis();
+  // #enddocregion avoid-Function
+
+  // #docregion function-arity
+  void handleError(void Function() operation, Function errorHandler) {
+    try {
+      operation();
+    } catch (err, stack) {
+      if (errorHandler is Function(Object)) {
+        errorHandler(err);
+      } else if (errorHandler is Function(Object, StackTrace)) {
+        errorHandler(err, stack);
+      } else {
+        throw ArgumentError("errorHandler has wrong signature.");
+      }
+    }
+  }
+  // #enddocregion function-arity
+
+  () {
+    // #docregion Object-vs-dynamic
+    /// Returns a Boolean representation for [arg], which must
+    /// be a String or bool.
+    bool convertToBool(Object arg) {
+      if (arg is bool) return arg;
+      if (arg is String) return arg.toLowerCase() == 'true';
+      throw ArgumentError('Cannot convert $arg to a bool.');
+    }
+    // #enddocregion Object-vs-dynamic
+  };
+
+  // #docregion future-or
+  Future<int> triple(FutureOr<int> value) async => (await value) * 3;
+  // #enddocregion future-or
+
+  // #docregion future-or-contra
+  Stream<S> asyncMap<T, S>(
+      Iterable<T> iterable, FutureOr<S> Function(T) callback) async* {
+    for (var element in iterable) {
+      yield await callback(element);
+    }
+  }
+  // #enddocregion future-or-contra
+
+  () {
+    // #docregion avoid-positional-bool-param
+    Task.oneShot();
+    Task.repeating();
+    ListBox(scroll: true, showScrollbars: true);
+    Button(ButtonState.enabled);
+    // #enddocregion avoid-positional-bool-param
+  };
+
+  (int start) {
+    // #docregion avoid-mandatory-param
+    var rest = string.substring(start);
+    // #enddocregion avoid-mandatory-param
+  };
+}
+
+class MyIterable<T> {
+  // #docregion function-type-param
+  Iterable<T> where(bool Function(T) predicate) => ellipsis();
+  // #enddocregion function-type-param
+}
+
+class Event {}
+
+// #docregion function-type
+class FilteredObservable {
+  final bool Function(Event) _predicate;
+  final List<void Function(Event)> _observers;
+
+  FilteredObservable(this._predicate, this._observers);
+
+  void Function(Event) notify(Event event) {
+    if (!_predicate(event)) return null;
+
+    void Function(Event) last;
+    for (var observer in _observers) {
+      observer(event);
+      last = observer;
+    }
+
+    return last;
+  }
+}
+// #enddocregion function-type
+
+//----------------------------------------------------------------------------
+
+// #docregion new-typedef
+typedef Comparison<T> = int Function(T, T);
+// #enddocregion new-typedef
+
+// #docregion new-typedef-param-name
+typedef Comparison2<T> = int Function(T a, T b);
+// #enddocregion new-typedef-param-name
+
+//----------------------------------------------------------------------------
+// Supporting declarations
+
+class AstNode {}
+
+class Constructor extends AstNode {
+  List<AstNode> get signature => [];
+}
+
+class Method extends AstNode {
+  List<AstNode> get parameters => [];
+}
+
+class Socket {
+  bool get isConnected => false;
+  bool get isDisconnected => false;
+  void write(String data) {}
+}
+
+class Database {
+  bool get hasData => false;
+  bool get isEmpty => false;
+  String read() => '';
+}
+
+class Monster {
+  bool hasClaws = false;
+}
+
+List<Person> people = [];
+
+class ListBox {
+  ListBox({bool scroll, bool showScrollbars});
+}
+
+class Button {
+  Button(ButtonState _);
+}
+
+enum ButtonState { enabled }
+
+class Task {
+  Task.oneShot();
+  Task.repeating();
+}
+
+class Ingredient {}
+
+final List<List<Ingredient>> cookbook = [];
+
+//----------------------------------------------------------------------------
+
+// #docregion type-parameter-e
+class IterableBase1<E> {}
+
+class List1<E> {}
+
+class HashSet1<E> {}
+
+class RedBlackTree<E> {}
+// #enddocregion type-parameter-e
+
+// #docregion type-parameter-k-v
+class Map1<K, V> {}
+
+class Multimap<K, V> {}
+
+class MapEntry1<K, V> {}
+// #enddocregion type-parameter-k-v
+
+class BinaryExpression {}
+
+class LiteralExpression {}
+
+class UnaryExpression {}
+
+// #docregion type-parameter-r
+abstract class ExpressionVisitor<R> {
+  R visitBinary(BinaryExpression node);
+  R visitLiteral(LiteralExpression node);
+  R visitUnary(UnaryExpression node);
+}
+// #enddocregion type-parameter-r
+
+// #docregion type-parameter-t
+class Future1<T> {
+  Future<S> then<S>(FutureOr<S> onValue(T value)) => ellipsis();
+}
+// #enddocregion type-parameter-t
+
+// #docregion type-parameter-graph
+class Graph<N, E> {
+  final List<N> nodes = [];
+  final List<E> edges = [];
+}
+
+class Graph1<Node, Edge> {
+  final List<Node> nodes = [];
+  final List<Edge> edges = [];
+}
+// #enddocregion type-parameter-graph
+
+//----------------------------------------------------------------------------
+
+class Control {}
+
+// #docregion mixin
+mixin ClickableMixin implements Control {
+  bool _isDown = false;
+
+  void click();
+
+  void mouseDown() {
+    _isDown = true;
+  }
+
+  void mouseUp() {
+    if (_isDown) click();
+    _isDown = false;
+  }
+}
+// #enddocregion mixin
+
+//----------------------------------------------------------------------------
+
+// #docregion one-member-abstract-class
+typedef Predicate<E> = bool Function(E element);
+// #enddocregion one-member-abstract-class
+
+//----------------------------------------------------------------------------
+
+class C<Foo> {
+  // #docregion avoid_return_types_on_setters
+  set foo(Foo value) {/* ... */}
+// #enddocregion avoid_return_types_on_setters
+}
+
+//----------------------------------------------------------------------------
+
+class String0 {
+  // #docregion omit-optional-positional
+  String0.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
+
+  // #enddocregion omit-optional-positional
+}
+
+class DateTime0 {
+  // #docregion omit-optional-positional
+  DateTime0(int year,
+      [int month = 1,
+      int day = 1,
+      int hour = 0,
+      int minute = 0,
+      int second = 0,
+      int millisecond = 0,
+      int microsecond = 0]);
+
+  // #enddocregion omit-optional-positional
+}
+
+class Duration0 {
+  // #docregion omit-optional-positional
+  Duration0(
+      {int days = 0,
+      int hours = 0,
+      int minutes = 0,
+      int seconds = 0,
+      int milliseconds = 0,
+      int microseconds = 0});
+  // #enddocregion omit-optional-positional
+}
+
+//----------------------------------------------------------------------------
+// ignore_for_file: annotate_overrides
+
+// #docregion eq-dont-check-for-null
+class Person {
+  final String name;
+  // #enddocregion eq-dont-check-for-null
+  Person(this.name);
+  // #docregion eq-dont-check-for-null
+  bool operator ==(other) => other is Person && name == other.name;
+
+  int get hashCode => name.hashCode;
+}
+// #enddocregion eq-dont-check-for-null

--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -287,10 +287,10 @@ class FilteredObservable {
 
   FilteredObservable(this._predicate, this._observers);
 
-  void Function(Event) notify(Event event) {
+  void Function(Event)? notify(Event event) {
     if (!_predicate(event)) return null;
 
-    void Function(Event) last;
+    void Function(Event)? last;
     for (var observer in _observers) {
       observer(event);
       last = observer;
@@ -343,7 +343,7 @@ class Monster {
 List<Person> people = [];
 
 class ListBox {
-  ListBox({bool scroll, bool showScrollbars});
+  ListBox({required bool scroll, required bool showScrollbars});
 }
 
 class Button {
@@ -452,7 +452,7 @@ class C<Foo> {
 
 class String0 {
   // #docregion omit-optional-positional
-  String0.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
+  String0.fromCharCodes(Iterable<int> charCodes, [int start = 0, int? end]);
 
   // #enddocregion omit-optional-positional
 }

--- a/null_safety_examples/misc/lib/effective_dart/docs_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/docs_bad.dart
@@ -1,0 +1,74 @@
+// ignore_for_file: type_annotate_public_apis, unused_element
+import 'package:examples_util/ellipsis.dart';
+
+void miscDeclAnalyzedButNotTested() {
+  // #docregion block-comments
+  greet(name) {
+    /* Assume we have a valid name. */
+    print('Hi, $name!');
+  }
+  // #enddocregion block-comments
+
+  {
+    // #docregion first-sentence
+    /// Depending on the state of the file system and the user's permissions,
+    /// certain operations may or may not be possible. If there is no file at
+    /// [path] or it can't be accessed, this function throws either [IOError]
+    /// or [PermissionError], respectively. Otherwise, this deletes the file.
+    void delete(String path) {
+      ellipsis();
+    }
+    // #enddocregion first-sentence
+  }
+
+  {
+    // #docregion first-sentence-a-paragraph
+    /// Deletes the file at [path]. Throws an [IOError] if the file could not
+    /// be found. Throws a [PermissionError] if the file is present but could
+    /// not be deleted.
+    void delete(String path) {
+      ellipsis();
+    }
+    // #enddocregion first-sentence-a-paragraph
+  }
+}
+
+class IOError {}
+
+class PermissionError {}
+
+class Widget {}
+
+// #docregion redundant
+class RadioButtonWidget extends Widget {
+  /// Sets the tooltip for this radio button widget to the list of strings in
+  /// [lines].
+  void tooltip(List<String> lines) {
+    ellipsis();
+  }
+}
+// #enddocregion redundant
+
+class C<ChunkBuilder, Flag, LineWriter> {
+  // #docregion no-annotations
+  /// Defines a flag with the given name and abbreviation.
+  ///
+  /// @param name The name of the flag.
+  /// @param abbr The abbreviation for the flag.
+  /// @returns The new flag.
+  /// @throws ArgumentError If there is already an option with
+  ///     the given name or abbreviation.
+  Flag addFlag(String name, String abbr) => ellipsis();
+  // #enddocregion no-annotations
+}
+
+class Component {
+  const Component({String selector = ''});
+}
+
+// #docregion doc-before-meta
+@Component(selector: 'toggle')
+
+/// A button that can be flipped on and off.
+class ToggleComponent {}
+// #enddocregion doc-before-meta

--- a/null_safety_examples/misc/lib/effective_dart/docs_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/docs_good.dart
@@ -1,0 +1,223 @@
+// ignore_for_file: type_annotate_public_apis, unused_element
+
+import 'package:examples_util/ellipsis.dart';
+
+void miscDeclAnalyzedButNotTested() {
+  (Iterable _chunks) {
+    // #docregion comments-like-sentences
+    // Not if there is nothing before it.
+    if (_chunks.isEmpty) return false;
+    // #enddocregion comments-like-sentences
+    return true;
+  };
+
+  // #docregion block-comments
+  greet(name) {
+    // Assume we have a valid name.
+    print('Hi, $name!');
+  }
+  // #enddocregion block-comments
+
+  <Flag>() {
+    // #docregion no-annotations
+    /// Defines a flag.
+    ///
+    /// Throws an [ArgumentError] if there is already an option named [name] or
+    /// there is already an option using abbreviation [abbr]. Returns the new flag.
+    Flag addFlag(String name, String abbr) => ellipsis();
+    // #enddocregion no-annotations
+  };
+
+  {
+    // #docregion first-sentence
+    /// Deletes the file at [path] from the file system.
+    void delete(String path) {
+      ellipsis();
+    }
+    // #enddocregion first-sentence
+  }
+
+  {
+    // #docregion first-sentence-a-paragraph
+    /// Deletes the file at [path].
+    ///
+    /// Throws an [IOError] if the file could not be found. Throws a
+    /// [PermissionError] if the file is present but could not be deleted.
+    void delete(String path) {
+      ellipsis();
+    }
+    // #enddocregion first-sentence-a-paragraph
+  }
+
+  <T>() {
+    // #docregion third-person
+    /// Returns `true` if every element satisfies the [predicate].
+    bool all(bool predicate(T element)) => ellipsis();
+
+    /// Starts the stopwatch if not already running.
+    void start() {
+      ellipsis();
+    }
+    // #enddocregion third-person
+  };
+
+  // #docregion code-sample
+  /// Returns the lesser of two numbers.
+  ///
+  /// ```dart
+  /// min(5, 3) == 3
+  /// ```
+  num min(num a, num b) => ellipsis();
+  // #enddocregion code-sample
+
+  () {
+    void anotherMethod() {}
+
+    // #docregion identifiers
+    /// Throws a [StateError] if ...
+    /// similar to [anotherMethod()], but ...
+    // #enddocregion identifiers
+
+    // #docregion member
+    /// Similar to [Duration.inDays], but handles fractional days.
+    // #enddocregion member
+    void method1() {}
+
+    // #docregion ctor
+    /// To create a point, call [Point()] or use [Point.polar()] to ...
+    // #enddocregion ctor
+    void method2() {}
+  };
+
+  // #docregion markdown
+  /// This is a paragraph of regular text.
+  ///
+  /// This sentence has *two* _emphasized_ words (italics) and **two**
+  /// __strong__ ones (bold).
+  ///
+  /// A blank line creates a separate paragraph. It has some `inline code`
+  /// delimited using backticks.
+  ///
+  /// * Unordered lists.
+  /// * Look like ASCII bullet lists.
+  /// * You can also use `-` or `+`.
+  ///
+  /// 1. Numbered lists.
+  /// 2. Are, well, numbered.
+  /// 1. But the values don't matter.
+  ///
+  ///     * You can nest lists too.
+  ///     * They must be indented at least 4 spaces.
+  ///     * (Well, 5 including the space after `///`.)
+  ///
+  /// Code blocks are fenced in triple backticks:
+  ///
+  /// ```
+  /// this.code
+  ///     .will
+  ///     .retain(its, formatting);
+  /// ```
+  ///
+  /// The code language (for syntax highlighting) defaults to Dart. You can
+  /// specify it by putting the name of the language after the opening backticks:
+  ///
+  /// ```html
+  /// <h1>HTML is magical!</h1>
+  /// ```
+  ///
+  /// Links can be:
+  ///
+  /// * https://www.just-a-bare-url.com
+  /// * [with the URL inline](https://google.com)
+  /// * [or separated out][ref link]
+  ///
+  /// [ref link]: https://google.com
+  ///
+  /// # A Header
+  ///
+  /// ## A subheader
+  ///
+  /// ### A subsubheader
+  ///
+  /// #### If you need this many levels of headers, you're doing it wrong
+  // #enddocregion markdown
+}
+
+class IOError {}
+
+class PermissionError {}
+
+class Widget {}
+
+// #docregion redundant
+class RadioButtonWidget extends Widget {
+  /// Sets the tooltip to [lines], which should have been word wrapped using
+  /// the current font.
+  void tooltip(List<String> lines) {
+    ellipsis();
+  }
+}
+// #enddocregion redundant
+
+//----------------------------------------------------------------------------
+
+class Point {
+  Point();
+  Point.polar();
+}
+
+//----------------------------------------------------------------------------
+
+class C0 {
+  // #docregion use-doc-comments
+  /// The number of characters in this chunk when unsplit.
+  int get length => ellipsis();
+// #enddocregion use-doc-comments
+}
+
+//----------------------------------------------------------------------------
+
+class C1 {
+  C1(this.weekday);
+
+// #docregion noun-phrases-for-var-etc
+  /// The current day of the week, where `0` is Sunday.
+  int weekday;
+
+  /// The number of checked buttons on the page.
+  int get checkedCount => ellipsis();
+// #enddocregion noun-phrases-for-var-etc
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion noun-phrases-for-type-or-lib
+/// A chunk of non-breaking output text terminated by a hard or soft newline.
+///
+/// ...
+class Chunk {/* ... */}
+// #enddocregion noun-phrases-for-type-or-lib
+
+//----------------------------------------------------------------------------
+
+class Component {
+  const Component({String selector = ''});
+}
+
+// #docregion doc-before-meta
+/// A button that can be flipped on and off.
+@Component(selector: 'toggle')
+class ToggleComponent {}
+// #enddocregion doc-before-meta
+
+//----------------------------------------------------------------------------
+
+// #docregion this
+class Box {
+  /// The value this wraps.
+  var _value;
+
+  /// True if this box contains a value.
+  bool get hasValue => _value != null;
+}
+// #enddocregion this

--- a/null_safety_examples/misc/lib/effective_dart/foo.dart
+++ b/null_safety_examples/misc/lib/effective_dart/foo.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/foo/SliderMenu.dart
+++ b/null_safety_examples/misc/lib/effective_dart/foo/SliderMenu.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/foo/file_system.dart
+++ b/null_safety_examples/misc/lib/effective_dart/foo/file_system.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/foo/foo.dart
+++ b/null_safety_examples/misc/lib/effective_dart/foo/foo.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/foo/slider_menu.dart
+++ b/null_safety_examples/misc/lib/effective_dart/foo/slider_menu.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/my_library.dart
+++ b/null_safety_examples/misc/lib/effective_dart/my_library.dart
@@ -1,0 +1,3 @@
+library my_library;
+
+part "some/other/file.dart";

--- a/null_safety_examples/misc/lib/effective_dart/some/other/file.dart
+++ b/null_safety_examples/misc/lib/effective_dart/some/other/file.dart
@@ -1,0 +1,1 @@
+part of "../../my_library.dart";

--- a/null_safety_examples/misc/lib/effective_dart/some/other/file_2.dart
+++ b/null_safety_examples/misc/lib/effective_dart/some/other/file_2.dart
@@ -1,0 +1,1 @@
+part of my_library;

--- a/null_safety_examples/misc/lib/effective_dart/src/error.dart
+++ b/null_safety_examples/misc/lib/effective_dart/src/error.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/src/foo_bar.dart
+++ b/null_safety_examples/misc/lib/effective_dart/src/foo_bar.dart
@@ -1,0 +1,1 @@
+// Purposefully empty. Used only to illustrate imports.

--- a/null_safety_examples/misc/lib/effective_dart/style_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/style_bad.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, type_annotate_public_apis, curly_braces_in_flow_control_structures
+import 'dart:math';
+
+// #docregion const-names
+const PI = 3.14;
+const DefaultTimeout = 1000;
+final URL_SCHEME = RegExp('^([a-z]+):');
+
+class Dice {
+  static final NUMBER_GENERATOR = Random();
+}
+// #enddocregion const-names
+
+oneLineIf(dynamic overflowChars, dynamic other) {
+  // #docregion one-line-if-wrap
+  if (overflowChars != other.overflowChars)
+    return overflowChars < other.overflowChars;
+  // #enddocregion one-line-if-wrap
+}

--- a/null_safety_examples/misc/lib/effective_dart/style_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/style_good.dart
@@ -1,0 +1,123 @@
+// ignore_for_file: annotate_overrides, type_annotate_public_apis, unused_element, unused_local_variable, sdk_version_extension_methods
+import 'dart:io';
+import 'dart:math';
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    // #docregion misc-names
+    var item;
+
+    HttpRequest httpRequest;
+
+    void align(bool clearItems) {
+      // ...
+    }
+    // #enddocregion misc-names
+  }
+
+  <IOStream, Id, DBIOPort, TVVcr>(uiHandler) => [
+        // #docregion acronyms-and-abbreviations
+        HttpConnectionInfo,
+        uiHandler,
+        IOStream,
+        HttpRequest,
+        Id,
+        DBIOPort,
+        TVVcr
+        // #enddocregion acronyms-and-abbreviations
+      ];
+
+  (bool isWeekDay) {
+    // #docregion curly-braces
+    if (isWeekDay) {
+      print('Bike to work!');
+    } else {
+      print('Go dancing or read a book!');
+    }
+    // #enddocregion curly-braces
+  };
+
+  (arg, defaultValue) {
+    // #docregion one-line-if
+    if (arg == null) return defaultValue;
+    // #enddocregion one-line-if
+  };
+
+  (dynamic overflowChars, dynamic other) {
+    // #docregion one-line-if-wrap
+    if (overflowChars != other.overflowChars) {
+      return overflowChars < other.overflowChars;
+    }
+    // #enddocregion one-line-if-wrap
+  };
+}
+
+//----------------------------------------------------------------------------
+
+class SomeType {}
+
+//----------------------------------------------------------------------------
+
+// #docregion type-names
+class SliderMenu {/* ... */}
+
+class HttpRequest {/* ... */}
+
+typedef Predicate<T> = bool Function(T value);
+// #enddocregion type-names
+
+//----------------------------------------------------------------------------
+
+const anArg = null;
+
+// #docregion annotation-type-names
+class Foo {
+  const Foo([arg]);
+}
+
+@Foo(anArg)
+class A {/* ... */}
+
+@Foo()
+class B {/* ... */}
+// #enddocregion annotation-type-names
+
+//----------------------------------------------------------------------------
+
+// #docregion annotation-const
+const foo = Foo();
+
+@foo
+class C {/* ... */}
+// #enddocregion annotation-const
+
+//----------------------------------------------------------------------------
+
+// #docregion const-names
+const pi = 3.14;
+const defaultTimeout = 1000;
+final urlScheme = RegExp('^([a-z]+):');
+
+class Dice {
+  static final numberGenerator = Random();
+}
+// #enddocregion const-names
+
+//----------------------------------------------------------------------------
+
+unusedCallbackParams() {
+  var futureOfVoid = Future<void>.value();
+  // #docregion unused-callback-params
+  futureOfVoid.then((_) {
+    print('Operation complete.');
+  });
+  // #enddocregion unused-callback-params
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion extension-names
+extension MyFancyList<T> on List<T> {/* ... */}
+
+extension SmartIterable<T> on Iterable<T> {/* ... */}
+// #enddocregion extension-names

--- a/null_safety_examples/misc/lib/effective_dart/style_lib_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/style_lib_bad.dart
@@ -1,0 +1,16 @@
+// ignore_for_file: unused_import
+// #docregion export
+import 'src/error.dart';
+export 'src/error.dart';
+import 'src/foo_bar.dart';
+// #enddocregion export
+
+//----------------------------------------------------------------------------
+
+// #docregion sorted
+import 'package:examples/effective_dart/foo/foo.dart';
+import 'package:examples/effective_dart/bar/bar.dart';
+
+import 'foo/foo.dart';
+import 'foo.dart';
+// #enddocregion sorted

--- a/null_safety_examples/misc/lib/effective_dart/style_lib_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/style_lib_good.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: unused_import
+// #docregion
+library peg_parser.source_scanner;
+
+import 'foo/file_system.dart';
+import 'foo/slider_menu.dart';
+// #enddocregion
+
+//----------------------------------------------------------------------------
+
+// #docregion import-as
+import 'dart:math' as math;
+import 'package:examples/effective_dart/foo.dart'
+    as angular_components;
+import 'package:js/js.dart' as js;
+// #enddocregion import-as
+
+//----------------------------------------------------------------------------
+
+// #docregion dart-import-first
+import 'dart:async';
+import 'dart:html';
+
+// #docregion pkg-import-before-local, sorted
+import 'package:examples/effective_dart/bar/bar.dart';
+import 'package:examples/effective_dart/foo/foo.dart';
+// #enddocregion dart-import-first, pkg-import-before-local, sorted
+
+// #docregion pkg-import-before-local, sorted
+
+import 'foo.dart';
+// #enddocregion pkg-import-before-local
+import 'foo/foo.dart';
+// #enddocregion sorted
+
+//----------------------------------------------------------------------------
+// #docregion export
+import 'src/error.dart';
+import 'src/foo_bar.dart';
+
+export 'src/error.dart';
+// #enddocregion export

--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -1,0 +1,412 @@
+// ignore_for_file: avoid_init_to_null, empty_constructor_bodies, final_not_initialized_constructor_1, prefer_is_not_empty, sort_constructors_first, type_annotate_public_apis, type_init_formals, unnecessary_brace_in_string_interps, unnecessary_getters_setters, unused_element, unused_local_variable, prefer_equal_for_default_values, use_rethrow_when_possible, prefer_is_empty, prefer_iterable_wheretype
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'usage_good.dart';
+
+class EnableableThing {
+  bool isEnabled;
+  EnableableThing(this.isEnabled);
+}
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    // ignore_for_file: null_aware_in_condition
+    var optionalThing = EnableableThing(true);
+    // #docregion null-aware-condition
+    if (optionalThing?.isEnabled) {
+      print("Have enabled thing.");
+    }
+    // #enddocregion null-aware-condition
+  }
+
+  {
+    dynamic optionalThing;
+    // #docregion convert-null-equals
+    // If you want null to be false:
+    optionalThing?.isEnabled == true;
+
+    // If you want null to be true:
+    optionalThing?.isEnabled != false;
+    // #enddocregion convert-null-equals
+  }
+
+  {
+    // #docregion adjacent-strings-literals
+    raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
+        'parts are overrun by martians. Unclear which are which.');
+    // #enddocregion adjacent-strings-literals
+  }
+
+  (String name, int year, int birth) {
+    // #docregion string-interpolation
+    'Hello, ' + name + '! You are ' + (year - birth).toString() + ' y...';
+    // #enddocregion string-interpolation
+  };
+
+  (name, decade) {
+    return
+        // #docregion string-interpolation-avoid-curly
+        'Hi, ${name}!'
+            "Wear your wildest ${decade}'s outfit."
+        // #enddocregion string-interpolation-avoid-curly
+        ;
+  };
+
+  {
+    // #docregion collection-literals
+    var points = List<Point>();
+    var addresses = Map<String, Address>();
+    var counts = Set<int>();
+    // #enddocregion collection-literals
+  }
+
+  (Iterable lunchBox, Iterable words) {
+    // #docregion dont-use-length
+    if (lunchBox.length == 0) return 'so hungry...';
+    if (!words.isEmpty) return words.join(' ');
+    // #enddocregion dont-use-length
+    return 'foo';
+  };
+
+  (Iterable people) {
+    // #docregion avoid-forEach
+    people.forEach((person) {
+      /*...*/
+    });
+
+    // #enddocregion avoid-forEach
+  };
+
+  {
+    // #docregion where-type
+    var objects = [1, "a", 2, "b", 3];
+    var ints = objects.where((e) => e is int);
+    // #enddocregion where-type
+  }
+
+  {
+    // #docregion cast-list
+    var stuff = <dynamic>[1, 2];
+    var ints = stuff.toList().cast<int>();
+    // #enddocregion cast-list
+  }
+
+  {
+    // #docregion cast-map
+    var stuff = <dynamic>[1, 2];
+    var reciprocals = stuff.map((n) => 1 / (n as int)).cast<double>();
+    // #enddocregion cast-map
+  }
+
+  // #docregion cast-at-create
+  List<int> singletonList(int value) {
+    var list = []; // List<dynamic>.
+    list.add(value);
+    return list.cast<int>();
+  }
+  // #enddocregion cast-at-create
+
+  // #docregion cast-iterate
+  void printEvens(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    for (var n in objects.cast<int>()) {
+      if (n.isEven) print(n);
+    }
+  }
+  // #enddocregion cast-iterate
+
+  // #docregion cast-from
+  int median(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    var ints = objects.cast<int>();
+    ints.sort();
+    return ints[ints.length ~/ 2];
+  }
+  // #enddocregion cast-from
+
+  {
+    // #docregion where-type-2
+    var objects = [1, "a", 2, "b", 3];
+    var ints = objects.where((e) => e is int).cast<int>();
+    // #enddocregion where-type-2
+  }
+
+  {
+    // #docregion func-decl
+    void main() {
+      var localFunction = () {
+        /*...*/
+      };
+    }
+    // #enddocregion func-decl
+  }
+
+  (Iterable names) {
+    // #docregion use-tear-off
+    names.forEach((name) {
+      print(name);
+    });
+    // #enddocregion use-tear-off
+  };
+
+  {
+    // #docregion default-separator
+    void insert(Object item, {int at: 0}) {/* ... */}
+    // #enddocregion default-separator
+  }
+
+  {
+    // #docregion default-value-null
+    void error([String message = null]) {
+      stderr.write(message ?? '\n');
+    }
+    // #enddocregion default-value-null
+  }
+
+  {
+    // #docregion rethrow
+    try {
+      somethingRisky();
+    } catch (e) {
+      if (!canHandle(e)) throw e;
+      handle(e);
+    }
+    // #enddocregion rethrow
+  }
+
+  {
+    // #docregion unnecessary-async
+    Future<void> afterTwoThings(Future<void> first, Future<void> second) async {
+      return Future.wait([first, second]);
+    }
+    // #enddocregion unnecessary-async
+  }
+
+  {
+    // #docregion avoid-completer
+    Future<bool> fileContainsBear(String path) {
+      var completer = Completer<bool>();
+
+      File(path).readAsString().then((contents) {
+        completer.complete(contents.contains('bear'));
+      });
+
+      return completer.future;
+    }
+    // #enddocregion avoid-completer
+  }
+
+  // #docregion test-future-or
+  Future<T> logValue<T>(FutureOr<T> value) async {
+    if (value is T) {
+      print(value);
+      return value;
+    } else {
+      var result = await value;
+      print(result);
+      return result;
+    }
+  }
+  // #enddocregion test-future-or
+
+  (Map<Chest, Treasure> _opened) {
+    // #docregion arrow-long
+    Treasure openChest(Chest chest, Point where) =>
+        _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
+          ..addAll(chest.contents);
+    // #enddocregion arrow-long
+  };
+}
+
+// #docregion this-dot-constructor
+class ShadeOfGray {
+  final int brightness;
+
+  ShadeOfGray(int val) : brightness = val;
+
+  ShadeOfGray.black() : this(0);
+
+  // This won't parse or compile!
+  // ShadeOfGray.alsoBlack() : black();
+}
+// #enddocregion this-dot-constructor
+
+//----------------------------------------------------------------------------
+
+class BadTeam extends Team {
+  @override
+  dynamic get log => null;
+
+  @override
+  // #docregion async-await
+  Future<int> countActivePlayers(String teamName) {
+    return downloadTeam(teamName).then((team) {
+      if (team == null) return Future.value(0);
+
+      return team.roster.then((players) {
+        return players.where((player) => player.isActive).length;
+      });
+    }).catchError((e) {
+      log.error(e);
+      return 0;
+    });
+  }
+  // #enddocregion async-await
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion no-null-init
+int _nextId = null;
+
+class LazyId {
+  int _id = null;
+
+  int get id {
+    if (_nextId == null) _nextId = 0;
+    if (_id == null) _id = _nextId++;
+
+    return _id;
+  }
+}
+// #enddocregion no-null-init
+
+//----------------------------------------------------------------------------
+
+// #docregion cacl-vs-store1
+class Circle1 {
+  double radius;
+  double area;
+  double circumference;
+
+  Circle1(double radius)
+      : radius = radius,
+        area = pi * radius * radius,
+        circumference = pi * 2.0 * radius;
+}
+// #enddocregion cacl-vs-store1
+
+//----------------------------------------------------------------------------
+
+// #docregion cacl-vs-store2
+class Circle2 {
+  double _radius;
+  double get radius => _radius;
+  set radius(double value) {
+    _radius = value;
+    _recalculate();
+  }
+
+  double _area;
+  double get area => _area;
+
+  double _circumference;
+  double get circumference => _circumference;
+
+  Circle2(this._radius) {
+    _recalculate();
+  }
+
+  void _recalculate() {
+    _area = pi * _radius * _radius;
+    _circumference = pi * 2.0 * _radius;
+  }
+}
+// #enddocregion cacl-vs-store2
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-wrap-field
+class Box {
+  var _contents;
+  get contents => _contents;
+  set contents(value) {
+    _contents = value;
+  }
+}
+// #enddocregion dont-wrap-field
+
+//----------------------------------------------------------------------------
+
+// #docregion final
+class Box1 {
+  var _contents;
+  get contents => _contents;
+}
+// #enddocregion final
+
+//----------------------------------------------------------------------------
+
+// #docregion this-dot
+class Box2 {
+  var value;
+
+  void clear() {
+    this.update(null);
+  }
+
+  void update(value) {
+    this.value = value;
+  }
+}
+// #enddocregion this-dot
+
+//----------------------------------------------------------------------------
+
+// #docregion field-init-as-param
+class Point0 {
+  double x, y;
+  Point0(double x, double y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+// #enddocregion field-init-as-param
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-type-init-formals
+class Point1 {
+  int x, y;
+  Point1(int this.x, int this.y);
+}
+// #enddocregion dont-type-init-formals
+
+//----------------------------------------------------------------------------
+
+// #docregion semicolon-for-empty-body
+class Point2 {
+  int x, y;
+  Point2(this.x, this.y) {}
+}
+// #enddocregion semicolon-for-empty-body
+
+//----------------------------------------------------------------------------
+// ignore_for_file: unnecessary_const, unnecessary_new
+
+void unnecessaryNewOrConst() {
+  // #docregion no-new
+  Widget build(BuildContext context) {
+    return new Row(
+      children: [
+        new RaisedButton(
+          child: new Text('Increment'),
+        ),
+        new Text('Click!'),
+      ],
+    );
+  }
+  // #enddocregion no-new
+
+  {
+    // #docregion no-const
+    const primaryColors = const [
+      const Color("red", const [255, 0, 0]),
+      const Color("green", const [0, 255, 0]),
+      const Color("blue", const [0, 0, 255]),
+    ];
+    // #enddocregion no-const
+  }
+}

--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -207,9 +207,9 @@ void miscDeclAnalyzedButNotTested() {
 
   (Map<Chest, Treasure> _opened) {
     // #docregion arrow-long
-    Treasure? openChest(Chest chest, Point where) =>
-        _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
-          ?..addAll(chest.contents);
+    Treasure? openChest(Chest chest, Point where) => _opened.containsKey(chest)
+        ? null
+        : _opened[chest] = (Treasure(where)..addAll(chest.contents));
     // #enddocregion arrow-long
   };
 }

--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -12,23 +12,17 @@ class EnableableThing {
 
 void miscDeclAnalyzedButNotTested() {
   {
-    // ignore_for_file: null_aware_in_condition
-    var optionalThing = EnableableThing(true);
-    // #docregion null-aware-condition
-    if (optionalThing?.isEnabled) {
-      print("Have enabled thing.");
-    }
-    // #enddocregion null-aware-condition
-  }
-
-  {
     dynamic optionalThing;
     // #docregion convert-null-equals
     // If you want null to be false:
-    optionalThing?.isEnabled == true;
+    if (optionalThing?.isEnabled == true) {
+      print("Have enabled thing.");
+    }
 
     // If you want null to be true:
-    optionalThing?.isEnabled != false;
+    if (optionalThing?.isEnabled != false) {
+      print("Have enabled thing or nothing.");
+    }
     // #enddocregion convert-null-equals
   }
 
@@ -56,7 +50,6 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion collection-literals
-    var points = List<Point>();
     var addresses = Map<String, Address>();
     var counts = Set<int>();
     // #enddocregion collection-literals
@@ -159,13 +152,14 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion default-value-null
-    void error([String message = null]) {
+    void error([String? message = null]) {
       stderr.write(message ?? '\n');
     }
     // #enddocregion default-value-null
   }
 
   {
+    // ignore_for_file: only_throw_errors
     // #docregion rethrow
     try {
       somethingRisky();
@@ -178,8 +172,8 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion unnecessary-async
-    Future<void> afterTwoThings(Future<void> first, Future<void> second) async {
-      return Future.wait([first, second]);
+    Future<int> fastestBranch(Future<int> left, Future<int> right) async {
+      return Future.any([left, right]);
     }
     // #enddocregion unnecessary-async
   }
@@ -213,9 +207,9 @@ void miscDeclAnalyzedButNotTested() {
 
   (Map<Chest, Treasure> _opened) {
     // #docregion arrow-long
-    Treasure openChest(Chest chest, Point where) =>
+    Treasure? openChest(Chest chest, Point where) =>
         _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
-          ..addAll(chest.contents);
+          ?..addAll(chest.contents);
     // #enddocregion arrow-long
   };
 }
@@ -258,24 +252,27 @@ class BadTeam extends Team {
 
 //----------------------------------------------------------------------------
 
+class Item {
+  int get price => 0;
+}
+
 // #docregion no-null-init
-int _nextId = null;
+Item? bestDeal(List<Item> cart) {
+  Item? bestItem = null;
 
-class LazyId {
-  int _id = null;
-
-  int get id {
-    if (_nextId == null) _nextId = 0;
-    if (_id == null) _id = _nextId++;
-
-    return _id;
+  for (var item in cart) {
+    if (bestItem == null || item.price < bestItem.price) {
+      bestItem = item;
+    }
   }
+
+  return bestItem;
 }
 // #enddocregion no-null-init
 
 //----------------------------------------------------------------------------
 
-// #docregion cacl-vs-store1
+// #docregion calc-vs-store1
 class Circle1 {
   double radius;
   double area;
@@ -286,11 +283,11 @@ class Circle1 {
         area = pi * radius * radius,
         circumference = pi * 2.0 * radius;
 }
-// #enddocregion cacl-vs-store1
+// #enddocregion calc-vs-store1
 
 //----------------------------------------------------------------------------
 
-// #docregion cacl-vs-store2
+// #docregion calc-vs-store2
 class Circle2 {
   double _radius;
   double get radius => _radius;
@@ -299,10 +296,10 @@ class Circle2 {
     _recalculate();
   }
 
-  double _area;
+  double _area = 0.0;
   double get area => _area;
 
-  double _circumference;
+  double _circumference = 0.0;
   double get circumference => _circumference;
 
   Circle2(this._radius) {
@@ -314,7 +311,7 @@ class Circle2 {
     _circumference = pi * 2.0 * _radius;
   }
 }
-// #enddocregion cacl-vs-store2
+// #enddocregion calc-vs-store2
 
 //----------------------------------------------------------------------------
 
@@ -358,10 +355,9 @@ class Box2 {
 // #docregion field-init-as-param
 class Point0 {
   double x, y;
-  Point0(double x, double y) {
-    this.x = x;
-    this.y = y;
-  }
+  Point0(double x, double y)
+      : x = x,
+        y = y;
 }
 // #enddocregion field-init-as-param
 
@@ -369,8 +365,8 @@ class Point0 {
 
 // #docregion dont-type-init-formals
 class Point1 {
-  int x, y;
-  Point1(int this.x, int this.y);
+  double x, y;
+  Point1(double this.x, double this.y);
 }
 // #enddocregion dont-type-init-formals
 
@@ -378,7 +374,7 @@ class Point1 {
 
 // #docregion semicolon-for-empty-body
 class Point2 {
-  int x, y;
+  double x, y;
   Point2(this.x, this.y) {}
 }
 // #enddocregion semicolon-for-empty-body

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -9,25 +9,31 @@ typedef Func1<S, T> = S Function(T _);
 Func0<Future> longRunningCalculation = () => Future.value();
 Func0 somethingRisky = () {};
 Func1 raiseAlarm = (_) {}, handle = (_) {};
-Func1<bool, dynamic> canHandle = (_) => false,
-    verifyResult = (_) => false;
+Func1<bool, dynamic> canHandle = (_) => false, verifyResult = (_) => false;
+
+class Thing {
+  bool get isEnabled => true;
+}
 
 void miscDeclAnalyzedButNotTested() {
   {
-    dynamic optionalThing;
+    Thing? optionalThing;
     // #docregion convert-null-aware
     // If you want null to be false:
-    optionalThing?.isEnabled ?? false;
+    if (optionalThing?.isEnabled ?? false) {
+      print("Have enabled thing.");
+    }
 
     // If you want null to be true:
-    optionalThing?.isEnabled ?? true;
+    if (optionalThing?.isEnabled ?? true) {
+      print("Have enabled thing or nothing.");
+    }
     // #enddocregion convert-null-aware
   }
 
   {
     // #docregion adjacent-strings-literals
-    raiseAlarm(
-        'ERROR: Parts of the spaceship are on fire. Other '
+    raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
         'parts are overrun by martians. Unclear which are which.');
     // #enddocregion adjacent-strings-literals
   }
@@ -147,7 +153,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion default-value-null
-    void error([String message]) {
+    void error([String? message]) {
       stderr.write(message ?? '\n');
     }
     // #enddocregion default-value-null
@@ -166,9 +172,8 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion unnecessary-async
-    Future<void> afterTwoThings(
-        Future<void> first, Future<void> second) {
-      return Future.wait([first, second]);
+    Future<int> fastestBranch(Future<int> left, Future<int> right) {
+      return Future.any([left, right]);
     }
     // #enddocregion unnecessary-async
   }
@@ -206,7 +211,7 @@ void miscDeclAnalyzedButNotTested() {
       return result;
     } else {
       print(value);
-      return value as T;
+      return value;
     }
   }
   // #enddocregion test-future-or
@@ -256,7 +261,7 @@ class Player {
 
 class Team {
   Future<List<Player>> get roster => Future.value([]);
-  Future<Team> downloadTeam(String name) => Future.value(Team());
+  Future<Team?> downloadTeam(String name) => Future.value(Team());
   dynamic get log => null;
 
   // #docregion async-await
@@ -277,24 +282,27 @@ class Team {
 
 //----------------------------------------------------------------------------
 
+class Item {
+  int get price => 0;
+}
+
 // #docregion no-null-init
-int _nextId;
+Item? bestDeal(List<Item> cart) {
+  Item? bestItem;
 
-class LazyId {
-  int _id;
-
-  int get id {
-    if (_nextId == null) _nextId = 0;
-    if (_id == null) _id = _nextId++;
-
-    return _id;
+  for (var item in cart) {
+    if (bestItem == null || item.price < bestItem.price) {
+      bestItem = item;
+    }
   }
+
+  return bestItem;
 }
 // #enddocregion no-null-init
 
 //----------------------------------------------------------------------------
 
-// #docregion cacl-vs-store
+// #docregion calc-vs-store
 class Circle {
   double radius;
 
@@ -303,7 +311,7 @@ class Circle {
   double get area => pi * radius * radius;
   double get circumference => pi * 2.0 * radius;
 }
-// #enddocregion cacl-vs-store
+// #enddocregion calc-vs-store
 
 //----------------------------------------------------------------------------
 
@@ -334,19 +342,12 @@ class Treasure {
 }
 
 class C {
-  double left = 0.0,
-      right = 0.0,
-      top = 0.0,
-      bottom = 0.0,
-      minTime = 0.0;
+  double left = 0.0, right = 0.0, top = 0.0, bottom = 0.0, minTime = 0.0;
   Point center = Point(0.0, 0.0);
   Map<Chest, Treasure> _opened = {};
 
   // #docregion use-arrow
   double get area => (right - left) * (bottom - top);
-
-  bool isReady(double time) =>
-      minTime == null || minTime <= time;
 
   String capitalize(String name) =>
       '${name[0].toUpperCase()}${name.substring(1)}';
@@ -358,7 +359,7 @@ class C {
   // #enddocregion arrow-setter
 
   // #docregion arrow-long
-  Treasure openChest(Chest chest, Point where) {
+  Treasure? openChest(Chest chest, Point where) {
     if (_opened.containsKey(chest)) return null;
 
     var treasure = Treasure(where);

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -1,0 +1,505 @@
+// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable, sort_constructors_first
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+typedef Func0<T> = T Function();
+typedef Func1<S, T> = S Function(T _);
+
+Func0<Future> longRunningCalculation = () => Future.value();
+Func0 somethingRisky = () {};
+Func1 raiseAlarm = (_) {}, handle = (_) {};
+Func1<bool, dynamic> canHandle = (_) => false,
+    verifyResult = (_) => false;
+
+void miscDeclAnalyzedButNotTested() {
+  {
+    dynamic optionalThing;
+    // #docregion convert-null-aware
+    // If you want null to be false:
+    optionalThing?.isEnabled ?? false;
+
+    // If you want null to be true:
+    optionalThing?.isEnabled ?? true;
+    // #enddocregion convert-null-aware
+  }
+
+  {
+    // #docregion adjacent-strings-literals
+    raiseAlarm(
+        'ERROR: Parts of the spaceship are on fire. Other '
+        'parts are overrun by martians. Unclear which are which.');
+    // #enddocregion adjacent-strings-literals
+  }
+
+  (String name, int year, int birth) {
+    // #docregion string-interpolation
+    'Hello, $name! You are ${year - birth} years old.';
+    // #enddocregion string-interpolation
+  };
+
+  (name, decade) {
+    return
+        // #docregion string-interpolation-avoid-curly
+        'Hi, $name!'
+            "Wear your wildest $decade's outfit."
+            'Wear your wildest ${decade}s outfit.'
+        // #enddocregion string-interpolation-avoid-curly
+        ;
+  };
+
+  {
+    // #docregion collection-literals
+    var points = <Point>[];
+    var addresses = <String, Address>{};
+    var counts = <int>{};
+    // #enddocregion collection-literals
+  }
+
+  (Iterable lunchBox, Iterable words) {
+    // #docregion dont-use-length
+    if (lunchBox.isEmpty) return 'so hungry...';
+    if (words.isNotEmpty) return words.join(' ');
+    // #enddocregion dont-use-length
+    return 'foo';
+  };
+
+  {
+    // #docregion cast-list
+    var stuff = <dynamic>[1, 2];
+    var ints = List<int>.from(stuff);
+    // #enddocregion cast-list
+  }
+
+  {
+    // #docregion cast-map
+    var stuff = <dynamic>[1, 2];
+    var reciprocals = stuff.map<double>((n) => 1 / (n as int));
+    // #enddocregion cast-map
+  }
+
+  // #docregion cast-at-create
+  List<int> singletonList(int value) {
+    var list = <int>[];
+    list.add(value);
+    return list;
+  }
+  // #enddocregion cast-at-create
+
+  // #docregion cast-iterate
+  void printEvens(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    for (var n in objects) {
+      if ((n as int).isEven) print(n);
+    }
+  }
+  // #enddocregion cast-iterate
+
+  // #docregion cast-from
+  int median(List<Object> objects) {
+    // We happen to know the list only contains ints.
+    var ints = List<int>.from(objects);
+    ints.sort();
+    return ints[ints.length ~/ 2];
+  }
+  // #enddocregion cast-from
+
+  (Iterable<Animal> animals) {
+    // #docregion use-higher-order-func
+    var aquaticNames = animals
+        .where((animal) => animal.isAquatic)
+        .map((animal) => animal.name);
+    // #enddocregion use-higher-order-func
+  };
+
+  (Iterable people) {
+    // #docregion avoid-forEach
+    for (var person in people) {
+      /*...*/
+    }
+    // #enddocregion avoid-forEach
+    // #docregion forEach-over-func
+    people.forEach(print);
+    // #enddocregion forEach-over-func
+  };
+
+  {
+    // #docregion func-decl
+    void main() {
+      localFunction() {
+        /*...*/
+      }
+    }
+    // #enddocregion func-decl
+  }
+
+  (Iterable names) {
+    // #docregion use-tear-off
+    names.forEach(print);
+    // #enddocregion use-tear-off
+  };
+
+  {
+    // #docregion default-separator
+    void insert(Object item, {int at = 0}) {/* ... */}
+    // #enddocregion default-separator
+  }
+
+  {
+    // #docregion default-value-null
+    void error([String message]) {
+      stderr.write(message ?? '\n');
+    }
+    // #enddocregion default-value-null
+  }
+
+  {
+    // #docregion rethrow
+    try {
+      somethingRisky();
+    } catch (e) {
+      if (!canHandle(e)) rethrow;
+      handle(e);
+    }
+    // #enddocregion rethrow
+  }
+
+  {
+    // #docregion unnecessary-async
+    Future<void> afterTwoThings(
+        Future<void> first, Future<void> second) {
+      return Future.wait([first, second]);
+    }
+    // #enddocregion unnecessary-async
+  }
+
+  {
+    // ignore_for_file: only_throw_errors
+    // #docregion async
+    Future<void> usesAwait(Future<String> later) async {
+      print(await later);
+    }
+
+    Future<void> asyncError() async {
+      throw 'Error!';
+    }
+
+    Future<void> asyncValue() async => 'value';
+    // #enddocregion async
+  }
+
+  {
+    // #docregion avoid-completer
+    Future<bool> fileContainsBear(String path) {
+      return File(path).readAsString().then((contents) {
+        return contents.contains('bear');
+      });
+    }
+    // #enddocregion avoid-completer
+  }
+
+  // #docregion test-future-or
+  Future<T> logValue<T>(FutureOr<T> value) async {
+    if (value is Future<T>) {
+      var result = await value;
+      print(result);
+      return result;
+    } else {
+      print(value);
+      return value as T;
+    }
+  }
+  // #enddocregion test-future-or
+
+  {
+    // #docregion avoid-completer-alt
+    Future<bool> fileContainsBear(String path) async {
+      var contents = await File(path).readAsString();
+      return contents.contains('bear');
+    }
+    // #enddocregion avoid-completer-alt
+  }
+
+  {
+    // #docregion no-const
+    const primaryColors = [
+      Color("red", [255, 0, 0]),
+      Color("green", [0, 255, 0]),
+      Color("blue", [0, 0, 255]),
+    ];
+    // #enddocregion no-const
+  }
+}
+
+//----------------------------------------------------------------------------
+
+class Address {}
+
+class Animal {
+  String name = '';
+  bool isAquatic = false;
+}
+
+class Person {
+  int zip = 12345;
+}
+
+class Color {
+  const Color(String name, List<int> channels);
+}
+
+//----------------------------------------------------------------------------
+
+class Player {
+  bool get isActive => false;
+}
+
+class Team {
+  Future<List<Player>> get roster => Future.value([]);
+  Future<Team> downloadTeam(String name) => Future.value(Team());
+  dynamic get log => null;
+
+  // #docregion async-await
+  Future<int> countActivePlayers(String teamName) async {
+    try {
+      var team = await downloadTeam(teamName);
+      if (team == null) return 0;
+
+      var players = await team.roster;
+      return players.where((player) => player.isActive).length;
+    } catch (e) {
+      log.error(e);
+      return 0;
+    }
+  }
+  // #enddocregion async-await
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion no-null-init
+int _nextId;
+
+class LazyId {
+  int _id;
+
+  int get id {
+    if (_nextId == null) _nextId = 0;
+    if (_id == null) _id = _nextId++;
+
+    return _id;
+  }
+}
+// #enddocregion no-null-init
+
+//----------------------------------------------------------------------------
+
+// #docregion cacl-vs-store
+class Circle {
+  double radius;
+
+  Circle(this.radius);
+
+  double get area => pi * radius * radius;
+  double get circumference => pi * 2.0 * radius;
+}
+// #enddocregion cacl-vs-store
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-wrap-field
+class Box {
+  var contents;
+}
+// #enddocregion dont-wrap-field
+
+//----------------------------------------------------------------------------
+
+// #docregion final
+class Box1 {
+  final contents = [];
+}
+// #enddocregion final
+
+//----------------------------------------------------------------------------
+
+class Chest {
+  List<String> get contents => [];
+}
+
+class Treasure {
+  Treasure(Point where);
+
+  void addAll(List<String> what) {}
+}
+
+class C {
+  double left = 0.0,
+      right = 0.0,
+      top = 0.0,
+      bottom = 0.0,
+      minTime = 0.0;
+  Point center = Point(0.0, 0.0);
+  Map<Chest, Treasure> _opened = {};
+
+  // #docregion use-arrow
+  double get area => (right - left) * (bottom - top);
+
+  bool isReady(double time) =>
+      minTime == null || minTime <= time;
+
+  String capitalize(String name) =>
+      '${name[0].toUpperCase()}${name.substring(1)}';
+  // #enddocregion use-arrow
+
+  // #docregion arrow-setter
+  num get x => center.x;
+  set x(num value) => center = Point(value, center.y);
+  // #enddocregion arrow-setter
+
+  // #docregion arrow-long
+  Treasure openChest(Chest chest, Point where) {
+    if (_opened.containsKey(chest)) return null;
+
+    var treasure = Treasure(where);
+    treasure.addAll(chest.contents);
+    _opened[chest] = treasure;
+    return treasure;
+  }
+  // #enddocregion arrow-long
+}
+
+//----------------------------------------------------------------------------
+
+// #docregion this-dot
+class Box2 {
+  var value;
+
+  void clear() {
+    update(null);
+  }
+
+  void update(value) {
+    this.value = value;
+  }
+}
+// #enddocregion this-dot
+
+//----------------------------------------------------------------------------
+
+// #docregion this-dot-constructor
+class ShadeOfGray {
+  final int brightness;
+
+  ShadeOfGray(int val) : brightness = val;
+
+  ShadeOfGray.black() : this(0);
+
+  // But now it will!
+  ShadeOfGray.alsoBlack() : this.black();
+}
+// #enddocregion this-dot-constructor
+
+//----------------------------------------------------------------------------
+
+class BaseBox {
+  BaseBox(_);
+}
+
+// #docregion param-dont-shadow-field-ctr-init
+class Box3 extends BaseBox {
+  var value;
+
+  Box3(value)
+      : value = value,
+        super(value);
+}
+// #enddocregion param-dont-shadow-field-ctr-init
+
+//----------------------------------------------------------------------------
+
+class Document {}
+
+// #docregion field-init-at-decl
+class Folder {
+  final String name;
+  final List<Document> contents = [];
+
+  Folder(this.name);
+  Folder.temp() : name = 'temporary';
+}
+// #enddocregion field-init-at-decl
+
+//----------------------------------------------------------------------------
+
+// #docregion field-init-as-param
+class Point0 {
+  double x, y;
+  Point0(this.x, this.y);
+}
+// #enddocregion field-init-as-param
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-type-init-formals
+class Point1 {
+  double x, y;
+  Point1(this.x, this.y);
+}
+// #enddocregion dont-type-init-formals
+
+//----------------------------------------------------------------------------
+
+// #docregion semicolon-for-empty-body
+class Point2 {
+  double x, y;
+  Point2(this.x, this.y);
+}
+// #enddocregion semicolon-for-empty-body
+
+class Widget {}
+
+class BuildContext {}
+
+class Row extends Widget {
+  Row({children});
+}
+
+class RaisedButton {
+  RaisedButton({child});
+}
+
+class Text {
+  Text(String text);
+}
+
+// #docregion no-new
+Widget build(BuildContext context) {
+  return Row(
+    children: [
+      RaisedButton(
+        child: Text('Increment'),
+      ),
+      Text('Click!'),
+    ],
+  );
+}
+// #enddocregion no-new
+
+//----------------------------------------------------------------------------
+
+class Style {}
+
+class ViewBase {
+  ViewBase(_);
+}
+
+class View extends ViewBase {
+  var _children;
+  // #docregion super-first
+  View(Style style, List children)
+      : _children = children,
+        super(style);
+  // #enddocregion super-first
+  get children => _children;
+}

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -9,7 +9,8 @@ typedef Func1<S, T> = S Function(T _);
 Func0<Future> longRunningCalculation = () => Future.value();
 Func0 somethingRisky = () {};
 Func1 raiseAlarm = (_) {}, handle = (_) {};
-Func1<bool, dynamic> canHandle = (_) => false, verifyResult = (_) => false;
+Func1<bool, dynamic> canHandle = (_) => false,
+    verifyResult = (_) => false;
 
 class Thing {
   bool get isEnabled => true;
@@ -33,7 +34,8 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion adjacent-strings-literals
-    raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
+    raiseAlarm(
+        'ERROR: Parts of the spaceship are on fire. Other '
         'parts are overrun by martians. Unclear which are which.');
     // #enddocregion adjacent-strings-literals
   }
@@ -172,7 +174,8 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion unnecessary-async
-    Future<int> fastestBranch(Future<int> left, Future<int> right) {
+    Future<int> fastestBranch(
+        Future<int> left, Future<int> right) {
       return Future.any([left, right]);
     }
     // #enddocregion unnecessary-async
@@ -261,7 +264,8 @@ class Player {
 
 class Team {
   Future<List<Player>> get roster => Future.value([]);
-  Future<Team?> downloadTeam(String name) => Future.value(Team());
+  Future<Team?> downloadTeam(String name) =>
+      Future.value(Team());
   dynamic get log => null;
 
   // #docregion async-await
@@ -342,7 +346,11 @@ class Treasure {
 }
 
 class C {
-  double left = 0.0, right = 0.0, top = 0.0, bottom = 0.0, minTime = 0.0;
+  double left = 0.0,
+      right = 0.0,
+      top = 0.0,
+      bottom = 0.0,
+      minTime = 0.0;
   Point center = Point(0.0, 0.0);
   Map<Chest, Treasure> _opened = {};
 

--- a/null_safety_examples/misc/test/effective_dart_test.dart
+++ b/null_safety_examples/misc/test/effective_dart_test.dart
@@ -1,0 +1,68 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('sublist', () {
+    // #docregion param-range
+    expect([0, 1, 2, 3].sublist(1, 3), /**/ [1, 2]);
+    // #enddocregion param-range
+  });
+
+  test('substring', () {
+    // #docregion param-range
+    expect('abcd'.substring(1, 3), /**/ 'bc');
+    // #enddocregion param-range
+  });
+
+  group('List.toList() and List.from()', () {
+    test('basic', () {
+      var iterable = [1, 2];
+      // #docregion list-from-1
+      var copy1 = iterable.toList();
+      var copy2 = List.from(iterable);
+      // #enddocregion list-from-1
+      expect(copy1, orderedEquals([1, 2]));
+      expect(copy2, orderedEquals([1, 2]));
+    });
+
+    test('runtimeType', () {
+      expect(() {
+        // #docregion list-from-good
+        // Creates a List<int>:
+        var iterable = [1, 2, 3];
+
+        // Prints "List<int>":
+        print(iterable.toList().runtimeType);
+        // #enddocregion list-from-good
+      }, prints('List<int>\n'));
+
+      expect(() {
+        // #docregion list-from-bad
+        // Creates a List<int>:
+        var iterable = [1, 2, 3];
+
+        // Prints "List<dynamic>":
+        print(List.from(iterable).runtimeType);
+        // #enddocregion list-from-bad
+      }, prints('List<dynamic>\n'));
+    });
+
+    test('List.from<int>() from List<num>', () {
+      // #docregion list-from-3
+      var numbers = [1, 2.3, 4]; // List<num>.
+      numbers.removeAt(1); // Now it only contains integers.
+      var ints = List<int>.from(numbers);
+      // #enddocregion list-from-3
+
+      expect(ints, orderedEquals([1, 4]));
+    });
+  });
+
+  test('whereType usage_good', () {
+    // #docregion whereType
+    var objects = [1, "a", 2, "b", 3];
+    var ints = objects.whereType<int>();
+    // #enddocregion whereType
+    expect(ints, TypeMatcher<Iterable<int>>());
+    expect(ints, [1, 2, 3]);
+  });
+}

--- a/null_safety_examples/util/lib/ellipsis.dart
+++ b/null_safety_examples/util/lib/ellipsis.dart
@@ -1,2 +1,3 @@
 dynamic blockEllipsis; // Use as replace="/=. blockEllipsis;/{ ... }/g"
-T? ellipsis<T>() => null; // Use as replace="/ellipsis;?/.../g"
+Never ellipsis<T>() =>
+    throw Exception('!'); // Use as replace="/ellipsis;?/.../g"

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1750,7 +1750,7 @@ than the index of the last item.
 This is consistent with core libraries that do the same thing.
 
 {:.good}
-<?code-excerpt "misc/test/effective_dart_test.dart (param-range)" replace="/expect\(//g; /, \/\*\*\// \/\//g; /\);//g"?>
+<?code-excerpt "../../test/effective_dart_test.dart (param-range)" replace="/expect\(//g; /, \/\*\*\// \/\//g; /\);//g"?>
 {% prettify dart tag=pre+code %}
 [0, 1, 2, 3].sublist(1, 3) // [1, 2]
 'abcd'.substring(1, 3) // 'bc'

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1,0 +1,1838 @@
+---
+title: "Effective Dart: Design"
+description: Design consistent, usable libraries.
+prevpage:
+  url: /guides/language/effective-dart/usage
+  title: Usage
+---
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt plaster="none"?>
+
+Here are some guidelines for writing consistent, usable APIs for libraries.
+
+## Names
+
+Naming is an important part of writing readable, maintainable code.
+The following best practices can help you achieve that goal.
+
+### DO use terms consistently.
+
+Use the same name for the same thing, throughout your code. If a precedent
+already exists outside your API that users are likely to know, follow that
+precedent.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+pageCount         // A field.
+updatePageCount() // Consistent with pageCount.
+toSomething()     // Consistent with Iterable's toList().
+asSomething()     // Consistent with List's asMap().
+Point             // A familiar concept.
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+renumberPages()      // Confusingly different from pageCount.
+convertToSomething() // Inconsistent with toX() precedent.
+wrappedAsSomething() // Inconsistent with asX() precedent.
+Cartesian            // Unfamiliar to most users.
+{% endprettify %}
+
+The goal is to take advantage of what the user already knows. This includes
+their knowledge of the problem domain itself, the conventions of the core
+libraries, and other parts of your own API. By building on top of those, you
+reduce the amount of new knowledge they have to acquire before they can be
+productive.
+
+
+### AVOID abbreviations.
+
+Unless the abbreviation is more common than the unabbreviated term, don't
+abbreviate. If you do abbreviate, [capitalize it correctly][caps].
+
+[caps]: /guides/language/effective-dart/style#identifiers
+
+{:.good}
+{% prettify dart tag=pre+code %}
+pageCount
+buildRectangles
+IOStream
+HttpRequest
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+numPages    // "num" is an abbreviation of number(of)
+buildRects
+InputOutputStream
+HypertextTransferProtocolRequest
+{% endprettify %}
+
+
+### PREFER putting the most descriptive noun last.
+
+The last word should be the most descriptive of what the thing is. You can
+prefix it with other words, such as adjectives, to further describe the thing.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+pageCount             // A count (of pages).
+ConversionSink        // A sink for doing conversions.
+ChunkedConversionSink // A ConversionSink that's chunked.
+CssFontFaceRule       // A rule for font faces in CSS.
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+numPages                  // Not a collection of pages.
+CanvasRenderingContext2D  // Not a "2D".
+RuleFontFaceCss           // Not a CSS.
+{% endprettify %}
+
+
+### CONSIDER making the code read like a sentence.
+
+When in doubt about naming, write some code that uses your API, and try to read
+it like a sentence.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (code-like-prose)"?>
+{% prettify dart tag=pre+code %}
+// "If errors is empty..."
+if (errors.isEmpty) ...
+
+// "Hey, subscription, cancel!"
+subscription.cancel();
+
+// "Get the monsters where the monster has claws."
+monsters.where((monster) => monster.hasClaws);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose)" replace="/ as bool//g"?>
+{% prettify dart tag=pre+code %}
+// Telling errors to empty itself, or asking if it is?
+if (errors.empty) ...
+
+// Toggle what? To what?
+subscription.toggle();
+
+// Filter the monsters with claws *out* or include *only* those?
+monsters.filter((monster) => monster.hasClaws);
+{% endprettify %}
+
+It's helpful to try out your API and see how it "reads" when used in code, but
+you can go too far. It's not helpful to add articles and other parts of speech
+to force your names to *literally* read like a grammatically correct sentence.
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose-overdone)"?>
+{% prettify dart tag=pre+code %}
+if (theCollectionOfErrors.isEmpty) ...
+
+monsters.producesANewSequenceWhereEach((monster) => monster.hasClaws);
+{% endprettify %}
+
+
+### PREFER a noun phrase for a non-boolean property or variable.
+
+The reader's focus is on *what* the property is. If the user cares more about
+*how* a property is determined, then it should probably be a method with a
+verb phrase name.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+list.length
+context.lineWidth
+quest.rampagingSwampBeast
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+list.deleteItems
+{% endprettify %}
+
+
+### PREFER a non-imperative verb phrase for a boolean property or variable.
+
+Boolean names are often used as conditions in control flow, so you want a name
+that reads well there. Compare:
+
+{% prettify dart tag=pre+code %}
+if (window.closeable) ...  // Adjective.
+if (window.canClose) ...   // Verb.
+{% endprettify %}
+
+Good names tend to start with one of a few kinds of verbs:
+
+*   a form of "to be": `isEnabled`, `wasShown`, `willFire`. These are, by far,
+    the most common.
+
+*   an [auxiliary verb][]: `hasElements`, `canClose`,
+    `shouldConsume`, `mustSave`.
+
+*   an active verb: `ignoresInput`, `wroteFile`. These are rare because they are
+    usually ambiguous. `loggedResult` is a bad name because it could mean
+    "whether or not a result was logged" or "the result that was logged".
+    Likewise, `closingConnection` could be "whether the connection is closing"
+    or "the connection that is closing". Active verbs are allowed when the name
+    can *only* be read as a predicate.
+
+[auxiliary verb]: https://en.wikipedia.org/wiki/Auxiliary_verb
+
+What separates all these verb phrases from method names is that they are not
+*imperative*. A boolean name should never sound like a command to tell the
+object to do something, because accessing a property doesn't change the object.
+(If the property *does* modify the object in a meaningful way, it should be a
+method.)
+
+{:.good}
+{% prettify dart tag=pre+code %}
+isEmpty
+hasElements
+canClose
+closesWindow
+canShowPopup
+hasShownPopup
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+empty         // Adjective or verb?
+withElements  // Sounds like it might hold elements.
+closeable     // Sounds like an interface.
+              // "canClose" reads better as a sentence.
+closingWindow // Returns a bool or a window?
+showPopup     // Sounds like it shows the popup.
+{% endprettify %}
+
+**Exception:** Input properties in [Angular][] components sometimes use
+imperative verbs for boolean setters because these setters are invoked in
+templates, not from other Dart code.
+
+[angular]: {{site.angulardart}}
+
+
+### CONSIDER omitting the verb for a named boolean *parameter*.
+
+This refines the previous rule. For named parameters that are boolean, the name
+is often just as clear without the verb, and the code reads better at the call
+site.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
+{% prettify dart tag=pre+code %}
+Isolate.spawn(entryPoint, message, paused: false);
+var copy = List.from(elements, growable: true);
+var regExp = RegExp(pattern, caseSensitive: false);
+{% endprettify %}
+
+
+### PREFER the "positive" name for a boolean property or variable.
+
+Most boolean names have conceptually "positive" and "negative" forms where the
+former feels like the fundamental concept and the latter is its
+negation&mdash;"open" and "closed", "enabled" and "disabled", etc. Often the
+latter name literally has a prefix that negates the former: "visible" and
+"*in*-visible", "connected" and "*dis*-connected", "zero" and "*non*-zero".
+
+When choosing which of the two cases that `true` represents &mdash; and thus
+which case the property is named for &mdash; prefer the positive or more
+fundamental one. Boolean members are often nested inside logical expressions,
+including negation operators. If your property itself reads like a negation,
+it's harder for the reader to mentally perform the double negation and
+understand what the code means.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (positive)"?>
+{% prettify dart tag=pre+code %}
+if (socket.isConnected && database.hasData) {
+  socket.write(database.read());
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (positive)"?>
+{% prettify dart tag=pre+code %}
+if (!socket.isDisconnected && !database.isEmpty) {
+  socket.write(database.read());
+}
+{% endprettify %}
+
+For some properties, there is no obvious positive form. Is a document that has
+been flushed to disk "saved" or "*un*-changed"? Is a document that *hasn't* been
+flushed "*un*-saved" or "changed"? In ambiguous cases, lean towards the choice
+that is less likely to be negated by users or has the shorter name.
+
+**Exception:** With some properties, the negative form is what users
+overwhelmingly need to use. Choosing the positive case would force them to
+negate the property with `!` everywhere. Instead, it may be better to use the
+negative case for that property.
+
+
+### PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.
+
+Callable members can return a result to the caller and perform other work or
+side effects. In an imperative language like Dart, members are often called
+mainly for their side effect: they may change an object's internal state,
+produce some output, or talk to the outside world.
+
+Those kinds of members should be named using an imperative verb phrase that
+clarifies the work the member performs.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-side-effect)"?>
+{% prettify dart tag=pre+code %}
+list.add("element");
+queue.removeFirst();
+window.refresh();
+{% endprettify %}
+
+This way, an invocation reads like a command to do that work.
+
+
+### PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.
+
+Other callable members have few side effects but return a useful result to the
+caller. If the member needs no parameters to do that, it should generally be a
+getter. But, sometimes a logical "property" needs some parameters. For example,
+`elementAt()` returns a piece of data from a collection, but it needs a
+parameter to know *which* piece of data to return.
+
+This means the member is *syntactically* a method, but *conceptually* it is a
+property, and should be named as such using a phrase that describes *what* the
+member returns.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (noun-for-func-returning-value)"?>
+{% prettify dart tag=pre+code %}
+var element = list.elementAt(3);
+var first = list.firstWhere(test);
+var char = string.codeUnitAt(4);
+{% endprettify %}
+
+This guideline is deliberately softer than the previous one. Sometimes a method
+has no side effects but is still simpler to name with a verb phrase like
+`list.take()` or `string.split()`.
+
+
+### CONSIDER an imperative verb phrase for a function or method if you want to draw attention to the work it performs.
+
+When a member produces a result without any side effects, it should usually be a
+getter or a method with a noun phrase name describing the result it returns.
+However, sometimes the work required to produce that result is important. It may
+be prone to runtime failures, or use heavyweight resources like networking or
+file I/O. In cases like this, where you want the caller to think about the work
+the member is doing, give the member a verb phrase name that describes that
+work.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-work)"?>
+{% prettify dart tag=pre+code %}
+var table = database.downloadData();
+var packageVersions = packageGraph.solveConstraints();
+{% endprettify %}
+
+Note, though, that this guideline is softer than the previous two. The work an
+operation performs is often an implementation detail that isn't relevant to the
+caller, and performance and robustness boundaries change over time. Most of the
+time, name your members based on *what* they do for the caller, not *how* they
+do it.
+
+
+### AVOID starting a method name with `get`.
+
+In most cases, the method should be a getter with `get` removed from the name.
+For example, instead of a method named `getBreakfastOrder()`, define a getter
+named `breakfastOrder`.
+
+Even if the member does need to be a method because it takes arguments or
+otherwise isn't a good fit for a getter, you should still avoid `get`. Like the
+previous guidelines state, either:
+
+* Simply drop `get` and [use a noun phrase name][noun] like `breakfastOrder()`
+  if the caller mostly cares about the value the method returns.
+
+* [Use a verb phrase name][verb] if the caller cares about the work being done,
+  but pick a verb that more precisely describes the work than `get`, like
+  `create`, `download`, `fetch`, `calculate`, `request`, `aggregate`, etc.
+
+[noun]: #prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
+
+[verb]: #consider-an-imperative-verb-phrase-for-a-function-or-method-if-you-want-to-draw-attention-to-the-work-it-performs
+
+
+### PREFER naming a method `to___()` if it copies the object's state to a new object.
+
+{% include linter-rule.html rule="use_to_and_as_if_applicable" %}
+
+A *conversion* method is one that returns a new object containing a copy of
+almost all of the state of the receiver but usually in some different form or
+representation. The core libraries have a convention that these methods are
+named starting with `to` followed by the kind of result.
+
+If you define a conversion method, it's helpful to follow that convention.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (to___)"?>
+{% prettify dart tag=pre+code %}
+list.toSet();
+stackTrace.toString();
+dateTime.toLocal();
+{% endprettify %}
+
+
+### PREFER naming a method `as___()` if it returns a different representation backed by the original object.
+
+{% include linter-rule.html rule="use_to_and_as_if_applicable" %}
+
+Conversion methods are "snapshots". The resulting object has its own copy of the
+original object's state. There are other conversion-like methods that return
+*views*&mdash;they provide a new object, but that object refers back to the
+original. Later changes to the original object are reflected in the view.
+
+The core library convention for you to follow is `as___()`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (as___)"?>
+{% prettify dart tag=pre+code %}
+var map = table.asMap();
+var list = bytes.asFloat32List();
+var future = subscription.asFuture();
+{% endprettify %}
+
+
+### AVOID describing the parameters in the function's or method's name.
+
+The user will see the argument at the callsite, so it usually doesn't help
+readability to also refer to it in the name itself.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-desc-param-in-func)"?>
+{% prettify dart tag=pre+code %}
+list.add(element);
+map.remove(key);
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+list.addElement(element)
+map.removeKey(key)
+{% endprettify %}
+
+However, it can be useful to mention a parameter to disambiguate it from other
+similarly-named methods that take different types:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (desc-param-in-func-ok)"?>
+{% prettify dart tag=pre+code %}
+map.containsKey(key);
+map.containsValue(value);
+{% endprettify %}
+
+
+### DO follow existing mnemonic conventions when naming type parameters.
+
+Single letter names aren't exactly illuminating, but almost all generic types
+use them. Fortunately, they mostly use them in a consistent, mnemonic way.
+The conventions are:
+
+*   `E` for the **element** type in a collection:
+
+    {:.good}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
+    {% prettify dart tag=pre+code %}
+    class IterableBase<E> {}
+    class List<E> {}
+    class HashSet<E> {}
+    class RedBlackTree<E> {}
+    {% endprettify %}
+
+*   `K` and `V` for the **key** and **value** types in an associative
+    collection:
+
+    {:.good}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
+    {% prettify dart tag=pre+code %}
+    class Map<K, V> {}
+    class Multimap<K, V> {}
+    class MapEntry<K, V> {}
+    {% endprettify %}
+
+*   `R` for a type used as the **return** type of a function or a class's
+    methods. This isn't common, but appears in typedefs sometimes and in classes
+    that implement the visitor pattern:
+
+    {:.good}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-r)"?>
+    {% prettify dart tag=pre+code %}
+    abstract class ExpressionVisitor<R> {
+      R visitBinary(BinaryExpression node);
+      R visitLiteral(LiteralExpression node);
+      R visitUnary(UnaryExpression node);
+    }
+    {% endprettify %}
+
+*   Otherwise, use `T`, `S`, and `U` for generics that have a single type
+    parameter and where the surrounding type makes its meaning obvious. There
+    are multiple letters here to allow nesting without shadowing a surrounding
+    name. For example:
+
+    {:.good}
+    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-t)"?>
+    {% prettify dart tag=pre+code %}
+    class Future<T> {
+      Future<S> then<S>(FutureOr<S> onValue(T value)) => ...
+    }
+    {% endprettify %}
+
+    Here, the generic method `then<S>()` uses `S` to avoid shadowing the `T`
+    on `Future<T>`.
+
+If none of the above cases are a good fit, then either another single-letter
+mnemonic name or a descriptive name is fine:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-graph)"?>
+{% prettify dart tag=pre+code %}
+class Graph<N, E> {
+  final List<N> nodes = [];
+  final List<E> edges = [];
+}
+
+class Graph<Node, Edge> {
+  final List<Node> nodes = [];
+  final List<Edge> edges = [];
+}
+{% endprettify %}
+
+In practice, the existing conventions cover most type parameters.
+
+## Libraries
+
+A leading underscore character ( `_` ) indicates that a member is private to its
+library. This is not mere convention, but is built into the language itself.
+
+### PREFER making declarations private.
+
+A public declaration in a library&mdash;either top level or in a class&mdash;is
+a signal that other libraries can and should access that member. It is also a
+commitment on your library's part to support that and behave properly when it
+happens.
+
+If that's not what you intend, add the little `_` and be happy. Narrow public
+interfaces are easier for you to maintain and easier for users to learn. As a
+nice bonus, the analyzer will tell you about unused private declarations so you
+can delete dead code. It can't do that if the member is public because it
+doesn't know if any code outside of its view is using it.
+
+
+### CONSIDER declaring multiple classes in the same library.
+
+Some languages, such as Java, tie the organization of files to the organization of
+classes&mdash;each file may only define a single top level class. Dart does not
+have that limitation. Libraries are distinct entities separate from classes.
+It's perfectly fine for a single library to contain multiple classes, top level
+variables, and functions if they all logically belong together.
+
+Placing multiple classes together in one library can enable some useful
+patterns. Since privacy in Dart works at the library level, not the class level,
+this is a way to define "friend" classes like you might in C++. Every class
+declared in the same library can access each other's private members, but code
+outside of that library cannot.
+
+Of course, this guideline doesn't mean you *should* put all of your classes into
+a huge monolithic library, just that you are allowed to place more than one
+class in a single library.
+
+
+## Classes and mixins
+
+Dart is a "pure" object-oriented language in that all objects are instances of
+classes. But Dart does not require all code to be defined inside a
+class&mdash;you can define top-level variables, constants, and functions like
+you can in a procedural or functional language.
+
+### AVOID defining a one-member abstract class when a simple function will do.
+
+{% include linter-rule.html rule="one_member_abstracts" %}
+
+Unlike Java, Dart has first-class functions, closures, and a nice light syntax
+for using them. If all you need is something like a callback, just use a
+function. If you're defining a class and it only has a single abstract member
+with a meaningless name like `call` or `invoke`, there is a good chance you
+just want a function.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (one-member-abstract-class)"?>
+{% prettify dart tag=pre+code %}
+typedef Predicate<E> = bool Function(E element);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (one-member-abstract-class)"?>
+{% prettify dart tag=pre+code %}
+abstract class Predicate<E> {
+  bool test(E element);
+}
+{% endprettify %}
+
+
+### AVOID defining a class that contains only static members.
+
+{% include linter-rule.html rule="avoid_classes_with_only_static_members" %}
+
+In Java and C#, every definition *must* be inside a class, so it's common to see
+"classes" that exist only as a place to stuff static members. Other classes are
+used as namespaces&mdash;a way to give a shared prefix to a bunch of members to
+relate them to each other or avoid a name collision.
+
+Dart has top-level functions, variables, and constants, so you don't *need* a
+class just to define something. If what you want is a namespace, a library is a
+better fit. Libraries support import prefixes and show/hide combinators. Those
+are powerful tools that let the consumer of your code handle name collisions in
+the way that works best for *them*.
+
+If a function or variable isn't logically tied to a class, put it at the top
+level. If you're worried about name collisions, give it a more precise name or
+move it to a separate library that can be imported with a prefix.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (class-only-static)"?>
+{% prettify dart tag=pre+code %}
+DateTime mostRecent(List<DateTime> dates) {
+  return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+}
+
+const _favoriteMammal = 'weasel';
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static)"?>
+{% prettify dart tag=pre+code %}
+class DateUtils {
+  static DateTime mostRecent(List<DateTime> dates) {
+    return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+  }
+}
+
+class _Favorites {
+  static const mammal = 'weasel';
+}
+{% endprettify %}
+
+In idiomatic Dart, classes define *kinds of objects*. A type that is never
+instantiated is a code smell.
+
+However, this isn't a hard rule. With constants and enum-like types, it may be
+natural to group them in a class.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static-exception)"?>
+{% prettify dart tag=pre+code %}
+class Color {
+  static const red = '#f00';
+  static const green = '#0f0';
+  static const blue = '#00f';
+  static const black = '#000';
+  static const white = '#fff';
+}
+{% endprettify %}
+
+
+### AVOID extending a class that isn't intended to be subclassed.
+
+If a constructor is changed from a generative constructor to a factory
+constructor, any subclass constructor calling that constructor will break.
+Also, if a class changes which of its own methods it invokes on `this`, that
+may break subclasses that override those methods and expect them to be called
+at certain points.
+
+Both of these mean that a class needs to be deliberate about whether or not it
+wants to allow subclassing. This can be communicated in a doc comment, or by
+giving the class an obvious name like `IterableBase`. If the author of the class
+doesn't do that, it's best to assume you should *not* extend the class.
+Otherwise, later changes to it may break your code.
+
+
+### DO document if your class supports being extended.
+
+This is the corollary to the above rule. If you want to allow subclasses of your
+class, state that. Suffix the class name with `Base`, or mention it in the
+class's doc comment.
+
+
+### AVOID implementing a class that isn't intended to be an interface.
+
+Implicit interfaces are a powerful tool in Dart to avoid having to repeat the
+contract of a class when it can be trivially inferred from the signatures of an
+implementation of that contract.
+
+But implementing a class's interface is a very tight coupling to that class. It
+means virtually *any* change to the class whose interface you are implementing
+will break your implementation. For example, adding a new member to a class is
+usually a safe, non-breaking change. But if you are implementing that class's
+interface, now your class has a static error because it lacks an implementation
+of that new method.
+
+Library maintainers need the ability to evolve existing classes without breaking
+users. If you treat every class like it exposes an interface that users are free
+to implement, then changing those classes becomes very difficult. That
+difficulty in turn means the libraries you rely on are slower to grow and adapt
+to new needs.
+
+To give the authors of the classes you use more leeway, avoid implementing
+implicit interfaces except for classes that are clearly intended to be
+implemented. Otherwise, you may introduce a coupling that the author doesn't
+intend, and they may break your code without realizing it.
+
+### DO document if your class supports being used as an interface.
+
+If your class can be used as an interface, mention that in the class's doc
+comment.
+
+
+### DO use `mixin` to define a mixin type.
+
+{% include linter-rule.html rule="prefer_mixin" %}
+
+Dart originally didn't have a separate syntax for declaring a class intended to
+be mixed in to other classes. Instead, any class that met certain restrictions
+(no non-default constructor, no superclass, etc.) could be used as a mixin. This
+was confusing because the author of the class might not have intended it to be
+mixed in.
+
+Dart 2.1.0 added a `mixin` keyword for explicitly declaring a mixin. Types
+created using that can *only* be used as mixins, and the language also ensures
+that your mixin stays within the restrictions. When defining a new type that you
+intend to be used as a mixin, use this syntax.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (mixin)"?>
+{% prettify dart tag=pre+code %}
+mixin ClickableMixin implements Control {
+  bool _isDown = false;
+
+  void click();
+
+  void mouseDown() {
+    _isDown = true;
+  }
+
+  void mouseUp() {
+    if (_isDown) click();
+    _isDown = false;
+  }
+}
+{% endprettify %}
+
+You might still encounter older code using `class` to define mixins, but the new
+syntax is preferred.
+
+
+### AVOID mixing in a type that isn't intended to be a mixin. {#avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin}
+
+{% include linter-rule.html rule="prefer_mixin" %}
+
+For compatibility, Dart still allows you to mix in classes that aren't defined
+using `mixin`. However, that's risky. If the author of the class doesn't intend
+the class to be used as a mixin, they might change the class in a way that
+breaks the mixin restrictions. For example, if they add a constructor, your
+class will break.
+
+If the class doesn't have a doc comment or an obvious name like `IterableMixin`,
+assume you cannot mix in the class if it isn't declared using `mixin`.
+
+
+## Constructors
+
+Dart constructors are created by declaring a function with the same name as the
+class and, optionally, an additional identifier. The latter are called *named
+constructors*.
+
+
+### CONSIDER making your constructor `const` if the class supports it.
+
+If you have a class where all the fields are final, and the constructor does
+nothing but initialize them, you can make that constructor `const`. That lets
+users create instances of your class in places where constants are
+required&mdash;inside other larger constants, switch cases, default parameter
+values, etc.
+
+If you don't explicitly make it `const`, they aren't able to do that.
+
+Note, however, that a `const` constructor is a commitment in your public API. If
+you later change the constructor to non-`const`, it will break users that are
+calling it in constant expressions. If you don't want to commit to that, don't
+make it `const`. In practice, `const` constructors are most useful for simple,
+immutable data record sorts of classes.
+
+
+## Members
+
+A member belongs to an object and can be either methods or instance variables.
+
+### PREFER making fields and top-level variables `final`.
+
+{% include linter-rule.html rule="prefer_final_fields" %}
+
+State that is not *mutable*&mdash;that does not change over time&mdash;is
+easier for programmers to reason about. Classes and libraries that minimize the
+amount of mutable state they work with tend to be easier to maintain.
+
+Of course, it is often useful to have mutable data. But, if you don't need it,
+your default should be to make fields and top-level variables `final` when you
+can.
+
+
+### DO use getters for operations that conceptually access properties.
+
+Deciding when a member should be a getter versus a method is a challenging,
+subtle, but important part of good API design, hence this very long guideline.
+Some other language's cultures shy away from getters. They only use them when
+the operation is almost exactly like a field&mdash;it does a miniscule amount of
+calculation on state that lives entirely on the object. Anything more complex or
+heavyweight than that gets `()` after the name to signal "computation goin' on
+here!" because a bare name after a `.` means "field".
+
+Dart is *not* like that. In Dart, *all* dotted names are member invocations that
+may do computation. Fields are special&mdash;they're getters whose
+implementation is provided by the language. In other words, getters are not
+"particularly slow fields" in Dart; fields are "particularly fast getters".
+
+Even so, choosing a getter over a method sends an important signal to the
+caller. The signal, roughly, is that the operation is "field-like". The
+operation, at least in principle, *could* be implemented using a field, as far
+as the caller knows. That implies:
+
+*   **The operation does not take any arguments and returns a result.**
+
+*   **The caller cares mostly about the result.** If you want the caller to
+    worry about *how* the operation produces its result more than they do the
+    result being produced, then give the operation a verb name that describes
+    the work and make it a method.
+
+    This does *not* mean the operation has to be particularly fast in order to
+    be a getter. `IterableBase.length` is `O(n)`, and that's OK. It's fine for a
+    getter to do significant calculation. But if it does a *surprising* amount
+    of work, you may want to draw their attention to that by making it a method
+    whose name is a verb describing what it does.
+
+    {:.bad}
+    {% prettify dart tag=pre+code %}
+    connection.nextIncomingMessage; // Does network I/O.
+    expression.normalForm; // Could be exponential to calculate.
+    {% endprettify %}
+
+*   **The operation does not have user-visible side effects.** Accessing a real
+    field does not alter the object or any other state in the program. It
+    doesn't produce output, write files, etc. A getter shouldn't do those things
+    either.
+
+    The "user-visible" part is important. It's fine for getters to modify hidden
+    state or produce out of band side effects. Getters can lazily calculate and
+    store their result, write to a cache, log stuff, etc. As long as the caller
+    doesn't *care* about the side effect, it's probably fine.
+
+    {:.bad}
+    {% prettify dart tag=pre+code %}
+    stdout.newline; // Produces output.
+    list.clear; // Modifies object.
+    {% endprettify %}
+
+*   **The operation is *idempotent*.** "Idempotent" is an odd word that, in this
+    context, basically means that calling the operation multiple times produces
+    the same result each time, unless some state is explicitly modified between
+    those calls. (Obviously, `list.length` produces different results if you add
+    an element to the list between calls.)
+
+    "Same result" here does not mean a getter must literally produce an
+    identical object on successive calls. Requiring that would force many
+    getters to have brittle caching, which negates the whole point of using a
+    getter. It's common, and perfectly fine, for a getter to return a new future
+    or list each time you call it. The important part is that the future
+    completes to the same value, and the list contains the same elements.
+
+    In other words, the result value should be the same *in the aspects that the
+    caller cares about.*
+
+    {:.bad}
+    {% prettify dart tag=pre+code %}
+    DateTime.now; // New result each time.
+    {% endprettify %}
+
+*   **The resulting object doesn't expose all of the original object's state.**
+    A field exposes only a piece of an object. If your operation returns a
+    result that exposes the original object's entire state, it's likely better
+    off as a [`to___()`][to] or [`as___()`][as] method.
+
+[to]: #prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object
+[as]: #prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object
+
+If all of the above describe your operation, it should be a getter. It seems
+like few members would survive that gauntlet, but surprisingly many do. Many
+operations just do some computation on some state and most of those can and
+should be getters.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+rectangle.area;
+collection.isEmpty;
+button.canShow;
+dataSet.minimumValue;
+{% endprettify %}
+
+
+### DO use setters for operations that conceptually change properties.
+
+{% include linter-rule.html rule="use_setters_to_change_properties" %}
+
+Deciding between a setter versus a method is similar to deciding between a
+getter versus a method. In both cases, the operation should be "field-like".
+
+For a setter, "field-like" means:
+
+*   **The operation takes a single argument and does not produce a result
+    value.**
+
+*   **The operation changes some state in the object.**
+
+*   **The operation is idempotent.** Calling the same setter twice with the same
+    value should do nothing the second time as far as the caller is concerned.
+    Internally, maybe you've got some cache invalidation or logging going on.
+    That's fine. But from the caller's perspective, it appears that the second
+    call does nothing.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+rectangle.width = 3;
+button.visible = false;
+{% endprettify %}
+
+
+### DON'T define a setter without a corresponding getter.
+
+{% include linter-rule.html rule="avoid_setters_without_getters" %}
+
+Users think of getters and setters as visible properties of an object. A
+"dropbox" property that can be written to but not seen is confusing and
+confounds their intuition about how properties work. For example, a setter
+without a getter means you can use `=` to modify it, but not `+=`.
+
+This guideline does *not* mean you should add a getter just to permit the setter
+you want to add. Objects shouldn't generally expose more state than they need
+to. If you have some piece of an object's state that can be modified but not
+exposed in the same way, use a method instead.
+
+**Exception:** An [Angular][] component class may expose setters that are
+invoked from a template to initialize the component. Often, these setters are
+not intended to be invoked from Dart code and don't need a corresponding getter.
+(If they are used from Dart code, they *should* have a getter.)
+
+[angular]: {{site.angulardart}}
+
+
+### AVOID returning `null` from members whose return type is `bool`, `double`, `int`, or `num`.
+
+{% include linter-rule.html rule="avoid_returning_null" %}
+
+Even though all types are nullable in Dart, users assume those types almost
+never contain `null`, and the lowercase names encourage a "Java primitive"
+mindset.
+
+It can be occasionally useful to have a "nullable primitive" type in your API,
+for example to indicate the absence of a value for some key in a map, but these
+should be rare.
+
+If you do have a member of this type that may return `null`, document it very
+clearly, including the conditions under which `null` will be returned.
+
+
+### AVOID returning `this` from methods just to enable a fluent interface.
+
+{% include linter-rule.html rule="avoid_returning_this" %}
+
+Method cascades are a better solution for chaining method calls.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (cascades)"?>
+{% prettify dart tag=pre+code %}
+var buffer = StringBuffer()
+  ..write('one')
+  ..write('two')
+  ..write('three');
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (cascades)"?>
+{% prettify dart tag=pre+code %}
+var buffer = StringBuffer()
+    .write('one')
+    .write('two')
+    .write('three');
+{% endprettify %}
+
+
+## Types
+
+When you write down a type in your program, you constrain the kinds of values
+that flow into different parts of your code. Types can appear in two kinds of
+places: *type annotations* on declarations and type arguments to *generic
+invocations*.
+
+Type annotations are what you normally think of when you think of "static
+types". You can type annotate a variable, parameter, field, or return type. In
+the following example, `bool` and `String` are type annotations. They hang off
+the static declarative structure of the code and aren't "executed" at runtime.
+
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-declaration)"?>
+{% prettify dart tag=pre+code %}
+bool isEmpty(String parameter) {
+  bool result = parameter.isEmpty;
+  return result;
+}
+{% endprettify %}
+
+A generic invocation is a collection literal, a call to a generic class's
+constructor, or an invocation of a generic method. In the next example, `num`
+and `int` are type arguments on generic invocations. Even though they are types,
+they are first-class entities that get reified and passed to the invocation at
+runtime.
+
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-invocation)"?>
+{% prettify dart tag=pre+code %}
+var lists = <num>[1, 2];
+lists.addAll(List<num>.filled(3, 4));
+lists.cast<int>();
+{% endprettify %}
+
+We stress the "generic invocation" part here, because type arguments can *also*
+appear in type annotations:
+
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-type-arg)"?>
+{% prettify dart tag=pre+code %}
+List<int> ints = [1, 2];
+{% endprettify %}
+
+Here, `int` is a type argument, but it appears inside a type annotation, not a
+generic invocation. You usually don't need to worry about this distinction, but
+in a couple of places, we have different guidance for when a type is used in a
+generic invocation as opposed to a type annotation.
+
+In most places, Dart allows you to omit a type annotation and infers a type for
+you based on the nearby context, or defaults to the `dynamic` type. The fact
+that Dart has both type inference and a `dynamic` type leads to some confusion
+about what it means to say code is "untyped". Does that mean the code is
+dynamically typed, or that you didn't *write* the type? To avoid that confusion,
+we avoid saying "untyped" and instead use the following terminology:
+
+*   If the code is *type annotated*, the type was explicitly written in the
+    code.
+
+*   If the code is *inferred*, no type annotation was written, and Dart
+    successfully figured out the type on its own. Inference can fail, in which
+    case the guidelines don't consider that inferred. In some places, inference
+    failure is a static error. In others, Dart uses `dynamic` as the fallback
+    type.
+
+*   If the code is *dynamic*, then its static type is the special `dynamic`
+    type. Code can be explicitly annotated `dynamic` or it can be inferred.
+
+In other words, whether some code is annotated or inferred is orthogonal to
+whether it is `dynamic` or some other type.
+
+Inference is a powerful tool to spare you the effort of writing and reading
+types that are obvious or uninteresting. Omitting types in obvious cases also
+draws the reader's attention to explicit types when those types are important,
+for things like casts.
+
+Explicit types are also a key part of robust, maintainable code. They define the
+static shape of an API. They document and enforce what kinds of values are
+allowed to reach different parts of the program.
+
+The guidelines here strike the best balance we've found between brevity and
+explicitness, flexibility and safety. When deciding which types to write, you
+need to answer two questions:
+
+* Which types should I write because I think it's best for them to be visible in
+  the code?
+* Which types should I write because inference can't provide them for me?
+
+These guidelines help you answer the first question:
+
+* [PREFER type annotating public fields and top-level variables if the type isn't obvious.](#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious)
+* [CONSIDER type annotating private fields and top-level variables if the type isn't obvious.](#consider-type-annotating-private-fields-and-top-level-variables-if-the-type-isnt-obvious)
+* [AVOID type annotating initialized local variables.](#avoid-type-annotating-initialized-local-variables)
+* [AVOID annotating inferred parameter types on function expressions.](#avoid-annotating-inferred-parameter-types-on-function-expressions)
+* [AVOID redundant type arguments on generic invocations.](#avoid-redundant-type-arguments-on-generic-invocations)
+
+These cover the second:
+
+* [DO annotate when Dart infers the wrong type.](#do-annotate-when-dart-infers-the-wrong-type)
+* [PREFER annotating with `dynamic` instead of letting inference fail.](#prefer-annotating-with-dynamic-instead-of-letting-inference-fail)
+
+The remaining guidelines cover other more specific questions around types.
+
+
+### PREFER type annotating public fields and top-level variables if the type isn't obvious.
+
+{% include linter-rule.html rule="type_annotate_public_apis" %}
+
+Type annotations are important documentation for how a library should be used.
+They form boundaries between regions of a program to isolate the source of a
+type error. Consider:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (type_annotate_public_apis)"?>
+{% prettify dart tag=pre+code %}
+install(id, destination) => ...
+{% endprettify %}
+
+Here, it's unclear what `id` is. A string? And what is `destination`? A string
+or a `File` object? Is this method synchronous or asynchronous? This is clearer:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (type_annotate_public_apis)"?>
+{% prettify dart tag=pre+code %}
+Future<bool> install(PackageId id, String destination) => ...
+{% endprettify %}
+
+In some cases, though, the type is so obvious that writing it is pointless:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred)"?>
+{% prettify dart tag=pre+code %}
+const screenWidth = 640; // Inferred as int.
+{% endprettify %}
+
+"Obvious" isn't precisely defined, but these are all good candidates:
+
+* Literals.
+* Constructor invocations.
+* References to other constants that are explicitly typed.
+* Simple expressions on numbers and strings.
+* Factory methods like `int.parse()`, `Future.wait()`, etc. that readers are
+  expected to be familiar with.
+
+When in doubt, add a type annotation. Even when a type is obvious, you may still
+wish to explicitly annotate. If the inferred type relies on values or
+declarations from other libraries, you may want to type annotate *your*
+declaration so that a change to that other library doesn't silently change the
+type of your own API without you realizing.
+
+
+### CONSIDER type annotating private fields and top-level variables if the type isn't obvious.
+
+{% include linter-rule.html rule="prefer_typing_uninitialized_variables" %}
+
+Type annotations on your public declarations help *users* of your code. Types on
+private members help *maintainers*. The scope of a private declaration is
+smaller and those who need to know the type of that declaration are also more
+likely to be familiar with the surrounding code. That makes it reasonable to
+lean more heavily on inference and omit types for private declarations, which is
+why this guideline is softer than the previous one.
+
+If you think the initializer expression&mdash;whatever it is&mdash;is
+sufficiently clear, then you may omit the annotation. But if you think
+annotating helps make the code clearer, then add one.
+
+
+### AVOID type annotating initialized local variables.
+
+{% include linter-rule.html rule="omit_local_variable_types" %}
+
+Local variables, especially in modern code where functions tend to be small,
+have very little scope. Omitting the type focuses the reader's attention on the
+more important *name* of the variable and its initialized value.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-types-on-locals)"?>
+{% prettify dart tag=pre+code %}
+List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
+  var desserts = <List<Ingredient>>[];
+  for (var recipe in cookbook) {
+    if (pantry.containsAll(recipe)) {
+      desserts.add(recipe);
+    }
+  }
+
+  return desserts;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (omit-types-on-locals)"?>
+{% prettify dart tag=pre+code %}
+List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
+  List<List<Ingredient>> desserts = <List<Ingredient>>[];
+  for (List<Ingredient> recipe in cookbook) {
+    if (pantry.containsAll(recipe)) {
+      desserts.add(recipe);
+    }
+  }
+
+  return desserts;
+}
+{% endprettify %}
+
+If the local variable doesn't have an initializer, then its type can't be
+inferred. In that case, it *is* a good idea to annotate. Otherwise, you get
+`dynamic` and lose the benefits of static type checking.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (uninitialized-local)"?>
+{% prettify dart tag=pre+code %}
+List<AstNode> parameters;
+if (node is Constructor) {
+  parameters = node.signature;
+} else if (node is Method) {
+  parameters = node.parameters;
+}
+{% endprettify %}
+
+
+### AVOID annotating inferred parameter types on function expressions.
+
+{% include linter-rule.html rule="avoid_types_on_closure_parameters" %}
+
+Anonymous functions are almost always immediately passed to a method taking a
+callback of some type. (If the function isn't used immediately, it's usually
+worth making it a named declaration.) When a function expression is created in a
+typed context, Dart tries to infer the function's parameter types based on the
+expected type.
+
+For example, when you pass a function expression to `Iterable.map()`, your
+function's parameter type is inferred based on the type of callback that `map()`
+expects:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (func-expr-no-param-type)"?>
+{% prettify dart tag=pre+code %}
+var names = people.map((person) => person.name);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (func-expr-no-param-type)"?>
+{% prettify dart tag=pre+code %}
+var names = people.map((Person person) => person.name);
+{% endprettify %}
+
+In rare cases, the surrounding context is not precise enough to provide a type
+for one or more of the function's parameters. In those cases, you may need to
+annotate.
+
+
+### AVOID redundant type arguments on generic invocations.
+
+A type argument is redundant if inference would fill in the same type. If the
+invocation is the initializer for a type-annotated variable, or is an argument
+to a function, then inference usually fills in the type for you:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (redundant)"?>
+{% prettify dart tag=pre+code %}
+Set<String> things = Set();
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (redundant)"?>
+{% prettify dart tag=pre+code %}
+Set<String> things = Set<String>();
+{% endprettify %}
+
+Here, the type annotation on the variable is used to infer the type argument of
+constructor call in the initializer.
+
+In other contexts, there isn't enough information to infer the type and then you
+should write the type argument:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (explicit)"?>
+{% prettify dart tag=pre+code %}
+var things = Set<String>();
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (explicit)"?>
+{% prettify dart tag=pre+code %}
+var things = Set();
+{% endprettify %}
+
+Here, since the variable has no type annotation, there isn't enough context to
+determine what kind of `Set` to create, so the type argument should be provided
+explicitly.
+
+
+### DO annotate when Dart infers the wrong type.
+
+Sometimes, Dart infers a type, but not the type you want. For example, you may
+want a variable's type to be a supertype of the initializer's type so that you
+can later assign some other sibling type to the variable:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred-wrong)"?>
+{% prettify dart tag=pre+code %}
+num highScore(List<num> scores) {
+  num highest = 0;
+  for (var score in scores) {
+    if (score > highest) highest = score;
+  }
+  return highest;
+}
+{% endprettify %}
+
+<!-- Q: As of 2.9, this code no longer works.
+  Should we change it or the recommendation? -->
+{:.bad}
+<!-- code-excerpt "misc/lib/effective_dart/design_bad.dart (inferred-wrong)" replace="/ +\/\/ ignore: .*?\n//g" -->
+{% prettify dart tag=pre+code %}
+num highScore(List<num> scores) {
+  var highest = 0;
+  for (var score in scores) {
+    if (score > highest) highest = score;
+  }
+  return highest;
+}
+{% endprettify %}
+
+Here, if `scores` contains doubles, like `[1.2]`, then the assignment to
+`highest` will fail since its inferred type is `int`, not `num`. In these cases,
+explicit annotations make sense.
+
+
+### PREFER annotating with `dynamic` instead of letting inference fail.
+
+Dart allows you to omit type annotations in many places and will try to infer a
+type for you. In some cases, if inference fails, it silently gives you
+`dynamic`. If `dynamic` is the type you want, this is technically the most terse
+way to get it.
+
+However, it's not the most *clear* way. A casual reader of your code who sees an
+annotation is missing has no way of knowing if you intended it to be `dynamic`,
+expected inference to fill in some other type, or simply forgot to write the
+annotation.
+
+When `dynamic` is the type you want, writing it explicitly makes your intent
+clear.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (prefer-dynamic)"?>
+{% prettify dart tag=pre+code %}
+dynamic mergeJson(dynamic original, dynamic changes) => ...
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (prefer-dynamic)"?>
+{% prettify dart tag=pre+code %}
+mergeJson(original, changes) => ...
+{% endprettify %}
+
+
+<aside class="alert alert-info" markdown="1">
+
+Before Dart 2, this guideline stated the exact opposite: *don't* annotate with
+`dynamic` when it is implicit. With the new stronger type system and type
+inference, users now expect Dart to behave like an inferred statically-typed
+language. With that mental model, it is an unpleasant surprise to discover that
+a region of code has silently lost all of the safety and performance of static
+types.
+
+</aside>
+
+
+### PREFER signatures in function type annotations.
+
+The identifier `Function` by itself without any return type or parameter
+signature refers to the special [Function][] type. This type is only
+marginally more useful than using `dynamic`. If you're going to annotate, prefer
+a full function type that includes the parameters and return type of the
+function.
+
+[Function]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+bool isValid(String value, [!bool Function(String)!] test) => ...
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+bool isValid(String value, [!Function!] test) => ...
+{% endprettify %}
+
+[fn syntax]: #prefer-inline-function-types-over-typedefs
+
+**Exception:** Sometimes, you want a type that represents the union of multiple
+different function types. For example, you may accept a function that takes one
+parameter or a function that takes two. Since we don't have union types, there's
+no way to precisely type that and you'd normally have to use `dynamic`.
+`Function` is at least a little more helpful than that:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-arity)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+void handleError([!void Function()!] operation, [!Function!] errorHandler) {
+  try {
+    operation();
+  } catch (err, stack) {
+    if (errorHandler is [!Function(Object)!]) {
+      errorHandler(err);
+    } else if (errorHandler is [!Function(Object, StackTrace)!]) {
+      errorHandler(err, stack);
+    } else {
+      throw ArgumentError("errorHandler has wrong signature.");
+    }
+  }
+}
+{% endprettify %}
+
+
+### DON'T specify a return type for a setter.
+
+{% include linter-rule.html rule="avoid_return_types_on_setters" %}
+
+Setters always return `void` in Dart. Writing the word is pointless.
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid_return_types_on_setters)"?>
+{% prettify dart tag=pre+code %}
+void set foo(Foo value) { ... }
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid_return_types_on_setters)"?>
+{% prettify dart tag=pre+code %}
+set foo(Foo value) { ... }
+{% endprettify %}
+
+
+### DON'T use the legacy typedef syntax.
+
+{% include linter-rule.html rule="prefer_generic_function_type_aliases" %}
+
+Dart has two notations for defining a named typedef for a function type. The
+original syntax looks like:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (old-typedef)"?>
+{% prettify dart tag=pre+code %}
+typedef int Comparison<T>(T a, T b);
+{% endprettify %}
+
+That syntax has a couple of problems:
+
+*   There is no way to assign a name to a *generic* function type. In the above
+    example, the typedef itself is generic. If you reference `Comparison` in
+    your code, without a type argument, you implicitly get the function type
+    `int Function(dynamic, dynamic)`, *not* `int Function<T>(T, T)`. This
+    doesn't come up in practice often, but it matters in certain corner cases.
+
+*   A single identifier in a parameter is interpreted as the parameter's *name*,
+    not its *type*. Given:
+
+    {:.bad}
+    <?code-excerpt "misc/lib/effective_dart/design_bad.dart (typedef-param)"?>
+    {% prettify dart tag=pre+code %}
+    typedef bool TestNumber(num);
+    {% endprettify %}
+
+    Most users expect this to be a function type that takes a `num` and returns
+    `bool`. It is actually a function type that takes *any* object (`dynamic`)
+    and returns `bool`. The parameter's *name* (which isn't used for anything
+    except documentation in the typedef) is "num". This has been a
+    long-standing source of errors in Dart.
+
+The new syntax looks like this:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef)"?>
+{% prettify dart tag=pre+code %}
+typedef Comparison<T> = int Function(T, T);
+{% endprettify %}
+
+If you want to include a parameter's name, you can do that too:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef-param-name)"?>
+{% prettify dart tag=pre+code %}
+typedef Comparison<T> = int Function(T a, T b);
+{% endprettify %}
+
+The new syntax can express anything the old syntax could express and more, and
+lacks the error-prone misfeature where a single identifier is treated as the
+parameter's name instead of its type. The same function type syntax after the
+`=` in the typedef is also allowed anywhere a type annotation may appear, giving
+us a single consistent way to write function types anywhere in a program.
+
+The old typedef syntax is still supported to avoid breaking existing code, but
+it's deprecated.
+
+
+### PREFER inline function types over typedefs.
+
+{% include linter-rule.html rule="avoid_private_typedef_functions" %}
+
+In Dart 1, if you wanted to use a function type for a field, variable, or
+generic type argument, you had to first define a typedef for it. Dart 2 supports
+a function type syntax that can be used anywhere a type annotation is allowed:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+class FilteredObservable {
+  final [!bool Function(Event)!] _predicate;
+  final List<[!void Function(Event)!]> _observers;
+
+  FilteredObservable(this._predicate, this._observers);
+
+  [!void Function(Event)!] notify(Event event) {
+    if (!_predicate(event)) return null;
+
+    [!void Function(Event)!] last;
+    for (var observer in _observers) {
+      observer(event);
+      last = observer;
+    }
+
+    return last;
+  }
+}
+{% endprettify %}
+
+It may still be worth defining a typedef if the function type is particularly
+long or frequently used. But in most cases, users want to see what the function
+type actually is right where it's used, and the function type syntax gives them
+that clarity.
+
+
+### CONSIDER using function type syntax for parameters.
+
+{% include linter-rule.html rule="use_function_type_syntax_for_parameters" %}
+
+Dart has a special syntax when defining a parameter whose type is a function.
+Sort of like in C, you surround the parameter's name with the function's return
+type and parameter signature:
+
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (function-type-param)"?>
+{% prettify dart tag=pre+code %}
+Iterable<T> where(bool predicate(T element)) => ...
+{% endprettify %}
+
+Before Dart 2 added function type syntax, this was the only way to give a
+parameter a function type without defining a typedef. Now that Dart has a
+general notation for function types, you can use it for function-typed
+parameters as well:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type-param)"?>
+{% prettify dart tag=pre+code %}
+Iterable<T> where(bool Function(T) predicate) => ...
+{% endprettify %}
+
+The new syntax is a little more verbose, but is consistent with other locations
+where you must use the new syntax.
+
+
+### AVOID using `dynamic` unless you want to disable static checking.
+
+Some operations work with any possible object. For example, a `log()` method
+could take any object and call `toString()` on it. Two types in Dart permit all
+values: `Object` and `dynamic`. However, they convey different things. If you
+simply want to state that you allow all objects, use `Object`, as you would in
+Java or C#.
+
+The type `dynamic` not only accepts all objects, but it also permits all
+*operations*. Any member access on a value of type `dynamic` is allowed at
+compile time, but may fail and throw an exception at runtime. If you want
+exactly that risky but flexible dynamic dispatch, then `dynamic` is the right
+type to use.
+
+Otherwise, prefer using `Object`. Rely on `is` checks and type promotion to
+ensure that the value's runtime type supports the member you want to access
+before you access it.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (Object-vs-dynamic)"?>
+{% prettify dart tag=pre+code %}
+/// Returns a Boolean representation for [arg], which must
+/// be a String or bool.
+bool convertToBool(Object arg) {
+  if (arg is bool) return arg;
+  if (arg is String) return arg.toLowerCase() == 'true';
+  throw ArgumentError('Cannot convert $arg to a bool.');
+}
+{% endprettify %}
+
+The main exception to this rule is when working with existing APIs that use
+`dynamic`, especially inside a generic type. For example, JSON objects have type
+`Map<String, dynamic>` and your code will need to accept that same type. Even
+so, when using a value from one of these APIs, it's often a good idea to cast it
+to a more precise type before accessing members.
+
+
+### DO use `Future<void>` as the return type of asynchronous members that do not produce values.
+
+When you have a synchronous function that doesn't return a value, you use `void`
+as the return type. The asynchronous equivalent for a method that doesn't
+produce a value, but that the caller might need to await, is `Future<void>`.
+
+You may see code that uses `Future` or `Future<Null>` instead because older
+versions of Dart didn't allow `void` as a type argument. Now that it does, you
+should use it. Doing so more directly matches how you'd type a similar
+synchronous function, and gives you better error-checking for callers and in the
+body of the function.
+
+For asynchronous functions that do not return a useful value and where no
+callers need to await the asynchronous work or handle an asynchronous failure,
+use a return type of `void`.
+
+
+### AVOID using `FutureOr<T>` as a return type.
+
+If a method accepts a `FutureOr<int>`, it is [generous in what it
+accepts][postel]. Users can call the method with either an `int` or a
+`Future<int>`, so they don't need to wrap an `int` in `Future` that you are
+going to unwrap anyway.
+
+[postel]: https://en.wikipedia.org/wiki/Robustness_principle
+
+If you *return* a `FutureOr<int>`, users need to check whether get back an `int`
+or a `Future<int>` before they can do anything useful. (Or they'll just `await`
+the value, effectively always treating it as a `Future`.) Just return a
+`Future<int>`, it's cleaner. It's easier for users to understand that a function
+is either always asynchronous or always synchronous, but a function that can be
+either is hard to use correctly.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or)"?>
+{% prettify dart tag=pre+code %}
+Future<int> triple(FutureOr<int> value) async => (await value) * 3;
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (future-or)"?>
+{% prettify dart tag=pre+code %}
+FutureOr<int> triple(FutureOr<int> value) {
+  if (value is int) return value * 3;
+  return (value as Future<int>).then((v) => v * 3);
+}
+{% endprettify %}
+
+The more precise formulation of this guideline is to *only use `FutureOr<T>` in
+[contravariant][] positions.* Parameters are contravariant and return types are
+covariant. In nested function types, this gets flipped&mdash;if you have a
+parameter whose type is itself a function, then the callback's return type is
+now in contravariant position and the callback's parameters are covariant. This
+means it's OK for a *callback's* type to return `FutureOr<T>`:
+
+[contravariant]: https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or-contra)" replace="/FutureOr.S./[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+Stream<S> asyncMap<T, S>(
+    Iterable<T> iterable, [!FutureOr<S>!] Function(T) callback) async* {
+  for (var element in iterable) {
+    yield await callback(element);
+  }
+}
+{% endprettify %}
+
+
+## Parameters
+
+In Dart, optional parameters can be either positional or named, but not both.
+
+
+### AVOID positional boolean parameters.
+
+{% include linter-rule.html rule="avoid_positional_boolean_parameters" %}
+
+Unlike other types, booleans are usually used in literal form. Things like
+numbers are usually wrapped in named constants, but we usually just pass around
+`true` and `false` directly. That can make callsites unreadable if it isn't
+clear what the boolean represents:
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+new Task(true);
+new Task(false);
+new ListBox(false, true, true);
+new Button(false);
+{% endprettify %}
+
+Instead, consider using named arguments, named constructors, or named constants
+to clarify what the call is doing.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-positional-bool-param)"?>
+{% prettify dart tag=pre+code %}
+Task.oneShot();
+Task.repeating();
+ListBox(scroll: true, showScrollbars: true);
+Button(ButtonState.enabled);
+{% endprettify %}
+
+Note that this doesn't apply to setters, where the name makes it clear what the
+value represents:
+
+{:.good}
+{% prettify dart tag=pre+code %}
+listBox.canScroll = true;
+button.isEnabled = false;
+{% endprettify %}
+
+
+### AVOID optional positional parameters if the user may want to omit earlier parameters.
+
+Optional positional parameters should have a logical progression such that
+earlier parameters are passed more often than later ones. Users should almost
+never need to explicitly pass a "hole" to omit an earlier positional argument to
+pass later one. You're better off using named arguments for that.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-optional-positional)"?>
+{% prettify dart tag=pre+code %}
+String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
+
+DateTime(int year,
+    [int month = 1,
+    int day = 1,
+    int hour = 0,
+    int minute = 0,
+    int second = 0,
+    int millisecond = 0,
+    int microsecond = 0]);
+
+Duration(
+    {int days = 0,
+    int hours = 0,
+    int minutes = 0,
+    int seconds = 0,
+    int milliseconds = 0,
+    int microseconds = 0});
+{% endprettify %}
+
+
+### AVOID mandatory parameters that accept a special "no argument" value.
+
+If the user is logically omitting a parameter, prefer letting them actually omit
+it by making the parameter optional instead of forcing them to pass `null`, an
+empty string, or some other special value that means "did not pass".
+
+Omitting the parameter is more terse and helps prevent bugs where a sentinel
+value like `null` is accidentally passed when the user thought they were
+providing a real value.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-mandatory-param)"?>
+{% prettify dart tag=pre+code %}
+var rest = string.substring(start);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-mandatory-param)"?>
+{% prettify dart tag=pre+code %}
+var rest = string.substring(start, null);
+{% endprettify %}
+
+
+### DO use inclusive start and exclusive end parameters to accept a range.
+
+If you are defining a method or function that lets a user select a range of
+elements or items from some integer-indexed sequence, take a start index, which
+refers to the first item and a (likely optional) end index which is one greater
+than the index of the last item.
+
+This is consistent with core libraries that do the same thing.
+
+{:.good}
+<?code-excerpt "misc/test/effective_dart_test.dart (param-range)" replace="/expect\(//g; /, \/\*\*\// \/\//g; /\);//g"?>
+{% prettify dart tag=pre+code %}
+[0, 1, 2, 3].sublist(1, 3) // [1, 2]
+'abcd'.substring(1, 3) // 'bc'
+{% endprettify %}
+
+It's particularly important to be consistent here because these parameters are
+usually unnamed. If your API takes a length instead of an end point, the
+difference won't be visible at all at the callsite.
+
+
+## Equality
+
+Implementing custom equality behavior for a class can be tricky. Users have deep
+intuition about how equality works that your objects need to match, and
+collection types like hash tables have subtle contracts that they expect
+elements to follow.
+
+### DO override `hashCode` if you override `==`.
+
+{% include linter-rule.html rule="hash_and_equals" %}
+
+The default hash code implementation provides an *identity* hash&mdash;two
+objects generally only have the same hash code if they are the exact same
+object. Likewise, the default behavior for `==` is identity.
+
+If you are overriding `==`, it implies you may have different objects that are
+considered "equal" by your class. **Any two objects that are equal must have the
+same hash code.** Otherwise, maps and other hash-based collections will fail to
+recognize that the two objects are equivalent.
+
+### DO make your `==` operator obey the mathematical rules of equality.
+
+An equivalence relation should be:
+
+* **Reflexive**: `a == a` should always return `true`.
+
+* **Symmetric**: `a == b` should return the same thing as `b == a`.
+
+* **Transitive**: If `a == b` and `b == c` both return `true`, then `a == c`
+  should too.
+
+Users and code that uses `==` expect all of these laws to be followed. If your
+class can't obey these rules, then `==` isn't the right name for the operation
+you're trying to express.
+
+### AVOID defining custom equality for mutable classes.
+
+{% include linter-rule.html rule="avoid_equals_and_hash_code_on_mutable_classes" %}
+
+When you define `==`, you also have to define `hashCode`. Both of those should
+take into account the object's fields. If those fields *change* then that
+implies the object's hash code can change.
+
+Most hash-based collections don't anticipate that&mdash;they assume an object's
+hash code will be the same forever and may behave unpredictably if that isn't
+true.
+
+### DON'T check for `null` in custom `==` operators.
+
+{% include linter-rule.html rule="avoid_null_checks_in_equality_operators" %}
+
+The language specifies that this check is done automatically and your `==`
+method is called only if the right-hand side is not `null`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/design_good.dart (eq-dont-check-for-null)" replace="/operator ==/[!$&!]/g" plaster?>
+{% prettify dart tag=pre+code %}
+class Person {
+  final String name;
+  // ···
+  bool [!operator ==!](other) => other is Person && name == other.name;
+
+  int get hashCode => name.hashCode;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/design_bad.dart (eq-dont-check-for-null)" replace="/\w+ != null/[!$&!]/g" plaster?>
+{% prettify dart tag=pre+code %}
+class Person {
+  final String name;
+  // ···
+  bool operator ==(other) => [!other != null!] && ...
+}
+{% endprettify %}
+

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1488,10 +1488,10 @@ class FilteredObservable {
 
   FilteredObservable(this._predicate, this._observers);
 
-  [!void Function(Event)!] notify(Event event) {
+  [!void Function(Event)!]? notify(Event event) {
     if (!_predicate(event)) return null;
 
-    [!void Function(Event)!] last;
+    [!void Function(Event)!]? last;
     for (var observer in _observers) {
       observer(event);
       last = observer;
@@ -1617,7 +1617,7 @@ Future<int> triple(FutureOr<int> value) async => (await value) * 3;
 {% prettify dart tag=pre+code %}
 FutureOr<int> triple(FutureOr<int> value) {
   if (value is int) return value * 3;
-  return (value as Future<int>).then((v) => v * 3);
+  return value.then((v) => v * 3);
 }
 {% endprettify %}
 
@@ -1696,7 +1696,7 @@ pass later one. You're better off using named arguments for that.
 {:.good}
 <?code-excerpt "design_good.dart (omit-optional-positional)"?>
 {% prettify dart tag=pre+code %}
-String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
+String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int? end]);
 
 DateTime(int year,
     [int month = 1,

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -7,6 +7,7 @@ prevpage:
 ---
 <?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 <?code-excerpt plaster="none"?>
+<?code-excerpt path-base="../null_safety_examples/misc/lib/effective_dart"?>
 
 Here are some guidelines for writing consistent, usable APIs for libraries.
 
@@ -96,7 +97,7 @@ When in doubt about naming, write some code that uses your API, and try to read
 it like a sentence.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (code-like-prose)"?>
+<?code-excerpt "design_good.dart (code-like-prose)"?>
 {% prettify dart tag=pre+code %}
 // "If errors is empty..."
 if (errors.isEmpty) ...
@@ -109,7 +110,7 @@ monsters.where((monster) => monster.hasClaws);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose)" replace="/ as bool//g"?>
+<?code-excerpt "design_bad.dart (code-like-prose)" replace="/ as bool//g"?>
 {% prettify dart tag=pre+code %}
 // Telling errors to empty itself, or asking if it is?
 if (errors.empty) ...
@@ -126,7 +127,7 @@ you can go too far. It's not helpful to add articles and other parts of speech
 to force your names to *literally* read like a grammatically correct sentence.
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (code-like-prose-overdone)"?>
+<?code-excerpt "design_bad.dart (code-like-prose-overdone)"?>
 {% prettify dart tag=pre+code %}
 if (theCollectionOfErrors.isEmpty) ...
 
@@ -220,7 +221,7 @@ is often just as clear without the verb, and the code reads better at the call
 site.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-verb-for-bool-param)"?>
+<?code-excerpt "design_good.dart (omit-verb-for-bool-param)"?>
 {% prettify dart tag=pre+code %}
 Isolate.spawn(entryPoint, message, paused: false);
 var copy = List.from(elements, growable: true);
@@ -244,7 +245,7 @@ it's harder for the reader to mentally perform the double negation and
 understand what the code means.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (positive)"?>
+<?code-excerpt "design_good.dart (positive)"?>
 {% prettify dart tag=pre+code %}
 if (socket.isConnected && database.hasData) {
   socket.write(database.read());
@@ -252,7 +253,7 @@ if (socket.isConnected && database.hasData) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (positive)"?>
+<?code-excerpt "design_bad.dart (positive)"?>
 {% prettify dart tag=pre+code %}
 if (!socket.isDisconnected && !database.isEmpty) {
   socket.write(database.read());
@@ -281,7 +282,7 @@ Those kinds of members should be named using an imperative verb phrase that
 clarifies the work the member performs.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-side-effect)"?>
+<?code-excerpt "design_good.dart (verb-for-func-with-side-effect)"?>
 {% prettify dart tag=pre+code %}
 list.add("element");
 queue.removeFirst();
@@ -304,7 +305,7 @@ property, and should be named as such using a phrase that describes *what* the
 member returns.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (noun-for-func-returning-value)"?>
+<?code-excerpt "design_good.dart (noun-for-func-returning-value)"?>
 {% prettify dart tag=pre+code %}
 var element = list.elementAt(3);
 var first = list.firstWhere(test);
@@ -327,7 +328,7 @@ the member is doing, give the member a verb phrase name that describes that
 work.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (verb-for-func-with-work)"?>
+<?code-excerpt "design_good.dart (verb-for-func-with-work)"?>
 {% prettify dart tag=pre+code %}
 var table = database.downloadData();
 var packageVersions = packageGraph.solveConstraints();
@@ -374,7 +375,7 @@ named starting with `to` followed by the kind of result.
 If you define a conversion method, it's helpful to follow that convention.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (to___)"?>
+<?code-excerpt "design_good.dart (to___)"?>
 {% prettify dart tag=pre+code %}
 list.toSet();
 stackTrace.toString();
@@ -394,7 +395,7 @@ original. Later changes to the original object are reflected in the view.
 The core library convention for you to follow is `as___()`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (as___)"?>
+<?code-excerpt "design_good.dart (as___)"?>
 {% prettify dart tag=pre+code %}
 var map = table.asMap();
 var list = bytes.asFloat32List();
@@ -408,7 +409,7 @@ The user will see the argument at the callsite, so it usually doesn't help
 readability to also refer to it in the name itself.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-desc-param-in-func)"?>
+<?code-excerpt "design_good.dart (avoid-desc-param-in-func)"?>
 {% prettify dart tag=pre+code %}
 list.add(element);
 map.remove(key);
@@ -424,7 +425,7 @@ However, it can be useful to mention a parameter to disambiguate it from other
 similarly-named methods that take different types:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (desc-param-in-func-ok)"?>
+<?code-excerpt "design_good.dart (desc-param-in-func-ok)"?>
 {% prettify dart tag=pre+code %}
 map.containsKey(key);
 map.containsValue(value);
@@ -440,7 +441,7 @@ The conventions are:
 *   `E` for the **element** type in a collection:
 
     {:.good}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
+    <?code-excerpt "design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
     {% prettify dart tag=pre+code %}
     class IterableBase<E> {}
     class List<E> {}
@@ -452,7 +453,7 @@ The conventions are:
     collection:
 
     {:.good}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
+    <?code-excerpt "design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
     {% prettify dart tag=pre+code %}
     class Map<K, V> {}
     class Multimap<K, V> {}
@@ -464,7 +465,7 @@ The conventions are:
     that implement the visitor pattern:
 
     {:.good}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-r)"?>
+    <?code-excerpt "design_good.dart (type-parameter-r)"?>
     {% prettify dart tag=pre+code %}
     abstract class ExpressionVisitor<R> {
       R visitBinary(BinaryExpression node);
@@ -479,7 +480,7 @@ The conventions are:
     name. For example:
 
     {:.good}
-    <?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-t)"?>
+    <?code-excerpt "design_good.dart (type-parameter-t)"?>
     {% prettify dart tag=pre+code %}
     class Future<T> {
       Future<S> then<S>(FutureOr<S> onValue(T value)) => ...
@@ -493,7 +494,7 @@ If none of the above cases are a good fit, then either another single-letter
 mnemonic name or a descriptive name is fine:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (type-parameter-graph)"?>
+<?code-excerpt "design_good.dart (type-parameter-graph)"?>
 {% prettify dart tag=pre+code %}
 class Graph<N, E> {
   final List<N> nodes = [];
@@ -564,13 +565,13 @@ with a meaningless name like `call` or `invoke`, there is a good chance you
 just want a function.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (one-member-abstract-class)"?>
+<?code-excerpt "design_good.dart (one-member-abstract-class)"?>
 {% prettify dart tag=pre+code %}
 typedef Predicate<E> = bool Function(E element);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (one-member-abstract-class)"?>
+<?code-excerpt "design_bad.dart (one-member-abstract-class)"?>
 {% prettify dart tag=pre+code %}
 abstract class Predicate<E> {
   bool test(E element);
@@ -598,7 +599,7 @@ level. If you're worried about name collisions, give it a more precise name or
 move it to a separate library that can be imported with a prefix.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (class-only-static)"?>
+<?code-excerpt "design_good.dart (class-only-static)"?>
 {% prettify dart tag=pre+code %}
 DateTime mostRecent(List<DateTime> dates) {
   return dates.reduce((a, b) => a.isAfter(b) ? a : b);
@@ -608,7 +609,7 @@ const _favoriteMammal = 'weasel';
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static)"?>
+<?code-excerpt "design_bad.dart (class-only-static)"?>
 {% prettify dart tag=pre+code %}
 class DateUtils {
   static DateTime mostRecent(List<DateTime> dates) {
@@ -628,7 +629,7 @@ However, this isn't a hard rule. With constants and enum-like types, it may be
 natural to group them in a class.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (class-only-static-exception)"?>
+<?code-excerpt "design_bad.dart (class-only-static-exception)"?>
 {% prettify dart tag=pre+code %}
 class Color {
   static const red = '#f00';
@@ -708,7 +709,7 @@ that your mixin stays within the restrictions. When defining a new type that you
 intend to be used as a mixin, use this syntax.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (mixin)"?>
+<?code-excerpt "design_good.dart (mixin)"?>
 {% prettify dart tag=pre+code %}
 mixin ClickableMixin implements Control {
   bool _isDown = false;
@@ -955,7 +956,7 @@ clearly, including the conditions under which `null` will be returned.
 Method cascades are a better solution for chaining method calls.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (cascades)"?>
+<?code-excerpt "design_good.dart (cascades)"?>
 {% prettify dart tag=pre+code %}
 var buffer = StringBuffer()
   ..write('one')
@@ -964,7 +965,7 @@ var buffer = StringBuffer()
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (cascades)"?>
+<?code-excerpt "design_bad.dart (cascades)"?>
 {% prettify dart tag=pre+code %}
 var buffer = StringBuffer()
     .write('one')
@@ -985,7 +986,7 @@ types". You can type annotate a variable, parameter, field, or return type. In
 the following example, `bool` and `String` are type annotations. They hang off
 the static declarative structure of the code and aren't "executed" at runtime.
 
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-declaration)"?>
+<?code-excerpt "design_good.dart (annotate-declaration)"?>
 {% prettify dart tag=pre+code %}
 bool isEmpty(String parameter) {
   bool result = parameter.isEmpty;
@@ -999,7 +1000,7 @@ and `int` are type arguments on generic invocations. Even though they are types,
 they are first-class entities that get reified and passed to the invocation at
 runtime.
 
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-invocation)"?>
+<?code-excerpt "design_good.dart (annotate-invocation)"?>
 {% prettify dart tag=pre+code %}
 var lists = <num>[1, 2];
 lists.addAll(List<num>.filled(3, 4));
@@ -1009,7 +1010,7 @@ lists.cast<int>();
 We stress the "generic invocation" part here, because type arguments can *also*
 appear in type annotations:
 
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (annotate-type-arg)"?>
+<?code-excerpt "design_good.dart (annotate-type-arg)"?>
 {% prettify dart tag=pre+code %}
 List<int> ints = [1, 2];
 {% endprettify %}
@@ -1083,7 +1084,7 @@ They form boundaries between regions of a program to isolate the source of a
 type error. Consider:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (type_annotate_public_apis)"?>
+<?code-excerpt "design_bad.dart (type_annotate_public_apis)"?>
 {% prettify dart tag=pre+code %}
 install(id, destination) => ...
 {% endprettify %}
@@ -1092,7 +1093,7 @@ Here, it's unclear what `id` is. A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous? This is clearer:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (type_annotate_public_apis)"?>
+<?code-excerpt "design_good.dart (type_annotate_public_apis)"?>
 {% prettify dart tag=pre+code %}
 Future<bool> install(PackageId id, String destination) => ...
 {% endprettify %}
@@ -1100,7 +1101,7 @@ Future<bool> install(PackageId id, String destination) => ...
 In some cases, though, the type is so obvious that writing it is pointless:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred)"?>
+<?code-excerpt "design_good.dart (inferred)"?>
 {% prettify dart tag=pre+code %}
 const screenWidth = 640; // Inferred as int.
 {% endprettify %}
@@ -1146,7 +1147,7 @@ have very little scope. Omitting the type focuses the reader's attention on the
 more important *name* of the variable and its initialized value.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-types-on-locals)"?>
+<?code-excerpt "design_good.dart (omit-types-on-locals)"?>
 {% prettify dart tag=pre+code %}
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
   var desserts = <List<Ingredient>>[];
@@ -1161,7 +1162,7 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (omit-types-on-locals)"?>
+<?code-excerpt "design_bad.dart (omit-types-on-locals)"?>
 {% prettify dart tag=pre+code %}
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
   List<List<Ingredient>> desserts = <List<Ingredient>>[];
@@ -1180,7 +1181,7 @@ inferred. In that case, it *is* a good idea to annotate. Otherwise, you get
 `dynamic` and lose the benefits of static type checking.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (uninitialized-local)"?>
+<?code-excerpt "design_good.dart (uninitialized-local)"?>
 {% prettify dart tag=pre+code %}
 List<AstNode> parameters;
 if (node is Constructor) {
@@ -1206,13 +1207,13 @@ function's parameter type is inferred based on the type of callback that `map()`
 expects:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (func-expr-no-param-type)"?>
+<?code-excerpt "design_good.dart (func-expr-no-param-type)"?>
 {% prettify dart tag=pre+code %}
 var names = people.map((person) => person.name);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (func-expr-no-param-type)"?>
+<?code-excerpt "design_bad.dart (func-expr-no-param-type)"?>
 {% prettify dart tag=pre+code %}
 var names = people.map((Person person) => person.name);
 {% endprettify %}
@@ -1229,13 +1230,13 @@ invocation is the initializer for a type-annotated variable, or is an argument
 to a function, then inference usually fills in the type for you:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (redundant)"?>
+<?code-excerpt "design_good.dart (redundant)"?>
 {% prettify dart tag=pre+code %}
 Set<String> things = Set();
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (redundant)"?>
+<?code-excerpt "design_bad.dart (redundant)"?>
 {% prettify dart tag=pre+code %}
 Set<String> things = Set<String>();
 {% endprettify %}
@@ -1247,13 +1248,13 @@ In other contexts, there isn't enough information to infer the type and then you
 should write the type argument:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (explicit)"?>
+<?code-excerpt "design_good.dart (explicit)"?>
 {% prettify dart tag=pre+code %}
 var things = Set<String>();
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (explicit)"?>
+<?code-excerpt "design_bad.dart (explicit)"?>
 {% prettify dart tag=pre+code %}
 var things = Set();
 {% endprettify %}
@@ -1270,7 +1271,7 @@ want a variable's type to be a supertype of the initializer's type so that you
 can later assign some other sibling type to the variable:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (inferred-wrong)"?>
+<?code-excerpt "design_good.dart (inferred-wrong)"?>
 {% prettify dart tag=pre+code %}
 num highScore(List<num> scores) {
   num highest = 0;
@@ -1316,13 +1317,13 @@ When `dynamic` is the type you want, writing it explicitly makes your intent
 clear.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (prefer-dynamic)"?>
+<?code-excerpt "design_good.dart (prefer-dynamic)"?>
 {% prettify dart tag=pre+code %}
 dynamic mergeJson(dynamic original, dynamic changes) => ...
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (prefer-dynamic)"?>
+<?code-excerpt "design_bad.dart (prefer-dynamic)"?>
 {% prettify dart tag=pre+code %}
 mergeJson(original, changes) => ...
 {% endprettify %}
@@ -1351,13 +1352,13 @@ function.
 [Function]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
+<?code-excerpt "design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 bool isValid(String value, [!bool Function(String)!] test) => ...
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
+<?code-excerpt "design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 bool isValid(String value, [!Function!] test) => ...
 {% endprettify %}
@@ -1371,7 +1372,7 @@ no way to precisely type that and you'd normally have to use `dynamic`.
 `Function` is at least a little more helpful than that:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-arity)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
+<?code-excerpt "design_good.dart (function-arity)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 void handleError([!void Function()!] operation, [!Function!] errorHandler) {
   try {
@@ -1396,13 +1397,13 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
 Setters always return `void` in Dart. Writing the word is pointless.
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid_return_types_on_setters)"?>
+<?code-excerpt "design_bad.dart (avoid_return_types_on_setters)"?>
 {% prettify dart tag=pre+code %}
 void set foo(Foo value) { ... }
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid_return_types_on_setters)"?>
+<?code-excerpt "design_good.dart (avoid_return_types_on_setters)"?>
 {% prettify dart tag=pre+code %}
 set foo(Foo value) { ... }
 {% endprettify %}
@@ -1416,7 +1417,7 @@ Dart has two notations for defining a named typedef for a function type. The
 original syntax looks like:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (old-typedef)"?>
+<?code-excerpt "design_bad.dart (old-typedef)"?>
 {% prettify dart tag=pre+code %}
 typedef int Comparison<T>(T a, T b);
 {% endprettify %}
@@ -1433,7 +1434,7 @@ That syntax has a couple of problems:
     not its *type*. Given:
 
     {:.bad}
-    <?code-excerpt "misc/lib/effective_dart/design_bad.dart (typedef-param)"?>
+    <?code-excerpt "design_bad.dart (typedef-param)"?>
     {% prettify dart tag=pre+code %}
     typedef bool TestNumber(num);
     {% endprettify %}
@@ -1447,7 +1448,7 @@ That syntax has a couple of problems:
 The new syntax looks like this:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef)"?>
+<?code-excerpt "design_good.dart (new-typedef)"?>
 {% prettify dart tag=pre+code %}
 typedef Comparison<T> = int Function(T, T);
 {% endprettify %}
@@ -1455,7 +1456,7 @@ typedef Comparison<T> = int Function(T, T);
 If you want to include a parameter's name, you can do that too:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (new-typedef-param-name)"?>
+<?code-excerpt "design_good.dart (new-typedef-param-name)"?>
 {% prettify dart tag=pre+code %}
 typedef Comparison<T> = int Function(T a, T b);
 {% endprettify %}
@@ -1479,7 +1480,7 @@ generic type argument, you had to first define a typedef for it. Dart 2 supports
 a function type syntax that can be used anywhere a type annotation is allowed:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
+<?code-excerpt "design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 class FilteredObservable {
   final [!bool Function(Event)!] _predicate;
@@ -1515,7 +1516,7 @@ Dart has a special syntax when defining a parameter whose type is a function.
 Sort of like in C, you surround the parameter's name with the function's return
 type and parameter signature:
 
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (function-type-param)"?>
+<?code-excerpt "design_bad.dart (function-type-param)"?>
 {% prettify dart tag=pre+code %}
 Iterable<T> where(bool predicate(T element)) => ...
 {% endprettify %}
@@ -1526,7 +1527,7 @@ general notation for function types, you can use it for function-typed
 parameters as well:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (function-type-param)"?>
+<?code-excerpt "design_good.dart (function-type-param)"?>
 {% prettify dart tag=pre+code %}
 Iterable<T> where(bool Function(T) predicate) => ...
 {% endprettify %}
@@ -1554,7 +1555,7 @@ ensure that the value's runtime type supports the member you want to access
 before you access it.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (Object-vs-dynamic)"?>
+<?code-excerpt "design_good.dart (Object-vs-dynamic)"?>
 {% prettify dart tag=pre+code %}
 /// Returns a Boolean representation for [arg], which must
 /// be a String or bool.
@@ -1606,13 +1607,13 @@ is either always asynchronous or always synchronous, but a function that can be
 either is hard to use correctly.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or)"?>
+<?code-excerpt "design_good.dart (future-or)"?>
 {% prettify dart tag=pre+code %}
 Future<int> triple(FutureOr<int> value) async => (await value) * 3;
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (future-or)"?>
+<?code-excerpt "design_bad.dart (future-or)"?>
 {% prettify dart tag=pre+code %}
 FutureOr<int> triple(FutureOr<int> value) {
   if (value is int) return value * 3;
@@ -1630,7 +1631,7 @@ means it's OK for a *callback's* type to return `FutureOr<T>`:
 [contravariant]: https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (future-or-contra)" replace="/FutureOr.S./[!$&!]/g"?>
+<?code-excerpt "design_good.dart (future-or-contra)" replace="/FutureOr.S./[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 Stream<S> asyncMap<T, S>(
     Iterable<T> iterable, [!FutureOr<S>!] Function(T) callback) async* {
@@ -1667,7 +1668,7 @@ Instead, consider using named arguments, named constructors, or named constants
 to clarify what the call is doing.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-positional-bool-param)"?>
+<?code-excerpt "design_good.dart (avoid-positional-bool-param)"?>
 {% prettify dart tag=pre+code %}
 Task.oneShot();
 Task.repeating();
@@ -1693,7 +1694,7 @@ never need to explicitly pass a "hole" to omit an earlier positional argument to
 pass later one. You're better off using named arguments for that.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (omit-optional-positional)"?>
+<?code-excerpt "design_good.dart (omit-optional-positional)"?>
 {% prettify dart tag=pre+code %}
 String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int end]);
 
@@ -1727,13 +1728,13 @@ value like `null` is accidentally passed when the user thought they were
 providing a real value.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (avoid-mandatory-param)"?>
+<?code-excerpt "design_good.dart (avoid-mandatory-param)"?>
 {% prettify dart tag=pre+code %}
 var rest = string.substring(start);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (avoid-mandatory-param)"?>
+<?code-excerpt "design_bad.dart (avoid-mandatory-param)"?>
 {% prettify dart tag=pre+code %}
 var rest = string.substring(start, null);
 {% endprettify %}
@@ -1815,7 +1816,7 @@ The language specifies that this check is done automatically and your `==`
 method is called only if the right-hand side is not `null`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/design_good.dart (eq-dont-check-for-null)" replace="/operator ==/[!$&!]/g" plaster?>
+<?code-excerpt "design_good.dart (eq-dont-check-for-null)" replace="/operator ==/[!$&!]/g" plaster?>
 {% prettify dart tag=pre+code %}
 class Person {
   final String name;
@@ -1827,7 +1828,7 @@ class Person {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/design_bad.dart (eq-dont-check-for-null)" replace="/\w+ != null/[!$&!]/g" plaster?>
+<?code-excerpt "design_bad.dart (eq-dont-check-for-null)" replace="/\w+ != null/[!$&!]/g" plaster?>
 {% prettify dart tag=pre+code %}
 class Person {
   final String name;

--- a/src/_guides/language/effective-dart/documentation_migrated.md
+++ b/src/_guides/language/effective-dart/documentation_migrated.md
@@ -1,0 +1,523 @@
+---
+title: "Effective Dart: Documentation"
+description: Clear, helpful comments and documentation.
+nextpage:
+  url: /guides/language/effective-dart/usage
+  title: Usage
+prevpage:
+  url: /guides/language/effective-dart/style
+  title: Style
+---
+
+It's easy to think your code is obvious today without realizing how much you
+rely on context already in your head. People new to your code, and
+even your forgetful future self won't have that context. A concise, accurate
+comment only takes a few seconds to write but can save one of those people
+hours of time.
+
+We all know code should be self-documenting and not all comments are helpful.
+But the reality is that most of us don't write as many comments as we should.
+It's like exercise: you technically *can* do too much, but it's a lot more
+likely that you're doing too little. Try to step it up.
+
+## Comments
+
+The following tips apply to comments that you don't want included in the
+generated documentation.
+
+### DO format comments like sentences.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (comments-like-sentences)"?>
+{% prettify dart tag=pre+code %}
+// Not if there is nothing before it.
+if (_chunks.isEmpty) return false;
+{% endprettify %}
+
+Capitalize the first word unless it's a case-sensitive identifier. End it with a
+period (or "!" or "?", I suppose). This is true for all comments: doc comments,
+inline stuff, even TODOs. Even if it's a sentence fragment.
+
+### DON'T use block comments for documentation.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (block-comments)"?>
+{% prettify dart tag=pre+code %}
+greet(name) {
+  // Assume we have a valid name.
+  print('Hi, $name!');
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (block-comments)"?>
+{% prettify dart tag=pre+code %}
+greet(name) {
+  /* Assume we have a valid name. */
+  print('Hi, $name!');
+}
+{% endprettify %}
+
+You can use a block comment (`/* ... */`) to temporarily comment out a section
+of code, but all other comments should use `//`.
+
+## Doc comments
+
+Doc comments are especially handy because [dartdoc][] parses them and generates
+[beautiful doc pages][docs] from them. A doc comment is any comment that appears
+before a declaration and uses the special `///` syntax that dartdoc looks for.
+
+[dartdoc]: https://github.com/dart-lang/dartdoc
+[docs]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}
+
+### DO use `///` doc comments to document members and types.
+
+{% include linter-rule.html rule="slash_for_doc_comments" %}
+
+Using a doc comment instead of a regular comment enables [dartdoc][] to find it
+and generate documentation for it.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)"?>
+{% prettify dart tag=pre+code %}
+/// The number of characters in this chunk when unsplit.
+int get length => ...
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)" replace="/^\///g"?>
+{% prettify dart tag=pre+code %}
+// The number of characters in this chunk when unsplit.
+int get length => ...
+{% endprettify %}
+
+For historical reasons, dartdoc supports two syntaxes of doc comments: `///`
+("C# style") and `/** ... */` ("JavaDoc style"). We prefer `///` because it's
+more compact. `/**` and `*/` add two content-free lines to a multiline doc
+comment. The `///` syntax is also easier to read in some situations, such as
+when a doc comment contains a bulleted list that uses `*` to mark list items.
+
+If you stumble onto code that still uses the JavaDoc style, consider cleaning it
+up.
+
+### PREFER writing doc comments for public APIs.
+
+{% include linter-rule.html rule1="package_api_docs" rule2="public_member_api_docs"%}
+
+You don't have to document every single library, top-level variable, type, and
+member, but you should document most of them.
+
+### CONSIDER writing a library-level doc comment.
+
+Unlike languages like Java where the class is the only unit of program
+organization, in Dart, a library is itself an entity that users work with
+directly, import, and think about. That makes the `library` directive a great
+place for documentation that introduces the reader to the main concepts and
+functionality provided within. Consider including:
+
+* A single-sentence summary of what the library is for.
+* Explanations of terminology used throughout the library.
+* A couple of complete code samples that walk through using the API.
+* Links to the most important or most commonly used classes and functions.
+* Links to external references on the domain the library is concerned with.
+
+You document a library by placing a doc comment right above the `library`
+directive at the start of the file. If the library doesn't have a `library`
+directive, you can add one just to hang the doc comment off of it.
+
+### CONSIDER writing doc comments for private APIs.
+
+Doc comments aren't just for external consumers of your library's public API.
+They can also be helpful for understanding private members that are called from
+other parts of the library.
+
+### DO start doc comments with a single-sentence summary.
+
+Start your doc comment with a brief, user-centric description ending with a
+period. A sentence fragment is often sufficient. Provide just enough context for
+the reader to orient themselves and decide if they should keep reading or look
+elsewhere for the solution to their problem.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence)"?>
+{% prettify dart tag=pre+code %}
+/// Deletes the file at [path] from the file system.
+void delete(String path) {
+  ...
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence)"?>
+{% prettify dart tag=pre+code %}
+/// Depending on the state of the file system and the user's permissions,
+/// certain operations may or may not be possible. If there is no file at
+/// [path] or it can't be accessed, this function throws either [IOError]
+/// or [PermissionError], respectively. Otherwise, this deletes the file.
+void delete(String path) {
+  ...
+}
+{% endprettify %}
+
+### DO separate the first sentence of a doc comment into its own paragraph.
+
+Add a blank line after the first sentence to split it out into its own
+paragraph. If more than a single sentence of explanation is useful, put the
+rest in later paragraphs.
+
+This helps you write a tight first sentence that summarizes the documentation.
+Also, tools like dartdoc use the first paragraph as a short summary in places
+like lists of classes and members.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence-a-paragraph)"?>
+{% prettify dart tag=pre+code %}
+/// Deletes the file at [path].
+///
+/// Throws an [IOError] if the file could not be found. Throws a
+/// [PermissionError] if the file is present but could not be deleted.
+void delete(String path) {
+  ...
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence-a-paragraph)"?>
+{% prettify dart tag=pre+code %}
+/// Deletes the file at [path]. Throws an [IOError] if the file could not
+/// be found. Throws a [PermissionError] if the file is present but could
+/// not be deleted.
+void delete(String path) {
+  ...
+}
+{% endprettify %}
+
+### AVOID redundancy with the surrounding context.
+
+The reader of a class's doc comment can clearly see the name of the class, what
+interfaces it implements, etc. When reading docs for a member, the signature is
+right there, and the enclosing class is obvious. None of that needs to be
+spelled out in the doc comment. Instead, focus on explaining what the reader
+*doesn't* already know.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (redundant)"?>
+{% prettify dart tag=pre+code %}
+class RadioButtonWidget extends Widget {
+  /// Sets the tooltip to [lines], which should have been word wrapped using
+  /// the current font.
+  void tooltip(List<String> lines) {
+    ...
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (redundant)"?>
+{% prettify dart tag=pre+code %}
+class RadioButtonWidget extends Widget {
+  /// Sets the tooltip for this radio button widget to the list of strings in
+  /// [lines].
+  void tooltip(List<String> lines) {
+    ...
+  }
+}
+{% endprettify %}
+
+
+### PREFER starting function or method comments with third-person verbs.
+
+The doc comment should focus on what the code *does*.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (third-person)"?>
+{% prettify dart tag=pre+code %}
+/// Returns `true` if every element satisfies the [predicate].
+bool all(bool predicate(T element)) => ...
+
+/// Starts the stopwatch if not already running.
+void start() {
+  ...
+}
+{% endprettify %}
+
+### PREFER starting variable, getter, or setter comments with noun phrases.
+
+The doc comment should stress what the property *is*. This is true even for
+getters which may do calculation or other work. What the caller cares about is
+the *result* of that work, not the work itself.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-var-etc)"?>
+{% prettify dart tag=pre+code %}
+/// The current day of the week, where `0` is Sunday.
+int weekday;
+
+/// The number of checked buttons on the page.
+int get checkedCount => ...
+{% endprettify %}
+
+If a property has both a getter and a setter, then create a doc comment for
+only one of them. Dartdoc treats the getter and setter like a single field,
+and if both the getter and the setter have doc comments, then
+dartdoc discards the setter's doc comment.
+
+### PREFER starting library or type comments with noun phrases.
+
+Doc comments for classes are often the most important documentation in your
+program. They describe the type's invariants, establish the terminology it uses,
+and provide context to the other doc comments for the class's members. A little
+extra effort here can make all of the other members simpler to document.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-type-or-lib)"?>
+{% prettify dart tag=pre+code %}
+/// A chunk of non-breaking output text terminated by a hard or soft newline.
+///
+/// ...
+class Chunk { ... }
+{% endprettify %}
+
+### CONSIDER including code samples in doc comments.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (code-sample)"?>
+{% prettify dart tag=pre+code %}
+/// Returns the lesser of two numbers.
+///
+/// ```dart
+/// min(5, 3) == 3
+/// ```
+num min(num a, num b) => ...
+{% endprettify %}
+
+Humans are great at generalizing from examples, so even a single code sample
+makes an API easier to learn.
+
+### DO use square brackets in doc comments to refer to in-scope identifiers.
+
+{% include linter-rule.html rule="comment_references" %}
+
+If you surround things like variable, method, or type names in square brackets,
+then dartdoc looks up the name and links to the relevant API docs. Parentheses
+are optional, but can make it clearer when you're referring to a method or
+constructor.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (identifiers)"?>
+{% prettify dart tag=pre+code %}
+/// Throws a [StateError] if ...
+/// similar to [anotherMethod()], but ...
+{% endprettify %}
+
+To link to a member of a specific class, use the class name and member name,
+separated by a dot:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (member)"?>
+{% prettify dart tag=pre+code %}
+/// Similar to [Duration.inDays], but handles fractional days.
+{% endprettify %}
+
+The dot syntax can also be used to refer to named constructors. For the unnamed
+constructor, put parentheses after the class name:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (ctor)"?>
+{% prettify dart tag=pre+code %}
+/// To create a point, call [Point()] or use [Point.polar()] to ...
+{% endprettify %}
+
+### DO use prose to explain parameters, return values, and exceptions.
+
+Other languages use verbose tags and sections to describe what the parameters
+and returns of a method are.
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (no-annotations)"?>
+{% prettify dart tag=pre+code %}
+/// Defines a flag with the given name and abbreviation.
+///
+/// @param name The name of the flag.
+/// @param abbr The abbreviation for the flag.
+/// @returns The new flag.
+/// @throws ArgumentError If there is already an option with
+///     the given name or abbreviation.
+Flag addFlag(String name, String abbr) => ...
+{% endprettify %}
+
+The convention in Dart is to integrate that into the description of the method
+and highlight parameters using square brackets.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (no-annotations)"?>
+{% prettify dart tag=pre+code %}
+/// Defines a flag.
+///
+/// Throws an [ArgumentError] if there is already an option named [name] or
+/// there is already an option using abbreviation [abbr]. Returns the new flag.
+Flag addFlag(String name, String abbr) => ...
+{% endprettify %}
+
+### DO put doc comments before metadata annotations.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (doc-before-meta)"?>
+{% prettify dart tag=pre+code %}
+/// A button that can be flipped on and off.
+@Component(selector: 'toggle')
+class ToggleComponent {}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (doc-before-meta)" replace="/\n\n/\n/g"?>
+{% prettify dart tag=pre+code %}
+@Component(selector: 'toggle')
+/// A button that can be flipped on and off.
+class ToggleComponent {}
+{% endprettify %}
+
+
+## Markdown
+
+You are allowed to use most [markdown][] formatting in your doc comments and
+dartdoc will process it accordingly using the [markdown package.][]
+
+[markdown]: https://daringfireball.net/projects/markdown/
+[markdown package.]: {{site.pub}}/packages/markdown
+
+There are tons of guides out there already to introduce you to Markdown. Its
+universal popularity is why we chose it. Here's just a quick example to give you
+a flavor of what's supported:
+
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (markdown)"?>
+{% prettify dart tag=pre+code %}
+/// This is a paragraph of regular text.
+///
+/// This sentence has *two* _emphasized_ words (italics) and **two**
+/// __strong__ ones (bold).
+///
+/// A blank line creates a separate paragraph. It has some `inline code`
+/// delimited using backticks.
+///
+/// * Unordered lists.
+/// * Look like ASCII bullet lists.
+/// * You can also use `-` or `+`.
+///
+/// 1. Numbered lists.
+/// 2. Are, well, numbered.
+/// 1. But the values don't matter.
+///
+///     * You can nest lists too.
+///     * They must be indented at least 4 spaces.
+///     * (Well, 5 including the space after `///`.)
+///
+/// Code blocks are fenced in triple backticks:
+///
+/// ```
+/// this.code
+///     .will
+///     .retain(its, formatting);
+/// ```
+///
+/// The code language (for syntax highlighting) defaults to Dart. You can
+/// specify it by putting the name of the language after the opening backticks:
+///
+/// ```html
+/// <h1>HTML is magical!</h1>
+/// ```
+///
+/// Links can be:
+///
+/// * https://www.just-a-bare-url.com
+/// * [with the URL inline](https://google.com)
+/// * [or separated out][ref link]
+///
+/// [ref link]: https://google.com
+///
+/// # A Header
+///
+/// ## A subheader
+///
+/// ### A subsubheader
+///
+/// #### If you need this many levels of headers, you're doing it wrong
+{% endprettify %}
+
+### AVOID using markdown excessively.
+
+When in doubt, format less. Formatting exists to illuminate your content, not
+replace it. Words are what matter.
+
+### AVOID using HTML for formatting.
+
+It *may* be useful to use it in rare cases for things like tables, but in almost
+all cases, if it's too complex to express in Markdown, you're better off not
+expressing it.
+
+### PREFER backtick fences for code blocks.
+
+Markdown has two ways to indicate a block of code: indenting the code four
+spaces on each line, or surrounding it in a pair of triple-backtick "fence"
+lines. The former syntax is brittle when used inside things like Markdown lists
+where indentation is already meaningful or when the code block itself contains
+indented code.
+
+The backtick syntax avoids those indentation woes, lets you indicate the code's
+language, and is consistent with using backticks for inline code.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+/// You can use [CodeBlockExample] like this:
+///
+/// ```
+/// var example = CodeBlockExample();
+/// print(example.isItGreat); // "Yes."
+/// ```
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+/// You can use [CodeBlockExample] like this:
+///
+///     var example = CodeBlockExample();
+///     print(example.isItGreat); // "Yes."
+{% endprettify %}
+
+## Writing
+
+We think of ourselves as programmers, but most of the characters in a source
+file are intended primarily for humans to read. English is the language we code
+in to modify the brains of our coworkers. As for any programming language, it's
+worth putting effort into improving your proficiency.
+
+This section lists a few guidelines for our docs. You can learn more about
+best practices for technical writing, in general, from articles such as
+[Technical writing style](https://en.wikiversity.org/wiki/Technical_writing_style).
+
+### PREFER brevity.
+
+Be clear and precise, but also terse.
+
+### AVOID abbreviations and acronyms unless they are obvious.
+
+Many people don't know what "i.e.", "e.g." and "et al." mean. That acronym
+that you're sure everyone in your field knows may not be as widely known as you
+think.
+
+### PREFER using "this" instead of "the" to refer to a member's instance.
+
+When documenting a member for a class, you often need to refer back to the
+object the member is being called on. Using "the" can be ambiguous.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/docs_good.dart (this)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  /// The value this wraps.
+  var _value;
+
+  /// True if this box contains a value.
+  bool get hasValue => _value != null;
+}
+{% endprettify %}

--- a/src/_guides/language/effective-dart/documentation_migrated.md
+++ b/src/_guides/language/effective-dart/documentation_migrated.md
@@ -9,6 +9,8 @@ prevpage:
   title: Style
 ---
 
+<?code-excerpt path-base="../null_safety_examples/misc/lib/effective_dart"?>
+
 It's easy to think your code is obvious today without realizing how much you
 rely on context already in your head. People new to your code, and
 even your forgetful future self won't have that context. A concise, accurate
@@ -28,7 +30,7 @@ generated documentation.
 ### DO format comments like sentences.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (comments-like-sentences)"?>
+<?code-excerpt "docs_good.dart (comments-like-sentences)"?>
 {% prettify dart tag=pre+code %}
 // Not if there is nothing before it.
 if (_chunks.isEmpty) return false;
@@ -41,7 +43,7 @@ inline stuff, even TODOs. Even if it's a sentence fragment.
 ### DON'T use block comments for documentation.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (block-comments)"?>
+<?code-excerpt "docs_good.dart (block-comments)"?>
 {% prettify dart tag=pre+code %}
 greet(name) {
   // Assume we have a valid name.
@@ -50,7 +52,7 @@ greet(name) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (block-comments)"?>
+<?code-excerpt "docs_bad.dart (block-comments)"?>
 {% prettify dart tag=pre+code %}
 greet(name) {
   /* Assume we have a valid name. */
@@ -78,14 +80,14 @@ Using a doc comment instead of a regular comment enables [dartdoc][] to find it
 and generate documentation for it.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)"?>
+<?code-excerpt "docs_good.dart (use-doc-comments)"?>
 {% prettify dart tag=pre+code %}
 /// The number of characters in this chunk when unsplit.
 int get length => ...
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (use-doc-comments)" replace="/^\///g"?>
+<?code-excerpt "docs_good.dart (use-doc-comments)" replace="/^\///g"?>
 {% prettify dart tag=pre+code %}
 // The number of characters in this chunk when unsplit.
 int get length => ...
@@ -139,7 +141,7 @@ the reader to orient themselves and decide if they should keep reading or look
 elsewhere for the solution to their problem.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence)"?>
+<?code-excerpt "docs_good.dart (first-sentence)"?>
 {% prettify dart tag=pre+code %}
 /// Deletes the file at [path] from the file system.
 void delete(String path) {
@@ -148,7 +150,7 @@ void delete(String path) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence)"?>
+<?code-excerpt "docs_bad.dart (first-sentence)"?>
 {% prettify dart tag=pre+code %}
 /// Depending on the state of the file system and the user's permissions,
 /// certain operations may or may not be possible. If there is no file at
@@ -170,7 +172,7 @@ Also, tools like dartdoc use the first paragraph as a short summary in places
 like lists of classes and members.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (first-sentence-a-paragraph)"?>
+<?code-excerpt "docs_good.dart (first-sentence-a-paragraph)"?>
 {% prettify dart tag=pre+code %}
 /// Deletes the file at [path].
 ///
@@ -182,7 +184,7 @@ void delete(String path) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (first-sentence-a-paragraph)"?>
+<?code-excerpt "docs_bad.dart (first-sentence-a-paragraph)"?>
 {% prettify dart tag=pre+code %}
 /// Deletes the file at [path]. Throws an [IOError] if the file could not
 /// be found. Throws a [PermissionError] if the file is present but could
@@ -201,7 +203,7 @@ spelled out in the doc comment. Instead, focus on explaining what the reader
 *doesn't* already know.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (redundant)"?>
+<?code-excerpt "docs_good.dart (redundant)"?>
 {% prettify dart tag=pre+code %}
 class RadioButtonWidget extends Widget {
   /// Sets the tooltip to [lines], which should have been word wrapped using
@@ -213,7 +215,7 @@ class RadioButtonWidget extends Widget {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (redundant)"?>
+<?code-excerpt "docs_bad.dart (redundant)"?>
 {% prettify dart tag=pre+code %}
 class RadioButtonWidget extends Widget {
   /// Sets the tooltip for this radio button widget to the list of strings in
@@ -230,7 +232,7 @@ class RadioButtonWidget extends Widget {
 The doc comment should focus on what the code *does*.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (third-person)"?>
+<?code-excerpt "docs_good.dart (third-person)"?>
 {% prettify dart tag=pre+code %}
 /// Returns `true` if every element satisfies the [predicate].
 bool all(bool predicate(T element)) => ...
@@ -248,7 +250,7 @@ getters which may do calculation or other work. What the caller cares about is
 the *result* of that work, not the work itself.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-var-etc)"?>
+<?code-excerpt "docs_good.dart (noun-phrases-for-var-etc)"?>
 {% prettify dart tag=pre+code %}
 /// The current day of the week, where `0` is Sunday.
 int weekday;
@@ -270,7 +272,7 @@ and provide context to the other doc comments for the class's members. A little
 extra effort here can make all of the other members simpler to document.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (noun-phrases-for-type-or-lib)"?>
+<?code-excerpt "docs_good.dart (noun-phrases-for-type-or-lib)"?>
 {% prettify dart tag=pre+code %}
 /// A chunk of non-breaking output text terminated by a hard or soft newline.
 ///
@@ -281,7 +283,7 @@ class Chunk { ... }
 ### CONSIDER including code samples in doc comments.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (code-sample)"?>
+<?code-excerpt "docs_good.dart (code-sample)"?>
 {% prettify dart tag=pre+code %}
 /// Returns the lesser of two numbers.
 ///
@@ -304,7 +306,7 @@ are optional, but can make it clearer when you're referring to a method or
 constructor.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (identifiers)"?>
+<?code-excerpt "docs_good.dart (identifiers)"?>
 {% prettify dart tag=pre+code %}
 /// Throws a [StateError] if ...
 /// similar to [anotherMethod()], but ...
@@ -314,7 +316,7 @@ To link to a member of a specific class, use the class name and member name,
 separated by a dot:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (member)"?>
+<?code-excerpt "docs_good.dart (member)"?>
 {% prettify dart tag=pre+code %}
 /// Similar to [Duration.inDays], but handles fractional days.
 {% endprettify %}
@@ -323,7 +325,7 @@ The dot syntax can also be used to refer to named constructors. For the unnamed
 constructor, put parentheses after the class name:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (ctor)"?>
+<?code-excerpt "docs_good.dart (ctor)"?>
 {% prettify dart tag=pre+code %}
 /// To create a point, call [Point()] or use [Point.polar()] to ...
 {% endprettify %}
@@ -334,7 +336,7 @@ Other languages use verbose tags and sections to describe what the parameters
 and returns of a method are.
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (no-annotations)"?>
+<?code-excerpt "docs_bad.dart (no-annotations)"?>
 {% prettify dart tag=pre+code %}
 /// Defines a flag with the given name and abbreviation.
 ///
@@ -350,7 +352,7 @@ The convention in Dart is to integrate that into the description of the method
 and highlight parameters using square brackets.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (no-annotations)"?>
+<?code-excerpt "docs_good.dart (no-annotations)"?>
 {% prettify dart tag=pre+code %}
 /// Defines a flag.
 ///
@@ -362,7 +364,7 @@ Flag addFlag(String name, String abbr) => ...
 ### DO put doc comments before metadata annotations.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (doc-before-meta)"?>
+<?code-excerpt "docs_good.dart (doc-before-meta)"?>
 {% prettify dart tag=pre+code %}
 /// A button that can be flipped on and off.
 @Component(selector: 'toggle')
@@ -370,7 +372,7 @@ class ToggleComponent {}
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/docs_bad.dart (doc-before-meta)" replace="/\n\n/\n/g"?>
+<?code-excerpt "docs_bad.dart (doc-before-meta)" replace="/\n\n/\n/g"?>
 {% prettify dart tag=pre+code %}
 @Component(selector: 'toggle')
 /// A button that can be flipped on and off.
@@ -390,7 +392,7 @@ There are tons of guides out there already to introduce you to Markdown. Its
 universal popularity is why we chose it. Here's just a quick example to give you
 a flavor of what's supported:
 
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (markdown)"?>
+<?code-excerpt "docs_good.dart (markdown)"?>
 {% prettify dart tag=pre+code %}
 /// This is a paragraph of regular text.
 ///
@@ -511,7 +513,7 @@ When documenting a member for a class, you often need to refer back to the
 object the member is being called on. Using "the" can be ambiguous.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/docs_good.dart (this)"?>
+<?code-excerpt "docs_good.dart (this)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   /// The value this wraps.

--- a/src/_guides/language/effective-dart/index_migrated.md
+++ b/src/_guides/language/effective-dart/index_migrated.md
@@ -1,0 +1,147 @@
+---
+title: Effective Dart
+description: Best practices for building consistent, maintainable, efficient Dart libraries.
+permalink: /guides/language/effective-dart-migrated
+nextpage:
+  url: /guides/language/effective-dart/style
+  title: Style
+---
+
+**TODO: permalink should be "/guides/language/effective-dart-migrated"**
+
+Over the past several years, we've written a ton of Dart code and learned a lot
+about what works well and what doesn't. We're sharing this with you so you can
+write consistent, robust, fast code too. There are two overarching themes:
+
+ 1. **Be consistent.** When it comes to things like formatting, and casing,
+    arguments about which is better are subjective and impossible to resolve.
+    What we do know is that being *consistent* is objectively helpful.
+
+    If two pieces of code look different it should be because they *are*
+    different in some meaningful way. When a bit of code stands out and catches
+    your eye, it should do so for a useful reason.
+
+ 2. **Be brief.** Dart was designed to be familiar, so it inherits many of the
+    same statements and expressions as C, Java, JavaScript and other languages.
+    But we created Dart because there is a lot of room to improve on what those
+    languages offer. We added a bunch of features, from string interpolation to
+    initializing formals, to help you express your intent more simply and
+    easily.
+
+    If there are multiple ways to say something, you should generally pick the
+    most concise one. This is not to say you should [code golf][] yourself into
+    cramming a whole program into a single line. The goal is code that is
+    *economical*, not *dense*.
+
+[code golf]: https://en.wikipedia.org/wiki/Code_golf
+
+The Dart analyzer has a linter to help you write good, consistent code.
+If a linter rule exists that can help you follow a guideline,
+then the guideline links to that rule. Here's an example:
+
+{% include linter-rule.html rule="prefer_collection_literals" %}
+
+For help on
+[enabling linter rules](/guides/language/analysis-options#enabling-linter-rules),
+see the documentation for
+[customizing static analysis](/guides/language/analysis-options).
+
+
+## The guides
+
+We split the guidelines into a few separate pages for easy digestion:
+
+  * **[Style Guide][]** &ndash; This defines the rules for laying out and
+    organizing code, or at least the parts that [dartfmt] doesn't handle for
+    you. The style guide also specifies how identifiers are formatted:
+    `camelCase`, `using_underscores`, etc.
+
+  * **[Documentation Guide][]** &ndash; This tells you everything you need to
+    know about what goes inside comments. Both doc comments and regular,
+    run-of-the-mill code comments.
+
+  * **[Usage Guide][]** &ndash; This teaches you how to make the best use of
+    language features to implement behavior. If it's in a statement or
+    expression, it's covered here.
+
+  * **[Design Guide][]** &ndash; This is the softest guide, but the one
+    with the widest scope. It covers what we've learned about designing
+    consistent, usable APIs for libraries. If it's in a type signature or
+    declaration, this goes over it.
+
+For links to all the guidelines, see the
+[summary](#summary-of-all-rules).
+
+{% comment %}
+<aside class="alert alert-info" markdown="1">
+  **Have feedback on the guides?** <br>
+  Please create a [new issue][] or comment on one of our [existing issues][].
+
+  [new issue]: {{site.repo.this}}/issues/new
+  [existing issues]: {{site.repo.this}}/issues?q=is%3Aopen+is%3Aissue+label%3AEffectiveDart
+</aside>
+{% endcomment %}
+
+[dartfmt]: https://github.com/dart-lang/dart_style#readme
+[style guide]: /guides/language/effective-dart/style
+[documentation guide]: /guides/language/effective-dart/documentation
+[usage guide]: /guides/language/effective-dart/usage
+[design guide]: /guides/language/effective-dart/design
+
+## How to read the guides
+
+Each guide is broken into a few sections. Sections contain a list of guidelines.
+Each guideline starts with one of these words:
+
+* **DO** guidelines describe practices that should always be followed. There
+  will almost never be a valid reason to stray from them.
+
+* **DON'T** guidelines are the converse: things that are almost never a good
+  idea. Hopefully, we don't have as many of these as other languages do because
+  we have less historical baggage.
+
+* **PREFER** guidelines are practices that you *should* follow. However, there
+  may be circumstances where it makes sense to do otherwise. Just make sure you
+  understand the full implications of ignoring the guideline when you do.
+
+* **AVOID** guidelines are the dual to "prefer": stuff you shouldn't do but
+  where there may be good reasons to on rare occasions.
+
+* **CONSIDER** guidelines are practices that you might or might not want to
+  follow, depending on circumstances, precedents, and your own preference.
+
+Some guidelines describe an **exception** where the rule does *not* apply. When
+listed, the exceptions may not be exhaustive&mdash;you might still need to use
+your judgement on other cases.
+
+This sounds like the police are going to beat down your door if you don't have
+your laces tied correctly. Things aren't that bad. Most of the guidelines here
+are common sense and we're all reasonable people. The goal, as always, is nice,
+readable and maintainable code.
+
+## Glossary
+
+To keep the guidelines brief, we use a few shorthand terms to refer to different
+Dart constructs.
+
+* A **library member** is a top-level field, getter, setter, or function.
+  Basically, anything at the top level that isn't a type.
+
+* A **class member** is a constructor, field, getter, setter, function, or
+  operator declared inside a class. Class members can be instance or static,
+  abstract or concrete.
+
+* A **member** is either a library member or a class member.
+
+* A **variable**, when used generally, refers to top-level variables,
+  parameters, and local variables. It doesn't include static or instance fields.
+
+* A **type** is any named type declaration: a class, typedef, or enum.
+
+* A **property** is a top-level variable, getter (inside a class or at the top
+  level, instance or static), setter (same), or field (instance or static).
+  Roughly any "field-like" named construct.
+
+## Summary of all rules
+
+{% include_relative toc_migrated.md %}

--- a/src/_guides/language/effective-dart/style_migrated.md
+++ b/src/_guides/language/effective-dart/style_migrated.md
@@ -1,0 +1,520 @@
+---
+title: "Effective Dart: Style"
+description: Formatting and naming rules for consistent, readable code.
+nextpage:
+  url: /guides/language/effective-dart/documentation
+  title: Documentation
+prevpage:
+  url: /guides/language/effective-dart
+  title: Overview
+---
+<?code-excerpt plaster="none"?>
+
+A surprisingly important part of good code is good style. Consistent naming,
+ordering, and formatting helps code that *is* the same *look* the same. It takes
+advantage of the powerful pattern-matching hardware most of us have in our
+ocular systems.  If we use a consistent style across the entire Dart ecosystem,
+it makes it easier for all of us to learn from and contribute to each others'
+code.
+
+## Identifiers
+
+Identifiers come in three flavors in Dart.
+
+*   `UpperCamelCase` names capitalize the first letter of each word, including
+    the first.
+
+*   `lowerCamelCase` names capitalize the first letter of each word, *except*
+    the first which is always lowercase, even if it's an acronym.
+
+*   `lowercase_with_underscores` use only lowercase letters, even for acronyms,
+    and separate words with `_`.
+
+
+### DO name types using `UpperCamelCase`.
+
+{% include linter-rule.html rule="camel_case_types" %}
+
+Classes, enum types, typedefs, and type parameters should capitalize the first
+letter of each word (including the first word), and use no separators.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (type-names)"?>
+{% prettify dart tag=pre+code %}
+class SliderMenu { ... }
+
+class HttpRequest { ... }
+
+typedef Predicate<T> = bool Function(T value);
+{% endprettify %}
+
+This even includes classes intended to be used in metadata annotations.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-type-names)"?>
+{% prettify dart tag=pre+code %}
+class Foo {
+  const Foo([arg]);
+}
+
+@Foo(anArg)
+class A { ... }
+
+@Foo()
+class B { ... }
+{% endprettify %}
+
+If the annotation class's constructor takes no parameters, you might want to
+create a separate `lowerCamelCase` constant for it.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-const)"?>
+{% prettify dart tag=pre+code %}
+const foo = Foo();
+
+@foo
+class C { ... }
+{% endprettify %}
+
+[camel_case_types]: https://dart-lang.github.io/linter/lints/camel_case_types.html
+[Linter rule]: /guides/language/analysis-options#the-analysis-options-file
+
+### DO name extensions using `UpperCamelCase`.
+
+{% include linter-rule.html rule="camel_case_extensions" %}
+
+Like types, extensions should capitalize the first letter of each word
+(including the first word),
+and use no separators.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (extension-names)"?>
+{% prettify dart tag=pre+code %}
+extension MyFancyList<T> on List<T> { ... }
+
+extension SmartIterable<T> on Iterable<T> { ... }
+{% endprettify %}
+
+{{site.alert.version-note}}
+  Extensions are a Dart 2.7 language feature.
+  For details, see the [extensions design document.][]
+{{site.alert.end}}
+
+[extensions design document.]: https://github.com/dart-lang/language/blob/master/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
+
+### DO name libraries, packages, directories, and source files using `lowercase_with_underscores`. {#do-name-libraries-and-source-files-using-lowercase_with_underscores}
+
+{% include linter-rule.html rule1="library_names" rule2="file_names" %}
+<!-- source for rules (update these if you update the guideline):
+https://github.com/dart-lang/linter/blob/master/lib/src/rules/library_names.dart
+https://github.com/dart-lang/linter/blob/master/lib/src/rules/file_names.dart -->
+
+Some file systems are not case-sensitive, so many projects require filenames to
+be all lowercase. Using a separating character allows names to still be readable
+in that form. Using underscores as the separator ensures that the name is still
+a valid Dart identifier, which may be helpful if the language later supports
+symbolic imports.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g"?>
+{% prettify dart tag=pre+code %}
+library peg_parser.source_scanner;
+
+import 'file_system.dart';
+import 'slider_menu.dart';
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g;/file./file-/g;/slider_menu/SliderMenu/g;/source_scanner/SourceScanner/g;/peg_parser/pegparser/g"?>
+{% prettify dart tag=pre+code %}
+library pegparser.SourceScanner;
+
+import 'file-system.dart';
+import 'SliderMenu.dart';
+{% endprettify %}
+
+<aside class="alert alert-info" markdown="1">
+  **Note:** This guideline specifies *how* to name a library *if you choose to
+  name it*. It is fine to _omit_ the library directive in a file if you want.
+</aside>
+
+
+### DO name import prefixes using `lowercase_with_underscores`.
+
+{% include linter-rule.html rule="library_prefixes" %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
+{% prettify dart tag=pre+code %}
+import 'dart:math' as math;
+import 'package:angular_components/angular_components'
+    as angular_components;
+import 'package:js/js.dart' as js;
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g;/as angular_components/as angularComponents/g;/ math/ Math/g;/as js/as JS/g"?>
+{% prettify dart tag=pre+code %}
+import 'dart:math' as Math;
+import 'package:angular_components/angular_components'
+    as angularComponents;
+import 'package:js/js.dart' as JS;
+{% endprettify %}
+
+
+### DO name other identifiers using `lowerCamelCase`.
+
+{% include linter-rule.html rule="non_constant_identifier_names" %}
+
+Class members, top-level definitions, variables, parameters, and named
+parameters should capitalize the first letter of each word *except* the first
+word, and use no separators.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (misc-names)"?>
+{% prettify dart tag=pre+code %}
+var item;
+
+HttpRequest httpRequest;
+
+void align(bool clearItems) {
+  // ...
+}
+{% endprettify %}
+
+
+### PREFER using `lowerCamelCase` for constant names.
+
+{% include linter-rule.html rule="constant_identifier_names" %}
+
+In new code, use `lowerCamelCase` for constant variables, including enum values.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (const-names)"?>
+{% prettify dart tag=pre+code %}
+const pi = 3.14;
+const defaultTimeout = 1000;
+final urlScheme = RegExp('^([a-z]+):');
+
+class Dice {
+  static final numberGenerator = Random();
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_bad.dart (const-names)"?>
+{% prettify dart tag=pre+code %}
+const PI = 3.14;
+const DefaultTimeout = 1000;
+final URL_SCHEME = RegExp('^([a-z]+):');
+
+class Dice {
+  static final NUMBER_GENERATOR = Random();
+}
+{% endprettify %}
+
+You may use `SCREAMING_CAPS` for consistency with existing code,
+as in the following cases:
+
+* When adding code to a file or library that already uses `SCREAMING_CAPS`.
+* When generating Dart code that's parallel to Java code —
+  for example, in enumerated types generated from [protobufs.][]
+
+<aside class="alert alert-info" markdown="1">
+  **Note:** We initially used Java's `SCREAMING_CAPS` style for constants. We
+  changed for a few reasons:
+
+  *   `SCREAMING_CAPS` looks bad for many cases, particularly enum values for
+      things like CSS colors.
+  *   Constants are often changed to final non-const variables, which would
+      necessitate a name change.
+  *   The `values` property automatically defined on an enum type is const and
+      lowercase.
+</aside>
+
+[protobufs.]: {{site.pub-pkg}}/protobuf
+
+
+### DO capitalize acronyms and abbreviations longer than two letters like words.
+
+Capitalized acronyms can be hard to read, and
+multiple adjacent acronyms can lead to ambiguous names.
+For example, given a name that starts with `HTTPSFTP`, there's no way
+to tell if it's referring to HTTPS FTP or HTTP SFTP.
+
+To avoid this, acronyms and abbreviations are capitalized like regular words.
+
+**Exception:** Two-letter *acronyms* like IO (input/output) are fully
+capitalized: `IO`. On the other hand, two-letter *abbreviations* like
+ID (identification) are still capitalized like regular words: `Id`.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+class HttpConnection {}
+class DBIOPort {}
+class TVVcr {}
+class MrRogers {}
+
+var httpRequest = ...
+var uiHandler = ...
+Id id;
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+class HTTPConnection {}
+class DbIoPort {}
+class TvVcr {}
+class MRRogers {}
+
+var hTTPRequest = ...
+var uIHandler = ...
+ID iD;
+{% endprettify %}
+
+
+### PREFER using `_`, `__`, etc. for unused callback parameters.
+
+Sometimes the type signature of a callback function requires a parameter,
+but the callback implementation doesn't _use_ the parameter.
+In this case, it's idiomatic to name the unused parameter `_`.
+If the function has multiple unused parameters, use additional
+underscores to avoid name collisions: `__`, `___`, etc.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (unused-callback-params)"?>
+{% prettify dart tag=pre+code %}
+futureOfVoid.then((_) {
+  print('Operation complete.');
+});
+{% endprettify %}
+
+This guideline is only for functions that are both *anonymous and local*.
+These functions are usually used immediately in a context where it's
+clear what the unused parameter represents.
+In contrast, top-level functions and method declarations don't have that context,
+so their parameters must be named so that it's clear what each parameter is for,
+even if it isn't used.
+
+
+### DON'T use a leading underscore for identifiers that aren't private.
+
+Dart uses a leading underscore in an identifier to mark members and top-level
+declarations as private. This trains users to associate a leading underscore
+with one of those kinds of declarations. They see "_" and think "private".
+
+There is no concept of "private" for local variables, parameters, local
+functions, or library prefixes. When one of those has a name that starts with an
+underscore, it sends a confusing signal to the reader. To avoid that, don't use
+leading underscores in those names.
+
+
+### DON'T use prefix letters.
+
+[Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation) and
+other schemes arose in the time of BCPL, when the compiler didn't do much to
+help you understand your code. Because Dart can tell you the type, scope,
+mutability, and other properties of your declarations, there's no reason to
+encode those properties in identifier names.
+
+{:.good}
+{% prettify dart tag=pre+code %}
+defaultTimeout
+{% endprettify %}
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+kDefaultTimeout
+{% endprettify %}
+
+
+## Ordering
+
+To keep the preamble of your file tidy, we have a prescribed order that
+directives should appear in. Each "section" should be separated by a blank line.
+
+A single linter rule handles all the ordering guidelines:
+[directives_ordering.]({{ site.lints }}/directives_ordering.html)
+
+
+### DO place "dart:" imports before other imports.
+
+{% include linter-rule.html rule="directives_ordering" %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
+{% prettify dart tag=pre+code %}
+import 'dart:async';
+import 'dart:html';
+
+import 'package:bar/bar.dart';
+import 'package:foo/foo.dart';
+{% endprettify %}
+
+
+### DO place "package:" imports before relative imports.
+
+{% include linter-rule.html rule="directives_ordering" %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
+{% prettify dart tag=pre+code %}
+import 'package:bar/bar.dart';
+import 'package:foo/foo.dart';
+
+import 'util.dart';
+{% endprettify %}
+
+
+### DO specify exports in a separate section after all imports.
+
+{% include linter-rule.html rule="directives_ordering" %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (export)"?>
+{% prettify dart tag=pre+code %}
+import 'src/error.dart';
+import 'src/foo_bar.dart';
+
+export 'src/error.dart';
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (export)"?>
+{% prettify dart tag=pre+code %}
+import 'src/error.dart';
+export 'src/error.dart';
+import 'src/foo_bar.dart';
+{% endprettify %}
+
+
+### DO sort sections alphabetically.
+
+{% include linter-rule.html rule="directives_ordering" %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
+{% prettify dart tag=pre+code %}
+import 'package:bar/bar.dart';
+import 'package:foo/foo.dart';
+
+import 'foo.dart';
+import 'foo/foo.dart';
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
+{% prettify dart tag=pre+code %}
+import 'package:foo/foo.dart';
+import 'package:bar/bar.dart';
+
+import 'foo/foo.dart';
+import 'foo.dart';
+{% endprettify %}
+
+
+## Formatting
+
+Like many languages, Dart ignores whitespace. However, *humans* don't. Having a
+consistent whitespace style helps ensure that human readers see code the same
+way the compiler does.
+
+
+### DO format your code using `dartfmt`.
+
+Formatting is tedious work and is particularly time-consuming during
+refactoring. Fortunately, you don't have to worry about it. We provide a
+sophisticated automated code formatter called [dartfmt][] that does it for
+you. We have [some documentation][dartfmt docs] on the rules it applies, but the
+official whitespace-handling rules for Dart are *whatever dartfmt produces*.
+
+The remaining formatting guidelines are for the few things dartfmt cannot fix
+for you.
+
+[dartfmt]: https://github.com/dart-lang/dart_style
+[dartfmt docs]: https://github.com/dart-lang/dart_style/wiki/Formatting-Rules
+
+### CONSIDER changing your code to make it more formatter-friendly.
+
+The formatter does the best it can with whatever code you throw at it, but it
+can't work miracles. If your code has particularly long identifiers, deeply
+nested expressions, a mixture of different kinds of operators, etc. the
+formatted output may still be hard to read.
+
+When that happens, reorganize or simplify your code. Consider shortening a local
+variable name or hoisting out an expression into a new local variable. In other
+words, make the same kinds of modifications that you'd make if you were
+formatting the code by hand and trying to make it more readable. Think of
+dartfmt as a partnership where you work together, sometimes iteratively, to
+produce beautiful code.
+
+
+### AVOID lines longer than 80 characters.
+
+{% include linter-rule.html rule="lines_longer_than_80_chars" %}
+
+Readability studies show that long lines of text are harder to read because your
+eye has to travel farther when moving to the beginning of the next line. This is
+why newspapers and magazines use multiple columns of text.
+
+If you really find yourself wanting lines longer than 80 characters, our
+experience is that your code is likely too verbose and could be a little more
+compact. The main offender is usually `VeryLongCamelCaseClassNames`. Ask
+yourself, "Does each word in that type name tell me something critical or
+prevent a name collision?" If not, consider omitting it.
+
+Note that dartfmt does 99% of this for you, but the last 1% is you. It does not
+split long string literals to fit in 80 columns, so you have to do that
+manually.
+
+**Exception:** When a URI or file path occurs in a comment or string (usually in
+an import or export), it may remain whole even if it causes the line to go over
+80 characters. This makes it easier to search source files for a path.
+
+**Exception:** Multi-line strings can contain lines longer than 80 characters
+because newlines are significant inside the string and splitting the lines into
+shorter ones can alter the program.
+
+### DO use curly braces for all flow control statements. {#do-use-curly-braces-for-all-flow-control-structures}
+
+{% include linter-rule.html rule="curly_braces_in_flow_control_structures" %}
+
+Doing so avoids the [dangling else][] problem.
+
+[dangling else]: https://en.wikipedia.org/wiki/Dangling_else
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (curly-braces)"?>
+{% prettify dart tag=pre+code %}
+if (isWeekDay) {
+  print('Bike to work!');
+} else {
+  print('Go dancing or read a book!');
+}
+{% endprettify %}
+
+**Exception:** When you have an `if` statement with no `else` clause and the
+whole `if` statement fits on one line, you can omit the braces if you prefer:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if)"?>
+{% prettify dart tag=pre+code %}
+if (arg == null) return defaultValue;
+{% endprettify %}
+
+If the body wraps to the next line, though, use braces:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if-wrap)"?>
+{% prettify dart tag=pre+code %}
+if (overflowChars != other.overflowChars) {
+  return overflowChars < other.overflowChars;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/style_bad.dart (one-line-if-wrap)"?>
+{% prettify dart tag=pre+code %}
+if (overflowChars != other.overflowChars)
+  return overflowChars < other.overflowChars;
+{% endprettify %}

--- a/src/_guides/language/effective-dart/style_migrated.md
+++ b/src/_guides/language/effective-dart/style_migrated.md
@@ -9,6 +9,7 @@ prevpage:
   title: Overview
 ---
 <?code-excerpt plaster="none"?>
+<?code-excerpt path-base="../null_safety_examples/misc/lib/effective_dart"?>
 
 A surprisingly important part of good code is good style. Consistent naming,
 ordering, and formatting helps code that *is* the same *look* the same. It takes
@@ -39,7 +40,7 @@ Classes, enum types, typedefs, and type parameters should capitalize the first
 letter of each word (including the first word), and use no separators.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (type-names)"?>
+<?code-excerpt "style_good.dart (type-names)"?>
 {% prettify dart tag=pre+code %}
 class SliderMenu { ... }
 
@@ -51,7 +52,7 @@ typedef Predicate<T> = bool Function(T value);
 This even includes classes intended to be used in metadata annotations.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-type-names)"?>
+<?code-excerpt "style_good.dart (annotation-type-names)"?>
 {% prettify dart tag=pre+code %}
 class Foo {
   const Foo([arg]);
@@ -68,7 +69,7 @@ If the annotation class's constructor takes no parameters, you might want to
 create a separate `lowerCamelCase` constant for it.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (annotation-const)"?>
+<?code-excerpt "style_good.dart (annotation-const)"?>
 {% prettify dart tag=pre+code %}
 const foo = Foo();
 
@@ -88,7 +89,7 @@ Like types, extensions should capitalize the first letter of each word
 and use no separators.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (extension-names)"?>
+<?code-excerpt "style_good.dart (extension-names)"?>
 {% prettify dart tag=pre+code %}
 extension MyFancyList<T> on List<T> { ... }
 
@@ -116,7 +117,7 @@ a valid Dart identifier, which may be helpful if the language later supports
 symbolic imports.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g"?>
+<?code-excerpt "style_lib_good.dart" replace="/foo\///g"?>
 {% prettify dart tag=pre+code %}
 library peg_parser.source_scanner;
 
@@ -125,7 +126,7 @@ import 'slider_menu.dart';
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart" replace="/foo\///g;/file./file-/g;/slider_menu/SliderMenu/g;/source_scanner/SourceScanner/g;/peg_parser/pegparser/g"?>
+<?code-excerpt "style_lib_good.dart" replace="/foo\///g;/file./file-/g;/slider_menu/SliderMenu/g;/source_scanner/SourceScanner/g;/peg_parser/pegparser/g"?>
 {% prettify dart tag=pre+code %}
 library pegparser.SourceScanner;
 
@@ -144,7 +145,7 @@ import 'SliderMenu.dart';
 {% include linter-rule.html rule="library_prefixes" %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
+<?code-excerpt "style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
 {% prettify dart tag=pre+code %}
 import 'dart:math' as math;
 import 'package:angular_components/angular_components'
@@ -153,7 +154,7 @@ import 'package:js/js.dart' as js;
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g;/as angular_components/as angularComponents/g;/ math/ Math/g;/as js/as JS/g"?>
+<?code-excerpt "style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g;/as angular_components/as angularComponents/g;/ math/ Math/g;/as js/as JS/g"?>
 {% prettify dart tag=pre+code %}
 import 'dart:math' as Math;
 import 'package:angular_components/angular_components'
@@ -171,7 +172,7 @@ parameters should capitalize the first letter of each word *except* the first
 word, and use no separators.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (misc-names)"?>
+<?code-excerpt "style_good.dart (misc-names)"?>
 {% prettify dart tag=pre+code %}
 var item;
 
@@ -190,7 +191,7 @@ void align(bool clearItems) {
 In new code, use `lowerCamelCase` for constant variables, including enum values.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (const-names)"?>
+<?code-excerpt "style_good.dart (const-names)"?>
 {% prettify dart tag=pre+code %}
 const pi = 3.14;
 const defaultTimeout = 1000;
@@ -202,7 +203,7 @@ class Dice {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_bad.dart (const-names)"?>
+<?code-excerpt "style_bad.dart (const-names)"?>
 {% prettify dart tag=pre+code %}
 const PI = 3.14;
 const DefaultTimeout = 1000;
@@ -282,7 +283,7 @@ If the function has multiple unused parameters, use additional
 underscores to avoid name collisions: `__`, `___`, etc.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (unused-callback-params)"?>
+<?code-excerpt "style_good.dart (unused-callback-params)"?>
 {% prettify dart tag=pre+code %}
 futureOfVoid.then((_) {
   print('Operation complete.');
@@ -342,7 +343,7 @@ A single linter rule handles all the ordering guidelines:
 {% include linter-rule.html rule="directives_ordering" %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
+<?code-excerpt "style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart tag=pre+code %}
 import 'dart:async';
 import 'dart:html';
@@ -357,7 +358,7 @@ import 'package:foo/foo.dart';
 {% include linter-rule.html rule="directives_ordering" %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
+<?code-excerpt "style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
 {% prettify dart tag=pre+code %}
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
@@ -371,7 +372,7 @@ import 'util.dart';
 {% include linter-rule.html rule="directives_ordering" %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (export)"?>
+<?code-excerpt "style_lib_good.dart (export)"?>
 {% prettify dart tag=pre+code %}
 import 'src/error.dart';
 import 'src/foo_bar.dart';
@@ -380,7 +381,7 @@ export 'src/error.dart';
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (export)"?>
+<?code-excerpt "style_lib_bad.dart (export)"?>
 {% prettify dart tag=pre+code %}
 import 'src/error.dart';
 export 'src/error.dart';
@@ -393,7 +394,7 @@ import 'src/foo_bar.dart';
 {% include linter-rule.html rule="directives_ordering" %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
+<?code-excerpt "style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart tag=pre+code %}
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
@@ -403,7 +404,7 @@ import 'foo/foo.dart';
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_lib_bad.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
+<?code-excerpt "style_lib_bad.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
 {% prettify dart tag=pre+code %}
 import 'package:foo/foo.dart';
 import 'package:bar/bar.dart';
@@ -484,7 +485,7 @@ Doing so avoids the [dangling else][] problem.
 [dangling else]: https://en.wikipedia.org/wiki/Dangling_else
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (curly-braces)"?>
+<?code-excerpt "style_good.dart (curly-braces)"?>
 {% prettify dart tag=pre+code %}
 if (isWeekDay) {
   print('Bike to work!');
@@ -497,7 +498,7 @@ if (isWeekDay) {
 whole `if` statement fits on one line, you can omit the braces if you prefer:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if)"?>
+<?code-excerpt "style_good.dart (one-line-if)"?>
 {% prettify dart tag=pre+code %}
 if (arg == null) return defaultValue;
 {% endprettify %}
@@ -505,7 +506,7 @@ if (arg == null) return defaultValue;
 If the body wraps to the next line, though, use braces:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/style_good.dart (one-line-if-wrap)"?>
+<?code-excerpt "style_good.dart (one-line-if-wrap)"?>
 {% prettify dart tag=pre+code %}
 if (overflowChars != other.overflowChars) {
   return overflowChars < other.overflowChars;
@@ -513,7 +514,7 @@ if (overflowChars != other.overflowChars) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/style_bad.dart (one-line-if-wrap)"?>
+<?code-excerpt "style_bad.dart (one-line-if-wrap)"?>
 {% prettify dart tag=pre+code %}
 if (overflowChars != other.overflowChars)
   return overflowChars < other.overflowChars;

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -1,0 +1,256 @@
+    {% comment %}
+    NOTE: The generator is broken.
+    See https://github.com/dart-lang/site-www/issues/1325.
+
+    This file is generated from the other files in this directory.
+    To re-generate it, please run the following command from root of
+    the project:
+
+      $ dart deploy/effective-dart-rules/bin/main.dart
+
+    {% endcomment %}
+
+<div class='effective_dart--summary_column' markdown='1'>
+
+### Style
+
+
+**Identifiers**
+
+* <a href='/guides/language/effective-dart/style#do-name-types-using-uppercamelcase'>DO name types using <code>UpperCamelCase</code>.</a>
+* <a href='/guides/language/effective-dart/style#do-name-extensions-using-uppercamelcase'>DO name extensions using <code>UpperCamelCase</code>.</a>
+* <a href='/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores'>DO name libraries, packages, directories, and source files using <code>lowercase_with_underscores</code>.</a>
+* <a href='/guides/language/effective-dart/style#do-name-import-prefixes-using-lowercase_with_underscores'>DO name import prefixes using <code>lowercase_with_underscores</code>.</a>
+* <a href='/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase'>DO name other identifiers using <code>lowerCamelCase</code>.</a>
+* <a href='/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names'>PREFER using <code>lowerCamelCase</code> for constant names.</a>
+* <a href='/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words'>DO capitalize acronyms and abbreviations longer than two letters like words.</a>
+* <a href='/guides/language/effective-dart/style#prefer-using-_-__-etc-for-unused-callback-parameters'>PREFER using <code>_</code>, <code>__</code>, etc. for unused callback parameters.</a>
+* <a href='/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private'>DON'T use a leading underscore for identifiers that aren't private.</a>
+* <a href='/guides/language/effective-dart/style#dont-use-prefix-letters'>DON'T use prefix letters.</a>
+
+**Ordering**
+
+* <a href='/guides/language/effective-dart/style#do-place-dart-imports-before-other-imports'>DO place "dart:" imports before other imports.</a>
+* <a href='/guides/language/effective-dart/style#do-place-package-imports-before-relative-imports'>DO place "package:" imports before relative imports.</a>
+* <a href='/guides/language/effective-dart/style#do-specify-exports-in-a-separate-section-after-all-imports'>DO specify exports in a separate section after all imports.</a>
+* <a href='/guides/language/effective-dart/style#do-sort-sections-alphabetically'>DO sort sections alphabetically.</a>
+
+**Formatting**
+
+* <a href='/guides/language/effective-dart/style#do-format-your-code-using-dartfmt'>DO format your code using <code>dartfmt</code>.</a>
+* <a href='/guides/language/effective-dart/style#consider-changing-your-code-to-make-it-more-formatter-friendly'>CONSIDER changing your code to make it more formatter-friendly.</a>
+* <a href='/guides/language/effective-dart/style#avoid-lines-longer-than-80-characters'>AVOID lines longer than 80 characters.</a>
+* <a href='/guides/language/effective-dart/style#do-use-curly-braces-for-all-flow-control-structures'>DO use curly braces for all flow control statements.</a>
+
+</div>
+<div class='effective_dart--summary_column' markdown='1'>
+
+
+### Documentation
+
+
+**Comments**
+
+* <a href='/guides/language/effective-dart/documentation#do-format-comments-like-sentences'>DO format comments like sentences.</a>
+* <a href='/guides/language/effective-dart/documentation#dont-use-block-comments-for-documentation'>DON'T use block comments for documentation.</a>
+
+**Doc comments**
+
+* <a href='/guides/language/effective-dart/documentation#do-use--doc-comments-to-document-members-and-types'>DO use <code>///</code> doc comments to document members and types.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis'>PREFER writing doc comments for public APIs.</a>
+* <a href='/guides/language/effective-dart/documentation#consider-writing-a-library-level-doc-comment'>CONSIDER writing a library-level doc comment.</a>
+* <a href='/guides/language/effective-dart/documentation#consider-writing-doc-comments-for-private-apis'>CONSIDER writing doc comments for private APIs.</a>
+* <a href='/guides/language/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary'>DO start doc comments with a single-sentence summary.</a>
+* <a href='/guides/language/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph'>DO separate the first sentence of a doc comment into its own paragraph.</a>
+* <a href='/guides/language/effective-dart/documentation#avoid-redundancy-with-the-surrounding-context'>AVOID redundancy with the surrounding context.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-starting-function-or-method-comments-with-third-person-verbs'>PREFER starting function or method comments with third-person verbs.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-starting-variable-getter-or-setter-comments-with-noun-phrases'>PREFER starting variable, getter, or setter comments with noun phrases.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-starting-library-or-type-comments-with-noun-phrases'>PREFER starting library or type comments with noun phrases.</a>
+* <a href='/guides/language/effective-dart/documentation#consider-including-code-samples-in-doc-comments'>CONSIDER including code samples in doc comments.</a>
+* <a href='/guides/language/effective-dart/documentation#do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers'>DO use square brackets in doc comments to refer to in-scope identifiers.</a>
+* <a href='/guides/language/effective-dart/documentation#do-use-prose-to-explain-parameters-return-values-and-exceptions'>DO use prose to explain parameters, return values, and exceptions.</a>
+* <a href='/guides/language/effective-dart/documentation#do-put-doc-comments-before-metadata-annotations'>DO put doc comments before metadata annotations.</a>
+
+**Markdown**
+
+* <a href='/guides/language/effective-dart/documentation#avoid-using-markdown-excessively'>AVOID using markdown excessively.</a>
+* <a href='/guides/language/effective-dart/documentation#avoid-using-html-for-formatting'>AVOID using HTML for formatting.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-backtick-fences-for-code-blocks'>PREFER backtick fences for code blocks.</a>
+
+**Writing**
+
+* <a href='/guides/language/effective-dart/documentation#prefer-brevity'>PREFER brevity.</a>
+* <a href='/guides/language/effective-dart/documentation#avoid-abbreviations-and-acronyms-unless-they-are-obvious'>AVOID abbreviations and acronyms unless they are obvious.</a>
+* <a href='/guides/language/effective-dart/documentation#prefer-using-this-instead-of-the-to-refer-to-a-members-instance'>PREFER using "this" instead of "the" to refer to a member's instance.</a>
+
+</div>
+<div style='clear:both'></div>
+<div class='effective_dart--summary_column' markdown='1'>
+
+
+### Usage
+
+
+**Libraries**
+
+* <a href='/guides/language/effective-dart/usage#do-use-strings-in-part-of-directives'>DO use strings in <code>part of</code> directives.</a>
+* <a href='/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package'>DON'T import libraries that are inside the <code>src</code> directory of another package.</a>
+* <a href='/guides/language/effective-dart/usage#do-use-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>DO use relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
+
+**Booleans**
+
+* <a href='/guides/language/effective-dart/usage#do-use--to-convert-null-to-a-boolean-value'>DO use <code>??</code> to convert <code>null</code> to a boolean value.</a>
+
+**Strings**
+
+* <a href='/guides/language/effective-dart/usage#do-use-adjacent-strings-to-concatenate-string-literals'>DO use adjacent strings to concatenate string literals.</a>
+* <a href='/guides/language/effective-dart/usage#prefer-using-interpolation-to-compose-strings-and-values'>PREFER using interpolation to compose strings and values.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-using-curly-braces-in-interpolation-when-not-needed'>AVOID using curly braces in interpolation when not needed.</a>
+
+**Collections**
+
+* <a href='/guides/language/effective-dart/usage#do-use-collection-literals-when-possible'>DO use collection literals when possible.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty'>DON'T use <code>.length</code> to see if a collection is empty.</a>
+* <a href='/guides/language/effective-dart/usage#consider-using-higher-order-methods-to-transform-a-sequence'>CONSIDER using higher-order methods to transform a sequence.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-using-iterableforeach-with-a-function-literal'>AVOID using <code>Iterable.forEach()</code> with a function literal.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-listfrom-unless-you-intend-to-change-the-type-of-the-result'>DON'T use <code>List.from()</code> unless you intend to change the type of the result.</a>
+* <a href='/guides/language/effective-dart/usage#do-use-wheretype-to-filter-a-collection-by-type'>DO use <code>whereType()</code> to filter a collection by type.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-cast-when-a-nearby-operation-will-do'>DON'T use <code>cast()</code> when a nearby operation will do.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-using-cast'>AVOID using <code>cast()</code>.</a>
+
+**Functions**
+
+* <a href='/guides/language/effective-dart/usage#do-use-a-function-declaration-to-bind-a-function-to-a-name'>DO use a function declaration to bind a function to a name.</a>
+* <a href='/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do'>DON'T create a lambda when a tear-off will do.</a>
+
+**Parameters**
+
+* <a href='/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value'>DO use <code>=</code> to separate a named parameter from its default value.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
+
+**Variables**
+
+* <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-storing-what-you-can-calculate'>AVOID storing what you can calculate.</a>
+
+**Members**
+
+* <a href='/guides/language/effective-dart/usage#dont-wrap-a-field-in-a-getter-and-setter-unnecessarily'>DON'T wrap a field in a getter and setter unnecessarily.</a>
+* <a href='/guides/language/effective-dart/usage#prefer-using-a-final-field-to-make-a-read-only-property'>PREFER using a <code>final</code> field to make a read-only property.</a>
+* <a href='/guides/language/effective-dart/usage#consider-using--for-simple-members'>CONSIDER using <code>=&gt;</code> for simple members.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-this-when-not-needed-to-avoid-shadowing'>DON'T use <code>this.</code> except to redirect to a named constructor or to avoid shadowing.</a>
+* <a href='/guides/language/effective-dart/usage#do-initialize-fields-at-their-declaration-when-possible'>DO initialize fields at their declaration when possible.</a>
+
+**Constructors**
+
+* <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
+* <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
+* <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
+
+**Error handling**
+
+* <a href='/guides/language/effective-dart/usage#avoid-catches-without-on-clauses'>AVOID catches without <code>on</code> clauses.</a>
+* <a href='/guides/language/effective-dart/usage#dont-discard-errors-from-catches-without-on-clauses'>DON'T discard errors from catches without <code>on</code> clauses.</a>
+* <a href='/guides/language/effective-dart/usage#do-throw-objects-that-implement-error-only-for-programmatic-errors'>DO throw objects that implement <code>Error</code> only for programmatic errors.</a>
+* <a href='/guides/language/effective-dart/usage#dont-explicitly-catch-error-or-types-that-implement-it'>DON'T explicitly catch <code>Error</code> or types that implement it.</a>
+* <a href='/guides/language/effective-dart/usage#do-use-rethrow-to-rethrow-a-caught-exception'>DO use <code>rethrow</code> to rethrow a caught exception.</a>
+
+**Asynchrony**
+
+* <a href='/guides/language/effective-dart/usage#prefer-asyncawait-over-using-raw-futures'>PREFER async/await over using raw futures.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-async-when-it-has-no-useful-effect'>DON'T use <code>async</code> when it has no useful effect.</a>
+* <a href='/guides/language/effective-dart/usage#consider-using-higher-order-methods-to-transform-a-stream'>CONSIDER using higher-order methods to transform a stream.</a>
+* <a href='/guides/language/effective-dart/usage#avoid-using-completer-directly'>AVOID using Completer directly.</a>
+* <a href='/guides/language/effective-dart/usage#do-test-for-futuret-when-disambiguating-a-futureort-whose-type-argument-could-be-object'>DO test for <code>Future&lt;T&gt;</code> when disambiguating a <code>FutureOr&lt;T&gt;</code> whose type argument could be <code>Object</code>.</a>
+
+</div>
+<div class='effective_dart--summary_column' markdown='1'>
+
+
+### Design
+
+
+**Names**
+
+* <a href='/guides/language/effective-dart/design#do-use-terms-consistently'>DO use terms consistently.</a>
+* <a href='/guides/language/effective-dart/design#avoid-abbreviations'>AVOID abbreviations.</a>
+* <a href='/guides/language/effective-dart/design#prefer-putting-the-most-descriptive-noun-last'>PREFER putting the most descriptive noun last.</a>
+* <a href='/guides/language/effective-dart/design#consider-making-the-code-read-like-a-sentence'>CONSIDER making the code read like a sentence.</a>
+* <a href='/guides/language/effective-dart/design#prefer-a-noun-phrase-for-a-non-boolean-property-or-variable'>PREFER a noun phrase for a non-boolean property or variable.</a>
+* <a href='/guides/language/effective-dart/design#prefer-a-non-imperative-verb-phrase-for-a-boolean-property-or-variable'>PREFER a non-imperative verb phrase for a boolean property or variable.</a>
+* <a href='/guides/language/effective-dart/design#consider-omitting-the-verb-for-a-named-boolean-parameter'>CONSIDER omitting the verb for a named boolean <em>parameter</em>.</a>
+* <a href='/guides/language/effective-dart/design#prefer-the-positive-name-for-a-boolean-property-or-variable'>PREFER the "positive" name for a boolean property or variable.</a>
+* <a href='/guides/language/effective-dart/design#prefer-an-imperative-verb-phrase-for-a-function-or-method-whose-main-purpose-is-a-side-effect'>PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.</a>
+* <a href='/guides/language/effective-dart/design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose'>PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.</a>
+* <a href='/guides/language/effective-dart/design#consider-an-imperative-verb-phrase-for-a-function-or-method-if-you-want-to-draw-attention-to-the-work-it-performs'>CONSIDER an imperative verb phrase for a function or method if you want to draw attention to the work it performs.</a>
+* <a href='/guides/language/effective-dart/design#avoid-starting-a-method-name-with-get'>AVOID starting a method name with <code>get</code>.</a>
+* <a href='/guides/language/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object'>PREFER naming a method <code>to___()</code> if it copies the object's state to a new object.</a>
+* <a href='/guides/language/effective-dart/design#prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object'>PREFER naming a method <code>as___()</code> if it returns a different representation backed by the original object.</a>
+* <a href='/guides/language/effective-dart/design#avoid-describing-the-parameters-in-the-functions-or-methods-name'>AVOID describing the parameters in the function's or method's name.</a>
+* <a href='/guides/language/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters'>DO follow existing mnemonic conventions when naming type parameters.</a>
+
+**Libraries**
+
+* <a href='/guides/language/effective-dart/design#prefer-making-declarations-private'>PREFER making declarations private.</a>
+* <a href='/guides/language/effective-dart/design#consider-declaring-multiple-classes-in-the-same-library'>CONSIDER declaring multiple classes in the same library.</a>
+
+**Classes and mixins**
+
+* <a href='/guides/language/effective-dart/design#avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do'>AVOID defining a one-member abstract class when a simple function will do.</a>
+* <a href='/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members'>AVOID defining a class that contains only static members.</a>
+* <a href='/guides/language/effective-dart/design#avoid-extending-a-class-that-isnt-intended-to-be-subclassed'>AVOID extending a class that isn't intended to be subclassed.</a>
+* <a href='/guides/language/effective-dart/design#do-document-if-your-class-supports-being-extended'>DO document if your class supports being extended.</a>
+* <a href='/guides/language/effective-dart/design#avoid-implementing-a-class-that-isnt-intended-to-be-an-interface'>AVOID implementing a class that isn't intended to be an interface.</a>
+* <a href='/guides/language/effective-dart/design#do-document-if-your-class-supports-being-used-as-an-interface'>DO document if your class supports being used as an interface.</a>
+* <a href='/guides/language/effective-dart/design#do-use-mixin-to-define-a-mixin-type'>DO use <code>mixin</code> to define a mixin type.</a>
+* <a href='/guides/language/effective-dart/design#avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin'>AVOID mixing in a type that isn't intended to be a mixin.</a>
+
+**Constructors**
+
+* <a href='/guides/language/effective-dart/design#consider-making-your-constructor-const-if-the-class-supports-it'>CONSIDER making your constructor <code>const</code> if the class supports it.</a>
+
+**Members**
+
+* <a href='/guides/language/effective-dart/design#prefer-making-fields-and-top-level-variables-final'>PREFER making fields and top-level variables <code>final</code>.</a>
+* <a href='/guides/language/effective-dart/design#do-use-getters-for-operations-that-conceptually-access-properties'>DO use getters for operations that conceptually access properties.</a>
+* <a href='/guides/language/effective-dart/design#do-use-setters-for-operations-that-conceptually-change-properties'>DO use setters for operations that conceptually change properties.</a>
+* <a href='/guides/language/effective-dart/design#dont-define-a-setter-without-a-corresponding-getter'>DON'T define a setter without a corresponding getter.</a>
+* <a href='/guides/language/effective-dart/design#avoid-returning-null-from-members-whose-return-type-is-bool-double-int-or-num'>AVOID returning <code>null</code> from members whose return type is <code>bool</code>, <code>double</code>, <code>int</code>, or <code>num</code>.</a>
+* <a href='/guides/language/effective-dart/design#avoid-returning-this-from-methods-just-to-enable-a-fluent-interface'>AVOID returning <code>this</code> from methods just to enable a fluent interface.</a>
+
+**Types**
+
+* <a href='/guides/language/effective-dart/design#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious'>PREFER type annotating public fields and top-level variables if the type isn't obvious.</a>
+* <a href='/guides/language/effective-dart/design#consider-type-annotating-private-fields-and-top-level-variables-if-the-type-isnt-obvious'>CONSIDER type annotating private fields and top-level variables if the type isn't obvious.</a>
+* <a href='/guides/language/effective-dart/design#avoid-type-annotating-initialized-local-variables'>AVOID type annotating initialized local variables.</a>
+* <a href='/guides/language/effective-dart/design#avoid-annotating-inferred-parameter-types-on-function-expressions'>AVOID annotating inferred parameter types on function expressions.</a>
+* <a href='/guides/language/effective-dart/design#avoid-redundant-type-arguments-on-generic-invocations'>AVOID redundant type arguments on generic invocations.</a>
+* <a href='/guides/language/effective-dart/design#do-annotate-when-dart-infers-the-wrong-type'>DO annotate when Dart infers the wrong type.</a>
+* <a href='/guides/language/effective-dart/design#prefer-annotating-with-dynamic-instead-of-letting-inference-fail'>PREFER annotating with <code>dynamic</code> instead of letting inference fail.</a>
+* <a href='/guides/language/effective-dart/design#prefer-signatures-in-function-type-annotations'>PREFER signatures in function type annotations.</a>
+* <a href='/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter'>DON'T specify a return type for a setter.</a>
+* <a href='/guides/language/effective-dart/design#dont-use-the-legacy-typedef-syntax'>DON'T use the legacy typedef syntax.</a>
+* <a href='/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs'>PREFER inline function types over typedefs.</a>
+* <a href='/guides/language/effective-dart/design#consider-using-function-type-syntax-for-parameters'>CONSIDER using function type syntax for parameters.</a>
+* <a href='/guides/language/effective-dart/design#avoid-using-dynamic-unless-you-want-to-disable-static-checking'>AVOID using <code>dynamic</code> unless you want to disable static checking.</a>
+* <a href='/guides/language/effective-dart/design#do-use-futurevoid-as-the-return-type-of-asynchronous-members-that-do-not-produce-values'>DO use <code>Future&lt;void&gt;</code> as the return type of asynchronous members that do not produce values.</a>
+* <a href='/guides/language/effective-dart/design#avoid-using-futureort-as-a-return-type'>AVOID using <code>FutureOr&lt;T&gt;</code> as a return type.</a>
+
+**Parameters**
+
+* <a href='/guides/language/effective-dart/design#avoid-positional-boolean-parameters'>AVOID positional boolean parameters.</a>
+* <a href='/guides/language/effective-dart/design#avoid-optional-positional-parameters-if-the-user-may-want-to-omit-earlier-parameters'>AVOID optional positional parameters if the user may want to omit earlier parameters.</a>
+* <a href='/guides/language/effective-dart/design#avoid-mandatory-parameters-that-accept-a-special-no-argument-value'>AVOID mandatory parameters that accept a special "no argument" value.</a>
+* <a href='/guides/language/effective-dart/design#do-use-inclusive-start-and-exclusive-end-parameters-to-accept-a-range'>DO use inclusive start and exclusive end parameters to accept a range.</a>
+
+**Equality**
+
+* <a href='/guides/language/effective-dart/design#do-override-hashcode-if-you-override-'>DO override <code>hashCode</code> if you override <code>==</code>.</a>
+* <a href='/guides/language/effective-dart/design#do-make-your--operator-obey-the-mathematical-rules-of-equality'>DO make your <code>==</code> operator obey the mathematical rules of equality.</a>
+* <a href='/guides/language/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes'>AVOID defining custom equality for mutable classes.</a>
+* <a href='/guides/language/effective-dart/design#dont-check-for-null-in-custom--operators'>DON'T check for <code>null</code> in custom <code>==</code> operators.</a>
+
+</div>
+<div style='clear:both'></div>

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -368,7 +368,7 @@ this guideline doesn't apply.
 Given an Iterable, there are two obvious ways to produce a new List that
 contains the same elements:
 
-<?code-excerpt "misc/test/effective_dart_test.dart (list-from-1)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (list-from-1)"?>
 {% prettify dart tag=pre+code %}
 var copy1 = iterable.toList();
 var copy2 = List.from(iterable);
@@ -379,7 +379,7 @@ difference is that the first one preserves the type argument of the original
 object:
 
 {:.good}
-<?code-excerpt "misc/test/effective_dart_test.dart (list-from-good)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (list-from-good)"?>
 {% prettify dart tag=pre+code %}
 // Creates a List<int>:
 var iterable = [1, 2, 3];
@@ -389,7 +389,7 @@ print(iterable.toList().runtimeType);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/test/effective_dart_test.dart (list-from-bad)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (list-from-bad)"?>
 {% prettify dart tag=pre+code %}
 // Creates a List<int>:
 var iterable = [1, 2, 3];
@@ -401,7 +401,7 @@ print(List.from(iterable).runtimeType);
 If you *want* to change the type, then calling `List.from()` is useful:
 
 {:.good}
-<?code-excerpt "misc/test/effective_dart_test.dart (list-from-3)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (list-from-3)"?>
 {% prettify dart tag=pre+code %}
 var numbers = [1, 2.3, 4]; // List<num>.
 numbers.removeAt(1); // Now it only contains integers.
@@ -446,7 +446,7 @@ the [`whereType()`][where-type] method for this exact use case:
 [where-type]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/whereType.html
 
 {:.good}
-<?code-excerpt "misc/test/effective_dart_test.dart (whereType)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (whereType)"?>
 {% prettify dart tag=pre+code %}
 var objects = [1, "a", 2, "b", 3];
 var ints = objects.whereType<int>();

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -188,7 +188,8 @@ a single long string that doesn't fit on one line.
 {:.good}
 <?code-excerpt "usage_good.dart (adjacent-strings-literals)"?>
 {% prettify dart tag=pre+code %}
-raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other '
     'parts are overrun by martians. Unclear which are which.');
 {% endprettify %}
 
@@ -1416,7 +1417,8 @@ omit the `async` without changing the behavior of the function, do so.
 {:.good}
 <?code-excerpt "usage_good.dart (unnecessary-async)"?>
 {% prettify dart tag=pre+code %}
-Future<int> fastestBranch(Future<int> left, Future<int> right) {
+Future<int> fastestBranch(
+    Future<int> left, Future<int> right) {
   return Future.any([left, right]);
 }
 {% endprettify %}

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -953,9 +953,9 @@ Treasure? openChest(Chest chest, Point where) {
 {:.bad}
 <?code-excerpt "usage_bad.dart (arrow-long)"?>
 {% prettify dart tag=pre+code %}
-Treasure? openChest(Chest chest, Point where) =>
-    _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
-      ?..addAll(chest.contents);
+Treasure? openChest(Chest chest, Point where) => _opened.containsKey(chest)
+    ? null
+    : _opened[chest] = (Treasure(where)..addAll(chest.contents));
 {% endprettify %}
 
 You can also use `=>` on members that don't return a value. This is idiomatic

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -1,0 +1,1568 @@
+---
+title: "Effective Dart: Usage"
+description: Guidelines for using language features to write maintainable code.
+nextpage:
+  url: /guides/language/effective-dart/design
+  title: Design
+prevpage:
+  url: /guides/language/effective-dart/documentation
+  title: Documentation
+---
+<?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
+
+You can use these guidelines every day in the bodies of your Dart code. *Users*
+of your library may not be able to tell that you've internalized the ideas here,
+but *maintainers* of it sure will.
+
+## Libraries
+
+These guidelines help you compose your program out of multiple files in a
+consistent, maintainable way. To keep these guidelines brief, they use "import"
+to cover `import` and `export` directives. The guidelines apply equally to both.
+
+### DO use strings in `part of` directives.
+
+Many Dart developers avoid using `part` entirely. They find it easier to reason
+about their code when each library is a single file. If you do choose to use
+`part` to split part of a library out into another file, Dart requires the other
+file to in turn indicate which library it's a part of. For legacy reasons, Dart
+allows this `part of` directive to use the *name* of the library it's a part of.
+That makes it harder for tools to physically find the main library file, and can
+make it ambiguous which library the part is actually part of.
+
+The preferred, modern syntax is to use a URI string that points directly to the
+library file, just like you use in other directives. If you have some library,
+`my_library.dart`, that contains:
+
+<?code-excerpt "misc/lib/effective_dart/my_library.dart"?>
+{% prettify dart tag=pre+code %}
+library my_library;
+
+part "some/other/file.dart";
+{% endprettify %}
+
+Then the part file should look like:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/some/other/file.dart"?>
+{% prettify dart tag=pre+code %}
+part of "../../my_library.dart";
+{% endprettify %}
+
+And not:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/some/other/file_2.dart"?>
+{% prettify dart tag=pre+code %}
+part of my_library;
+{% endprettify %}
+
+### DON'T import libraries that are inside the `src` directory of another package.
+
+{% include linter-rule.html rule="implementation_imports" %}
+
+The `src` directory under `lib` [is specified][package guide] to contain
+libraries private to the package's own implementation. The way package
+maintainers version their package takes this convention into account. They are
+free to make sweeping changes to code under `src` without it being a breaking
+change to the package.
+
+[package guide]: /tools/pub/package-layout
+
+That means that if you import some other package's private library, a minor,
+theoretically non-breaking point release of that package could break your code.
+
+### DO use relative paths when importing libraries within your own package's `lib` directory.
+
+{% include linter-rule.html rule1="avoid_relative_lib_imports" rule2="prefer_relative_imports" %}
+
+When referencing a library inside your package's `lib` directory from another
+library in that same package, use a relative URI, not an explicit `package:`
+URI.
+
+For example, say your directory structure looks like:
+
+```text
+my_package
+└─ lib
+   ├─ src
+   │  └─ utils.dart
+   └─ api.dart
+```
+
+If `api.dart` wants to import `utils.dart`, it should do so using:
+
+{:.good}
+{% prettify dart tag=pre+code %}
+import 'src/utils.dart';
+{% endprettify %}
+
+And not:
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+import 'package:my_package/src/utils.dart';
+{% endprettify %}
+
+The "within your own package's `lib` directory" part is important. Libraries
+inside `lib` can import other libraries inside `lib` (or in subdirectories of
+it). Libraries outside of `lib` can use relative imports to reach other
+libraries outside of `lib`. For example, you may have a test utility library
+under `test` that other libraries in `test` import.
+
+But you can't "cross the streams". A library outside of `lib` should never use a
+relative import to reach a library under `lib`, or vice versa. Doing so will
+break Dart's ability to correctly tell if two library URIs refer to the same
+library, which can lead to unexpected duplicated types.
+
+Follow these two rules:
+
+* An import path should never contain `/lib/`.
+* A library under `lib` should never use `../` to escape the `lib` directory.
+
+## Booleans
+
+### DO use `??` to convert `null` to a boolean value.
+
+This rule applies when an expression can evaluate `true`, `false`, or `null`,
+and you need to pass the result to something that doesn't accept `null`. A
+common case is the result of a null-aware method call being used as a condition:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (null-aware-condition)"?>
+{% prettify dart tag=pre+code %}
+if (optionalThing?.isEnabled) {
+  print("Have enabled thing.");
+}
+{% endprettify %}
+
+This code throws an exception if `optionalThing` is `null`. To fix this, you
+need to "convert" the `null` value to either `true` or `false`. Although you
+could do this using `==`, we recommend using `??`:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (convert-null-aware)"?>
+{% prettify dart tag=pre+code %}
+// If you want null to be false:
+optionalThing?.isEnabled ?? false;
+
+// If you want null to be true:
+optionalThing?.isEnabled ?? true;
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (convert-null-equals)"?>
+{% prettify dart tag=pre+code %}
+// If you want null to be false:
+optionalThing?.isEnabled == true;
+
+// If you want null to be true:
+optionalThing?.isEnabled != false;
+{% endprettify %}
+
+Both operations produce the same result and do the right thing, but `??` is
+preferred for three main reasons:
+
+*   The `??` operator clearly signals that the code has something to do with a
+    `null` value.
+
+*   The `== true` looks like a common new programmer mistake where the equality
+    operator is redundant and can be removed. That's true when the boolean
+    expression on the left will not produce `null`, but not when it can.
+
+*   The `?? false` and `?? true` clearly show what value will be used when the
+    expression is `null`. With `== true`, you have to think through the boolean
+    logic to realize that means that a `null` gets converted to *false*.
+
+## Strings
+
+Here are some best practices to keep in mind when composing strings in Dart.
+
+### DO use adjacent strings to concatenate string literals.
+
+{% include linter-rule.html rule="prefer_adjacent_string_concatenation" %}
+
+If you have two string literals&mdash;not values, but the actual quoted literal
+form&mdash;you do not need to use `+` to concatenate them. Just like in C and
+C++, simply placing them next to each other does it. This is a good way to make
+a single long string that doesn't fit on one line.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (adjacent-strings-literals)"?>
+{% prettify dart tag=pre+code %}
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other '
+    'parts are overrun by martians. Unclear which are which.');
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (adjacent-strings-literals)"?>
+{% prettify dart tag=pre+code %}
+raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
+    'parts are overrun by martians. Unclear which are which.');
+{% endprettify %}
+
+### PREFER using interpolation to compose strings and values.
+
+{% include linter-rule.html rule="prefer_interpolation_to_compose_strings" %}
+
+If you're coming from other languages, you're used to using long chains of `+`
+to build a string out of literals and other values. That does work in Dart, but
+it's almost always cleaner and shorter to use interpolation:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation)"?>
+{% prettify dart tag=pre+code %}
+'Hello, $name! You are ${year - birth} years old.';
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation)"?>
+{% prettify dart tag=pre+code %}
+'Hello, ' + name + '! You are ' + (year - birth).toString() + ' y...';
+{% endprettify %}
+
+### AVOID using curly braces in interpolation when not needed.
+
+{% include linter-rule.html rule="unnecessary_brace_in_string_interps" %}
+
+If you're interpolating a simple identifier not immediately followed by more
+alphanumeric text, the `{}` should be omitted.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation-avoid-curly)"?>
+{% prettify dart tag=pre+code %}
+'Hi, $name!'
+    "Wear your wildest $decade's outfit."
+    'Wear your wildest ${decade}s outfit.'
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation-avoid-curly)"?>
+{% prettify dart tag=pre+code %}
+'Hi, ${name}!'
+    "Wear your wildest ${decade}'s outfit."
+{% endprettify %}
+
+## Collections
+
+Out of the box, Dart supports four collection types: lists, maps, queues, and sets.
+The following best practices apply to collections.
+
+### DO use collection literals when possible.
+
+{% include linter-rule.html rule="prefer_collection_literals" %}
+
+Dart has three core collection types: List, Map, and Set. These classes have
+unnamed constructors like most classes do. But because these collections are
+used so frequently, Dart has nicer built-in syntax for creating them:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (collection-literals)"?>
+{% prettify dart tag=pre+code %}
+var points = <Point>[];
+var addresses = <String, Address>{};
+var counts = <int>{};
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (collection-literals)"?>
+{% prettify dart tag=pre+code %}
+var points = List<Point>();
+var addresses = Map<String, Address>();
+var counts = Set<int>();
+{% endprettify %}
+
+Note that this guideline doesn't apply to the *named* constructors for those
+classes. `List.from()`, `Map.fromIterable()`, and friends all have their uses.
+Likewise, if you're passing a size to `List()` to create a non-growable one,
+then it makes sense to use that.
+
+### DON'T use `.length` to see if a collection is empty.
+
+{% include linter-rule.html rule1="prefer_is_empty" rule2="prefer_is_not_empty" %}
+
+The [Iterable][] contract does not require that a collection know its length or
+be able to provide it in constant time. Calling `.length` just to see if the
+collection contains *anything* can be painfully slow.
+
+[iterable]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
+
+Instead, there are faster and more readable getters: `.isEmpty` and
+`.isNotEmpty`. Use the one that doesn't require you to negate the result.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-use-length)"?>
+{% prettify dart tag=pre+code %}
+if (lunchBox.isEmpty) return 'so hungry...';
+if (words.isNotEmpty) return words.join(' ');
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-use-length)"?>
+{% prettify dart tag=pre+code %}
+if (lunchBox.length == 0) return 'so hungry...';
+if (!words.isEmpty) return words.join(' ');
+{% endprettify %}
+
+### CONSIDER using higher-order methods to transform a sequence.
+
+If you have a collection and want to produce a new modified collection from it,
+it's often shorter and more declarative to use `.map()`, `.where()`, and the
+other handy methods on `Iterable`.
+
+Using those instead of an imperative `for` loop makes it clear that your intent
+is to produce a new sequence and not to produce side effects.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-higher-order-func)"?>
+{% prettify dart tag=pre+code %}
+var aquaticNames = animals
+    .where((animal) => animal.isAquatic)
+    .map((animal) => animal.name);
+{% endprettify %}
+
+At the same time, this can be taken too far. If you are chaining or nesting
+many higher-order methods, it may be clearer to write a chunk of imperative
+code.
+
+### AVOID using `Iterable.forEach()` with a function literal.
+
+{% include linter-rule.html rule="avoid_function_literals_in_foreach_calls" %}
+
+`forEach()` functions are widely used in JavaScript because the built in
+`for-in` loop doesn't do what you usually want. In Dart, if you want to iterate
+over a sequence, the idiomatic way to do that is using a loop.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-forEach)"?>
+{% prettify dart tag=pre+code %}
+for (var person in people) {
+  ...
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-forEach)"?>
+{% prettify dart tag=pre+code %}
+people.forEach((person) {
+  ...
+});
+{% endprettify %}
+
+Note that this guideline specifically says "function *literal*". If you want to
+invoke some *already existing* function on each element, `forEach()` is fine.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (forEach-over-func)"?>
+{% prettify dart tag=pre+code %}
+people.forEach(print);
+{% endprettify %}
+
+Also note that it's always OK to use `Map.forEach()`. Maps aren't iterable, so
+this guideline doesn't apply.
+
+### DON'T use `List.from()` unless you intend to change the type of the result.
+
+Given an Iterable, there are two obvious ways to produce a new List that
+contains the same elements:
+
+<?code-excerpt "misc/test/effective_dart_test.dart (list-from-1)"?>
+{% prettify dart tag=pre+code %}
+var copy1 = iterable.toList();
+var copy2 = List.from(iterable);
+{% endprettify %}
+
+The obvious difference is that the first one is shorter. The *important*
+difference is that the first one preserves the type argument of the original
+object:
+
+{:.good}
+<?code-excerpt "misc/test/effective_dart_test.dart (list-from-good)"?>
+{% prettify dart tag=pre+code %}
+// Creates a List<int>:
+var iterable = [1, 2, 3];
+
+// Prints "List<int>":
+print(iterable.toList().runtimeType);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/test/effective_dart_test.dart (list-from-bad)"?>
+{% prettify dart tag=pre+code %}
+// Creates a List<int>:
+var iterable = [1, 2, 3];
+
+// Prints "List<dynamic>":
+print(List.from(iterable).runtimeType);
+{% endprettify %}
+
+If you *want* to change the type, then calling `List.from()` is useful:
+
+{:.good}
+<?code-excerpt "misc/test/effective_dart_test.dart (list-from-3)"?>
+{% prettify dart tag=pre+code %}
+var numbers = [1, 2.3, 4]; // List<num>.
+numbers.removeAt(1); // Now it only contains integers.
+var ints = List<int>.from(numbers);
+{% endprettify %}
+
+But if your goal is just to copy the iterable and preserve its original type, or
+you don't care about the type, then use `toList()`.
+
+
+### DO use `whereType()` to filter a collection by type.
+
+{% include linter-rule.html rule="prefer_iterable_whereType" %}
+
+Let's say you have a list containing a mixture of objects, and you want to get
+just the integers out of it. You could use `where()` like this:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type)"?>
+{% prettify dart tag=pre+code %}
+var objects = [1, "a", 2, "b", 3];
+var ints = objects.where((e) => e is int);
+{% endprettify %}
+
+This is verbose, but, worse, it returns an iterable whose type probably isn't
+what you want. In the example here, it returns an `Iterable<Object>` even though
+you likely want an `Iterable<int>` since that's the type you're filtering it to.
+
+Sometimes you see code that "corrects" the above error by adding `cast()`:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type-2)"?>
+{% prettify dart tag=pre+code %}
+var objects = [1, "a", 2, "b", 3];
+var ints = objects.where((e) => e is int).cast<int>();
+{% endprettify %}
+
+That's verbose and causes two wrappers to be created, with two layers of
+indirection and redundant runtime checking. Fortunately, the core library has
+the [`whereType()`][where-type] method for this exact use case:
+
+[where-type]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/whereType.html
+
+{:.good}
+<?code-excerpt "misc/test/effective_dart_test.dart (whereType)"?>
+{% prettify dart tag=pre+code %}
+var objects = [1, "a", 2, "b", 3];
+var ints = objects.whereType<int>();
+{% endprettify %}
+
+Using `whereType()` is concise, produces an [Iterable][] of the desired type,
+and has no unnecessary levels of wrapping.
+
+
+### DON'T use `cast()` when a nearby operation will do.
+
+Often when you're dealing with an iterable or stream, you perform several
+transformations on it. At the end, you want to produce an object with a certain
+type argument. Instead of tacking on a call to `cast()`, see if one of the
+existing transformations can change the type.
+
+If you're already calling `toList()`, replace that with a call to
+[`List<T>.from()`][list-from] where `T` is the type of resulting list you want.
+
+[list-from]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List/List.from.html
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-list)"?>
+{% prettify dart tag=pre+code %}
+var stuff = <dynamic>[1, 2];
+var ints = List<int>.from(stuff);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-list)"?>
+{% prettify dart tag=pre+code %}
+var stuff = <dynamic>[1, 2];
+var ints = stuff.toList().cast<int>();
+{% endprettify %}
+
+If you are calling `map()`, give it an explicit type argument so that it
+produces an iterable of the desired type. Type inference often picks the correct
+type for you based on the function you pass to `map()`, but sometimes you need
+to be explicit.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
+{% prettify dart tag=pre+code %}
+var stuff = <dynamic>[1, 2];
+var reciprocals = stuff.map<double>((n) => 1 / n);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
+{% prettify dart tag=pre+code %}
+var stuff = <dynamic>[1, 2];
+var reciprocals = stuff.map((n) => 1 / n).cast<double>();
+{% endprettify %}
+
+
+### AVOID using `cast()`.
+
+This is the softer generalization of the previous rule. Sometimes there is no
+nearby operation you can use to fix the type of some object. Even then, when
+possible avoid using `cast()` to "change" a collection's type.
+
+Prefer any of these options instead:
+
+*   **Create it with the right type.** Change the code where the collection is
+    first created so that it has the right type.
+
+*   **Cast the elements on access.** If you immediately iterate over the
+    collection, cast each element inside the iteration.
+
+*   **Eagerly cast using `List.from()`.** If you'll eventually access most of
+    the elements in the collection, and you don't need the object to be backed
+    by the original live object, convert it using `List.from()`.
+
+    The `cast()` method returns a lazy collection that checks the element type
+    on *every operation*. If you perform only a few operations on only a few
+    elements, that laziness can be good. But in many cases, the overhead of lazy
+    validation and of wrapping outweighs the benefits.
+
+Here is an example of **creating it with the right type:**
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-at-create)"?>
+{% prettify dart tag=pre+code %}
+List<int> singletonList(int value) {
+  var list = <int>[];
+  list.add(value);
+  return list;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-at-create)"?>
+{% prettify dart tag=pre+code %}
+List<int> singletonList(int value) {
+  var list = []; // List<dynamic>.
+  list.add(value);
+  return list.cast<int>();
+}
+{% endprettify %}
+
+Here is **casting each element on access:**
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+void printEvens(List<Object> objects) {
+  // We happen to know the list only contains ints.
+  for (var n in objects) {
+    if ([!(n as int)!].isEven) print(n);
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-iterate)"?>
+{% prettify dart tag=pre+code %}
+void printEvens(List<Object> objects) {
+  // We happen to know the list only contains ints.
+  for (var n in objects.cast<int>()) {
+    if (n.isEven) print(n);
+  }
+}
+{% endprettify %}
+
+Here is **casting eagerly using `List.from()`:**
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-from)"?>
+{% prettify dart tag=pre+code %}
+int median(List<Object> objects) {
+  // We happen to know the list only contains ints.
+  var ints = List<int>.from(objects);
+  ints.sort();
+  return ints[ints.length ~/ 2];
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-from)"?>
+{% prettify dart tag=pre+code %}
+int median(List<Object> objects) {
+  // We happen to know the list only contains ints.
+  var ints = objects.cast<int>();
+  ints.sort();
+  return ints[ints.length ~/ 2];
+}
+{% endprettify %}
+
+These alternatives don't always work, of course, and sometimes `cast()` is the
+right answer. But consider that method a little risky and undesirable&mdash;it
+can be slow and may fail at runtime if you aren't careful.
+
+
+## Functions
+
+In Dart, even functions are objects. Here are some best practices
+involving functions.
+
+
+### DO use a function declaration to bind a function to a name.
+
+{% include linter-rule.html rule="prefer_function_declarations_over_variables" %}
+
+Modern languages have realized how useful local nested functions and closures
+are. It's common to have a function defined inside another one. In many cases,
+this function is used as a callback immediately and doesn't need a name. A
+function expression is great for that.
+
+But, if you do need to give it a name, use a function declaration statement
+instead of binding a lambda to a variable.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (func-decl)"?>
+{% prettify dart tag=pre+code %}
+void main() {
+  localFunction() {
+    ...
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (func-decl)"?>
+{% prettify dart tag=pre+code %}
+void main() {
+  var localFunction = () {
+    ...
+  };
+}
+{% endprettify %}
+
+### DON'T create a lambda when a tear-off will do.
+
+{% include linter-rule.html rule="unnecessary_lambdas" %}
+
+If you refer to a method on an object but omit the parentheses, Dart gives you
+a "tear-off"&mdash;a closure that takes the same parameters as the method and
+invokes it when you call it.
+
+If you have a function that invokes a method with the same arguments as are
+passed to it, you don't need to manually wrap the call in a lambda.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-tear-off)"?>
+{% prettify dart tag=pre+code %}
+names.forEach(print);
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (use-tear-off)"?>
+{% prettify dart tag=pre+code %}
+names.forEach((name) {
+  print(name);
+});
+{% endprettify %}
+
+
+## Parameters
+
+### DO use `=` to separate a named parameter from its default value.
+
+{% include linter-rule.html rule="prefer_equal_for_default_values" %}
+
+For legacy reasons, Dart allows both `:` and `=` as the default value separator
+for named parameters. For consistency with optional positional parameters, use
+`=`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-separator)"?>
+{% prettify dart tag=pre+code %}
+void insert(Object item, {int at = 0}) { ... }
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-separator)"?>
+{% prettify dart tag=pre+code %}
+void insert(Object item, {int at: 0}) { ... }
+{% endprettify %}
+
+
+### DON'T use an explicit default value of `null`.
+
+{% include linter-rule.html rule="avoid_init_to_null" %}
+
+If you make a parameter optional but don't give it a default value, the language
+implicitly uses `null` as the default, so there's no need to write it.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-value-null)"?>
+{% prettify dart tag=pre+code %}
+void error([String message]) {
+  stderr.write(message ?? '\n');
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-value-null)"?>
+{% prettify dart tag=pre+code %}
+void error([String message = null]) {
+  stderr.write(message ?? '\n');
+}
+{% endprettify %}
+
+## Variables
+
+The following best practices describe how to best use variables in Dart.
+
+### DON'T explicitly initialize variables to `null`.
+
+{% include linter-rule.html rule="avoid_init_to_null" %}
+
+In Dart, a variable or field that is not explicitly initialized automatically
+gets initialized to `null`. This is reliably specified by the language. There's
+no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and
+unneeded.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-null-init)"?>
+{% prettify dart tag=pre+code %}
+int _nextId;
+
+class LazyId {
+  int _id;
+
+  int get id {
+    if (_nextId == null) _nextId = 0;
+    if (_id == null) _id = _nextId++;
+
+    return _id;
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-null-init)"?>
+{% prettify dart tag=pre+code %}
+int _nextId = null;
+
+class LazyId {
+  int _id = null;
+
+  int get id {
+    if (_nextId == null) _nextId = 0;
+    if (_id == null) _id = _nextId++;
+
+    return _id;
+  }
+}
+{% endprettify %}
+
+
+### AVOID storing what you can calculate.
+
+When designing a class, you often want to expose multiple views into the same
+underlying state. Often you see code that calculates all of those views in the
+constructor and then stores them:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store1)"?>
+{% prettify dart tag=pre+code %}
+class Circle {
+  double radius;
+  double area;
+  double circumference;
+
+  Circle(double radius)
+      : radius = radius,
+        area = pi * radius * radius,
+        circumference = pi * 2.0 * radius;
+}
+{% endprettify %}
+
+This code has two things wrong with it. First, it's likely wasting memory. The
+area and circumference, strictly speaking, are *caches*. They are stored
+calculations that we could recalculate from other data we already have. They are
+trading increased memory for reduced CPU usage. Do we know we have a performance
+problem that merits that trade-off?
+
+Worse, the code is *wrong*. The problem with caches is *invalidation*&mdash;how
+do you know when the cache is out of date and needs to be recalculated? Here, we
+never do, even though `radius` is mutable. You can assign a different value and
+the `area` and `circumference` will retain their previous, now incorrect values.
+
+To correctly handle cache invalidation, we need to do this:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store2)"?>
+{% prettify dart tag=pre+code %}
+class Circle {
+  double _radius;
+  double get radius => _radius;
+  set radius(double value) {
+    _radius = value;
+    _recalculate();
+  }
+
+  double _area;
+  double get area => _area;
+
+  double _circumference;
+  double get circumference => _circumference;
+
+  Circle(this._radius) {
+    _recalculate();
+  }
+
+  void _recalculate() {
+    _area = pi * _radius * _radius;
+    _circumference = pi * 2.0 * _radius;
+  }
+}
+{% endprettify %}
+
+That's an awful lot of code to write, maintain, debug, and read. Instead, your
+first implementation should be:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cacl-vs-store)"?>
+{% prettify dart tag=pre+code %}
+class Circle {
+  double radius;
+
+  Circle(this.radius);
+
+  double get area => pi * radius * radius;
+  double get circumference => pi * 2.0 * radius;
+}
+{% endprettify %}
+
+This code is shorter, uses less memory, and is less error-prone. It stores the
+minimal amount of data needed to represent the circle. There are no fields to
+get out of sync because there is only a single source of truth.
+
+In some cases, you may need to cache the result of a slow calculation, but only
+do that after you know you have a performance problem, do it carefully, and
+leave a comment explaining the optimization.
+
+
+## Members
+
+In Dart, objects have members which can be functions (methods) or data (instance
+variables). The following best practices apply to an object's members.
+
+### DON'T wrap a field in a getter and setter unnecessarily.
+
+{% include linter-rule.html rule="unnecessary_getters_setters" %}
+
+In Java and C#, it's common to hide all fields behind getters and setters (or
+properties in C#), even if the implementation just forwards to the field. That
+way, if you ever need to do more work in those members, you can without needing
+to touch the callsites. This is because calling a getter method is different
+than accessing a field in Java, and accessing a property isn't binary-compatible
+with accessing a raw field in C#.
+
+Dart doesn't have this limitation. Fields and getters/setters are completely
+indistinguishable. You can expose a field in a class and later wrap it in a
+getter and setter without having to touch any code that uses that field.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-wrap-field)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  var contents;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-wrap-field)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  var _contents;
+  get contents => _contents;
+  set contents(value) {
+    _contents = value;
+  }
+}
+{% endprettify %}
+
+
+### PREFER using a `final` field to make a read-only property.
+
+{% include linter-rule.html rule="unnecessary_getters" %}
+
+If you have a field that outside code should be able to see but not assign to, a
+simple solution that works in many cases is to simply mark it `final`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (final)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  final contents = [];
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (final)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  var _contents;
+  get contents => _contents;
+}
+{% endprettify %}
+
+Of course, if you need to internally assign to the field outside of the
+constructor, you may need to do the "private field, public getter" pattern, but
+don't reach for that until you need to.
+
+
+### CONSIDER using `=>` for simple members.
+
+{% include linter-rule.html rule="prefer_expression_function_bodies" %}
+
+In addition to using `=>` for function expressions, Dart also lets you define
+members with it. That style is a good fit for simple members that just calculate
+and return a value.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-arrow)"?>
+{% prettify dart tag=pre+code %}
+double get area => (right - left) * (bottom - top);
+
+bool isReady(double time) =>
+    minTime == null || minTime <= time;
+
+String capitalize(String name) =>
+    '${name[0].toUpperCase()}${name.substring(1)}';
+{% endprettify %}
+
+People *writing* code seem to love `=>`, but it's very easy to abuse it and end
+up with code that's hard to *read*. If your declaration is more than a couple of
+lines or contains deeply nested expressions&mdash;cascades and conditional
+operators are common offenders&mdash;do yourself and everyone who has to read
+your code a favor and use a block body and some statements.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-long)"?>
+{% prettify dart tag=pre+code %}
+Treasure openChest(Chest chest, Point where) {
+  if (_opened.containsKey(chest)) return null;
+
+  var treasure = Treasure(where);
+  treasure.addAll(chest.contents);
+  _opened[chest] = treasure;
+  return treasure;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (arrow-long)"?>
+{% prettify dart tag=pre+code %}
+Treasure openChest(Chest chest, Point where) =>
+    _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
+      ..addAll(chest.contents);
+{% endprettify %}
+
+You can also use `=>` on members that don't return a value. This is idiomatic
+when a setter is small and has a corresponding getter that uses `=>`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-setter)"?>
+{% prettify dart tag=pre+code %}
+num get x => center.x;
+set x(num value) => center = Point(value, center.y);
+{% endprettify %}
+
+
+### DON'T use `this.` except to redirect to a named constructor or to avoid shadowing. {#dont-use-this-when-not-needed-to-avoid-shadowing}
+
+{% include linter-rule.html rule="unnecessary_this" %}
+
+JavaScript requires an explicit `this.` to refer to members on the object whose
+method is currently being executed, but Dart&mdash;like C++, Java, and
+C#&mdash;doesn't have that limitation.
+
+There are only two times you need to use `this.`. One is when a local variable
+with the same name shadows the member you want to access:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  var value;
+
+  void clear() {
+    this.update(null);
+  }
+
+  void update(value) {
+    this.value = value;
+  }
+}
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot)"?>
+{% prettify dart tag=pre+code %}
+class Box {
+  var value;
+
+  void clear() {
+    update(null);
+  }
+
+  void update(value) {
+    this.value = value;
+  }
+}
+{% endprettify %}
+
+The other time to use `this.` is when redirecting to a named constructor:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot-constructor)"?>
+{% prettify dart tag=pre+code %}
+class ShadeOfGray {
+  final int brightness;
+
+  ShadeOfGray(int val) : brightness = val;
+
+  ShadeOfGray.black() : this(0);
+
+  // This won't parse or compile!
+  // ShadeOfGray.alsoBlack() : black();
+}
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot-constructor)"?>
+{% prettify dart tag=pre+code %}
+class ShadeOfGray {
+  final int brightness;
+
+  ShadeOfGray(int val) : brightness = val;
+
+  ShadeOfGray.black() : this(0);
+
+  // But now it will!
+  ShadeOfGray.alsoBlack() : this.black();
+}
+{% endprettify %}
+
+Note that constructor parameters never shadow fields in constructor
+initialization lists:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (param-dont-shadow-field-ctr-init)"?>
+{% prettify dart tag=pre+code %}
+class Box extends BaseBox {
+  var value;
+
+  Box(value)
+      : value = value,
+        super(value);
+}
+{% endprettify %}
+
+This looks surprising, but works like you want. Fortunately, code like this is
+relatively rare thanks to initializing formals.
+
+
+### DO initialize fields at their declaration when possible.
+
+If a field doesn't depend on any constructor parameters, it can and should be
+initialized at its declaration. It takes less code and makes sure you won't
+forget to initialize it if the class has multiple constructors.
+
+<!-- Q: As of 2.9, this code no longer works.
+  Should we change it or the recommendation? -->
+{:.bad}
+<!-- code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-at-decl)" -->
+{% prettify dart tag=pre+code %}
+class Folder {
+  final String name;
+  final List<Document> contents;
+
+  Folder(this.name) : contents = [];
+  Folder.temp() : name = 'temporary'; // Oops! Forgot contents.
+}
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-at-decl)"?>
+{% prettify dart tag=pre+code %}
+class Folder {
+  final String name;
+  final List<Document> contents = [];
+
+  Folder(this.name);
+  Folder.temp() : name = 'temporary';
+}
+{% endprettify %}
+
+Of course, if a field depends on constructor parameters, or is initialized
+differently by different constructors, then this guideline does not apply.
+
+
+## Constructors
+
+The following best practices apply to declaring constructors for a class.
+
+### DO use initializing formals when possible.
+
+{% include linter-rule.html rule="prefer_initializing_formals" %}
+
+Many fields are initialized directly from a constructor parameter, like:
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-as-param)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  double x, y;
+  Point(double x, double y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+{% endprettify %}
+
+We've got to type `x` _four_ times here to define a field. We can do better:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-as-param)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  double x, y;
+  Point(this.x, this.y);
+}
+{% endprettify %}
+
+This `this.` syntax before a constructor parameter is called an "initializing
+formal". You can't always take advantage of it. Sometimes you want to have a
+named parameter whose name doesn't match the name of the field you are
+initializing. But when you *can* use initializing formals, you *should*.
+
+### DON'T type annotate initializing formals.
+
+{% include linter-rule.html rule="type_init_formals" %}
+
+If a constructor parameter is using `this.` to initialize a field, then the type
+of the parameter is understood to be the same type as the field.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-type-init-formals)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  double x, y;
+  Point(this.x, this.y);
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-type-init-formals)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  int x, y;
+  Point(int this.x, int this.y);
+}
+{% endprettify %}
+
+
+### DO use `;` instead of `{}` for empty constructor bodies.
+
+{% include linter-rule.html rule="empty_constructor_bodies" %}
+
+In Dart, a constructor with an empty body can be terminated with just a
+semicolon. (In fact, it's required for const constructors.)
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (semicolon-for-empty-body)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  double x, y;
+  Point(this.x, this.y);
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (semicolon-for-empty-body)"?>
+{% prettify dart tag=pre+code %}
+class Point {
+  int x, y;
+  Point(this.x, this.y) {}
+}
+{% endprettify %}
+
+### DON'T use `new`.
+
+{% include linter-rule.html rule="unnecessary_new" %}
+
+Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
+clear because factory constructors mean a `new` invocation may still not
+actually return a new object.
+
+The language still permits `new` in order to make migration less painful, but
+consider it deprecated and remove it from your code.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)"?>
+{% prettify dart tag=pre+code %}
+Widget build(BuildContext context) {
+  return Row(
+    children: [
+      RaisedButton(
+        child: Text('Increment'),
+      ),
+      Text('Click!'),
+    ],
+  );
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+Widget build(BuildContext context) {
+  return [!new!] Row(
+    children: [
+      [!new!] RaisedButton(
+        child: [!new!] Text('Increment'),
+      ),
+      [!new!] Text('Click!'),
+    ],
+  );
+}
+{% endprettify %}
+
+
+### DON'T use `const` redundantly.
+
+{% include linter-rule.html rule="unnecessary_const" %}
+
+In contexts where an expression *must* be constant, the `const` keyword is
+implicit, doesn't need to be written, and shouldn't. Those contexts are any
+expression inside:
+
+* A const collection literal.
+* A const constructor call
+* A metadata annotation.
+* The initializer for a const variable declaration.
+* A switch case expression&mdash;the part right after `case` before the `:`, not
+  the body of the case.
+
+(Default values are not included in this list because future versions of Dart
+may support non-const default values.)
+
+Basically, any place where it would be an error to write `new` instead of
+`const`, Dart 2 allows you to omit the `const`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-const)"?>
+{% prettify dart tag=pre+code %}
+const primaryColors = [
+  Color("red", [255, 0, 0]),
+  Color("green", [0, 255, 0]),
+  Color("blue", [0, 0, 255]),
+];
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
+{% prettify dart tag=pre+code %}
+const primaryColors = [!const!] [
+  [!const!] Color("red", [!const!] [255, 0, 0]),
+  [!const!] Color("green", [!const!] [0, 255, 0]),
+  [!const!] Color("blue", [!const!] [0, 0, 255]),
+];
+{% endprettify %}
+
+## Error handling
+
+Dart uses exceptions when an error occurs in your program. The following
+best practices apply to catching and throwing exceptions.
+
+### AVOID catches without `on` clauses.
+
+{% include linter-rule.html rule="avoid_catches_without_on_clauses" %}
+
+A catch clause with no `on` qualifier catches *anything* thrown by the code in
+the try block. [Pokémon exception handling][pokemon] is very likely not what you
+want. Does your code correctly handle [StackOverflowError][] or
+[OutOfMemoryError][]? If you incorrectly pass the wrong argument to a method in
+that try block do you want to have your debugger point you to the mistake or
+would you rather that helpful [ArgumentError][] get swallowed? Do you want any
+`assert()` statements inside that code to effectively vanish since you're
+catching the thrown [AssertionError][]s?
+
+The answer is probably "no", in which case you should filter the types you
+catch. In most cases, you should have an `on` clause that limits you to the
+kinds of runtime failures you are aware of and are correctly handling.
+
+In rare cases, you may wish to catch any runtime error. This is usually in
+framework or low-level code that tries to insulate arbitrary application code
+from causing problems. Even here, it is usually better to catch [Exception][]
+than to catch all types. Exception is the base class for all *runtime* errors
+and excludes errors that indicate *programmatic* bugs in the code.
+
+
+### DON'T discard errors from catches without `on` clauses.
+
+If you really do feel you need to catch *everything* that can be thrown from a
+region of code, *do something* with what you catch. Log it, display it to the
+user or rethrow it, but do not silently discard it.
+
+
+### DO throw objects that implement `Error` only for programmatic errors.
+
+The [Error][] class is the base class for *programmatic* errors. When an object
+of that type or one of its subinterfaces like [ArgumentError][] is thrown, it
+means there is a *bug* in your code. When your API wants to report to a caller
+that it is being used incorrectly throwing an Error sends that signal clearly.
+
+Conversely, if the exception is some kind of runtime failure that doesn't
+indicate a bug in the code, then throwing an Error is misleading. Instead, throw
+one of the core Exception classes or some other type.
+
+
+### DON'T explicitly catch `Error` or types that implement it.
+
+{% include linter-rule.html rule="avoid_catching_errors" %}
+
+This follows from the above. Since an Error indicates a bug in your code, it
+should unwind the entire callstack, halt the program, and print a stack trace so
+you can locate and fix the bug.
+
+Catching errors of these types breaks that process and masks the bug. Instead of
+*adding* error-handling code to deal with this exception after the fact, go back
+and fix the code that is causing it to be thrown in the first place.
+
+
+### DO use `rethrow` to rethrow a caught exception.
+
+{% include linter-rule.html rule="use_rethrow_when_possible" %}
+
+If you decide to rethrow an exception, prefer using the `rethrow` statement
+instead of throwing the same exception object using `throw`.
+`rethrow` preserves the original stack trace of the exception. `throw` on the
+other hand resets the stack trace to the last thrown position.
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (rethrow)"?>
+{% prettify dart tag=pre+code %}
+try {
+  somethingRisky();
+} catch (e) {
+  if (!canHandle(e)) throw e;
+  handle(e);
+}
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (rethrow)" replace="/rethrow/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+try {
+  somethingRisky();
+} catch (e) {
+  if (!canHandle(e)) [!rethrow!];
+  handle(e);
+}
+{% endprettify %}
+
+
+## Asynchrony
+
+Dart has several language features to support asynchronous programming.
+The following best practices apply to asynchronous coding.
+
+### PREFER async/await over using raw futures.
+
+Asynchronous code is notoriously hard to read and debug, even when using a nice
+abstraction like futures. The `async`/`await` syntax improves readability and
+lets you use all of the Dart control flow structures within your async code.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (async-await)" replace="/async|await/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+Future<int> countActivePlayers(String teamName) [!async!] {
+  try {
+    var team = [!await!] downloadTeam(teamName);
+    if (team == null) return 0;
+
+    var players = [!await!] team.roster;
+    return players.where((player) => player.isActive).length;
+  } catch (e) {
+    log.error(e);
+    return 0;
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (async-await)"?>
+{% prettify dart tag=pre+code %}
+Future<int> countActivePlayers(String teamName) {
+  return downloadTeam(teamName).then((team) {
+    if (team == null) return Future.value(0);
+
+    return team.roster.then((players) {
+      return players.where((player) => player.isActive).length;
+    });
+  }).catchError((e) {
+    log.error(e);
+    return 0;
+  });
+}
+{% endprettify %}
+
+### DON'T use `async` when it has no useful effect.
+
+It's easy to get in the habit of using `async` on any function that does
+anything related to asynchrony. But in some cases, it's extraneous. If you can
+omit the `async` without changing the behavior of the function, do so.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (unnecessary-async)"?>
+{% prettify dart tag=pre+code %}
+Future<void> afterTwoThings(
+    Future<void> first, Future<void> second) {
+  return Future.wait([first, second]);
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (unnecessary-async)"?>
+{% prettify dart tag=pre+code %}
+Future<void> afterTwoThings(Future<void> first, Future<void> second) async {
+  return Future.wait([first, second]);
+}
+{% endprettify %}
+
+Cases where `async` *is* useful include:
+
+* You are using `await`. (This is the obvious one.)
+
+* You are returning an error asynchronously. `async` and then `throw` is shorter
+  than `return Future.error(...)`.
+
+* You are returning a value and you want it implicitly wrapped in a future.
+  `async` is shorter than `Future.value(...)`.
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (async)"?>
+{% prettify dart tag=pre+code %}
+Future<void> usesAwait(Future<String> later) async {
+  print(await later);
+}
+
+Future<void> asyncError() async {
+  throw 'Error!';
+}
+
+Future<void> asyncValue() async => 'value';
+{% endprettify %}
+
+### CONSIDER using higher-order methods to transform a stream.
+
+This parallels the above suggestion on iterables. Streams support many of the
+same methods and also handle things like transmitting errors, closing, etc.
+correctly.
+
+### AVOID using Completer directly.
+
+Many people new to asynchronous programming want to write code that produces a
+future. The constructors in Future don't seem to fit their need so they
+eventually find the Completer class and use that.
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-completer)"?>
+{% prettify dart tag=pre+code %}
+Future<bool> fileContainsBear(String path) {
+  var completer = Completer<bool>();
+
+  File(path).readAsString().then((contents) {
+    completer.complete(contents.contains('bear'));
+  });
+
+  return completer.future;
+}
+{% endprettify %}
+
+Completer is needed for two kinds of low-level code: new asynchronous
+primitives, and interfacing with asynchronous code that doesn't use futures.
+Most other code should use async/await or [`Future.then()`][then], because
+they're clearer and make error handling easier.
+
+[then]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future/then.html
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer)"?>
+{% prettify dart tag=pre+code %}
+Future<bool> fileContainsBear(String path) {
+  return File(path).readAsString().then((contents) {
+    return contents.contains('bear');
+  });
+}
+{% endprettify %}
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer-alt)"?>
+{% prettify dart tag=pre+code %}
+Future<bool> fileContainsBear(String path) async {
+  var contents = await File(path).readAsString();
+  return contents.contains('bear');
+}
+{% endprettify %}
+
+
+### DO test for `Future<T>` when disambiguating a `FutureOr<T>` whose type argument could be `Object`.
+
+Before you can do anything useful with a `FutureOr<T>`, you typically need to do
+an `is` check to see if you have a `Future<T>` or a bare `T`. If the type
+argument is some specific type as in `FutureOr<int>`, it doesn't matter which
+test you use, `is int` or `is Future<int>`. Either works because those two types
+are disjoint.
+
+However, if the value type is `Object` or a type parameter that could possibly
+be instantiated with `Object`, then the two branches overlap. `Future<Object>`
+itself implements `Object`, so `is Object` or `is T` where `T` is some type
+parameter that could be instantiated with `Object` returns true even when the
+object is a future. Instead, explicitly test for the `Future` case:
+
+{:.good}
+<?code-excerpt "misc/lib/effective_dart/usage_good.dart (test-future-or)"?>
+{% prettify dart tag=pre+code %}
+Future<T> logValue<T>(FutureOr<T> value) async {
+  if (value is Future<T>) {
+    var result = await value;
+    print(result);
+    return result;
+  } else {
+    print(value);
+    return value as T;
+  }
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (test-future-or)"?>
+{% prettify dart tag=pre+code %}
+Future<T> logValue<T>(FutureOr<T> value) async {
+  if (value is T) {
+    print(value);
+    return value;
+  } else {
+    var result = await value;
+    print(result);
+    return result;
+  }
+}
+{% endprettify %}
+
+In the bad example, if you pass it a `Future<Object>`, it incorrectly treats it
+like a bare, synchronous value.
+
+[pokemon]: https://blog.codinghorror.com/new-programming-jargon/
+[Error]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
+[StackOverflowError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/StackOverflowError-class.html
+[OutOfMemoryError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/OutOfMemoryError-class.html
+[ArgumentError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/ArgumentError-class.html
+[AssertionError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
+[Exception]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -9,6 +9,7 @@ prevpage:
   title: Documentation
 ---
 <?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt path-base="../null_safety_examples/misc/lib/effective_dart"?>
 
 You can use these guidelines every day in the bodies of your Dart code. *Users*
 of your library may not be able to tell that you've internalized the ideas here,
@@ -34,7 +35,7 @@ The preferred, modern syntax is to use a URI string that points directly to the
 library file, just like you use in other directives. If you have some library,
 `my_library.dart`, that contains:
 
-<?code-excerpt "misc/lib/effective_dart/my_library.dart"?>
+<?code-excerpt "my_library.dart"?>
 {% prettify dart tag=pre+code %}
 library my_library;
 
@@ -44,7 +45,7 @@ part "some/other/file.dart";
 Then the part file should look like:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/some/other/file.dart"?>
+<?code-excerpt "some/other/file.dart"?>
 {% prettify dart tag=pre+code %}
 part of "../../my_library.dart";
 {% endprettify %}
@@ -52,7 +53,7 @@ part of "../../my_library.dart";
 And not:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/some/other/file_2.dart"?>
+<?code-excerpt "some/other/file_2.dart"?>
 {% prettify dart tag=pre+code %}
 part of my_library;
 {% endprettify %}
@@ -129,7 +130,7 @@ and you need to pass the result to something that doesn't accept `null`. A
 common case is the result of a null-aware method call being used as a condition:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (null-aware-condition)"?>
+<?code-excerpt "usage_bad.dart (null-aware-condition)"?>
 {% prettify dart tag=pre+code %}
 if (optionalThing?.isEnabled) {
   print("Have enabled thing.");
@@ -141,7 +142,7 @@ need to "convert" the `null` value to either `true` or `false`. Although you
 could do this using `==`, we recommend using `??`:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (convert-null-aware)"?>
+<?code-excerpt "usage_good.dart (convert-null-aware)"?>
 {% prettify dart tag=pre+code %}
 // If you want null to be false:
 optionalThing?.isEnabled ?? false;
@@ -151,7 +152,7 @@ optionalThing?.isEnabled ?? true;
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (convert-null-equals)"?>
+<?code-excerpt "usage_bad.dart (convert-null-equals)"?>
 {% prettify dart tag=pre+code %}
 // If you want null to be false:
 optionalThing?.isEnabled == true;
@@ -188,7 +189,7 @@ C++, simply placing them next to each other does it. This is a good way to make
 a single long string that doesn't fit on one line.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (adjacent-strings-literals)"?>
+<?code-excerpt "usage_good.dart (adjacent-strings-literals)"?>
 {% prettify dart tag=pre+code %}
 raiseAlarm(
     'ERROR: Parts of the spaceship are on fire. Other '
@@ -196,7 +197,7 @@ raiseAlarm(
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (adjacent-strings-literals)"?>
+<?code-excerpt "usage_bad.dart (adjacent-strings-literals)"?>
 {% prettify dart tag=pre+code %}
 raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
     'parts are overrun by martians. Unclear which are which.');
@@ -211,13 +212,13 @@ to build a string out of literals and other values. That does work in Dart, but
 it's almost always cleaner and shorter to use interpolation:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation)"?>
+<?code-excerpt "usage_good.dart (string-interpolation)"?>
 {% prettify dart tag=pre+code %}
 'Hello, $name! You are ${year - birth} years old.';
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation)"?>
+<?code-excerpt "usage_bad.dart (string-interpolation)"?>
 {% prettify dart tag=pre+code %}
 'Hello, ' + name + '! You are ' + (year - birth).toString() + ' y...';
 {% endprettify %}
@@ -230,7 +231,7 @@ If you're interpolating a simple identifier not immediately followed by more
 alphanumeric text, the `{}` should be omitted.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (string-interpolation-avoid-curly)"?>
+<?code-excerpt "usage_good.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart tag=pre+code %}
 'Hi, $name!'
     "Wear your wildest $decade's outfit."
@@ -238,7 +239,7 @@ alphanumeric text, the `{}` should be omitted.
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (string-interpolation-avoid-curly)"?>
+<?code-excerpt "usage_bad.dart (string-interpolation-avoid-curly)"?>
 {% prettify dart tag=pre+code %}
 'Hi, ${name}!'
     "Wear your wildest ${decade}'s outfit."
@@ -258,7 +259,7 @@ unnamed constructors like most classes do. But because these collections are
 used so frequently, Dart has nicer built-in syntax for creating them:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (collection-literals)"?>
+<?code-excerpt "usage_good.dart (collection-literals)"?>
 {% prettify dart tag=pre+code %}
 var points = <Point>[];
 var addresses = <String, Address>{};
@@ -266,7 +267,7 @@ var counts = <int>{};
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (collection-literals)"?>
+<?code-excerpt "usage_bad.dart (collection-literals)"?>
 {% prettify dart tag=pre+code %}
 var points = List<Point>();
 var addresses = Map<String, Address>();
@@ -292,14 +293,14 @@ Instead, there are faster and more readable getters: `.isEmpty` and
 `.isNotEmpty`. Use the one that doesn't require you to negate the result.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-use-length)"?>
+<?code-excerpt "usage_good.dart (dont-use-length)"?>
 {% prettify dart tag=pre+code %}
 if (lunchBox.isEmpty) return 'so hungry...';
 if (words.isNotEmpty) return words.join(' ');
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-use-length)"?>
+<?code-excerpt "usage_bad.dart (dont-use-length)"?>
 {% prettify dart tag=pre+code %}
 if (lunchBox.length == 0) return 'so hungry...';
 if (!words.isEmpty) return words.join(' ');
@@ -315,7 +316,7 @@ Using those instead of an imperative `for` loop makes it clear that your intent
 is to produce a new sequence and not to produce side effects.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-higher-order-func)"?>
+<?code-excerpt "usage_good.dart (use-higher-order-func)"?>
 {% prettify dart tag=pre+code %}
 var aquaticNames = animals
     .where((animal) => animal.isAquatic)
@@ -335,7 +336,7 @@ code.
 over a sequence, the idiomatic way to do that is using a loop.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-forEach)"?>
+<?code-excerpt "usage_good.dart (avoid-forEach)"?>
 {% prettify dart tag=pre+code %}
 for (var person in people) {
   ...
@@ -343,7 +344,7 @@ for (var person in people) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-forEach)"?>
+<?code-excerpt "usage_bad.dart (avoid-forEach)"?>
 {% prettify dart tag=pre+code %}
 people.forEach((person) {
   ...
@@ -354,7 +355,7 @@ Note that this guideline specifically says "function *literal*". If you want to
 invoke some *already existing* function on each element, `forEach()` is fine.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (forEach-over-func)"?>
+<?code-excerpt "usage_good.dart (forEach-over-func)"?>
 {% prettify dart tag=pre+code %}
 people.forEach(print);
 {% endprettify %}
@@ -419,7 +420,7 @@ Let's say you have a list containing a mixture of objects, and you want to get
 just the integers out of it. You could use `where()` like this:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type)"?>
+<?code-excerpt "usage_bad.dart (where-type)"?>
 {% prettify dart tag=pre+code %}
 var objects = [1, "a", 2, "b", 3];
 var ints = objects.where((e) => e is int);
@@ -432,7 +433,7 @@ you likely want an `Iterable<int>` since that's the type you're filtering it to.
 Sometimes you see code that "corrects" the above error by adding `cast()`:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (where-type-2)"?>
+<?code-excerpt "usage_bad.dart (where-type-2)"?>
 {% prettify dart tag=pre+code %}
 var objects = [1, "a", 2, "b", 3];
 var ints = objects.where((e) => e is int).cast<int>();
@@ -468,14 +469,14 @@ If you're already calling `toList()`, replace that with a call to
 [list-from]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List/List.from.html
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-list)"?>
+<?code-excerpt "usage_good.dart (cast-list)"?>
 {% prettify dart tag=pre+code %}
 var stuff = <dynamic>[1, 2];
 var ints = List<int>.from(stuff);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-list)"?>
+<?code-excerpt "usage_bad.dart (cast-list)"?>
 {% prettify dart tag=pre+code %}
 var stuff = <dynamic>[1, 2];
 var ints = stuff.toList().cast<int>();
@@ -487,14 +488,14 @@ type for you based on the function you pass to `map()`, but sometimes you need
 to be explicit.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
+<?code-excerpt "usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 {% prettify dart tag=pre+code %}
 var stuff = <dynamic>[1, 2];
 var reciprocals = stuff.map<double>((n) => 1 / n);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
+<?code-excerpt "usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 {% prettify dart tag=pre+code %}
 var stuff = <dynamic>[1, 2];
 var reciprocals = stuff.map((n) => 1 / n).cast<double>();
@@ -527,7 +528,7 @@ Prefer any of these options instead:
 Here is an example of **creating it with the right type:**
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-at-create)"?>
+<?code-excerpt "usage_good.dart (cast-at-create)"?>
 {% prettify dart tag=pre+code %}
 List<int> singletonList(int value) {
   var list = <int>[];
@@ -537,7 +538,7 @@ List<int> singletonList(int value) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-at-create)"?>
+<?code-excerpt "usage_bad.dart (cast-at-create)"?>
 {% prettify dart tag=pre+code %}
 List<int> singletonList(int value) {
   var list = []; // List<dynamic>.
@@ -549,7 +550,7 @@ List<int> singletonList(int value) {
 Here is **casting each element on access:**
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
+<?code-excerpt "usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 void printEvens(List<Object> objects) {
   // We happen to know the list only contains ints.
@@ -560,7 +561,7 @@ void printEvens(List<Object> objects) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-iterate)"?>
+<?code-excerpt "usage_bad.dart (cast-iterate)"?>
 {% prettify dart tag=pre+code %}
 void printEvens(List<Object> objects) {
   // We happen to know the list only contains ints.
@@ -573,7 +574,7 @@ void printEvens(List<Object> objects) {
 Here is **casting eagerly using `List.from()`:**
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cast-from)"?>
+<?code-excerpt "usage_good.dart (cast-from)"?>
 {% prettify dart tag=pre+code %}
 int median(List<Object> objects) {
   // We happen to know the list only contains ints.
@@ -584,7 +585,7 @@ int median(List<Object> objects) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cast-from)"?>
+<?code-excerpt "usage_bad.dart (cast-from)"?>
 {% prettify dart tag=pre+code %}
 int median(List<Object> objects) {
   // We happen to know the list only contains ints.
@@ -618,7 +619,7 @@ But, if you do need to give it a name, use a function declaration statement
 instead of binding a lambda to a variable.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (func-decl)"?>
+<?code-excerpt "usage_good.dart (func-decl)"?>
 {% prettify dart tag=pre+code %}
 void main() {
   localFunction() {
@@ -628,7 +629,7 @@ void main() {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (func-decl)"?>
+<?code-excerpt "usage_bad.dart (func-decl)"?>
 {% prettify dart tag=pre+code %}
 void main() {
   var localFunction = () {
@@ -649,13 +650,13 @@ If you have a function that invokes a method with the same arguments as are
 passed to it, you don't need to manually wrap the call in a lambda.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-tear-off)"?>
+<?code-excerpt "usage_good.dart (use-tear-off)"?>
 {% prettify dart tag=pre+code %}
 names.forEach(print);
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (use-tear-off)"?>
+<?code-excerpt "usage_bad.dart (use-tear-off)"?>
 {% prettify dart tag=pre+code %}
 names.forEach((name) {
   print(name);
@@ -674,13 +675,13 @@ for named parameters. For consistency with optional positional parameters, use
 `=`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-separator)"?>
+<?code-excerpt "usage_good.dart (default-separator)"?>
 {% prettify dart tag=pre+code %}
 void insert(Object item, {int at = 0}) { ... }
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-separator)"?>
+<?code-excerpt "usage_bad.dart (default-separator)"?>
 {% prettify dart tag=pre+code %}
 void insert(Object item, {int at: 0}) { ... }
 {% endprettify %}
@@ -694,7 +695,7 @@ If you make a parameter optional but don't give it a default value, the language
 implicitly uses `null` as the default, so there's no need to write it.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (default-value-null)"?>
+<?code-excerpt "usage_good.dart (default-value-null)"?>
 {% prettify dart tag=pre+code %}
 void error([String message]) {
   stderr.write(message ?? '\n');
@@ -702,7 +703,7 @@ void error([String message]) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (default-value-null)"?>
+<?code-excerpt "usage_bad.dart (default-value-null)"?>
 {% prettify dart tag=pre+code %}
 void error([String message = null]) {
   stderr.write(message ?? '\n');
@@ -723,7 +724,7 @@ no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and
 unneeded.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-null-init)"?>
+<?code-excerpt "usage_good.dart (no-null-init)"?>
 {% prettify dart tag=pre+code %}
 int _nextId;
 
@@ -740,7 +741,7 @@ class LazyId {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-null-init)"?>
+<?code-excerpt "usage_bad.dart (no-null-init)"?>
 {% prettify dart tag=pre+code %}
 int _nextId = null;
 
@@ -764,7 +765,7 @@ underlying state. Often you see code that calculates all of those views in the
 constructor and then stores them:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store1)"?>
+<?code-excerpt "usage_bad.dart (cacl-vs-store1)"?>
 {% prettify dart tag=pre+code %}
 class Circle {
   double radius;
@@ -792,7 +793,7 @@ the `area` and `circumference` will retain their previous, now incorrect values.
 To correctly handle cache invalidation, we need to do this:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (cacl-vs-store2)"?>
+<?code-excerpt "usage_bad.dart (cacl-vs-store2)"?>
 {% prettify dart tag=pre+code %}
 class Circle {
   double _radius;
@@ -823,7 +824,7 @@ That's an awful lot of code to write, maintain, debug, and read. Instead, your
 first implementation should be:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (cacl-vs-store)"?>
+<?code-excerpt "usage_good.dart (cacl-vs-store)"?>
 {% prettify dart tag=pre+code %}
 class Circle {
   double radius;
@@ -865,7 +866,7 @@ indistinguishable. You can expose a field in a class and later wrap it in a
 getter and setter without having to touch any code that uses that field.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-wrap-field)"?>
+<?code-excerpt "usage_good.dart (dont-wrap-field)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   var contents;
@@ -873,7 +874,7 @@ class Box {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-wrap-field)"?>
+<?code-excerpt "usage_bad.dart (dont-wrap-field)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   var _contents;
@@ -893,7 +894,7 @@ If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (final)"?>
+<?code-excerpt "usage_good.dart (final)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   final contents = [];
@@ -901,7 +902,7 @@ class Box {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (final)"?>
+<?code-excerpt "usage_bad.dart (final)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   var _contents;
@@ -923,7 +924,7 @@ members with it. That style is a good fit for simple members that just calculate
 and return a value.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (use-arrow)"?>
+<?code-excerpt "usage_good.dart (use-arrow)"?>
 {% prettify dart tag=pre+code %}
 double get area => (right - left) * (bottom - top);
 
@@ -941,7 +942,7 @@ operators are common offenders&mdash;do yourself and everyone who has to read
 your code a favor and use a block body and some statements.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-long)"?>
+<?code-excerpt "usage_good.dart (arrow-long)"?>
 {% prettify dart tag=pre+code %}
 Treasure openChest(Chest chest, Point where) {
   if (_opened.containsKey(chest)) return null;
@@ -954,7 +955,7 @@ Treasure openChest(Chest chest, Point where) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (arrow-long)"?>
+<?code-excerpt "usage_bad.dart (arrow-long)"?>
 {% prettify dart tag=pre+code %}
 Treasure openChest(Chest chest, Point where) =>
     _opened.containsKey(chest) ? null : _opened[chest] = Treasure(where)
@@ -965,7 +966,7 @@ You can also use `=>` on members that don't return a value. This is idiomatic
 when a setter is small and has a corresponding getter that uses `=>`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (arrow-setter)"?>
+<?code-excerpt "usage_good.dart (arrow-setter)"?>
 {% prettify dart tag=pre+code %}
 num get x => center.x;
 set x(num value) => center = Point(value, center.y);
@@ -984,7 +985,7 @@ There are only two times you need to use `this.`. One is when a local variable
 with the same name shadows the member you want to access:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot)"?>
+<?code-excerpt "usage_bad.dart (this-dot)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   var value;
@@ -1000,7 +1001,7 @@ class Box {
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot)"?>
+<?code-excerpt "usage_good.dart (this-dot)"?>
 {% prettify dart tag=pre+code %}
 class Box {
   var value;
@@ -1018,7 +1019,7 @@ class Box {
 The other time to use `this.` is when redirecting to a named constructor:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (this-dot-constructor)"?>
+<?code-excerpt "usage_bad.dart (this-dot-constructor)"?>
 {% prettify dart tag=pre+code %}
 class ShadeOfGray {
   final int brightness;
@@ -1033,7 +1034,7 @@ class ShadeOfGray {
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (this-dot-constructor)"?>
+<?code-excerpt "usage_good.dart (this-dot-constructor)"?>
 {% prettify dart tag=pre+code %}
 class ShadeOfGray {
   final int brightness;
@@ -1051,7 +1052,7 @@ Note that constructor parameters never shadow fields in constructor
 initialization lists:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (param-dont-shadow-field-ctr-init)"?>
+<?code-excerpt "usage_good.dart (param-dont-shadow-field-ctr-init)"?>
 {% prettify dart tag=pre+code %}
 class Box extends BaseBox {
   var value;
@@ -1087,7 +1088,7 @@ class Folder {
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-at-decl)"?>
+<?code-excerpt "usage_good.dart (field-init-at-decl)"?>
 {% prettify dart tag=pre+code %}
 class Folder {
   final String name;
@@ -1113,7 +1114,7 @@ The following best practices apply to declaring constructors for a class.
 Many fields are initialized directly from a constructor parameter, like:
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-as-param)"?>
+<?code-excerpt "usage_bad.dart (field-init-as-param)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   double x, y;
@@ -1127,7 +1128,7 @@ class Point {
 We've got to type `x` _four_ times here to define a field. We can do better:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (field-init-as-param)"?>
+<?code-excerpt "usage_good.dart (field-init-as-param)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   double x, y;
@@ -1148,7 +1149,7 @@ If a constructor parameter is using `this.` to initialize a field, then the type
 of the parameter is understood to be the same type as the field.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (dont-type-init-formals)"?>
+<?code-excerpt "usage_good.dart (dont-type-init-formals)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   double x, y;
@@ -1157,7 +1158,7 @@ class Point {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (dont-type-init-formals)"?>
+<?code-excerpt "usage_bad.dart (dont-type-init-formals)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   int x, y;
@@ -1174,7 +1175,7 @@ In Dart, a constructor with an empty body can be terminated with just a
 semicolon. (In fact, it's required for const constructors.)
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (semicolon-for-empty-body)"?>
+<?code-excerpt "usage_good.dart (semicolon-for-empty-body)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   double x, y;
@@ -1183,7 +1184,7 @@ class Point {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (semicolon-for-empty-body)"?>
+<?code-excerpt "usage_bad.dart (semicolon-for-empty-body)"?>
 {% prettify dart tag=pre+code %}
 class Point {
   int x, y;
@@ -1203,7 +1204,7 @@ The language still permits `new` in order to make migration less painful, but
 consider it deprecated and remove it from your code.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-new)"?>
+<?code-excerpt "usage_good.dart (no-new)"?>
 {% prettify dart tag=pre+code %}
 Widget build(BuildContext context) {
   return Row(
@@ -1218,7 +1219,7 @@ Widget build(BuildContext context) {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
+<?code-excerpt "usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 Widget build(BuildContext context) {
   return [!new!] Row(
@@ -1255,7 +1256,7 @@ Basically, any place where it would be an error to write `new` instead of
 `const`, Dart 2 allows you to omit the `const`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (no-const)"?>
+<?code-excerpt "usage_good.dart (no-const)"?>
 {% prettify dart tag=pre+code %}
 const primaryColors = [
   Color("red", [255, 0, 0]),
@@ -1265,7 +1266,7 @@ const primaryColors = [
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
+<?code-excerpt "usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
 {% prettify dart tag=pre+code %}
 const primaryColors = [!const!] [
   [!const!] Color("red", [!const!] [255, 0, 0]),
@@ -1345,7 +1346,7 @@ instead of throwing the same exception object using `throw`.
 other hand resets the stack trace to the last thrown position.
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (rethrow)"?>
+<?code-excerpt "usage_bad.dart (rethrow)"?>
 {% prettify dart tag=pre+code %}
 try {
   somethingRisky();
@@ -1356,7 +1357,7 @@ try {
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (rethrow)" replace="/rethrow/[!$&!]/g"?>
+<?code-excerpt "usage_good.dart (rethrow)" replace="/rethrow/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 try {
   somethingRisky();
@@ -1379,7 +1380,7 @@ abstraction like futures. The `async`/`await` syntax improves readability and
 lets you use all of the Dart control flow structures within your async code.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (async-await)" replace="/async|await/[!$&!]/g"?>
+<?code-excerpt "usage_good.dart (async-await)" replace="/async|await/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 Future<int> countActivePlayers(String teamName) [!async!] {
   try {
@@ -1396,7 +1397,7 @@ Future<int> countActivePlayers(String teamName) [!async!] {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (async-await)"?>
+<?code-excerpt "usage_bad.dart (async-await)"?>
 {% prettify dart tag=pre+code %}
 Future<int> countActivePlayers(String teamName) {
   return downloadTeam(teamName).then((team) {
@@ -1419,7 +1420,7 @@ anything related to asynchrony. But in some cases, it's extraneous. If you can
 omit the `async` without changing the behavior of the function, do so.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (unnecessary-async)"?>
+<?code-excerpt "usage_good.dart (unnecessary-async)"?>
 {% prettify dart tag=pre+code %}
 Future<void> afterTwoThings(
     Future<void> first, Future<void> second) {
@@ -1428,7 +1429,7 @@ Future<void> afterTwoThings(
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (unnecessary-async)"?>
+<?code-excerpt "usage_bad.dart (unnecessary-async)"?>
 {% prettify dart tag=pre+code %}
 Future<void> afterTwoThings(Future<void> first, Future<void> second) async {
   return Future.wait([first, second]);
@@ -1446,7 +1447,7 @@ Cases where `async` *is* useful include:
   `async` is shorter than `Future.value(...)`.
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (async)"?>
+<?code-excerpt "usage_good.dart (async)"?>
 {% prettify dart tag=pre+code %}
 Future<void> usesAwait(Future<String> later) async {
   print(await later);
@@ -1472,7 +1473,7 @@ future. The constructors in Future don't seem to fit their need so they
 eventually find the Completer class and use that.
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (avoid-completer)"?>
+<?code-excerpt "usage_bad.dart (avoid-completer)"?>
 {% prettify dart tag=pre+code %}
 Future<bool> fileContainsBear(String path) {
   var completer = Completer<bool>();
@@ -1493,7 +1494,7 @@ they're clearer and make error handling easier.
 [then]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future/then.html
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer)"?>
+<?code-excerpt "usage_good.dart (avoid-completer)"?>
 {% prettify dart tag=pre+code %}
 Future<bool> fileContainsBear(String path) {
   return File(path).readAsString().then((contents) {
@@ -1503,7 +1504,7 @@ Future<bool> fileContainsBear(String path) {
 {% endprettify %}
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (avoid-completer-alt)"?>
+<?code-excerpt "usage_good.dart (avoid-completer-alt)"?>
 {% prettify dart tag=pre+code %}
 Future<bool> fileContainsBear(String path) async {
   var contents = await File(path).readAsString();
@@ -1527,7 +1528,7 @@ parameter that could be instantiated with `Object` returns true even when the
 object is a future. Instead, explicitly test for the `Future` case:
 
 {:.good}
-<?code-excerpt "misc/lib/effective_dart/usage_good.dart (test-future-or)"?>
+<?code-excerpt "usage_good.dart (test-future-or)"?>
 {% prettify dart tag=pre+code %}
 Future<T> logValue<T>(FutureOr<T> value) async {
   if (value is Future<T>) {
@@ -1542,7 +1543,7 @@ Future<T> logValue<T>(FutureOr<T> value) async {
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "misc/lib/effective_dart/usage_bad.dart (test-future-or)"?>
+<?code-excerpt "usage_bad.dart (test-future-or)"?>
 {% prettify dart tag=pre+code %}
 Future<T> logValue<T>(FutureOr<T> value) async {
   if (value is T) {

--- a/tool/dartformat.sh
+++ b/tool/dartformat.sh
@@ -36,6 +36,8 @@ if [[ $NULL_SAFETY == 1 ]]; then
 
   dart format -l 65 \
     $NULL_SAFETY_EXAMPLES/misc/lib/language_tour/exceptions.dart \
+    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/style_lib_good.dart \
+    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/usage_good.dart
     # $NULL_SAFETY_EXAMPLES/httpserver/bin/basic_writer_server.dart \
     # $NULL_SAFETY_EXAMPLES/httpserver/bin/note_server.dart \
     # $NULL_SAFETY_EXAMPLES/misc/bin/dcat.dart \
@@ -43,9 +45,7 @@ if [[ $NULL_SAFETY == 1 ]]; then
     # $NULL_SAFETY_EXAMPLES/misc/lib/library_tour/async/future.dart \
     # $NULL_SAFETY_EXAMPLES/misc/lib/library_tour/async/stream.dart \
     # $NULL_SAFETY_EXAMPLES/misc/test/library_tour/core_test.dart \
-    # $NULL_SAFETY_EXAMPLES/misc/test/library_tour/io_test.dart \
-    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/style_lib_good.dart \
-    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/usage_good.dart
+    # $NULL_SAFETY_EXAMPLES/misc/test/library_tour/io_test.dart
 else
   echo "Formatting example files..."
   dart format $* `find $EXAMPLES -name "*.dart" \

--- a/tool/dartformat.sh
+++ b/tool/dartformat.sh
@@ -35,7 +35,7 @@ if [[ $NULL_SAFETY == 1 ]]; then
     # $NULL_SAFETY_EXAMPLES/misc/lib/samples/spacecraft.dart
 
   dart format -l 65 \
-    $NULL_SAFETY_EXAMPLES/misc/lib/language_tour/exceptions.dart
+    $NULL_SAFETY_EXAMPLES/misc/lib/language_tour/exceptions.dart \
     # $NULL_SAFETY_EXAMPLES/httpserver/bin/basic_writer_server.dart \
     # $NULL_SAFETY_EXAMPLES/httpserver/bin/note_server.dart \
     # $NULL_SAFETY_EXAMPLES/misc/bin/dcat.dart \
@@ -44,8 +44,8 @@ if [[ $NULL_SAFETY == 1 ]]; then
     # $NULL_SAFETY_EXAMPLES/misc/lib/library_tour/async/stream.dart \
     # $NULL_SAFETY_EXAMPLES/misc/test/library_tour/core_test.dart \
     # $NULL_SAFETY_EXAMPLES/misc/test/library_tour/io_test.dart \
-    # $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/style_lib_good.dart \
-    # $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/usage_good.dart
+    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/style_lib_good.dart \
+    $NULL_SAFETY_EXAMPLES/misc/lib/effective_dart/usage_good.dart
 else
   echo "Formatting example files..."
   dart format $* `find $EXAMPLES -name "*.dart" \


### PR DESCRIPTION
This forks the Markdown and code for "Effective Dart" and migrates the result to null safety.

I split the work into separate commits so that the mechanical changes aren't mixed with the real ones. The only substantive changes are in the last commit and just migrate the existing excerpts (and prose where needed) to make sense with null safety.

New guidelines and other clean up will be in subsequent PRs. :)