### PR TITLE
Beefed up built-in types section

### DIFF
--- a/src/_guides/language/language-tour_migrated.md
+++ b/src/_guides/language/language-tour_migrated.md
@@ -62,10 +62,7 @@ apps:
 :   A special type that indicates a value that's never used.
     Functions like `printInteger()` and `main()` that don't explicitly return a value
     have the `void` return type.
-    For more information, see [this article][void article].
     
-[void article]: https://medium.com/dartlang/dart-2-legacy-of-the-void-e7afb5f44df0
-
 `int`
 :   Another type, indicating an integer.
     Some additional [built-in types](#built-in-types)
@@ -110,7 +107,7 @@ mind:
 -   Everything you can place in a variable is an *object*, and every
     object is an instance of a *class*. Even numbers, functions, and
     `null` are objects.
-    All objects except `null` inherit from the [Object][] class.
+    All objects except `null` inherit from the [`Object`][] class.
 
 -   Although Dart is strongly typed, type annotations are optional
     because Dart can infer types. In the code above, `number`
@@ -132,17 +129,6 @@ mind:
     (if you've [enabled null safety][ns-enable]), `Object`, or —
     if you must defer type checking until runtime —
     the [special type `dynamic`][ObjectVsDynamic].
-
-    {% comment %}
-    [TODO #2950: Better link? Cover `dynamic` more in the language tour?]
-
-    Here's a nice example that illustrates what dynamic does:
-      dynamic a = 2;
-      String b = a; // No problem! Until runtime, when you get an uncaught error.
-  
-      Object c = 2;
-      String d = c;  // Problem!
-    {% endcomment %}
 
 -   Dart supports generic types, like `List<int>` (a list of integers)
     or `List<Object>` (a list of objects of any type).
@@ -274,7 +260,7 @@ The following table lists the words that the Dart language treats specially.
 [try]: #catch
 [typedef]: #typedefs
 [var]: #variables
-[void]: https://medium.com/dartlang/dart-2-legacy-of-the-void-e7afb5f44df0
+[void]: #built-in-types
 {% comment %}
   TODO #2950: Add coverage of void to the language tour.
 {% endcomment %}
@@ -466,35 +452,63 @@ For more information on using `const` to create constant values, see
 
 The Dart language has special support for the following types:
 
-- numbers
-- strings
-- booleans
-- lists (also known as *arrays*)
-- sets
-- maps
-- runes (for expressing Unicode characters in a string)
-- symbols
+- [Numbers](#numbers) (`int`, `double`)
+- [Strings](#strings) (`String`)
+- [Booleans](#booleans) (`bool`)
+- [Lists](#lists) (`List`, also known as *arrays*)
+- [Sets](#sets) (`Set`)
+- [Maps](#maps) (`Map`)
+- [Runes](#characters) (`Runes`; often replaced by the `characters` API)
+- [Symbols](#symbols) (`Symbol`)
 
-You can initialize an object of any of these special types using a
-literal. For example, `'this is a string'` is a string literal,
+This support includes the ability to create objects using literals.
+For example, `'this is a string'` is a string literal,
 and `true` is a boolean literal.
-
-{% comment %}
-[TODO #2950: add info about support for Iterable, Future, Stream?
-Those can't be initialized using literals, but they do have special support.
-{% endcomment %}
 
 Because every variable in Dart refers to an object—an instance of a
 *class*—you can usually use *constructors* to initialize variables. Some
 of the built-in types have their own constructors. For example, you can
 use the `Map()` constructor to create a map.
 
+Some other types also have special roles in the Dart language:
+
+* `Object`: The superclass of all Dart classes except `Null`.
+* `Null`: The type of `null` objects.
+* `Future` and `Stream`: Used in [asynchrony support](#asynchrony-support).
+* `Iterable`: Used in [for-in loops](#iteration).
+* `Never`: Indicates that an expression can never
+  successfully finish evaluating.
+  Most often used for functions that always throw an exception.
+* `dynamic`: Indicates that you want to disable static checking.
+  Usually you should use `Object` or `Object?` instead.
+* `void`: Indicates that a value is never used.
+  Often used as a return type.
+
+{% comment %}
+[TODO: move/add for-in coverage to language tour?]
+{% endcomment %}
+
+The `Object`, `Object?`, `Null`, and `Never` classes
+have special roles in the class hierarchy,
+as described in the [top-and-bottom][] section of
+[Understanding null safety][].
+
+{% comment %}
+If we decide to cover `dynamic` more,
+here's a nice example that illustrates what dynamic does:
+  dynamic a = 2;
+  String b = a; // No problem! Until runtime, when you get an uncaught error.
+
+  Object c = 2;
+  String d = c;  // Problem!
+{% endcomment %}
+
 
 ### Numbers
 
 Dart numbers come in two flavors:
 
-[int][]
+[`int`][]
 
 :   Integer values no larger than 64 bits,
     depending on the platform.
@@ -510,12 +524,12 @@ The informal spec is at
 https://github.com/dart-lang/sdk/blob/master/docs/language/informal/int64.md.
 {% endcomment %}
 
-[double][]
+[`double`][]
 
 :   64-bit (double-precision) floating-point numbers, as specified by
     the IEEE 754 standard.
 
-Both `int` and `double` are subtypes of [`num`.][num]
+Both `int` and `double` are subtypes of [`num`][].
 The num type includes basic operators such as +, -, /, and \*,
 and is also where you’ll find `abs()`,` ceil()`,
 and `floor()`, among other methods.
@@ -594,7 +608,8 @@ const msUntilRetry = secondsUntilRetry * msPerSecond;
 
 ### Strings
 
-A Dart string is a sequence of UTF-16 code units. You can use either
+A Dart string (`String` object) holds a sequence of UTF-16 code units.
+You can use either
 single or double quotes to create a string:
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/built_in_types.dart (quoting)"?>
@@ -729,7 +744,7 @@ assert(iMeantToDoThis.isNaN);
 
 Perhaps the most common collection in nearly every programming language
 is the *array*, or ordered group of objects. In Dart, arrays are
-[List][] objects, so most people just call them *lists*.
+[`List`][] objects, so most people just call them *lists*.
 
 Dart list literals look like JavaScript array literals. Here’s a simple
 Dart list:
@@ -859,7 +874,8 @@ information about lists, see [Generics](#generics) and
 ### Sets
 
 A set in Dart is an unordered collection of unique items.
-Dart support for sets is provided by set literals and the [Set][Set class] type.
+Dart support for sets is provided by set literals and the
+[`Set`][] type.
 
 Here is a simple Dart set, created using a set literal:
 
@@ -942,7 +958,7 @@ For more information about sets, see
 In general, a map is an object that associates keys and values. Both
 keys and values can be any type of object. Each *key* occurs only once,
 but you can use the same *value* multiple times. Dart support for maps
-is provided by map literals and the [Map][] type.
+is provided by map literals and the [`Map`][] type.
 
 Here are a couple of simple Dart maps, created using map literals:
 
@@ -1044,9 +1060,10 @@ For details and examples, see the
 [spread operator proposal][spread proposal] and the
 [control flow collections proposal.][collections proposal]
 
-For more information about maps, see
-[Generics](#generics) and
-[Maps](/guides/libraries/library-tour#maps).
+For more information about maps, see the
+[generics](#generics) section and
+the library tour's coverage of
+the [`Maps` API](/guides/libraries/library-tour#maps).
 
 <a id="characters"></a>
 ### Runes and grapheme clusters
@@ -1105,7 +1122,7 @@ for the characters package.
 
 ### Symbols
 
-A [Symbol][] object
+A [`Symbol`][] object
 represents an operator or identifier declared in a Dart program. You
 might never need to use symbols, but they're invaluable for APIs that
 refer to identifiers by name, because minification changes identifier
@@ -2211,7 +2228,7 @@ for (int i = 0; i < candidates.length; i++) {
 ```
 
 You might write that example differently if you’re using an
-[Iterable][] such as a list or set:
+[`Iterable`][] such as a list or set:
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/control_flow.dart (where)"?>
 ```dart
@@ -2349,7 +2366,7 @@ The first argument to `assert` can be any expression that
 resolves to a boolean value. If the expression’s value
 is true, the assertion succeeds and execution
 continues. If it's false, the assertion fails and an exception (an
-[AssertionError][]) is thrown.
+[`AssertionError`][]) is thrown.
 
 When exactly do assertions work?
 That depends on the tools and framework you're using:
@@ -2375,7 +2392,7 @@ In contrast to Java, all of Dart’s exceptions are unchecked exceptions.
 Methods do not declare which exceptions they might throw, and you are
 not required to catch any exceptions.
 
-Dart provides [Exception][] and [Error][]
+Dart provides [`Exception`][] and [`Error`][]
 types, as well as numerous predefined subtypes. You can, of course,
 define your own exceptions. However, Dart programs can throw any
 non-null object—not just Exception and Error objects—as an exception.
@@ -2397,8 +2414,8 @@ throw 'Out of llamas!';
 ```
 
 {{site.alert.note}}
-  Production-quality code usually throws types that implement [Error][] or
-  [Exception][].
+  Production-quality code usually throws types that implement [`Error`][] or
+  [`Exception`][].
 {{site.alert.end}}
 
 Because throwing an exception is an expression, you can throw exceptions
@@ -2452,7 +2469,7 @@ your exception handler needs the exception object.
 
 You can specify one or two parameters to `catch()`.
 The first is the exception that was thrown,
-and the second is the stack trace (a [StackTrace][] object).
+and the second is the stack trace (a [`StackTrace`][] object).
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/exceptions.dart (try-catch-2)" replace="/\(e.*?\)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
@@ -2529,9 +2546,10 @@ section of the library tour.
 
 Dart is an object-oriented language with classes and mixin-based
 inheritance. Every object is an instance of a class, and all classes
-descend from [Object.][Object]
-*Mixin-based inheritance* means that although every class (except for
-Object) has exactly one superclass, a class body can be reused in
+except `Null` descend from [`Object`][].
+*Mixin-based inheritance* means that although every class
+(except for the [top class][top-and-bottom],`Object?`)
+has exactly one superclass, a class body can be reused in
 multiple class hierarchies.
 [Extension methods](#extension-methods) are a way to
 add functionality to a class without changing the class or creating a subclass.
@@ -2662,8 +2680,8 @@ assert(!identical(a, b)); // NOT the same instance!
 ### Getting an object's type
 
 To get an object's type at runtime,
-you can use Object's `runtimeType` property,
-which returns a [Type][] object.
+you can use the `Object` property `runtimeType`,
+which returns a [`Type`][] object.
 
 <?code-excerpt "../null_safety_examples/misc/test/language_tour/classes_test.dart (runtimeType)"?>
 ```dart
@@ -3561,7 +3579,7 @@ can pass a static method as a parameter to a constant constructor.
 ## Generics
 
 If you look at the API documentation for the basic array type,
-[List,][List] you’ll see that the
+[`List`][], you’ll see that the
 type is actually `List<E>`. The \<...\> notation marks List as a
 *generic* (or *parameterized*) type—a type that has formal type
 parameters. [By convention][], most type variables have single-letter names,
@@ -3891,7 +3909,7 @@ Keep in mind the following when you use deferred loading:
   both the deferred library and the importing file.
 * Dart implicitly inserts `loadLibrary()` into the namespace that you define
   using <code>deferred as <em>namespace</em></code>.
-  The `loadLibrary()` function returns a [Future](/guides/libraries/library-tour#future).
+  The `loadLibrary()` function returns a [`Future`](/guides/libraries/library-tour#future).
 
 
 ### Implementing libraries
@@ -3912,7 +3930,7 @@ for advice on how to implement a library package, including:
 ## Asynchrony support
 
 Dart libraries are full of functions that
-return [Future][] or [Stream][] objects.
+return [`Future`][] or [`Stream`][] objects.
 These functions are _asynchronous_:
 they return after setting up
 a possibly time-consuming operation
@@ -4111,8 +4129,8 @@ When you need to lazily produce a sequence of values,
 consider using a _generator function_.
 Dart has built-in support for two kinds of generator functions:
 
-* **Synchronous** generator: Returns an **[Iterable]** object.
-* **Asynchronous** generator: Returns a **[Stream]** object.
+* **Synchronous** generator: Returns an **[`Iterable`]** object.
+* **Asynchronous** generator: Returns a **[`Stream`]** object.
 
 To implement a **synchronous** generator function,
 mark the function body as `sync*`,
@@ -4448,7 +4466,7 @@ existing code. For more information, see the [Dart language specification][] and
 To learn more about Dart's core libraries, see
 [A Tour of the Dart Libraries](/guides/libraries/library-tour).
 
-[AssertionError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
+[`AssertionError`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
 [`Characters`]: {{site.pub-api}}/characters/latest/characters/Characters-class.html
 [characters API]: {{site.pub-api}}/characters
 [characters example]: {{site.pub-pkg}}/characters/example
@@ -4461,34 +4479,36 @@ To learn more about Dart's core libraries, see
 [Dart language specification]: /guides/language/spec
 [dartdevc]: /tools/dartdevc
 [DON’T use const redundantly]: /guides/language/effective-dart/usage#dont-use-const-redundantly
-[double]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
-[Error]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
-[Exception]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
+[`double`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
+[`Error`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
+[`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
 [extension methods page]: /guides/language/extension-methods
 [Flutter]: {{site.flutter}}
 [Flutter debug mode]: {{site.flutter}}/docs/testing/debugging#debug-mode-assertions
 [forEach()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/forEach.html
 [Function API reference]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
-[Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
+[`Future`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
 [grapheme clusters]: https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries
 [identical()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/identical.html
-[int]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/int-class.html
-[Iterable]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
+[`int`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/int-class.html
+[`Iterable`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
 [js numbers]: https://stackoverflow.com/questions/2802957/number-of-bits-in-javascript-numbers/2803010#2803010
-[List]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
-[Map]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html
+[`List`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
+[`Map`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html
 [meta]: {{site.pub-pkg}}/meta
 [ns]: /null-safety
 [ns-enable]: /null-safety#enable-null-safety
-[num]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num-class.html
-[Object]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Object-class.html
+[`num`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num-class.html
+[`Object`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Object-class.html
 [ObjectVsDynamic]: /guides/language/effective-dart/design_migrated#avoid-using-dynamic-unless-you-want-to-disable-static-checking
 [runes]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Runes-class.html
-[Set class]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Set-class.html
-[StackTrace]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/StackTrace-class.html
-[Stream]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Stream-class.html
-[String]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/String-class.html
-[Symbol]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Symbol-class.html
+[`Set`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Set-class.html
+[`StackTrace`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/StackTrace-class.html
+[`Stream`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Stream-class.html
+[`String`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/String-class.html
+[`Symbol`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Symbol-class.html
 [synchronous-async-start]: https://github.com/dart-lang/sdk/blob/master/docs/newsletter/20170915.md#synchronous-async-start
+[top-and-bottom]: /null-safety/understanding-null-safety#top-and-bottom
 [trailing commas]: #trailing-comma
-[Type]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Type-class.html
+[`Type`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Type-class.html
+[Understanding null safety]: /null-safety/understanding-null-safety

--- a/src/_guides/language/language-tour_migrated.md
+++ b/src/_guides/language/language-tour_migrated.md
@@ -450,7 +450,7 @@ For more information on using `const` to create constant values, see
 
 ## Built-in types
 
-The Dart language has special support for the following types:
+The Dart language has special support for the following:
 
 - [Numbers](#numbers) (`int`, `double`)
 - [Strings](#strings) (`String`)
@@ -460,6 +460,7 @@ The Dart language has special support for the following types:
 - [Maps](#maps) (`Map`)
 - [Runes](#characters) (`Runes`; often replaced by the `characters` API)
 - [Symbols](#symbols) (`Symbol`)
+- The value `null` (`Null`)
 
 This support includes the ability to create objects using literals.
 For example, `'this is a string'` is a string literal,
@@ -473,9 +474,9 @@ use the `Map()` constructor to create a map.
 Some other types also have special roles in the Dart language:
 
 * `Object`: The superclass of all Dart classes except `Null`.
-* `Null`: The type of `null` objects.
 * `Future` and `Stream`: Used in [asynchrony support](#asynchrony-support).
-* `Iterable`: Used in [for-in loops](#iteration).
+* `Iterable`: Used in [for-in loops](#iteration) and
+  in synchronous [generator functions](#generator).
 * `Never`: Indicates that an expression can never
   successfully finish evaluating.
   Most often used for functions that always throw an exception.
@@ -4129,8 +4130,8 @@ When you need to lazily produce a sequence of values,
 consider using a _generator function_.
 Dart has built-in support for two kinds of generator functions:
 
-* **Synchronous** generator: Returns an **[`Iterable`]** object.
-* **Asynchronous** generator: Returns a **[`Stream`]** object.
+* **Synchronous** generator: Returns an [`Iterable`] object.
+* **Asynchronous** generator: Returns a [`Stream`] object.
 
 To implement a **synchronous** generator function,
 mark the function body as `sync*`,


### PR DESCRIPTION
* Added coverage of `Null` and `Never` (contributing to #2485)
* Code fonted more class names

Staged: https://dartlang-org-staging-0.firebaseapp.com/guides/language/language-tour_migrated#built-in-types
