### PR TITLE
Clean up and fix named constructor portion of cheatsheet

### DIFF
--- a/examples/misc/bin/named_constructor.dart
+++ b/examples/misc/bin/named_constructor.dart
@@ -6,10 +6,9 @@ class Point {
 
   Point(this.x, this.y);
 
-  Point.origin() {
-    x = 0;
-    y = 0;
-  }
+  Point.origin()
+      : x = 0,
+        y = 0;
 }
 // #enddocregion
 

--- a/examples/misc/lib/language_tour/classes/point.dart
+++ b/examples/misc/lib/language_tour/classes/point.dart
@@ -14,10 +14,9 @@ class Point {
   // #enddocregion class-with-distanceTo, constructor-initializer
 
   // Named constructor
-  Point.origin() {
-    x = 0;
-    y = 0;
-  }
+  Point.origin()
+      : x = 0,
+        y = 0;
   // #enddocregion named-constructor
 
   // Initializer list sets instance variables before

--- a/null_safety_examples/misc/bin/named_constructor.dart
+++ b/null_safety_examples/misc/bin/named_constructor.dart
@@ -2,14 +2,13 @@
 
 // #docregion
 class Point {
-  late double x, y;
+  double x, y;
 
   Point(this.x, this.y);
 
-  Point.origin() {
-    x = 0;
-    y = 0;
-  }
+  Point.origin()
+      : x = 0,
+        y = 0;
 }
 // #enddocregion
 

--- a/null_safety_examples/misc/lib/language_tour/classes/point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point.dart
@@ -18,10 +18,9 @@ class Point {
   // #enddocregion class-with-distanceTo, constructor-initializer
 
   // Named constructor
-  Point.origin() {
-    x = xOrigin;
-    y = yOrigin;
-  }
+  Point.origin()
+      : x = xOrigin,
+        y = yOrigin;
   // #enddocregion named-constructor
 
   // Initializer list sets instance variables before

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2742,10 +2742,9 @@ class Point {
   Point(this.x, this.y);
 
   // Named constructor
-  [!Point.origin()!] {
-    x = 0;
-    y = 0;
-  }
+  [!Point.origin()!]
+      : x = 0,
+        y = 0;
 }
 {% endprettify %}
 

--- a/src/_guides/language/language-tour_migrated.md
+++ b/src/_guides/language/language-tour_migrated.md
@@ -2779,10 +2779,9 @@ class Point {
   Point(this.x, this.y);
 
   // Named constructor
-  [!Point.origin()!] {
-    x = xOrigin;
-    y = yOrigin;
-  }
+  [!Point.origin()!]
+      : x = xOrigin,
+        y = yOrigin;
 }
 {% endprettify %}
 

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -1582,10 +1582,9 @@ class Point {
 
   Point(this.x, this.y);
 
-  Point.origin() {
-    x = 0;
-    y = 0;
-  }
+  Point.origin()
+      : x = 0,
+        y = 0;
 }
 ```
 

--- a/src/codelabs/dart-cheatsheet_migrated.md
+++ b/src/codelabs/dart-cheatsheet_migrated.md
@@ -1669,19 +1669,15 @@ Dart supports named constructors:
 <?code-excerpt "../null_safety_examples/misc/bin/named_constructor.dart"?>
 ```dart
 class Point {
-  late double x, y;
+  double x, y;
 
   Point(this.x, this.y);
 
-  Point.origin() {
-    x = 0;
-    y = 0;
-  }
+  Point.origin()
+      : x = 0,
+        y = 0;
 }
 ```
-
-This example uses the `late` annotation to indicate that `x` and `y` are
-initialized before they're used.
 
 To use a named constructor, invoke it using its full name:
 
@@ -1699,9 +1695,9 @@ Ignore all initial errors in the DartPad.
 ```dart:run-dartpad:height-240px:ga_id-named_constructors:null_safety-true
 {$ begin main.dart $}
 class Color {
-  late int red;
-  late int green;
-  late int blue;
+  int red;
+  int green;
+  int blue;
   
   Color(this.red, this.green, this.blue);
 
@@ -1710,17 +1706,16 @@ class Color {
 {$ end main.dart $}
 {$ begin solution.dart $}
 class Color {
-  late int red;
-  late int green;
-  late int blue;
+  int red;
+  int green;
+  int blue;
   
   Color(this.red, this.green, this.blue);
 
-  Color.black() {
-    red = 0;
-    green = 0;
-    blue = 0;
-  } 
+  Color.black()
+      : red = 0,
+        green = 0,
+        blue = 0;
 }
 {$ end solution.dart $}
 {$ begin test.dart $}
@@ -1741,9 +1736,6 @@ void main() {
     if (result.blue != 0) {
   errs.add('Called Color.black() and got a Color with blue equal to ${result.blue} instead of the expected value (0).');
     }
-  } on LateInitializationError {
-     _result(false, ['Called Color.black() and got an error. Did you forget to initalize a property?']);
-    return;
   } catch (e) {
     _result(false, ['Called Color.black() and got an exception of type ${e.runtimeType}.']);
     return;


### PR DESCRIPTION
Switches to an initializer list in the related code to avoid need to use `late` and removes the testing code which depended on the now removed `LateInitializationError`.

Fixes https://github.com/dart-lang/dart-pad/issues/1766