### PR TITLE
Minor corrections/improvements to language tour's doc comments section

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/comments.dart
+++ b/null_safety_examples/misc/lib/language_tour/comments.dart
@@ -35,8 +35,8 @@ class Activity {}
 ///
 /// Andean cultures have used llamas as meat and pack
 /// animals since pre-Hispanic times.
-/// 
-/// Just like any other animal, they need to eat,
+///
+/// Just like any other animal, llamas need to eat,
 /// so don't forget to [feed] them some [Food].
 class Llama {
   String? name;

--- a/null_safety_examples/misc/lib/language_tour/comments.dart
+++ b/null_safety_examples/misc/lib/language_tour/comments.dart
@@ -38,7 +38,7 @@ class Activity {}
 class Llama {
   String? name;
 
-  /// Feeds your llama [Food].
+  /// Feeds your llama [food].
   ///
   /// The typical llama eats one bale of hay per week.
   void feed(Food food) {

--- a/null_safety_examples/misc/lib/language_tour/comments.dart
+++ b/null_safety_examples/misc/lib/language_tour/comments.dart
@@ -35,6 +35,9 @@ class Activity {}
 ///
 /// Andean cultures have used llamas as meat and pack
 /// animals since pre-Hispanic times.
+/// 
+/// Just like any other animal, they need to eat,
+/// so don't forget to [feed] them some [Food].
 class Llama {
   String? name;
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4538,7 +4538,7 @@ classes and arguments:
 class Llama {
   String? name;
 
-  /// Feeds your llama [Food].
+  /// Feeds your llama [food].
   ///
   /// The typical llama eats one bale of hay per week.
   void feed(Food food) {
@@ -4553,7 +4553,7 @@ class Llama {
 }
 ```
 
-In the generated documentation, `[Food]` becomes a link to the API docs
+In the generated documentation, `[food]` becomes a link to the API docs
 for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4520,7 +4520,7 @@ Documentation comments are multi-line or single-line comments that begin
 with `///` or `/**`. Using `///` on consecutive lines has the same
 effect as a multi-line doc comment.
 
-Inside a documentation comment, the Dart compiler ignores all text
+Inside a documentation comment, Dart progam analysis ignores all text
 unless it is enclosed in brackets. Using brackets, you can refer to
 classes, methods, fields, top-level variables, functions, and
 parameters. The names in brackets are resolved in the lexical scope of
@@ -4554,10 +4554,10 @@ class Llama {
 ```
 
 In the generated documentation, `[Food]` becomes a link to the API docs
-for the Food class.
+for the `Food` class.
 
-To parse Dart code and generate HTML documentation, you can use the SDK’s
-[documentation generation tool.](https://github.com/dart-lang/dartdoc#dartdoc)
+To parse Dart code and generate HTML documentation, you can use Dart's
+[documentation generation tool, dartdoc.](https://github.com/dart-lang/dartdoc#dartdoc)
 For an example of generated documentation, see the [Dart API
 documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
 your comments, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4535,8 +4535,8 @@ classes and arguments:
 ///
 /// Andean cultures have used llamas as meat and pack
 /// animals since pre-Hispanic times.
-/// 
-/// Just like any other animal, they need to eat,
+///
+/// Just like any other animal, llamas need to eat,
 /// so don't forget to [feed] them some [Food].
 class Llama {
   String? name;

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4535,6 +4535,9 @@ classes and arguments:
 ///
 /// Andean cultures have used llamas as meat and pack
 /// animals since pre-Hispanic times.
+/// 
+/// Just like any other animal, they need to eat,
+/// so don't forget to [feed] them some [Food].
 class Llama {
   String? name;
 
@@ -4553,8 +4556,8 @@ class Llama {
 }
 ```
 
-In the generated documentation, `[food]` becomes a link to the API docs
-for the `Food` class.
+In the class's generated documentation, `[feed]` becomes a link to the `feed` method,
+and `[Food]` becomes a link to the API docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
 [documentation generation tool, dartdoc.](https://github.com/dart-lang/dartdoc#dartdoc)

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4520,7 +4520,7 @@ Documentation comments are multi-line or single-line comments that begin
 with `///` or `/**`. Using `///` on consecutive lines has the same
 effect as a multi-line doc comment.
 
-Inside a documentation comment, Dart progam analysis ignores all text
+Inside a documentation comment, the analyzer ignores all text
 unless it is enclosed in brackets. Using brackets, you can refer to
 classes, methods, fields, top-level variables, functions, and
 parameters. The names in brackets are resolved in the lexical scope of

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4561,7 +4561,7 @@ to the docs for the `feed` method,
 and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
-[documentation generation tool, dartdoc.](https://github.com/dart-lang/dartdoc#dartdoc)
+[documentation generation tool, dartdoc.](/tools/dartdoc)
 For an example of generated documentation, see the [Dart API
 documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
 your comments, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4556,8 +4556,9 @@ class Llama {
 }
 ```
 
-In the class's generated documentation, `[feed]` becomes a link to the `feed` method,
-and `[Food]` becomes a link to the API docs for the `Food` class.
+In the class's generated documentation, `[feed]` becomes a link
+to the docs for the `feed` method,
+and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
 [documentation generation tool, dartdoc.](https://github.com/dart-lang/dartdoc#dartdoc)


### PR DESCRIPTION
I'm not sure it's really the compiler that does the resolution in the doc comments but rather the analyzer and surrounding tools, so I updated `the Dart compiler` to `Dart program analysis` but if desired I think `the Dart analyzer` could work too, but I'm not sure if most users know what that is.

Also, instead of calling dartdoc the SDK's documentation tool I thought it was a bit more friendly and easy to understand to just call it `Dart's documentation tool`. 

I've also made `Food` an inline code block.