### PR TITLE
Specify map generics to actually be equivalent to literal example

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/built_in_types.dart
+++ b/null_safety_examples/misc/lib/language_tour/built_in_types.dart
@@ -153,12 +153,12 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion map-constructor
-    var gifts = Map();
+    var gifts = Map<String, String>();
     gifts['first'] = 'partridge';
     gifts['second'] = 'turtledoves';
     gifts['fifth'] = 'golden rings';
 
-    var nobleGases = Map();
+    var nobleGases = Map<int, String>();
     nobleGases[2] = 'helium';
     nobleGases[10] = 'neon';
     nobleGases[18] = 'argon';

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1066,12 +1066,12 @@ You can create the same objects using a Map constructor:
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/built_in_types.dart (map-constructor)"?>
 ```dart
-var gifts = Map();
+var gifts = Map<String, String>();
 gifts['first'] = 'partridge';
 gifts['second'] = 'turtledoves';
 gifts['fifth'] = 'golden rings';
 
-var nobleGases = Map();
+var nobleGases = Map<int, String>();
 nobleGases[2] = 'helium';
 nobleGases[10] = 'neon';
 nobleGases[18] = 'argon';


### PR DESCRIPTION
If we want the the `Map` constructor example to be equivalent to the preceding literal example which we specify by saying ("You can create the same objects using a Map constructor:") we need to specify the generic type arguments or else they're assumed to be `dynamic`. 