### PR TITLE
Fix assert in migrated list tour example

### DIFF
--- a/null_safety_examples/misc/test/library_tour/core_test.dart
+++ b/null_safety_examples/misc/test/library_tour/core_test.dart
@@ -239,8 +239,8 @@ void main() {
 
       // You can also create a List using one of the constructors.
       var vegetables = List.filled(99, 'broccoli');
+      assert(vegetables.every((v) => v == 'broccoli'));
       // #enddocregion List
-      assert(vegetables.isEmpty);
     });
 
     test('indexOf', () {

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -378,6 +378,7 @@ assert(fruits.isEmpty);
 
 // You can also create a List using one of the constructors.
 var vegetables = List.filled(99, 'broccoli');
+assert(vegetables.every((v) => v == 'broccoli'));
 ```
 
 Use `indexOf()` to find the index of an object in a list:


### PR DESCRIPTION
I've updated the `vegetables` `assert` as it should no longer be empty but rather be filled with a lot of broccoli. I hope it's roasted - yum!