### PR TITLE
Revamp the guidelines around types.

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/design_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_bad.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable, avoid_types_as_parameter_names, sort_constructors_first, unused_field
+// ignore_for_file: close_sinks, type_annotate_public_apis, unused_element, unused_local_variable, avoid_types_as_parameter_names, sort_constructors_first, type_init_formals, unused_field
 
 import 'dart:async';
 
@@ -72,15 +72,54 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion redundant
-    Set<String> things = Set<String>();
-    // #enddocregion redundant
+    // #docregion annotate-return-types
+    makeGreeting(String who) {
+      return "Hello, $who!";
+    }
+    // #enddocregion annotate-return-types
+  }
+
+  {
+    // Hack. The `(count as num)` is replaced with `count` when the excerpt is
+    // included to workaround no implicit casts in the examples.
+    // #docregion annotate-parameters
+    void sayRepeatedly(message, {count = 2}) {
+      for (var i = 0; i < (count as num); i++) {
+        print(message);
+      }
+    }
+    // #enddocregion annotate-parameters
+  }
+
+  (AstNode node) {
+    // #docregion uninitialized-local
+    var parameters;
+    if (node is Constructor) {
+      parameters = node.signature;
+    } else if (node is Method) {
+      parameters = node.parameters;
+    }
+    // #enddocregion uninitialized-local
+  };
+
+  {
+    // #docregion non-inferred-type-args
+    var playerScores = {};
+    final events = StreamController();
+    // #enddocregion non-inferred-type-args
   }
 
   {
     // #docregion explicit
-    var things = Set();
+    var items = Future<List<int>>.value(<int>[1, 2, 3]);
     // #enddocregion explicit
+  }
+
+  {
+    // #docregion incomplete-generic
+    List numbers = [1, 2, 3];
+    var completer = Completer<Map>();
+    // #enddocregion incomplete-generic
   }
 
   {
@@ -112,6 +151,31 @@ class MyIterable<T> {
   Iterable<T> where(bool predicate(T element)) => ellipsis();
   // #enddocregion function-type-param
 }
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-type-init-formals
+class Point1 {
+  double x, y;
+  Point1(double this.x, double this.y);
+}
+// #enddocregion dont-type-init-formals
+
+//----------------------------------------------------------------------------
+
+// #docregion inferred-type-args
+class Downloader {
+  final response = Completer();
+}
+// #enddocregion inferred-type-args
+
+//----------------------------------------------------------------------------
+
+// #docregion redundant
+class Downloader1 {
+  final Completer<String> response = Completer<String>();
+}
+// #enddocregion redundant
 
 //----------------------------------------------------------------------------
 

--- a/null_safety_examples/misc/lib/effective_dart/design_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_bad.dart
@@ -74,7 +74,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion annotate-return-types
     makeGreeting(String who) {
-      return "Hello, $who!";
+      return 'Hello, $who!';
     }
     // #enddocregion annotate-return-types
   }

--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -239,7 +239,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion infer-dynamic
-    Map<String, dynamic> readJson() { ellipsis(); }
+    Map<String, dynamic> readJson() => ellipsis();
 
     void printUsers() {
       var json = readJson();

--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable, sort_constructors_first
+// ignore_for_file: close_sinks, type_annotate_public_apis, unused_element, unused_local_variable, sort_constructors_first
 
 import 'dart:async';
 import 'dart:collection';
@@ -158,6 +158,13 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
+    // #docregion non-inferred-type-args
+    var playerScores = <String, int>{};
+    final events = StreamController<Event>();
+    // #enddocregion non-inferred-type-args
+  }
+
+  {
     // #docregion omit-types-on-locals
     List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
       var desserts = <List<Ingredient>>[];
@@ -170,6 +177,24 @@ void miscDeclAnalyzedButNotTested() {
       return desserts;
     }
     // #enddocregion omit-types-on-locals
+  }
+
+  {
+    // #docregion annotate-return-types
+    String makeGreeting(String who) {
+      return "Hello, $who!";
+    }
+    // #enddocregion annotate-return-types
+  }
+
+  {
+    // #docregion annotate-parameters
+    void sayRepeatedly(String message, {int count = 2}) {
+      for (var i = 0; i < count; i++) {
+        print(message);
+      }
+    }
+    // #enddocregion annotate-parameters
   }
 
   (AstNode node) {
@@ -194,21 +219,34 @@ void miscDeclAnalyzedButNotTested() {
   // #enddocregion inferred-wrong
 
   {
-    // #docregion redundant
-    Set<String> things = Set();
-    // #enddocregion redundant
+    // #docregion explicit
+    var items = Future.value([1, 2, 3]);
+    // #enddocregion explicit
   }
 
   {
-    // #docregion explicit
-    var things = Set<String>();
-    // #enddocregion explicit
+    // #docregion incomplete-generic
+    List<num> numbers = [1, 2, 3];
+    var completer = Completer<Map<String, int>>();
+    // #enddocregion incomplete-generic
   }
 
   {
     // #docregion prefer-dynamic
     dynamic mergeJson(dynamic original, dynamic changes) => ellipsis();
     // #enddocregion prefer-dynamic
+  }
+
+  {
+    // #docregion infer-dynamic
+    Map<String, dynamic> readJson() { ellipsis(); }
+
+    void printUsers() {
+      var json = readJson();
+      var users = json['users'];
+      print(users);
+    }
+    // #enddocregion infer-dynamic
   }
 
   // #docregion avoid-Function
@@ -271,6 +309,33 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion avoid-mandatory-param
   };
 }
+
+//----------------------------------------------------------------------------
+
+// #docregion dont-type-init-formals
+class Point1 {
+  double x, y;
+  Point1(this.x, this.y);
+}
+// #enddocregion dont-type-init-formals
+
+//----------------------------------------------------------------------------
+
+// #docregion inferred-type-args
+class Downloader {
+  final Completer<String> response = Completer();
+}
+// #enddocregion inferred-type-args
+
+//----------------------------------------------------------------------------
+
+// #docregion redundant
+class Downloader1 {
+  final Completer<String> response = Completer();
+}
+// #enddocregion redundant
+
+//----------------------------------------------------------------------------
 
 class MyIterable<T> {
   // #docregion function-type-param

--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -182,7 +182,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion annotate-return-types
     String makeGreeting(String who) {
-      return "Hello, $who!";
+      return 'Hello, $who!';
     }
     // #enddocregion annotate-return-types
   }

--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -374,15 +374,6 @@ class Point0 {
 
 //----------------------------------------------------------------------------
 
-// #docregion dont-type-init-formals
-class Point1 {
-  double x, y;
-  Point1(double this.x, double this.y);
-}
-// #enddocregion dont-type-init-formals
-
-//----------------------------------------------------------------------------
-
 // #docregion semicolon-for-empty-body
 class Point2 {
   double x, y;

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -446,15 +446,6 @@ class Point0 {
 
 //----------------------------------------------------------------------------
 
-// #docregion dont-type-init-formals
-class Point1 {
-  double x, y;
-  Point1(this.x, this.y);
-}
-// #enddocregion dont-type-init-formals
-
-//----------------------------------------------------------------------------
-
 // #docregion semicolon-for-empty-body
 class Point2 {
   double x, y;

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1209,7 +1209,7 @@ the return type yourself.
 <?code-excerpt "design_good.dart (annotate-return-types)"?>
 {% prettify dart tag=pre+code %}
 String makeGreeting(String who) {
-  return "Hello, $who!";
+  return 'Hello, $who!';
 }
 {% endprettify %}
 
@@ -1217,7 +1217,7 @@ String makeGreeting(String who) {
 <?code-excerpt "design_bad.dart (annotate-return-types)"?>
 {% prettify dart tag=pre+code %}
 makeGreeting(String who) {
-  return "Hello, $who!";
+  return 'Hello, $who!';
 }
 {% endprettify %}
 
@@ -1228,7 +1228,7 @@ There are two cases that seem like exceptions but aren't:
     type annotation. But these aren't what we consider function *declarations*.
 
 *   The return type of an overriding method can be inferred from the method it
-    overrides. However, this is a rarely-known feature and even in this case
+    overrides. However, this is a little-known feature and even in this case
     it's better to still write the type explicitly.
 
 
@@ -1409,9 +1409,10 @@ their elements and arguments.
 
 ### AVOID writing incomplete generic types.
 
-When writing a type annotation or type argument, it's still possible to not pin
-down a complete type by writing the name of a generic type but omitting its type
-arguments. In Java, these are called "raw types". For example:
+The goal of writing a type annotation or type argument is to pin down a complete
+type. However, if you write the name of a generic type but omit its type
+arguments, you haven't fully specified the type. In Java, these are called "raw
+types". For example:
 
 {:.bad}
 <?code-excerpt "design_bad.dart (incomplete-generic)"?>

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1201,7 +1201,7 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 
 ### DO annotate return types on function declarations.
 
-Dart does not generally infer the return type of a function declaration from its body,
+Dart doesn't generally infer the return type of a function declaration from its body,
 unlike some other languages. That means you should write a type annotation for
 the return type yourself.
 
@@ -1223,7 +1223,7 @@ makeGreeting(String who) {
 
 There are two cases that seem like exceptions but aren't:
 
-*   Function *expressions* ("lambdas" or "anonymous functions") do infer a
+*   _Function expressions_ (_lambdas_ or _anonymous functions_) do infer a
     return type from the body. In fact, the syntax doesn't even allow a return
     type annotation. But these aren't what we consider function *declarations*.
 
@@ -1235,9 +1235,9 @@ There are two cases that seem like exceptions but aren't:
 ### DO annotate parameter types on function declarations.
 
 A function's parameter list determines its boundary to the outside world.
-Parameters should have their types annotated so that boundary is well defined.
-Note that even though they look like variable initializers, Dart does not infer
-an optional parameter's type from its default value.
+Annotating parameter types makes that boundary well defined.
+Note that even though default parameter values look like variable initializers,
+Dart doesn't infer an optional parameter's type from its default value.
 
 {:.good}
 <?code-excerpt "design_good.dart (annotate-parameters)"?>
@@ -1259,8 +1259,7 @@ void sayRepeatedly(message, {count = 2}) {
 }
 {% endprettify %}
 
-**Exceptions:** Function expressions and initializing formals, which are covered
-by the next two guidelines.
+**Exception:** Function expressions and initializing formals have different type annotation conventions, as described in the next two guidelines.
 
 
 ### DON'T annotate inferred parameter types on function expressions.
@@ -1290,8 +1289,8 @@ var names = people.map((Person person) => person.name);
 {% endprettify %}
 
 If the language is able to infer the type you want for a parameter in a function
-expression, then let it and don't annotate. In rare cases, the surrounding
-context is not precise enough to provide a type for one or more of the
+expression, then don't annotate. In rare cases, the surrounding
+context isn't precise enough to provide a type for one or more of the
 function's parameters. In those cases, you may need to annotate.
 
 
@@ -1324,7 +1323,7 @@ class Point {
 ### DO write type arguments on generic invocations that aren't inferred.
 
 Dart is pretty smart about inferring type arguments in generic invocations. It
-will look at the expected type where the expression occurs and the types of
+looks at the expected type where the expression occurs and the types of
 values being passed to the invocation. However, sometimes those aren't enough to
 fully determine a type argument. In that case, write the entire type argument
 list explicitly.
@@ -1344,7 +1343,7 @@ final events = StreamController();
 {% endprettify %}
 
 Sometimes the invocation occurs as the initializer to a variable declaration. If
-variable is *not* a local then instead of writing the type argument list on the
+the variable is *not* local, then instead of writing the type argument list on the
 invocation itself, you may put a type annotation on the declaration:
 
 {:.good}
@@ -1428,7 +1427,7 @@ rest of the type for you using the surrounding context. Instead, it silently
 fills in any missing type arguments with with `dynamic` (or the bound if the
 class has one). That's rarely what you want.
 
-Instead, if you are writing a generic type in a type annotation or as a type
+Instead, if you're writing a generic type either in a type annotation or as a type
 argument inside some invocation, make sure to write a complete type:
 
 {:.good}
@@ -1444,7 +1443,7 @@ var completer = Completer<Map<String, int>>();
 When inference doesn't fill in a type, it usually defaults to `dynamic`. If
 `dynamic` is the type you want, this is technically the most terse way to get
 it. However, it's not the most *clear* way. A casual reader of your code who
-sees an annotation is missing has no way of knowing if you intended it to be
+sees that an annotation is missing has no way of knowing if you intended it to be
 `dynamic`, expected inference to fill in some other type, or simply forgot to
 write the annotation.
 
@@ -1991,4 +1990,3 @@ class Person {
   bool operator ==(other) => [!other != null!] && ...
 }
 {% endprettify %}
-

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -1468,7 +1468,7 @@ Note that it's OK to omit the type when Dart *successfully* infers `dynamic`.
 {:.good}
 <?code-excerpt "design_good.dart (infer-dynamic)"?>
 {% prettify dart tag=pre+code %}
-Map<String, dynamic> readJson() { ... }
+Map<String, dynamic> readJson() => ...
 
 void printUsers() {
   var json = readJson();

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -142,7 +142,6 @@
 **Constructors**
 
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
-* <a href='/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
@@ -220,18 +219,22 @@
 
 **Types**
 
-* <a href='/guides/language/effective-dart/design#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious'>PREFER type annotating public fields and top-level variables if the type isn't obvious.</a>
-* <a href='/guides/language/effective-dart/design#consider-type-annotating-private-fields-and-top-level-variables-if-the-type-isnt-obvious'>CONSIDER type annotating private fields and top-level variables if the type isn't obvious.</a>
-* <a href='/guides/language/effective-dart/design#avoid-type-annotating-initialized-local-variables'>AVOID type annotating initialized local variables.</a>
-* <a href='/guides/language/effective-dart/design#avoid-annotating-inferred-parameter-types-on-function-expressions'>AVOID annotating inferred parameter types on function expressions.</a>
-* <a href='/guides/language/effective-dart/design#avoid-redundant-type-arguments-on-generic-invocations'>AVOID redundant type arguments on generic invocations.</a>
-* <a href='/guides/language/effective-dart/design#do-annotate-when-dart-infers-the-wrong-type'>DO annotate when Dart infers the wrong type.</a>
-* <a href='/guides/language/effective-dart/design#prefer-annotating-with-dynamic-instead-of-letting-inference-fail'>PREFER annotating with <code>dynamic</code> instead of letting inference fail.</a>
+* <a href='/guides/language/effective-dart/design#do-type-annotate-variables-without-initializers'>DO type annotate variables without initializers.</a>
+* <a href='/guides/language/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious'>DO type annotate fields and top-level variables if the type isn't obvious.</a>
+* <a href='/guides/language/effective-dart/design#dont-type-annotate-initialized-local-variables'>DON'T type annotate initialized local variables.</a>
+* <a href='/guides/language/effective-dart/design#do-annotate-return-types-on-function-declarations'>DO annotate return types on function declarations.</a>
+* <a href='/guides/language/effective-dart/design#do-annotate-parameter-types-on-function-declarations'>DO annotate parameter types on function declarations.</a>
+* <a href='/guides/language/effective-dart/design#dont-annotate-inferred-parameter-types-on-function-expressions'>DON'T annotate inferred parameter types on function expressions.</a>
+* <a href='/guides/language/effective-dart/design#dont-type-annotate-initializing-formals'>DON'T type annotate initializing formals.</a>
+* <a href='/guides/language/effective-dart/design#do-write-type-arguments-on-generic-invocations-that-arent-inferred'>DO write type arguments on generic invocations that aren't inferred.</a>
+* <a href='/guides/language/effective-dart/design#dont-write-type-arguments-on-generic-invocations-that-are-inferred'>DON'T write type arguments on generic invocations that are inferred.</a>
+* <a href='/guides/language/effective-dart/design#avoid-writing-incomplete-generic-types'>AVOID writing incomplete generic types.</a>
+* <a href='/guides/language/effective-dart/design#do-annotate-with-dynamic-instead-of-letting-inference-fail'>DO annotate with <code>dynamic</code> instead of letting inference fail.</a>
 * <a href='/guides/language/effective-dart/design#prefer-signatures-in-function-type-annotations'>PREFER signatures in function type annotations.</a>
 * <a href='/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter'>DON'T specify a return type for a setter.</a>
 * <a href='/guides/language/effective-dart/design#dont-use-the-legacy-typedef-syntax'>DON'T use the legacy typedef syntax.</a>
 * <a href='/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs'>PREFER inline function types over typedefs.</a>
-* <a href='/guides/language/effective-dart/design#consider-using-function-type-syntax-for-parameters'>CONSIDER using function type syntax for parameters.</a>
+* <a href='/guides/language/effective-dart/design#prefer-using-function-type-syntax-for-parameters'>PREFER using function type syntax for parameters.</a>
 * <a href='/guides/language/effective-dart/design#avoid-using-dynamic-unless-you-want-to-disable-static-checking'>AVOID using <code>dynamic</code> unless you want to disable static checking.</a>
 * <a href='/guides/language/effective-dart/design#do-use-futurevoid-as-the-return-type-of-asynchronous-members-that-do-not-produce-values'>DO use <code>Future&lt;void&gt;</code> as the return type of asynchronous members that do not produce values.</a>
 * <a href='/guides/language/effective-dart/design#avoid-using-futureort-as-a-return-type'>AVOID using <code>FutureOr&lt;T&gt;</code> as a return type.</a>

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -1151,31 +1151,6 @@ formal". You can't always take advantage of it. Sometimes you want to have a
 named parameter whose name doesn't match the name of the field you are
 initializing. But when you *can* use initializing formals, you *should*.
 
-### DON'T type annotate initializing formals.
-
-{% include linter-rule.html rule="type_init_formals" %}
-
-If a constructor parameter is using `this.` to initialize a field, then the type
-of the parameter is understood to be the same type as the field.
-
-{:.good}
-<?code-excerpt "usage_good.dart (dont-type-init-formals)"?>
-{% prettify dart tag=pre+code %}
-class Point {
-  double x, y;
-  Point(this.x, this.y);
-}
-{% endprettify %}
-
-{:.bad}
-<?code-excerpt "usage_bad.dart (dont-type-init-formals)"?>
-{% prettify dart tag=pre+code %}
-class Point {
-  double x, y;
-  Point(double this.x, double this.y);
-}
-{% endprettify %}
-
 
 ### DO use `;` instead of `{}` for empty constructor bodies.
 


### PR DESCRIPTION
This is a pretty big textual change, but the actual effective change is
small. It's mostly clarifying existing practices and covering omissions.

Fix #996. Fix #1387.

I'd like to run this by the Dart readability folks before this lands. Is there an easy way I can stage this and share it with them in some kind of readable form?