### PR TITLE
Known null safety issues

### DIFF
--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -339,7 +339,7 @@ If you find any issues with null safety please [give us feedback.][]
 Some parts of the Dart ecosystem still need additional work to
 [migrate to null safety](/null-safety/migration-guide).
 
-We're currently aware of the following issues:
+The Dart team is currently aware of the following issues:
 
   * Migration of the pub.dev packages owned by the Dart team
     is nearly complete, but a few are still missing. See pub.dev for

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -338,7 +338,7 @@ If you find any issues with null safety please [give us feedback.][]
 
 Not all parts of the Dart SDK support null safety yet,
 as some parts still need additional work to
-[migrate to null safety](https://dart.dev/null-safety/migration-guide).
+[migrate to null safety](/null-safety/migration-guide).
 
 We're currently aware of the following issues:
 

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -334,6 +334,18 @@ If you find any issues with null safety please [give us feedback.][]
 
 [language version]: /guides/language/evolution#language-versioning
 
+## Known issues
+
+Not all parts of the Dart SDK support null safety yet,
+as some parts still need additional work to
+[migrate to null safety](https://dart.dev/null-safety/migration-guide).
+
+We're currently aware of the following issues:
+
+  * Migration of the pub.dev packages owned by the Dart team
+    is nearly complete, but a few are still missing. See pub.dev for
+    [the current list](https://pub.dev/packages?q=publisher%3Adart.dev&null-safe=1).
+
 ## Where to learn more
 
 For more information about null safety, see the following resources:

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -344,7 +344,9 @@ We're currently aware of the following issues:
 
   * Migration of the pub.dev packages owned by the Dart team
     is nearly complete, but a few are still missing. See pub.dev for
-    [the current list](https://pub.dev/packages?q=publisher%3Adart.dev&null-safe=1).
+    [null-safe packages from the Dart team][ns-dart-pkgs].
+
+[ns-dart-pkgs]: {{site.pub-pkg}}?q=publisher%3Adart.dev&null-safe=1
 
 ## Where to learn more
 

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -336,8 +336,7 @@ If you find any issues with null safety please [give us feedback.][]
 
 ## Known issues
 
-Not all parts of the Dart SDK support null safety yet,
-as some parts still need additional work to
+Some parts of the Dart ecosystem still need additional work to
 [migrate to null safety](/null-safety/migration-guide).
 
 We're currently aware of the following issues:


### PR DESCRIPTION
Add a new section with known null safety issues.

Corresponding Flutter PR: https://github.com/flutter/website/pull/5284