### PR TITLE
Remove the incorrect guidance on linking to the unnamed constructor.

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/docs_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/docs_good.dart
@@ -84,7 +84,7 @@ void miscDeclAnalyzedButNotTested() {
     void method1() {}
 
     // #docregion ctor
-    /// To create a point, call [Point()] or use [Point.polar()] to ...
+    /// To create a point from polar coordinates, use [Point.polar()].
     // #enddocregion ctor
     void method2() {}
   };

--- a/src/_guides/language/effective-dart/documentation_migrated.md
+++ b/src/_guides/language/effective-dart/documentation_migrated.md
@@ -321,13 +321,12 @@ separated by a dot:
 /// Similar to [Duration.inDays], but handles fractional days.
 {% endprettify %}
 
-The dot syntax can also be used to refer to named constructors. For the unnamed
-constructor, put parentheses after the class name:
+The dot syntax can also be used to refer to named constructors:
 
 {:.good}
 <?code-excerpt "docs_good.dart (ctor)"?>
 {% prettify dart tag=pre+code %}
-/// To create a point, call [Point()] or use [Point.polar()] to ...
+/// To create a point from polar coordinates, use [Point.polar()].
 {% endprettify %}
 
 ### DO use prose to explain parameters, return values, and exceptions.


### PR DESCRIPTION
Ideally, we tell people how to do this, but the current dartdoc syntax
is kind of weird, so I think it's best for now to just say nothing.

Fix #1244.