### PR TITLE
Document options for pub get and upgrade

### DIFF
--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -143,16 +143,22 @@ command-line argument, as mentioned above.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
+### `--offline`
+
+Uses cached packages rather than downloading
+from the network. See above for a more detailed
+explanation.
+
 ### `--dry-run` or `-n`
 
-With this, pub reports the dependencies that would
-but does not make the changes. This is useful if you
+Reports the dependencies that would be changed,
+but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
 
 ### `--precompile`
 
-This option makes pub compile executables in its dependencies
-before running the get process.
+Creates snapshots of the
+project's executables in direct dependencies.
 
 <aside class="alert alert-info" markdown="1">
 *Problems?*

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -137,23 +137,20 @@ run [`dart pub upgrade`](/tools/pub/cmd/pub-upgrade) to upgrade to a later versi
 
 ## Options
 
-The `dart pub get` command supports the `--offline`
-command-line argument, as mentioned above.
-
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
-
-### `--offline`
-
-Uses cached packages rather than downloading
-from the network. See above for a more detailed
-explanation.
 
 ### `--dry-run` or `-n`
 
 Reports the dependencies that would be changed,
 but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
+
+### `--offline`
+
+Uses cached packages rather than downloading
+from the network.
+For details, see [Getting while offline](#getting-while-offline).
 
 ### `--precompile`
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -6,7 +6,7 @@ description: Use dart pub get to retrieve the dependencies used by your Dart app
 _Get_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify nocode tag=pre+code %}
-$ dart pub get [--offline]
+$ dart pub get [--offline] [--dry-run] [--precompile]
 {% endprettify %}
 
 This command gets all the dependencies listed in the
@@ -142,6 +142,18 @@ command-line argument, as mentioned above.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
+
+### `--dry-run` or `-n`
+
+With this, pub reports the dependencies that would
+but does not make the changes. This is useful if you
+want to analyze the updates before making them,
+as you cannot undo the changes afterwards.
+
+### `--precompile`
+
+This option makes pub compile executables in its dependencies
+before running the get process.
 
 <aside class="alert alert-info" markdown="1">
 *Problems?*

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -147,8 +147,7 @@ For options that apply to all pub commands, see
 
 With this, pub reports the dependencies that would
 but does not make the changes. This is useful if you
-want to analyze the updates before making them,
-as you cannot undo the changes afterwards.
+want to analyze updates before making them.
 
 ### `--precompile`
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -6,7 +6,7 @@ description: Use dart pub get to retrieve the dependencies used by your Dart app
 _Get_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify nocode tag=pre+code %}
-$ dart pub get [--offline] [--dry-run] [--precompile]
+$ dart pub get [args]
 {% endprettify %}
 
 This command gets all the dependencies listed in the

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -7,7 +7,7 @@ toc: false
 _Publish_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 {% prettify nocode tag=pre+code %}
-$ dart pub publish [--dry-run] [--force]
+$ dart pub publish [options]
 {% endprettify %}
 
 This command publishes your package on the

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -109,6 +109,38 @@ The `dart pub upgrade` command supports the
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
+### `--dry-run` or `-n`
+
+With this, pub reports the dependencies that would
+but does not make the changes. This is useful if you
+want to analyze the updates before making them.
+
+### `--precompile`
+
+This option makes pub compile executables in its dependencies
+before running the get process.
+
+### `--major-versions`
+
+When pub upgrades with this option, it will do so
+ignoring any upper-bound constraint in the
+`pubspec.yaml` file. It will also update `pubspec.yaml`
+with the newly defined constraints.
+The packages it gets are those
+listed as "Resolvable" with `dart pub outdated`.
+
+It is recommended to commit your `pubspec.yaml` file
+before running this, as this cannot be undone otherwise.
+You can use `dart pub upgrade --major-versions --dry-run`
+to quickly check which dependencies would be upgraded. 
+
+### `--null-safety`
+
+This is similar to `--major-versions`, except that pub will
+force dependencies to use null-safety versions. The packages
+it gets are those listed in `dart pub outdated --mode=null-safety`.
+This option will also guide you to do a partial null-safety migration.
+
 <aside class="alert alert-info" markdown="1">
 *Problems?*
 See [Troubleshooting Pub](/tools/pub/troubleshoot).

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -113,7 +113,7 @@ For options that apply to all pub commands, see
 
 With this, pub reports the dependencies that would
 but does not make the changes. This is useful if you
-want to analyze the updates before making them.
+want to analyze updates before making them.
 
 ### `--precompile`
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -109,16 +109,22 @@ The `dart pub upgrade` command supports the
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
+### `--offline`
+
+Uses cached packages rather than downloading
+from the network. See above for a more detailed
+explanation.
+
 ### `--dry-run` or `-n`
 
-With this, pub reports the dependencies that would
-but does not make the changes. This is useful if you
+Reports the dependencies that would be changed,
+but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
 
 ### `--precompile`
 
-This option makes pub compile executables in its dependencies
-before running the get process.
+Creates snapshots of the
+project's executables in direct dependencies.
 
 ### `--major-versions`
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -132,10 +132,17 @@ you can use `dart pub upgrade --major-versions --dry-run`.
 
 ### `--null-safety`
 
-This is similar to `--major-versions`, except that pub will
-force dependencies to use null-safety versions. The packages
-it gets are those listed in `dart pub outdated --mode=null-safety`.
-This option will also guide you to do a partial null-safety migration.
+Gets the packages that
+[`dart pub outdated --mode=null-safety`][`dart pub outdated`]
+lists as _resolvable_,
+ignoring any upper-bound constraint in the `pubspec.yaml` file.
+Also updates `pubspec.yaml` with the new constraints.
+This command is similar to `--major-versions`.
+
+{{ site.alert.tip }}
+  Commit the `pubspec.yaml` file before running this command,
+  so that you can undo the changes if necessary.
+{{ site.alert.end }}
 
 ### `--offline`
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -117,12 +117,11 @@ want to analyze updates before making them.
 
 ### `--major-versions`
 
-When pub upgrades with this option, it will do so
-ignoring any upper-bound constraint in the
-`pubspec.yaml` file. It will also update `pubspec.yaml`
-with the newly defined constraints.
-The packages it gets are those
-listed as "Resolvable" with `dart pub outdated`.
+Gets the packages that [`dart pub outdated`][] lists as _resolvable_,
+ignoring any upper-bound constraint in the`pubspec.yaml` file.
+Also updates `pubspec.yaml` with the new constraints.
+
+[`dart pub outdated`]: /tools/pub/cmd/pub-outdated
 
 It is recommended to commit your `pubspec.yaml` file
 before running this, as this cannot be undone otherwise.

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -105,7 +105,6 @@ run `dart pub upgrade` again to upgrade to a later version.
 
 The `dart pub upgrade` command supports the
 [`dart pub get` options](/tools/pub/cmd/pub-get#options).
-
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
@@ -118,7 +117,7 @@ want to analyze updates before making them.
 ### `--major-versions`
 
 Gets the packages that [`dart pub outdated`][] lists as _resolvable_,
-ignoring any upper-bound constraint in the`pubspec.yaml` file.
+ignoring any upper-bound constraint in the `pubspec.yaml` file.
 Also updates `pubspec.yaml` with the new constraints.
 
 [`dart pub outdated`]: /tools/pub/cmd/pub-outdated

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -125,8 +125,8 @@ Also updates `pubspec.yaml` with the new constraints.
 
 It is recommended to commit your `pubspec.yaml` file
 before running this, as this cannot be undone otherwise.
-You can use `dart pub upgrade --major-versions --dry-run`
-to quickly check which dependencies would be upgraded. 
+To check which dependencies will be upgraded,
+you can use `dart pub upgrade --major-versions --dry-run`.
 
 ### `--null-safety`
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -109,22 +109,11 @@ The `dart pub upgrade` command supports the
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-### `--offline`
-
-Uses cached packages rather than downloading
-from the network. See above for a more detailed
-explanation.
-
 ### `--dry-run` or `-n`
 
 Reports the dependencies that would be changed,
 but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
-
-### `--precompile`
-
-Creates snapshots of the
-project's executables in direct dependencies.
 
 ### `--major-versions`
 
@@ -146,6 +135,17 @@ This is similar to `--major-versions`, except that pub will
 force dependencies to use null-safety versions. The packages
 it gets are those listed in `dart pub outdated --mode=null-safety`.
 This option will also guide you to do a partial null-safety migration.
+
+### `--offline`
+
+Uses cached packages rather than downloading
+from the network. See above for a more detailed
+explanation.
+
+### `--precompile`
+
+Creates snapshots of the
+project's executables in direct dependencies.
 
 <aside class="alert alert-info" markdown="1">
 *Problems?*

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -123,8 +123,10 @@ Also updates `pubspec.yaml` with the new constraints.
 
 [`dart pub outdated`]: /tools/pub/cmd/pub-outdated
 
-It is recommended to commit your `pubspec.yaml` file
-before running this, as this cannot be undone otherwise.
+{{ site.alert.tip }}
+  Commit the `pubspec.yaml` file before running this command,
+  so that you can undo the changes if necessary.
+{{ site.alert.end }}
 To check which dependencies will be upgraded,
 you can use `dart pub upgrade --major-versions --dry-run`.
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -147,8 +147,8 @@ This command is similar to `--major-versions`.
 ### `--offline`
 
 Uses cached packages rather than downloading
-from the network. See above for a more detailed
-explanation.
+from the network.
+For details, see [Upgrading while offline](#upgrading-while-offline).
 
 ### `--precompile`
 


### PR DESCRIPTION
Partially fixes #2898

Documents unlisted options for `dart pub get` and `dart pub upgrade`. I don't know too much about precompile, so it would be useful if someone else went more in-depth about what exactly that option implies.

Also, perhaps there is something to be done about the amount of overlap between the two articles?

This is also just a general issue I noticed, but the wording between the different `help` sections on the CLI are very inconsistent. I might file an issue for this on the main repository, because we can't make the docs for these commands consistent when the CLI's built-in documentation isn't. 