### PR TITLE
Revert "Switch favicon to new icon"

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -15,7 +15,7 @@
   <title>{% if page.short-title %}{{ page.short-title }}{% else %}{{ page.title }}{% endif %} | {{ site.title }}</title>
 
   <!-- Favicon / Touch Icons -->
-  <link rel="icon" sizes="64x64" href="{% asset shared/dart/icon/64.png @path %}">
+  <link rel="icon" sizes="64x64" href="/assets/shared/dart/icon/64.png">
   <link href="{% asset touch-icon-iphone.png @path %}" rel="apple-touch-icon">
   <link href="{% asset touch-icon-ipad.png @path %}" rel="apple-touch-icon" sizes="76x76">
   <link href="{% asset touch-icon-iphone-retina.png @path %}" rel="apple-touch-icon" sizes="120x120">


### PR DESCRIPTION
Reverts dart-lang/site-www#2946

Instead will use static non-hashed icon after https://github.com/dart-lang/site-shared/pull/127 is merged and the submodule is update.

Refer to https://github.com/dart-lang/site-www/issues/2472#issuecomment-781797538 for more context.

cc @chalin 