### PR TITLE
Improvements for long text in TOC

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -584,7 +584,16 @@ img {
   }
   .toc-entry {
     padding-bottom: 0.5rem;
+
+    // Indent subsequent lines
+    margin-left: 1rem;
+    text-indent: -1rem;
+
+    & .toc-entry {
+      margin-left: 0;
+    }
   }
+
   .nav {
     display: block;
     padding-top: 0.5rem;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -563,11 +563,13 @@ img {
   @include sidenav-top-position;
 
   position: fixed;
-  bottom: 0px;
-  width: 226px;
-  right: 0px;
+  bottom: 0;
+  min-width: 226px;
+  max-width: 256px;
+  right: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  overflow-wrap: break-word;
   z-index: 999;
 
   // override shared/_toc.scss

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -565,7 +565,7 @@ img {
   position: fixed;
   bottom: 0;
   min-width: 226px;
-  max-width: 256px;
+  max-width: 246px;
   right: 0;
   overflow-x: hidden;
   overflow-y: auto;
@@ -574,7 +574,7 @@ img {
 
   // override shared/_toc.scss
   &.site-toc {
-    padding: $top-content-padding 30px $content-padding;
+    padding: $top-content-padding 20px $content-padding 30px;
   }
 
   // Override BS defaults for .nav, etc.


### PR DESCRIPTION
Currently for pages like [Diagnostic messages](https://dart.dev/tools/diagnostic-messages) and the [linter page](https://github.com/dart-lang/site-www/pull/3064) in the future, the full-width TOC cuts off the full name of long entries, making it hard to determine what you're navigating to. Especially since a lot of rules share the same beginning, so there is no way to differentiate between them.

This PR slightly increases the width that is available to the TOC when needed as well as allowing wrapping in the middle of words.

**After change:**
![image](https://user-images.githubusercontent.com/18372958/111918755-ad0b0a80-8a54-11eb-9a7b-4541df8284d5.png)

**Before change:**
![image](https://user-images.githubusercontent.com/18372958/111918739-a11f4880-8a54-11eb-8d9a-f69d02326bb1.png)
