### PR TITLE
remove final keyword

### DIFF
--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -1291,7 +1291,7 @@ T` cast, *not* the `!` operator:
 ```dart
 // Using null safety:
 class Box<T> {
-  final T? object;
+  T? object;
   Box.empty();
   Box.full(this.object);
 


### PR DESCRIPTION
Removed `final` keyword from `understanding_null_safety.md`

fixes #2692