### PR TITLE
Add 2.12 debut info to /tools/dart-fix

### DIFF
--- a/src/tools/dart-fix.md
+++ b/src/tools/dart-fix.md
@@ -4,7 +4,8 @@ description: Help for bringing your code up-to-date.
 toc: false
 ---
 
-The `dart fix` command finds and fixes two types of issues:
+The `dart fix` command (added in Dart 2.12)
+finds and fixes two types of issues:
 
 * Analysis issues that have associated automated fixes
   (sometimes called _quick-fixes_ or _code actions_)


### PR DESCRIPTION
I started to update /tools/dart-tool as well, but it made the table rather busy. I think it's OK to keep the change in this page only.

Fixes #2858