### PR TITLE
Fix typo: `startWith()` should be `startsWith()`

### DIFF
--- a/src/codelabs/iterables.md
+++ b/src/codelabs/iterables.md
@@ -369,7 +369,7 @@ void main() {
 }
 {$ end test.dart $}
 {$ begin hint.txt $}
-Use the methods `contains()` and `startWith()` from the `String` class.
+Use the methods `contains()` and `startsWith()` from the `String` class.
 {$ end hint.txt $}
 ```
 


### PR DESCRIPTION
Page URL: https://dart.dev/codelabs/iterables.html
Page source: https://github.com/dart-lang/site-www/tree/master/src/codelabs/iterables.md

Found a typo? You can fix it yourself by going to the page source and clicking the pencil icon. Or finish creating this issue.

Description of issue: 
The "hint" in the exercise [Practice writing a test predicate](https://dart.dev/codelabs/iterables#exercise-practice-writing-a-test-predicate) has a typo: `startWith()` should be `startsWith()`

The hint:
> Use the methods `contains()` and `startWith()` from the `String` class.