### PR TITLE
Fix base and focus styles of Try Dart select

### DIFF
--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -306,6 +306,11 @@ $dash-dartpad-border: #293542;
 
   select {
     margin: 8px 0 8px 0;
+    border-radius: 4px;
+    &:focus, &:active {
+      outline: none;
+      box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%), 0 0 0 0.2rem rgb(255 255 255 / 50%);
+    }
   }
 
   a {

--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -309,7 +309,7 @@ $dash-dartpad-border: #293542;
     border-radius: 4px;
     &:focus, &:active {
       outline: none;
-      box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%), 0 0 0 0.2rem rgb(255 255 255 / 50%);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, .08), 0 0 0 0.2rem rgba(255, 255, 255, 0.5)
     }
   }
 


### PR DESCRIPTION
Before this change it was almost impossible to tell the element was focused.

### Previously:

Base: 
![image](https://user-images.githubusercontent.com/18372958/109870420-aea09a00-7c2f-11eb-8c6c-b3500f3a7873.png)

Focus:
![image](https://user-images.githubusercontent.com/18372958/109870455-b9f3c580-7c2f-11eb-9ade-35aa22909417.png)


### After:

Base:
![image](https://user-images.githubusercontent.com/18372958/109870480-c37d2d80-7c2f-11eb-8385-656e96f77374.png)

Focus:
![image](https://user-images.githubusercontent.com/18372958/109870545-dabc1b00-7c2f-11eb-8dea-58cc036de94d.png)

I rounded the corners of the select to better match the other buttons on the page.

