### PR TITLE
Improve title consistency

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -1,7 +1,7 @@
 ---
 layout: error
 title: "404: Page not found"
-description: "dartlang's 404 page."
+description: "dart.dev's 404 page."
 permalink: /404
 sitemap: false
 ---

--- a/src/_articles/archive/numeric-computation.md
+++ b/src/_articles/archive/numeric-computation.md
@@ -1,5 +1,5 @@
 ---
-title: Numeric Computation
+title: Numeric computation
 description: How you store and use numbers can have a big impact on your app's performance. This article focuses on the Dart VM.
 original-date: 2013-05-22
 date: 2018-07-26

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -165,7 +165,7 @@
           permalink: /tutorials/web/fetch-data
         - title: Low-level web programming
           children:
-          - title: Connect Dart and HTML
+          - title: Connect Dart & HTML
             permalink: /tutorials/web/low-level-html/connect-dart-html
           - title: Add elements to the DOM
             permalink: /tutorials/web/low-level-html/add-elements
@@ -260,7 +260,7 @@
       permalink: /resources
     - title: Books
       permalink: /resources/books
-    - title: DartPad in tutorials&#58; Best practices
+    - title: "DartPad in tutorials: Best practices"
       permalink: /resources/dartpad-best-practices
     - title: Code of conduct
       permalink: /code-of-conduct

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -165,7 +165,7 @@
           permalink: /tutorials/web/fetch-data
         - title: Low-level web programming
           children:
-          - title: Connect Dart & HTML
+          - title: Connect Dart and HTML
             permalink: /tutorials/web/low-level-html/connect-dart-html
           - title: Add elements to the DOM
             permalink: /tutorials/web/low-level-html/add-elements
@@ -260,7 +260,7 @@
       permalink: /resources
     - title: Books
       permalink: /resources/books
-    - title: DartPad in tutorials&#58; best practices
+    - title: DartPad in tutorials&#58; Best practices
       permalink: /resources/dartpad-best-practices
     - title: Code of conduct
       permalink: /code-of-conduct

--- a/src/_guides/language/index.md
+++ b/src/_guides/language/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview: the Dart language"
+title: "Overview: The Dart language"
 permalink: /guides/language
 short-title: Dart language
 toc: false

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1,6 +1,6 @@
 ---
 title: A tour of the Dart language
-description: A tour of all of the major Dart language features.
+description: A tour of all the major Dart language features.
 short-title: Language tour
 js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
 ---

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -1,6 +1,6 @@
 ---
 title: "C interop using dart:ffi"
-description: "To use C code in your Dart program, use the dart:ffi library (currently in preview)."
+description: "To use C code in your Dart program, use the dart:ffi library."
 hw: "https://github.com/dart-lang/samples/tree/master/ffi/hello_world"
 samples: "https://github.com/dart-lang/samples/tree/master/ffi"
 sqllite: "https://github.com/dart-lang/sdk/tree/master/samples/ffi/sqlite"

--- a/src/_includes/web-tutorials.md
+++ b/src/_includes/web-tutorials.md
@@ -6,7 +6,7 @@ These tutorials cover topics relevant to Dart web apps.
     <p> Load data from a static file or from a server. </p>
   </div>
   <div class="card">
-    <h3><a href="/tutorials/web/low-level-html/connect-dart-html">Connect Dart & HTML</a></h3>
+    <h3><a href="/tutorials/web/low-level-html/connect-dart-html">Connect Dart and HTML</a></h3>
     <p> Include a Dart script in an HTML page. </p>
   </div>
   <div class="card">

--- a/src/_tutorials/language/index.md
+++ b/src/_tutorials/language/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Dart tutorials: language"
+title: "Dart tutorials: The language"
 description: Tutorials pertaining to the Dart language, such as asynchronous programming.
 toc: false
 ---

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -1,5 +1,5 @@
 ---
-title: "Asynchronous programming: streams"
+title: "Asynchronous programming: Streams"
 description: Learn how to consume single-subscriber and broadcast streams.
 ---
 

--- a/src/_tutorials/libraries/index.md
+++ b/src/_tutorials/libraries/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Dart tutorials: libraries"
+title: "Dart tutorials: Libraries"
 description: "Tutorials relating to Dart's core libraries and APIs."
 toc: false
 ---

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -3,7 +3,7 @@ title: Write command-line apps
 description: Basics for command-line apps.
 nextpage:
   url: /tutorials/server/httpserver
-  title: Write HTTP clients & servers
+  title: Write HTTP clients and servers
 prevpage:
   url: /tutorials/server/get-started
   title: "Get started: Command-line and server apps"

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -6,7 +6,7 @@ nextpage:
   title: Write HTTP clients & servers
 prevpage:
   url: /tutorials/server/get-started
-  title: "Get started: command-line & server apps"
+  title: "Get started: Command-line and server apps"
 ---
 
 {% assign _api = site.dart_api | append: '/' | append: site.data.pkg-vers.SDK.channel -%}

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -1,6 +1,6 @@
 ---
-title: "Get started: command-line and server apps"
-description: Get Dart, run and compile a small app
+title: "Get started: Command-line and server apps"
+description: Get Dart, run and compile a small app.
 nextpage:
   url: /tutorials/server/cmdline
   title: Write command-line apps

--- a/src/_tutorials/server/index.md
+++ b/src/_tutorials/server/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorials: command-line apps and servers'
+title: "Tutorials: Command-line apps and servers"
 description: Tutorials for writing command-line apps and servers.
 ---
 

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Get started: web apps"
+title: "Get started: Web apps"
 description: A guide to get you quickly writing web apps in Dart.
 ---
 

--- a/src/_tutorials/web/index.md
+++ b/src/_tutorials/web/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorials: web apps'
+title: "Tutorials: web apps"
 description: Tutorials for writing Dart web apps.
 ---
 

--- a/src/_tutorials/web/low-level-html/add-elements.md
+++ b/src/_tutorials/web/low-level-html/add-elements.md
@@ -1,13 +1,13 @@
 ---
-title: "Add elements to the DOM"
-description: "You have an Element object, now what?"
+title: Add elements to the DOM
+description: You have an Element object, now what?
 
 nextpage:
   url: /tutorials/web/low-level-html/remove-elements
-  title: "Remove DOM elements"
+  title: Remove DOM elements
 prevpage:
   url: /tutorials/web/low-level-html/connect-dart-html
-  title: "Connect Dart & HTML"
+  title: Connect Dart and HTML
 ---
 
 <div class="panel" markdown="1">

--- a/src/_tutorials/web/low-level-html/connect-dart-html.md
+++ b/src/_tutorials/web/low-level-html/connect-dart-html.md
@@ -1,9 +1,9 @@
 ---
-title: "Connect Dart &amp; HTML"
-description: "Shows basic scaffolding of a Dart web app."
+title: Connect Dart and HTML
+description: Shows basic scaffolding of a Dart web app.
 nextpage:
   url: /tutorials/web/low-level-html/add-elements
-  title: "Add elements to the DOM"
+  title: Add elements to the DOM
 ---
 
 This tutorial is the first of a series on

--- a/src/_tutorials/web/low-level-html/index.md
+++ b/src/_tutorials/web/low-level-html/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Dart tutorials: low-level HTML"
-description: "Dart tutorials related to low-level web programming using HTML."
+title: "Dart tutorials: Low-level HTML"
+description: Dart tutorials related to low-level web programming using HTML.
 toc: false
 ---
 
@@ -24,7 +24,7 @@ Then learn how to add, move, and remove DOM elements.
 
 <div class="card-grid">
   <div class="card">
-    <h3><a href="/tutorials/web/low-level-html/connect-dart-html">Connect Dart & HTML</a></h3>
+    <h3><a href="/tutorials/web/low-level-html/connect-dart-html">Connect Dart and HTML</a></h3>
     <p>Include a Dart script in an HTML page.</p>
   </div>
   <div class="card">

--- a/src/_tutorials/web/low-level-html/remove-elements.md
+++ b/src/_tutorials/web/low-level-html/remove-elements.md
@@ -1,10 +1,10 @@
 ---
-title: "Remove DOM elements"
-description: "Remove a child element from the DOM"
+title: Remove DOM elements
+description: Remove a child element from the DOM.
 
 prevpage:
   url: /tutorials/web/low-level-html/add-elements
-  title: "Add elements to the DOM"
+  title: Add elements to the DOM
 ---
 
 <div class="panel" markdown="1">

--- a/src/map.html
+++ b/src/map.html
@@ -1,6 +1,6 @@
 ---
-title: "Sitemap"
-description: "Human Readable Sitemap"
+title: Sitemap
+description: Human Readable Sitemap
 toc: false
 permalink: /map
 ---

--- a/src/map.html
+++ b/src/map.html
@@ -1,6 +1,6 @@
 ---
 title: Sitemap
-description: Human Readable Sitemap
+description: Human-readable sitemap
 toc: false
 permalink: /map
 ---

--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -1,5 +1,5 @@
 ---
-title: "Null safety: frequently asked questions"
+title: "Null safety: Frequently asked questions"
 description: FAQs to help you migrate your Dart code to null safety
 short-title: FAQ (null safety)
 ---

--- a/src/overview.md
+++ b/src/overview.md
@@ -214,7 +214,7 @@ manages memory using fast object allocation and a
 [generational garbage collector](https://medium.com/flutter-io/flutter-dont-fear-the-garbage-collector-d69b3ff1ca30).
 
 More information:
-* [Get started: command-line and server apps](/tutorials/server/get-started)
+* [Get started: Command-line and server apps](/tutorials/server/get-started)
 * [`dart` tool for running with JIT or AOT compiling to machine code](/tools/dart-tool)
 * [Write command-line apps](/tutorials/server/cmdline)
 * [Write HTTP clients and servers](/tutorials/server/httpserver)
@@ -232,7 +232,7 @@ code to fast, compact, deployable JavaScript using techniques such as dead-code
 elimination.
 
 More information:
-* [Get started: web apps](/tutorials/web/get-started)
+* [Get started: Web apps](/tutorials/web/get-started)
 * [`dartdevc` compiler](/tools/dartdevc)
 * [`webdev` tool](/tools/webdev)
 * [Web deployment tips](/web/deployment)

--- a/src/resources/dartpad-best-practices.md
+++ b/src/resources/dartpad-best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: "DartPad in tutorials: best practices"
+title: "DartPad in tutorials: Best practices"
 description: Research-tested advice for creating effective and engaging educational content for Dart and Flutter users.
 ---
 <style>

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -14,7 +14,7 @@ Check out the following Dart language resources:
   </div>
   
   <div class="card">
-    <h3><a href="/resources/dartpad-best-practices">DartPad in tutorials: best practices</a></h3>
+    <h3><a href="/resources/dartpad-best-practices">DartPad in tutorials: Best practices</a></h3>
     <p>A guide to using embedded DartPads in educational content for Dart and Flutter users.</p>
   </div>
 

--- a/src/server/index.md
+++ b/src/server/index.md
@@ -1,5 +1,6 @@
 ---
-title: Command-line & server apps
+title: Command-line and server apps
+short-title: CLI & server apps
 description: All things relating to command-line and server apps.
 toc: false
 ---

--- a/src/server/libraries.md
+++ b/src/server/libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Command-line & server libraries and packages
+title: Command-line and server libraries and packages
 short-title: CLI & server libraries
 description: Libraries and packages that can help you write Dart command-line & server apps.
 ---

--- a/src/server/libraries.md
+++ b/src/server/libraries.md
@@ -1,5 +1,5 @@
 ---
-title: "Command-line & server libraries and packages"
+title: Command-line & server libraries and packages
 short-title: CLI & server libraries
 description: Libraries and packages that can help you write Dart command-line & server apps.
 ---

--- a/src/tools/dartdevc/index.md
+++ b/src/tools/dartdevc/index.md
@@ -1,5 +1,5 @@
 ---
-title: "dartdevc: the Dart dev compiler"
+title: "dartdevc: The Dart dev compiler"
 short-title: dartdevc
 description: Fast, modular compilation of Dart code to JavaScript.
 ---

--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -1,7 +1,7 @@
 ---
 permalink: /tools/pub/troubleshoot
-title: "Troubleshooting pub"
-description: "Common gotchas you might run into when using pub."
+title: Troubleshooting pub
+description: Common gotchas you might run into when using pub.
 ---
 
 ## Getting a "403" error when publishing a package {#pub-publish-403}


### PR DESCRIPTION
Follows the standards for titles and capitalization from the [Google style guide](https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings).

Fixes #2242