### PR TITLE
Remove mention of dartdevc from analysis options page

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -481,7 +481,6 @@ Use the following resources to learn more about static analysis in Dart:
 * [Dart's type system][type-system]
 * [Dart linter](https://github.com/dart-lang/linter#linter-for-dart)
 * [Dart linter rules][linter rules]
-* [dartdevc](/tools/dartdevc)
 * [analyzer package]({{site.pub}}/packages/analyzer)
 
 [analysis_option_deprecated]: {{site.pub-api}}/analyzer/latest/analyzer/AnalysisOptionsWarningCode/ANALYSIS_OPTION_DEPRECATED-constant.html


### PR DESCRIPTION
I'm not sure this mention of a resource makes a lot of sense anymore as it's a tool for compiling and debugging web applications rather than a static analysis tool. 

I believe in the past this page had a lot of mentions of strong mode and how dartdevc only supported it or something along those line, but those mentions aren't relevant and do not exist anymore.

_Sorry if this PR ends up appearing multiple times, Github is being flaky and providing me with lots of unicorns!_