### PR TITLE
Document abstract fields in "Understanding Null Safety".

### DIFF
--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -1157,7 +1157,7 @@ It sees that `contents` declaration as a real field.
 And, unfortunately, that field is non-nullable and has no initializer,
 so you get a compile error.
 
-One fix is to use the explicit abstract getter/setter declarations
+One fix is to use explicit abstract getter/setter declarations
 like in the second example.
 But that's a little verbose,
 so with null safety

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -1122,6 +1122,56 @@ non-nullable types (if they have a default value).
 This is another one of those features that I think makes Dart better regardless
 of null safety. It simply makes the language feel more complete to me.
 
+### Abstract fields
+
+One of the neat features of Dart is that
+it upholds a thing called the [uniform access principle][].
+In human terms it means that
+fields are indistinguishable from getters and setters.
+It's an implementation detail whether a "property" in some Dart class
+is computed or stored.
+Because of this,
+when defining an interface using an abstract class,
+it's typical to use a field declaration:
+
+[uniform access principle]: https://en.wikipedia.org/wiki/Uniform_access_principle
+
+```dart
+abstract class Cup {
+  Beverage contents;
+}
+```
+
+The intent is that users only implement that class and don't extend it.
+The field syntax is simply a shorter way of writing a getter/setter pair:
+
+```dart
+abstract class Cup {
+  Beverage get contents;
+  set contents(Beverage);
+}
+```
+
+But Dart doesn't *know* that this class will never be used as a concrete type.
+It sees that `contents` declaration as a real field.
+And, unfortunately, that field is non-nullable and has no initializer,
+so you get a compile error.
+
+One fix is to use the explicit abstract getter/setter declarations
+like in the second example.
+But that's a little verbose,
+so with null safety
+we also added support for explicit abstract field declarations:
+
+```dart
+abstract class Cup {
+  abstract Beverage contents;
+}
+```
+
+This behaves exactly like the second example.
+It simply declares an abstract getter and setter with the given name and type.
+
 ### Working with nullable fields
 
 These new features cover many common patterns and make working with `null`


### PR DESCRIPTION
I tried
using semantic line breaks.
It makes my technical prose
read like some weird form
of nerd poetry
(which I sort of like).

Fix #2695.