### PR TITLE
Improve focus and hover style readability in the navbar

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -306,7 +306,7 @@ img {
   background-color: $site-color-header;
   color: $site-color-header-text;
   display: flex;
-  $mainnav-entry-spacing: 15px;
+  $mainnav-entry-spacing: 12px;
   ul {
     margin: auto;
     margin-right: 0;
@@ -316,24 +316,22 @@ img {
       display: flex;
       flex-wrap: wrap;
       justify-content: center;
-      align-items: flex-end;
+      align-items: center;
     }
     li {
       padding: 0 $mainnav-entry-spacing;
       a {
         color: $site-color-header-text;
         display: inline-block;
-        padding: 0;
+        padding: 0 6px;
         font-size: $site-font-size-header;
         font-weight: 400;
-        line-height: 50px;
-        &:hover, &:focus, &:active {
-          color: $gray-lighter;
+        &:hover, &:active {
+          color: $site-color-card-link;
         }
       }
       &.searchfield {
         position: relative;
-        top: -2px;
       }
     }
   }


### PR DESCRIPTION
Previously there was no great indication that you were hovering outside of the cursor(which can be hard to distinguish) and the focus style outline included a lot of unnecessary space on the y axis but not enough on the x axis.

**After changes:**
_In this case, "Overview" is focused and "Community" is hovered_
![image](https://user-images.githubusercontent.com/18372958/111892751-30344e00-89cc-11eb-8cac-7aed8bbd0b60.png)

**Before changes:**
_Similar to the previous example, "Overview" is focused and "Community" is hovered_
![image](https://user-images.githubusercontent.com/18372958/111892767-4cd08600-89cc-11eb-90ec-5703173172bc.png)

Fixes #1195 - This was already fixed with previous design changes anyway, but this makes further improvements.