### PR TITLE
More safety changes for "Effective Dart".

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -374,6 +374,18 @@ class Point0 {
 
 //----------------------------------------------------------------------------
 
+// #docregion late-init-list
+class Point1 {
+  late double x, y;
+  Point1.polar(double theta, double radius) {
+    x = cos(theta) * radius;
+    y = sin(theta) * radius;
+  }
+}
+// #enddocregion late-init-list
+
+//----------------------------------------------------------------------------
+
 // #docregion semicolon-for-empty-body
 class Point2 {
   double x, y;

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -446,6 +446,17 @@ class Point0 {
 
 //----------------------------------------------------------------------------
 
+// #docregion late-init-list
+class Point1 {
+  double x, y;
+  Point1.polar(double theta, double radius)
+      : x = cos(theta) * radius,
+        y = sin(theta) * radius;
+}
+// #enddocregion late-init-list
+
+//----------------------------------------------------------------------------
+
 // #docregion semicolon-for-empty-body
 class Point2 {
   double x, y;

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -947,11 +947,12 @@ rarely what you want. Fields are usually marked late so that they can be
 initialized *internally* at some point in the instance's lifetime, often inside
 the constructor body.
 
-Unless you do want users to call the setter, it's better to either:
+Unless you *do* want users to call the setter, it's better to pick one of the
+following solutions:
 
-* not use `late`,
-* ensure the `late` field is initialized at its declaration,
-* or make the `late` field private and define a public getter to access it.
+* Don't use `late`.
+* Use `late`, but initialize the `late` field at its declaration.
+* Use `late`, but make the `late` field private and define a public getter for it.
 
 ### AVOID returning nullable `Future`, `Stream`, and collection types.
 

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -947,10 +947,11 @@ rarely what you want. Fields are usually marked late so that they can be
 initialized *internally* at some point in the instance's lifetime, often inside
 the constructor body.
 
-Unless you do intend to expose the setter publicly and allow users to invoke it,
-it's better to not use `late`, ensure the `late` field is initialized at its
-declaration, or make the `late` field private with a public getter.
+Unless you do want users to call the setter, it's better to either:
 
+* not use `late`,
+* ensure the `late` field is initialized at its declaration,
+* or make the `late` field private and define a public getter to access it.
 
 ### AVOID returning nullable `Future`, `Stream`, and collection types.
 

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -785,6 +785,11 @@ Of course, it is often useful to have mutable data. But, if you don't need it,
 your default should be to make fields and top-level variables `final` when you
 can.
 
+Sometimes an instance field doesn't change after it has been initialized, but
+can't be initialized until after the instance is constructed. For example, it
+may need to reference `this` or some other field on the instance. In cases like,
+that, consider making the field `late final`.
+
 
 ### DO use getters for operations that conceptually access properties.
 
@@ -933,20 +938,31 @@ not intended to be invoked from Dart code and don't need a corresponding getter.
 [angular]: {{site.angulardart}}
 
 
-### AVOID returning `null` from members whose return type is `bool`, `double`, `int`, or `num`.
+### AVOID public `late final` fields.
 
-{% include linter-rule.html rule="avoid_returning_null" %}
+Unlike other final fields, a late final field *does* define a setter. If
+that field is public, then the setter is public. This is rarely what you want.
+Fields are usually marked late so that they can be initialized *internally* at
+some point in the instance's lifetime, often inside the constructor body.
 
-Even though all types are nullable in Dart, users assume those types almost
-never contain `null`, and the lowercase names encourage a "Java primitive"
-mindset.
+Unless you do intend to expose the setter publicly and allow users to invoke it,
+it's better to either not use `late`, or make the late field private with a
+public getter.
 
-It can be occasionally useful to have a "nullable primitive" type in your API,
-for example to indicate the absence of a value for some key in a map, but these
-should be rare.
 
-If you do have a member of this type that may return `null`, document it very
-clearly, including the conditions under which `null` will be returned.
+### AVOID returning nullable `Future`, `Stream`, and collection types.
+
+When an API returns a container type, it has two ways to indicate the absence of
+data: It can return an empty container or it can return `null`. Users generally
+assume and prefer that you use an empty container to indicate "no data". That
+way, they have a real object that they can call methods on like `isEmpty`.
+
+Prefer returning an empty collection, a future that doesn't complete, or a
+stream that doesn't emit any values to indicate that your API has no data to
+provide.
+
+**Exception:** If returning `null` *means something different* from yielding an
+empty container, it may make sense to use a nullable type.
 
 
 ### AVOID returning `this` from methods just to enable a fluent interface.

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -787,8 +787,9 @@ can.
 
 Sometimes an instance field doesn't change after it has been initialized, but
 can't be initialized until after the instance is constructed. For example, it
-may need to reference `this` or some other field on the instance. In cases like,
-that, consider making the field `late final`.
+may need to reference `this` or some other field on the instance. In cases like
+that, consider making the field `late final`. When you do, you may also be able
+to initialize the field at its declaration.
 
 
 ### DO use getters for operations that conceptually access properties.
@@ -938,16 +939,17 @@ not intended to be invoked from Dart code and don't need a corresponding getter.
 [angular]: {{site.angulardart}}
 
 
-### AVOID public `late final` fields.
+### AVOID public `late final` fields without initializers.
 
-Unlike other final fields, a late final field *does* define a setter. If
-that field is public, then the setter is public. This is rarely what you want.
-Fields are usually marked late so that they can be initialized *internally* at
-some point in the instance's lifetime, often inside the constructor body.
+Unlike other `final` fields, a `late final` field without an initializer *does*
+define a setter. If that field is public, then the setter is public. This is
+rarely what you want. Fields are usually marked late so that they can be
+initialized *internally* at some point in the instance's lifetime, often inside
+the constructor body.
 
 Unless you do intend to expose the setter publicly and allow users to invoke it,
-it's better to either not use `late`, or make the late field private with a
-public getter.
+it's better to not use `late`, ensure the `late` field is initialized at its
+declaration, or make the `late` field private with a public getter.
 
 
 ### AVOID returning nullable `Future`, `Stream`, and collection types.
@@ -957,9 +959,9 @@ data: It can return an empty container or it can return `null`. Users generally
 assume and prefer that you use an empty container to indicate "no data". That
 way, they have a real object that they can call methods on like `isEmpty`.
 
-Prefer returning an empty collection, a future that doesn't complete, or a
-stream that doesn't emit any values to indicate that your API has no data to
-provide.
+Prefer returning an empty collection, a non-nullable future of a nullable type,
+or a stream that doesn't emit any values to indicate that your API has no data
+to provide.
 
 **Exception:** If returning `null` *means something different* from yielding an
 empty container, it may make sense to use a nullable type.

--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -959,12 +959,12 @@ data: It can return an empty container or it can return `null`. Users generally
 assume and prefer that you use an empty container to indicate "no data". That
 way, they have a real object that they can call methods on like `isEmpty`.
 
-Prefer returning an empty collection, a non-nullable future of a nullable type,
-or a stream that doesn't emit any values to indicate that your API has no data
-to provide.
+To indicate that your API has no data to provide, prefer returning an empty
+collection, a non-nullable future of a nullable type, or a stream that doesn't
+emit any values.
 
 **Exception:** If returning `null` *means something different* from yielding an
-empty container, it may make sense to use a nullable type.
+empty container, it might make sense to use a nullable type.
 
 
 ### AVOID returning `this` from methods just to enable a fluent interface.

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -142,6 +142,7 @@
 **Constructors**
 
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-late-when-a-constructor-initialization-list-will-do'>DON'T use <code>late</code> when a constructor initialization list will do.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>
@@ -214,7 +215,8 @@
 * <a href='/guides/language/effective-dart/design#do-use-getters-for-operations-that-conceptually-access-properties'>DO use getters for operations that conceptually access properties.</a>
 * <a href='/guides/language/effective-dart/design#do-use-setters-for-operations-that-conceptually-change-properties'>DO use setters for operations that conceptually change properties.</a>
 * <a href='/guides/language/effective-dart/design#dont-define-a-setter-without-a-corresponding-getter'>DON'T define a setter without a corresponding getter.</a>
-* <a href='/guides/language/effective-dart/design#avoid-returning-null-from-members-whose-return-type-is-bool-double-int-or-num'>AVOID returning <code>null</code> from members whose return type is <code>bool</code>, <code>double</code>, <code>int</code>, or <code>num</code>.</a>
+* <a href='/guides/language/effective-dart/design#avoid-public-late-final-fields'>AVOID public <code>late final</code> fields.</a>
+* <a href='/guides/language/effective-dart/design#avoid-returning-nullable-future-stream-and-collection-types'>AVOID returning nullable <code>Future</code>, <code>Stream</code>, and collection types.</a>
 * <a href='/guides/language/effective-dart/design#avoid-returning-this-from-methods-just-to-enable-a-fluent-interface'>AVOID returning <code>this</code> from methods just to enable a fluent interface.</a>
 
 **Types**

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -142,7 +142,7 @@
 **Constructors**
 
 * <a href='/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible'>DO use initializing formals when possible.</a>
-* <a href='/guides/language/effective-dart/usage#dont-use-late-when-a-constructor-initialization-list-will-do'>DON'T use <code>late</code> when a constructor initialization list will do.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-late-when-a-constructor-initializer-list-will-do'>DON'T use <code>late</code> when a constructor initializer list will do.</a>
 * <a href='/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies'>DO use <code>;</code> instead of <code>{}</code> for empty constructor bodies.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-new'>DON'T use <code>new</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-const-redundantly'>DON'T use <code>const</code> redundantly.</a>

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -215,7 +215,7 @@
 * <a href='/guides/language/effective-dart/design#do-use-getters-for-operations-that-conceptually-access-properties'>DO use getters for operations that conceptually access properties.</a>
 * <a href='/guides/language/effective-dart/design#do-use-setters-for-operations-that-conceptually-change-properties'>DO use setters for operations that conceptually change properties.</a>
 * <a href='/guides/language/effective-dart/design#dont-define-a-setter-without-a-corresponding-getter'>DON'T define a setter without a corresponding getter.</a>
-* <a href='/guides/language/effective-dart/design#avoid-public-late-final-fields'>AVOID public <code>late final</code> fields.</a>
+* <a href='/guides/language/effective-dart/design#avoid-public-late-final-fields-without-initializers'>AVOID public <code>late final</code> fields without initializers.</a>
 * <a href='/guides/language/effective-dart/design#avoid-returning-nullable-future-stream-and-collection-types'>AVOID returning nullable <code>Future</code>, <code>Stream</code>, and collection types.</a>
 * <a href='/guides/language/effective-dart/design#avoid-returning-this-from-methods-just-to-enable-a-fluent-interface'>AVOID returning <code>this</code> from methods just to enable a fluent interface.</a>
 

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -1059,8 +1059,8 @@ class ShadeOfGray {
 }
 {% endprettify %}
 
-Note that constructor parameters never shadow fields in constructor
-initialization lists:
+Note that constructor parameters never shadow fields in constructor initializer
+lists:
 
 {:.good}
 <?code-excerpt "usage_good.dart (param-dont-shadow-field-ctr-init)"?>
@@ -1110,7 +1110,7 @@ class ProfileMark {
 }
 {% endprettify %}
 
-Some fields can't be initialized at declaration because they need to reference
+Some fields can't be initialized at their declarations because they need to reference
 `this` — to use other fields or call methods, for example. However, if the
 field is marked `late`, then the initializer *can* access `this`.
 
@@ -1156,7 +1156,7 @@ named parameter whose name doesn't match the name of the field you are
 initializing. But when you *can* use initializing formals, you *should*.
 
 
-### DON'T use `late` when a constructor initialization list will do.
+### DON'T use `late` when a constructor initializer list will do.
 
 Sound null safety requires Dart to ensure that a non-nullable field is
 initialized before it can be read. Since fields can be read inside the
@@ -1166,7 +1166,7 @@ non-nullable field before the body runs.
 You can make this error go away by marking the field `late`. That turns the
 compile-time error into a *runtime* error if you access the field before it is
 initialized. That's what you need in some cases, but often the right fix is to
-initialize the field in the constructor initialization list:
+initialize the field in the constructor initializer list:
 
 {:.good}
 <?code-excerpt "usage_good.dart (late-init-list)"?>
@@ -1192,8 +1192,8 @@ class Point {
 {% endprettify %}
 
 
-The initialization list gives you access to constructor parameters and lets you
-initialize fields before they can be read. So, if it's possible to use an initialization list,
+The initializer list gives you access to constructor parameters and lets you
+initialize fields before they can be read. So, if it's possible to use an initializer list,
 that's better than making the field `late` and losing some static safety and
 performance.
 

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -1113,11 +1113,7 @@ class ProfileMark {
 One common reason that fields are *not* initialized at the declaration is
 because they need to reference `this` or call methods on the containing
 instance. However, if the field is marked `late`, then the initializer *can*
-access `this`. In cases where the initialization doesn't depend on constructor
-parameters, you may be able to move the initialization to the field's
-declaration. That doesn't necessarily mean you *should* use `late` just to be
-able to initialize at the declaration. But if you want the field to be `late`,
-it gives you additional flexibility.
+access `this`.
 
 Of course, if a field depends on constructor parameters, or is initialized
 differently by different constructors, then this guideline does not apply.
@@ -1197,7 +1193,10 @@ class Point {
 {% endprettify %}
 
 
-The initialization list gives you access to constructor parameters and lets you initialize fields before they can be read. So, if it's possible to use that, that's better than making the field `late` and losing some static safety and performance.
+The initialization list gives you access to constructor parameters and lets you
+initialize fields before they can be read. So, if it's possible to use that,
+that's better than making the field `late` and losing some static safety and
+performance.
 
 
 ### DO use `;` instead of `{}` for empty constructor bodies.

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -1110,10 +1110,9 @@ class ProfileMark {
 }
 {% endprettify %}
 
-One common reason that fields are *not* initialized at the declaration is
-because they need to reference `this` or call methods on the containing
-instance. However, if the field is marked `late`, then the initializer *can*
-access `this`.
+Some fields can't be initialized at declaration because they need to reference
+`this` — to use other fields or call methods, for example. However, if the
+field is marked `late`, then the initializer *can* access `this`.
 
 Of course, if a field depends on constructor parameters, or is initialized
 differently by different constructors, then this guideline does not apply.
@@ -1159,7 +1158,7 @@ initializing. But when you *can* use initializing formals, you *should*.
 
 ### DON'T use `late` when a constructor initialization list will do.
 
-Sound null safety requires Dart to ensure that a non-nullable field must be
+Sound null safety requires Dart to ensure that a non-nullable field is
 initialized before it can be read. Since fields can be read inside the
 constructor body, this means you get an error if you don't initialize a
 non-nullable field before the body runs.
@@ -1194,7 +1193,7 @@ class Point {
 
 
 The initialization list gives you access to constructor parameters and lets you
-initialize fields before they can be read. So, if it's possible to use that,
+initialize fields before they can be read. So, if it's possible to use an initialization list,
 that's better than making the field `late` and losing some static safety and
 performance.
 


### PR DESCRIPTION
- Add note suggesting late fields.
- Add guideline about late public fields.
- Remove outdated guideline about nullable primitives.
- Add guideline about nullable container types.
- Explain initializing late fields at the declaration.
- Add guideline encouraging constructor initialization lists.