### PR TITLE
Add a mention that the books precede Dart releases with null safety

### DIFF
--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -9,6 +9,11 @@ also cover Dart.
 If you find another Dart book that might be helpful, please
 [let us know.](https://github.com/dart-lang/site-www/issues)
 
+
+## Dart books preceding null safety
+
+The following books cover Dart versions preceding the release of null safety.
+
 {% for book in site.data.books-dart2 %}
 <div class="book-img-with-details row">
 <a href="{{book.link}}" title="{{book.title}}" class="col-sm-3 no-automatic-external">

--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -12,7 +12,9 @@ If you find another Dart book that might be helpful, please
 
 ## Dart books preceding null safety
 
-The following books cover Dart versions preceding the release of null safety.
+The following books cover Dart versions preceding the release of [null safety][].
+
+[null safety]: /null-safety
 
 {% for book in site.data.books-dart2 %}
 <div class="book-img-with-details row">


### PR DESCRIPTION
I thought this would be worth mentioning as null safety can have a large impact on your code and the explanations around it.