### PR TITLE
Make some minor cleanup and corrections to the DartPad page

### DIFF
--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -27,7 +27,7 @@ Here's what DartPad looks like:
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. It doesn't support those marked native
-platform nor does it support [deferred loading][].
+platform, and it doesn't support [deferred loading][].
 
 It also doesn't support using packages from the [pub.dev]({{site.pub}}) package
 repository.

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -27,7 +27,7 @@ Here's what DartPad looks like:
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. It doesn't support those marked native
-platform.
+platform nor does it support [deferred loading][].
 
 It also doesn't support using packages from the [pub.dev]({{site.pub}}) package
 repository.
@@ -132,4 +132,5 @@ For technical details on embedding DartPads, see the
 
 [best practices for using DartPad in tutorials]: /resources/dartpad-best-practices
 [DartPad embedding guide.]: https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide
+[deferred loading]: /guides/language/language-tour#lazily-loading-a-library
 [futures codelab]: /codelabs/async-await

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -57,7 +57,7 @@ try running some samples and then creating a simple command-line app.
 
   <li markdown="1">
   Choose a Flutter sample like **Sunflower**,
-  using the **Samples** list in the upper right.
+  using the **Samples** list at the upper right.
 
   Again, the rendered output appears to the right.
   </li>
@@ -116,7 +116,7 @@ for (var char in 'hello'.split('')) {
   try introducing a bug.
 
   For example, if you change `split` to `spit`,
-  you get warnings in the bottom right of the window.
+  you get warnings at the bottom right of the window.
   If you run the app, a compilation error appears in the console.
   </li>
 </ol>

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -117,7 +117,7 @@ for (var char in 'hello'.split('')) {
 
   For example, if you change `split` to `spit`,
   you get warnings in the bottom right of the window.
-  If you run the app, you'll see a compilation error in the console.
+  If you run the app, a compilation error appears in the console.
   </li>
 </ol>
 

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -44,7 +44,8 @@ try running some samples and then creating a simple command-line app.
   <li markdown="1">
   Go to <a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad.</a>
 
-  A sample appears on the left and the output appears on the right.
+  Dart code appears on the left, and
+  a place for the output appears on the right.
   If you've used DartPad before,
   you can click **New Pad** to get back to the original sample.
   </li>
@@ -59,12 +60,9 @@ try running some samples and then creating a simple command-line app.
   Choose a Flutter sample like **Sunflower**,
   using the **Samples** list at the upper right.
 
-  Again, the rendered output appears to the right.
+  The rendered output appears to the right.
   </li>
 
-  <li markdown="1">
-  Click **CONSOLE** to view the sample's console output.
-  </li>
 </ol>
 
 
@@ -77,13 +75,11 @@ To create a simple command-line app, use **New Pad**.
   Click the **New Pad** button,
   and confirm that you want to discard changes to the current pad.
 
-  Click on the Dart logo to access the source code for
-  the Hello World app.
   </li>
 
   <li markdown="1">
-  Using the toggle underneath the logo,
-  verify **HTML** support is disabled.
+  Click the Dart logo, make sure that **HTML** support is disabled,
+  and then click **Create**.
   </li>
 
   <li markdown="1">

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -115,8 +115,8 @@ for (var char in 'hello'.split('')) {
   If you didn't happen to have any bugs while you were entering the code,
   try introducing a bug.
 
-  For example, if you change `split` to `spit`, you get warnings in the bottom
-  right of the window.
+  For example, if you change `split` to `spit`,
+  you get warnings in the bottom right of the window.
   If you run the app, you'll see a compilation error in the console.
   </li>
 </ol>

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -45,7 +45,7 @@ try running some samples and then creating a simple command-line app.
   Go to <a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad.</a>
 
   A sample appears on the left and the output appears on the right.
-  If you've played with DartPad before,
+  If you've used DartPad before,
   you can click **New Pad** to get back to the original sample.
   </li>
 
@@ -56,19 +56,14 @@ try running some samples and then creating a simple command-line app.
   </li>
 
   <li markdown="1">
-  Choose an HTML sample like **Sunflower**,
-  using the **Samples** list at the upper right.
+  Choose a Flutter sample like **Sunflower**,
+  using the **Samples** list in the upper right.
 
-  Again, the output appears to the right.
-  By default, you see the HTML output—what you'd see in a browser.
+  Again, the rendered output appears to the right.
   </li>
 
   <li markdown="1">
   Click **CONSOLE** to view the sample's console output.
-  </li>
-
-  <li markdown="1">
-  On the left, click the **HTML** tab to view the sample's HTML markup.
   </li>
 </ol>
 
@@ -82,14 +77,13 @@ To create a simple command-line app, use **New Pad**.
   Click the **New Pad** button,
   and confirm that you want to discard changes to the current pad.
 
-  The source code for the Hello World app appears
-  under the DART tab.
+  Click on the Dart logo to access the source code for
+  the Hello World app.
   </li>
 
   <li markdown="1">
-  Turn off **HTML**, using the toggle
-  underneath the Dart logo.
-  The HTML and CSS tabs disappear.
+  Using the toggle underneath the logo,
+  verify **HTML** support is disabled.
   </li>
 
   <li markdown="1">
@@ -121,9 +115,9 @@ for (var char in 'hello'.split('')) {
   If you didn't happen to have any bugs while you were entering the code,
   try introducing a bug.
 
-  For example, if you change `split` to `spit`,
-  you get warnings at the bottom of the window and in the Run button.
-  If you run the app, you'll see output from an uncaught exception.
+  For example, if you change `split` to `spit`, you get warnings in the bottom
+  right of the window.
+  If you run the app, you'll see a compilation error in the console.
   </li>
 </ol>
 
@@ -137,7 +131,7 @@ You can find the SDK version at the bottom right of DartPad.
 ## Embedding DartPad in web pages {#embedding}
 
 You can embed DartPad inside of web pages,
-customizing it to suit your purpose.
+customizing it to suit your use case.
 For example, the [futures codelab][]
 contains multiple embedded DartPads
 labeled as _examples_ and _exercises_.

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -38,7 +38,7 @@ To get familiar with DartPad,
 try running some samples and then creating a simple command-line app.
 
 
-### Open DartPad, and run some samples {#step-1-open-and-run}
+### Open DartPad, and run a sample {#step-1-open-and-run}
 
 <ol markdown="1">
   <li markdown="1">
@@ -46,18 +46,10 @@ try running some samples and then creating a simple command-line app.
 
   Dart code appears on the left, and
   a place for the output appears on the right.
-  If you've used DartPad before,
-  you can click **New Pad** to get back to the original sample.
   </li>
 
   <li markdown="1">
-  Click **Run**.
-
-  The sample runs again, updating the output.
-  </li>
-
-  <li markdown="1">
-  Choose a Flutter sample like **Sunflower**,
+  Choose a Flutter sample such as **Sunflower**,
   using the **Samples** list at the upper right.
 
   The rendered output appears to the right.


### PR DESCRIPTION
We no longer include the `HTML` version of the Sunflower example so this page may have been slightly confusing for readers. I've updated the page to specify the Flutter example and removed or modified some other outdated information.

The page could likely use some more love, but I think this prolongs its life a bit.