### PR TITLE
Update guidance around using collections.

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -52,6 +52,24 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion collection-literals
   }
 
+  {
+    var command = 'c';
+    var options = ['a'];
+    var modeFlags = ['b'];
+    var filePaths = ['p'];
+    String removeExtension(String path) => path;
+
+    // #docregion spread-etc
+    var arguments = <String>[];
+    arguments.addAll(options);
+    arguments.add(command);
+    if (modeFlags != null) arguments.addAll(modeFlags);
+    arguments.addAll(filePaths
+        .where((path) => path.endsWith('.dart'))
+        .map((path) => path.replaceAll('.dart', '.js')));
+    // #enddocregion spread-etc
+  }
+
   (Iterable lunchBox, Iterable words) {
     // #docregion dont-use-length
     if (lunchBox.length == 0) return 'so hungry...';

--- a/null_safety_examples/misc/lib/effective_dart/usage_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_good.dart
@@ -60,6 +60,25 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion collection-literals
   }
 
+  {
+    var command = 'c';
+    var options = ['a'];
+    var modeFlags = ['b'] as List<String>?;
+    var filePaths = ['p'];
+    String removeExtension(String path) => path;
+
+    // #docregion spread-etc
+    var arguments = [
+      ...options,
+      command,
+      ...?modeFlags,
+      for (var path in filePaths)
+        if (path.endsWith('.dart'))
+          path.replaceAll('.dart', '.js')
+    ];
+    // #enddocregion spread-etc
+  }
+
   (Iterable lunchBox, Iterable words) {
     // #docregion dont-use-length
     if (lunchBox.isEmpty) return 'so hungry...';

--- a/src/_guides/language/effective-dart/usage_migrated.md
+++ b/src/_guides/language/effective-dart/usage_migrated.md
@@ -481,11 +481,43 @@ var counts = Set<int>();
 
 Note that this guideline doesn't apply to the *named* constructors for those
 classes. `List.from()`, `Map.fromIterable()`, and friends all have their uses.
-Likewise, if you're passing a size to `List()` to create a non-growable one,
-then it makes sense to use that.
-
 (The List class also has an unnamed constructor, but it is prohibited in null
 safe Dart.)
+
+Collection literals are particularly powerful in Dart
+because they give you access to the [spread operator][spread]
+for including the contents of other collections,
+and [`if` and `for`][control] for performing control flow while
+building the contents:
+
+[spread]: /guides/language/language-tour#spread-operator
+[control]: /guides/language/language-tour#collection-operators
+
+{:.good}
+<?code-excerpt "usage_good.dart (spread-etc)"?>
+{% prettify dart tag=pre+code %}
+var arguments = [
+  ...options,
+  command,
+  ...?modeFlags,
+  for (var path in filePaths)
+    if (path.endsWith('.dart'))
+      path.replaceAll('.dart', '.js')
+];
+{% endprettify %}
+
+{:.bad}
+<?code-excerpt "usage_bad.dart (spread-etc)"?>
+{% prettify dart tag=pre+code %}
+var arguments = <String>[];
+arguments.addAll(options);
+arguments.add(command);
+if (modeFlags != null) arguments.addAll(modeFlags);
+arguments.addAll(filePaths
+    .where((path) => path.endsWith('.dart'))
+    .map((path) => path.replaceAll('.dart', '.js')));
+{% endprettify %}
+
 
 ### DON'T use `.length` to see if a collection is empty.
 
@@ -514,26 +546,6 @@ if (lunchBox.length == 0) return 'so hungry...';
 if (!words.isEmpty) return words.join(' ');
 {% endprettify %}
 
-### CONSIDER using higher-order methods to transform a sequence.
-
-If you have a collection and want to produce a new modified collection from it,
-it's often shorter and more declarative to use `.map()`, `.where()`, and the
-other handy methods on `Iterable`.
-
-Using those instead of an imperative `for` loop makes it clear that your intent
-is to produce a new sequence and not to produce side effects.
-
-{:.good}
-<?code-excerpt "usage_good.dart (use-higher-order-func)"?>
-{% prettify dart tag=pre+code %}
-var aquaticNames = animals
-    .where((animal) => animal.isAquatic)
-    .map((animal) => animal.name);
-{% endprettify %}
-
-At the same time, this can be taken too far. If you are chaining or nesting
-many higher-order methods, it may be clearer to write a chunk of imperative
-code.
 
 ### AVOID using `Iterable.forEach()` with a function literal.
 


### PR DESCRIPTION
- Remove incorrect sentence about deprecate List constructor.

- Encourage using new spread, if, and for.

- Remove rule about higher-order methods. Most Dart users seem to know
  about them now, and we don't necessarily want to stress them over the
  new spread, if, and for.

Fix #2872.