### PR TITLE
Add a reference to the behavior change of async to dart-2

### DIFF
--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -28,10 +28,9 @@ The Dart language, libraries, build system, and web development tools have chang
   * [Assert statements][] are still supported, but you enable them differently.
 * Functions marked `async` now run synchronously
   until the first `await` statement. 
-  * Previously, they would return to the event loop once
-    at the top of the function body before any code runs.
-  * Visit [the Dart newsletter][sync async start] describing
-    the original motivation behind this change.
+  * Previously, execution returned immediately to the caller, and
+    the function body was scheduled to run later.
+  * To learn more, read [the September 2017 Dart newsletter][sync async start].
 * The Dart language and core libraries have changed,
   partly as a result of the type system changes.
   * [Dev channel API reference documentation][apiref]

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -26,6 +26,12 @@ The Dart language, libraries, build system, and web development tools have chang
   * `const` is optional inside of a constant context.
 * Dart no longer has checked mode.
   * [Assert statements][] are still supported, but you enable them differently.
+* Functions marked `async` now run synchronously
+  until the first `await` statement. 
+  * Previously, they would return to the event loop once
+    at the top of the function body before any code runs.
+  * Visit [the Dart newsletter][sync async start] describing
+    the original motivation behind this change.
 * The Dart language and core libraries have changed,
   partly as a result of the type system changes.
   * [Dev channel API reference documentation][apiref]
@@ -190,3 +196,4 @@ environment:
 [Updating your pub package to Dart 2,]: https://medium.com/@filiph/updating-your-pub-package-to-dart-2-cd8ca343b1be
 [Using constructors]: /guides/language/language-tour#using-constructors
 [webdev dart2]: /web/dart-2
+[sync async start]: https://github.com/dart-lang/sdk/blob/master/docs/newsletter/20170915.md#synchronous-async-start


### PR DESCRIPTION
Add a reference to the behavior change of async to dart-2 for historical purposes.

While this is _likely_ not needed for migration by many users at this point, can be useful to include this change for historical reference.

Fixes #751