### PR TITLE
Remove link to unsupported russian site

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -55,7 +55,6 @@ Dart is open source. Learn how to
 Our wonderful community has provided these resources.
 
 * [Chinese version of this site (此网站的中文版)](https://dart.cn)
-* [Russian version of this site (Русскоязычная версия сайта)](https://www.dart-lang.ru)
 
 
 Also see the [Flutter community page.]({{site.flutter}}/community)


### PR DESCRIPTION
The link is currently dead and it wasn't updated in over a year according to the [Github repository](https://github.com/iboldurev/dart-lang). Best not to confuse users or bring them to quite outdated information if it does come back up.

If it comes back up and has updates, then this would definitely be worth being re-included. 