### PR TITLE
Add language info strings to Markdown code blocks in Effective Dart

### DIFF
--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -421,7 +421,7 @@ a flavor of what's supported:
 ///
 /// Code blocks are fenced in triple backticks:
 ///
-/// ```
+/// ```dart
 /// this.code
 ///     .will
 ///     .retain(its, formatting);
@@ -477,7 +477,7 @@ language, and is consistent with using backticks for inline code.
 {% prettify dart tag=pre+code %}
 /// You can use [CodeBlockExample] like this:
 ///
-/// ```
+/// ```dart
 /// var example = CodeBlockExample();
 /// print(example.isItGreat); // "Yes."
 /// ```


### PR DESCRIPTION
Since we are adding a warning to dartdoc that users should specify a language, best to lead by example.

Fixes #3052