### PR TITLE
Add "Effective Dart" rule about using "var" and "final" consistently.

### DIFF
--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -130,6 +130,7 @@
 
 **Variables**
 
+* <a href='/guides/language/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables'>DO follow a consistent rule for <code>var</code> and <code>final</code> on local variables.</a>
 * <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
 * <a href='/guides/language/effective-dart/usage#avoid-storing-what-you-can-calculate'>AVOID storing what you can calculate.</a>
 

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -725,8 +725,8 @@ or the other:
     still encouraged, of course.)
 
 Either rule is acceptable, but pick *one* and apply it consistently throughout
-your code. That way when a reader sees `var`, they know whether it is sending a
-signal that the variable is assigned.
+your code. That way when a reader sees `var`, they know whether it means that
+the variable is assigned later in the function.
 
 
 ### DON'T explicitly initialize variables to `null`.

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -713,14 +713,14 @@ The following best practices describe how to best use variables in Dart.
 
 ### DO follow a consistent rule for `var` and `final` on local variables.
 
-Most local variables should not have type annotations and should be declared
+Most local variables shouldn't have type annotations and should be declared
 using just `var` or `final`. There are two rules in wide use for when to use one
 or the other:
 
-*   Use `final` for local variables that are not re-assigned and `var` for those
+*   Use `final` for local variables that are not reassigned and `var` for those
     that are.
 
-*   Use `var` for all local variables, even ones that are re-assigned. Never use
+*   Use `var` for all local variables, even ones that are reassigned. Never use
     `final` for locals. (Using `final` for fields and top-level variables is
     still encouraged, of course.)
 

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -711,6 +711,24 @@ void error([String? message = null]) {
 
 The following best practices describe how to best use variables in Dart.
 
+### DO follow a consistent rule for `var` and `final` on local variables.
+
+Most local variables should not have type annotations and should be declared
+using just `var` or `final`. There are two rules in wide use for when to use one
+or the other:
+
+*   Use `final` for local variables that are not re-assigned and `var` for those
+    that are.
+
+*   Use `var` for all local variables, even ones that are re-assigned. Never use
+    `final` for locals. (Using `final` for fields and top-level variables is
+    still encouraged, of course.)
+
+Either rule is acceptable, but pick *one* and apply it consistently throughout
+your code. That way when a reader sees `var`, they know whether it is sending a
+signal that the variable is assigned.
+
+
 ### DON'T explicitly initialize variables to `null`.
 
 {% include linter-rule.html rule="avoid_init_to_null" %}


### PR DESCRIPTION
Very excited about adding this guideline. This has been desired for a long time. :)