### PR TITLE
Add null safety guidance

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -156,6 +156,20 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
+    var message = "hello" as String?;
+    // #docregion null-aware-promote
+    int measureMessage(String? message) {
+      if (message?.isNotEmpty ?? false) {
+        // message is not promoted to String.
+        return message!.length;
+      }
+
+      return 0;
+    }
+    // #enddocregion null-aware-promote
+  }
+
+  {
     // ignore_for_file: only_throw_errors
     // #docregion rethrow
     try {
@@ -266,6 +280,26 @@ Item? bestDeal(List<Item> cart) {
   return bestItem;
 }
 // #enddocregion no-null-init
+
+//----------------------------------------------------------------------------
+
+// #docregion copy-nullable-field
+class UploadException {
+  final Response? response;
+
+  UploadException([this.response]);
+
+  @override
+  String toString() {
+    if (response != null) {
+      return "Could not complete upload to ${response!.url} "
+          "(error code ${response!.errorCode}): ${response!.reason}.";
+    }
+
+    return "Could not upload (no response).";
+  }
+}
+// #enddocregion copy-nullable-field
 
 //----------------------------------------------------------------------------
 

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -158,6 +158,20 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
+    var message = "hello" as String?;
+    // #docregion null-aware-promote
+    int measureMessage(String? message) {
+      if (message != null && message.isNotEmpty) {
+        // message is promoted to String.
+        return message.length;
+      }
+
+      return 0;
+    }
+    // #enddocregion null-aware-promote
+  }
+
+  {
     // #docregion rethrow
     try {
       somethingRisky();
@@ -299,6 +313,33 @@ Item? bestDeal(List<Item> cart) {
   return bestItem;
 }
 // #enddocregion no-null-init
+
+//----------------------------------------------------------------------------
+
+class Response {
+  String get url => "";
+  String get errorCode => "";
+  String get reason => "";
+}
+
+// #docregion copy-nullable-field
+class UploadException {
+  final Response? response;
+
+  UploadException([this.response]);
+
+  @override
+  String toString() {
+    var response = this.response;
+    if (response != null) {
+      return "Could not complete upload to ${response.url} "
+          "(error code ${response.errorCode}): ${response.reason}.";
+    }
+
+    return "Could not upload (no response).";
+  }
+}
+// #enddocregion copy-nullable-field
 
 //----------------------------------------------------------------------------
 

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -98,7 +98,8 @@
 
 * <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
-* <a href='/guides/language/effective-dart/usage#do-use--to-convert-null-to-a-boolean-value'>DO use <code>??</code> to convert <code>null</code> to a boolean value.</a>
+* <a href='/guides/language/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value'>PREFER using <code>??</code> to convert <code>null</code> to a boolean value.</a>
+* <a href='/guides/language/effective-dart/usage#consider-copying-a-nullable-field-to-a-local-variable-to-enable-type-promotion'>CONSIDER copying a nullable field to a local variable to enable type promotion.</a>
 
 **Strings**
 

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -94,8 +94,10 @@
 * <a href='/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package'>DON'T import libraries that are inside the <code>src</code> directory of another package.</a>
 * <a href='/guides/language/effective-dart/usage#do-use-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>DO use relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
 
-**Booleans**
+**Null**
 
+* <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--to-convert-null-to-a-boolean-value'>DO use <code>??</code> to convert <code>null</code> to a boolean value.</a>
 
 **Strings**
@@ -119,16 +121,11 @@
 
 * <a href='/guides/language/effective-dart/usage#do-use-a-function-declaration-to-bind-a-function-to-a-name'>DO use a function declaration to bind a function to a name.</a>
 * <a href='/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do'>DON'T create a lambda when a tear-off will do.</a>
-
-**Parameters**
-
 * <a href='/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value'>DO use <code>=</code> to separate a named parameter from its default value.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
 
 **Variables**
 
 * <a href='/guides/language/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables'>DO follow a consistent rule for <code>var</code> and <code>final</code> on local variables.</a>
-* <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
 * <a href='/guides/language/effective-dart/usage#avoid-storing-what-you-can-calculate'>AVOID storing what you can calculate.</a>
 
 **Members**

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -240,10 +240,10 @@ preferred for three main reasons:
     expression is `null`. With `== true`, you have to think through the boolean
     logic to realize that means that a `null` gets converted to *false*.
 
-**Exception:** Using a null-aware operator on a variable inside a condition does
-not promote the variable to a non-nullable type. If you want the variable to be
-promoted inside the body of the if statement, it may be better to use an
-explicit `!= null` check instead of `?.` followed by `??`:
+**Exception:** Using a null-aware operator on a variable inside a condition
+doesn't promote the variable to a non-nullable type. If you want the variable
+to be promoted inside the body of the `if` statement, it might be better to use
+an explicit `!= null` check instead of `?.` followed by `??`:
 
 {:.good}
 <?code-excerpt "usage_good.dart (null-aware-promote)"?>
@@ -277,11 +277,11 @@ int measureMessage(String? message) {
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
 to functions expecting a non-nullable type. Unfortunately, promotion is only
-sound for local variables and parameters, so fields and top-level variables are
-not promoted.
+sound for local variables and parameters, so fields and top-level variables
+aren't promoted.
 
 One pattern to work around this is to copy the field's value to a local
-variable. Null checks on that variable do promote and then you can safely treat
+variable. Null checks on that variable do promote, so you can safely treat
 it as non-nullable.
 
 {:.good}
@@ -305,8 +305,8 @@ class UploadException {
 }
 {% endprettify %}
 
-This can be cleaner and safer than using `!` every place the field or top level
-variable is used.
+Copying to a local variable can be cleaner and safer than using `!` every place
+the field or top-level variable is used:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (copy-nullable-field)" replace="/!\./[!!!]./g"?>
@@ -328,10 +328,10 @@ class UploadException {
 }
 {% endprettify %}
 
-This pattern must be applied with some care. If you need to write back to the
-field make sure you do so, and not just to the local variable. Also, if there
-may be other changes to the field while the local is still in scope, it may end
-up having a stale value. Sometimes it is best to simply use `!` on the field.
+Be careful when using a local copy. If you need to write back to the field,
+then make sure you do so, and don't just write to the local variable. Also, if
+the field might change while the local is still in scope, then the local might
+have a stale value. Sometimes it's best to simply use `!` on the field.
 
 
 ## Strings

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -121,7 +121,75 @@ Follow these two rules:
 * An import path should never contain `/lib/`.
 * A library under `lib` should never use `../` to escape the `lib` directory.
 
-## Booleans
+## Null
+
+
+### DON'T explicitly initialize variables to `null`.
+
+{% include linter-rule.html rule="avoid_init_to_null" %}
+
+If a variable has a non-nullable type, Dart reports a compile error if you try
+to use it before it has been definitely initialized. If the variable is
+nullable, then it is implicitly initialized to `null` for you. There's no
+concept of "uninitialized memory" in Dart and no need to explicitly initialize a
+variable to `null` to be "safe".
+
+{:.good}
+<?code-excerpt "usage_good.dart (no-null-init)"?>
+{% prettify dart tag=pre+code %}
+Item? bestDeal(List<Item> cart) {
+  Item? bestItem;
+
+  for (var item in cart) {
+    if (bestItem == null || item.price < bestItem.price) {
+      bestItem = item;
+    }
+  }
+
+  return bestItem;
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "usage_bad.dart (no-null-init)" replace="/ = null/[!$&!]/g"?>
+{% prettify dart tag=pre+code %}
+Item? bestDeal(List<Item> cart) {
+  Item? bestItem[! = null!];
+
+  for (var item in cart) {
+    if (bestItem == null || item.price < bestItem.price) {
+      bestItem = item;
+    }
+  }
+
+  return bestItem;
+}
+{% endprettify %}
+
+
+### DON'T use an explicit default value of `null`.
+
+{% include linter-rule.html rule="avoid_init_to_null" %}
+
+If you make a nullable parameter optional but don't give it a default value, the
+language implicitly uses `null` as the default, so there's no need to write it.
+
+{:.good}
+<?code-excerpt "usage_good.dart (default-value-null)"?>
+{% prettify dart tag=pre+code %}
+void error([String? message]) {
+  stderr.write(message ?? '\n');
+}
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "usage_bad.dart (default-value-null)"?>
+{% prettify dart tag=pre+code %}
+void error([String? message = null]) {
+  stderr.write(message ?? '\n');
+}
+{% endprettify %}
+
 
 ### DO use `??` to convert `null` to a boolean value.
 
@@ -171,6 +239,7 @@ preferred for three main reasons:
 *   The `?? false` and `?? true` clearly show what value will be used when the
     expression is `null`. With `== true`, you have to think through the boolean
     logic to realize that means that a `null` gets converted to *false*.
+
 
 ## Strings
 
@@ -661,8 +730,6 @@ names.forEach((name) {
 {% endprettify %}
 
 
-## Parameters
-
 ### DO use `=` to separate a named parameter from its default value.
 
 {% include linter-rule.html rule="prefer_equal_for_default_values" %}
@@ -684,29 +751,6 @@ void insert(Object item, {int at: 0}) { ... }
 {% endprettify %}
 
 
-### DON'T use an explicit default value of `null`.
-
-{% include linter-rule.html rule="avoid_init_to_null" %}
-
-If you make a parameter optional but don't give it a default value, the language
-implicitly uses `null` as the default, so there's no need to write it.
-
-{:.good}
-<?code-excerpt "usage_good.dart (default-value-null)"?>
-{% prettify dart tag=pre+code %}
-void error([String? message]) {
-  stderr.write(message ?? '\n');
-}
-{% endprettify %}
-
-{:.bad}
-<?code-excerpt "usage_bad.dart (default-value-null)"?>
-{% prettify dart tag=pre+code %}
-void error([String? message = null]) {
-  stderr.write(message ?? '\n');
-}
-{% endprettify %}
-
 ## Variables
 
 The following best practices describe how to best use variables in Dart.
@@ -727,49 +771,6 @@ or the other:
 Either rule is acceptable, but pick *one* and apply it consistently throughout
 your code. That way when a reader sees `var`, they know whether it means that
 the variable is assigned later in the function.
-
-
-### DON'T explicitly initialize variables to `null`.
-
-{% include linter-rule.html rule="avoid_init_to_null" %}
-
-If a variable has a non-nullable type, Dart reports a compile error if you try
-to use it before it has been definitely initialized. If the variable is
-nullable, then it is implicitly initialized to `null` for you. There's no
-concept of "uninitialized memory" in Dart and no need to explicitly initialize a
-variable to `null` to be "safe".
-
-{:.good}
-<?code-excerpt "usage_good.dart (no-null-init)"?>
-{% prettify dart tag=pre+code %}
-Item? bestDeal(List<Item> cart) {
-  Item? bestItem;
-
-  for (var item in cart) {
-    if (bestItem == null || item.price < bestItem.price) {
-      bestItem = item;
-    }
-  }
-
-  return bestItem;
-}
-{% endprettify %}
-
-{:.bad}
-<?code-excerpt "usage_bad.dart (no-null-init)" replace="/ = null/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
-Item? bestDeal(List<Item> cart) {
-  Item? bestItem[! = null!];
-
-  for (var item in cart) {
-    if (bestItem == null || item.price < bestItem.price) {
-      bestItem = item;
-    }
-  }
-
-  return bestItem;
-}
-{% endprettify %}
 
 
 ### AVOID storing what you can calculate.

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -274,9 +274,15 @@ int measureMessage(String? message) {
 
 ### CONSIDER copying a nullable field to a local variable to enable type promotion.
 
-Checking that a nullable variable is not `null` promotes it to a non-nullable type so that you can then call methods on the variable. Unfortunately, that is only sound for local variables and parameters, so fields and top-level variables are not promoted.
+Checking that a nullable variable is not equal to `null` promotes the variable
+to a non-nullable type. That lets you access members on the variable and pass it
+to functions expecting a non-nullable type. Unfortunately, promotion is only
+sound for local variables and parameters, so fields and top-level variables are
+not promoted.
 
-One pattern to work around this is to copy the field's value to a local variable. Null checks on that variable do promote and then you can safely treat it as non-nullable.
+One pattern to work around this is to copy the field's value to a local
+variable. Null checks on that variable do promote and then you can safely treat
+it as non-nullable.
 
 {:.good}
 <?code-excerpt "usage_good.dart (copy-nullable-field)"?>
@@ -299,7 +305,8 @@ class UploadException {
 }
 {% endprettify %}
 
-This can be cleaner and safer than using `!` every place the field or top level variable is used.
+This can be cleaner and safer than using `!` every place the field or top level
+variable is used.
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (copy-nullable-field)" replace="/!\./[!!!]./g"?>


### PR DESCRIPTION
The first commit just moves some existing rules around to get ready for more. The second commit adds a new guideline and adds an exception to an existing one.

I've got a couple more planned but I'll do those in a separate PR.

Fix #2445. (There are other null safety changes coming, but this fixes the one concrete request on that issue.)
