### PR TITLE
Remove mention of asm.js

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -441,22 +441,6 @@ and thus does not support Int64List or Uint64List.
 Dart code compiled via dart2js results in a runtime exception
 if either of those lists is used.
 
-### Q. Why not compile Dart to asm.js instead of JavaScript?
-
-Asm.js is a very restricted subset of JavaScript best suited as a compilation
-target for C compilers. It does not include JavaScript objects or direct
-access to the DOM. Essentially, it allows only arithmetic operations and
-manipulations on typed arrays.
-
-While it is possible to implement the features that Dart requires,
-they would incur a large overhead in both speed and size, compared to
-relying on the already existing features provided by the underlying
-JavaScript engine.
-For example, any JavaScript machine comes with a garbage collector;
-implementing another one in asm.js would increase the output size, and be
-noticeably slower than the well-tuned garbage collectors of
-modern JavaScript VMs.
-
 
 [ppwsize]: https://work.j832.com/2012/11/excited-to-see-dart2js-minified-output.html
 [sourcemaps]: https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/


### PR DESCRIPTION
Since `asm.js` is no longer developed and has long been superseded by WebAssembly, this section doesn't make much sense anymore.

This could be replaced by a section about WebAssembly, but it seems that answer is still in flux but perhaps @mraleph could follow up with a replacement piece, but it's not necessary. 