### PR TITLE
Revise import guidelines.

### DIFF
--- a/src/_guides/language/effective-dart/design_migrated.md
+++ b/src/_guides/language/effective-dart/design_migrated.md
@@ -265,10 +265,12 @@ been flushed to disk "saved" or "*un*-changed"? Is a document that *hasn't* been
 flushed "*un*-saved" or "changed"? In ambiguous cases, lean towards the choice
 that is less likely to be negated by users or has the shorter name.
 
-**Exceptions:** With some properties, the negative form is what users
+**Exception:** With some properties, the negative form is what users
 overwhelmingly need to use. Choosing the positive case would force them to
 negate the property with `!` everywhere. Instead, it may be better to use the
-negative case for that property. Also, properties accessed in [Angular][]
+negative case for that property.
+
+**Exception:** Properties accessed in [Angular][]
 templates are often better in the negative form because the property is used to
 *hide* or *disable* content.
 

--- a/src/_guides/language/effective-dart/toc_migrated.md
+++ b/src/_guides/language/effective-dart/toc_migrated.md
@@ -92,7 +92,8 @@
 
 * <a href='/guides/language/effective-dart/usage#do-use-strings-in-part-of-directives'>DO use strings in <code>part of</code> directives.</a>
 * <a href='/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package'>DON'T import libraries that are inside the <code>src</code> directory of another package.</a>
-* <a href='/guides/language/effective-dart/usage#do-use-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory'>DO use relative paths when importing libraries within your own package's <code>lib</code> directory.</a>
+* <a href='/guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib'>DON'T allow an import path to reach into or out of <code>lib</code>.</a>
+* <a href='/guides/language/effective-dart/usage#prefer-relative-import-paths'>PREFER relative import paths.</a>
 
 **Null**
 


### PR DESCRIPTION
Make it clearer that you should prefer relative imports even outside of
"lib".

Fix #2496. Fix #2606.