### PR TITLE
Clarify that you can annotate locals when the inferred type is wrong.

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/design_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/design_good.dart
@@ -17,6 +17,22 @@ Map map = {};
 String string = '';
 StreamSubscription subscription = Stream.empty().listen((_) {});
 
+class BuildContext {}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(String label);
+}
+
+class EdgeInsets {
+  static double all(double value) => value;
+}
+
+class Padding extends Widget {
+  Padding({required double padding, required Widget child});
+}
+
 void miscDeclAnalyzedButNotTested() {
   (Iterable errors, Iterable<Monster> monsters) {
     // #docregion code-like-prose
@@ -177,6 +193,20 @@ void miscDeclAnalyzedButNotTested() {
       return desserts;
     }
     // #enddocregion omit-types-on-locals
+  }
+
+  {
+    var applyPadding = false;
+
+    // #docregion upcast-local
+    Widget build(BuildContext context) {
+      Widget result = Text('You won!');
+      if (applyPadding) {
+        result = Padding(padding: EdgeInsets.all(8.0), child: result);
+      }
+      return result;
+    }
+    // #enddocregion upcast-local
   }
 
   {

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1217,7 +1217,7 @@ annotations on APIs help *users* of your code, types on private members help
 *maintainers*.
 
 
-### DON'T type redundantly annotate initialized local variables.
+### DON'T redundantly type annotate initialized local variables.
 
 {% include linter-rule.html rule="omit_local_variable_types" %}
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1257,8 +1257,7 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 
 Sometimes the inferred type is not the type you want the variable to have. For
 example, you may intend to assign values of other types later. In that case,
-annotate the variable with the type you want. This guideline only applies when
-the inferred type is the *same* as the type you would annotate.
+annotate the variable with the type you want.
 
 {:.good}
 <?code-excerpt "design_good.dart (upcast-local)" replace="/Widget result/[!Widget!] result/g"?>

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1217,7 +1217,7 @@ annotations on APIs help *users* of your code, types on private members help
 *maintainers*.
 
 
-### DON'T type annotate initialized local variables.
+### DON'T type redundantly annotate initialized local variables.
 
 {% include linter-rule.html rule="omit_local_variable_types" %}
 
@@ -1252,6 +1252,23 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
   }
 
   return desserts;
+}
+{% endprettify %}
+
+Sometimes the inferred type is not the type you want the variable to have. For
+example, you may intend to assign values of other types later. In that case,
+annotate the variable with the type you want. This guideline only applies when
+the inferred type is the *same* as the type you would annotate.
+
+{:.good}
+<?code-excerpt "design_good.dart (upcast-local)" replace="/Widget result/[!Widget!] result/g"?>
+{% prettify dart tag=pre+code %}
+Widget build(BuildContext context) {
+  [!Widget!] result = Text('You won!');
+  if (applyPadding) {
+    result = Padding(padding: EdgeInsets.all(8.0), child: result);
+  }
+  return result;
 }
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -223,7 +223,7 @@
 
 * <a href='/guides/language/effective-dart/design#do-type-annotate-variables-without-initializers'>DO type annotate variables without initializers.</a>
 * <a href='/guides/language/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious'>DO type annotate fields and top-level variables if the type isn't obvious.</a>
-* <a href='/guides/language/effective-dart/design#dont-type-redundantly-annotate-initialized-local-variables'>DON'T type redundantly annotate initialized local variables.</a>
+* <a href='/guides/language/effective-dart/design#dont-redundantly-type-annotate-initialized-local-variables'>DON'T redundantly type annotate initialized local variables.</a>
 * <a href='/guides/language/effective-dart/design#do-annotate-return-types-on-function-declarations'>DO annotate return types on function declarations.</a>
 * <a href='/guides/language/effective-dart/design#do-annotate-parameter-types-on-function-declarations'>DO annotate parameter types on function declarations.</a>
 * <a href='/guides/language/effective-dart/design#dont-annotate-inferred-parameter-types-on-function-expressions'>DON'T annotate inferred parameter types on function expressions.</a>

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -113,7 +113,6 @@
 
 * <a href='/guides/language/effective-dart/usage#do-use-collection-literals-when-possible'>DO use collection literals when possible.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty'>DON'T use <code>.length</code> to see if a collection is empty.</a>
-* <a href='/guides/language/effective-dart/usage#consider-using-higher-order-methods-to-transform-a-sequence'>CONSIDER using higher-order methods to transform a sequence.</a>
 * <a href='/guides/language/effective-dart/usage#avoid-using-iterableforeach-with-a-function-literal'>AVOID using <code>Iterable.forEach()</code> with a function literal.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-listfrom-unless-you-intend-to-change-the-type-of-the-result'>DON'T use <code>List.from()</code> unless you intend to change the type of the result.</a>
 * <a href='/guides/language/effective-dart/usage#do-use-wheretype-to-filter-a-collection-by-type'>DO use <code>whereType()</code> to filter a collection by type.</a>
@@ -224,7 +223,7 @@
 
 * <a href='/guides/language/effective-dart/design#do-type-annotate-variables-without-initializers'>DO type annotate variables without initializers.</a>
 * <a href='/guides/language/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious'>DO type annotate fields and top-level variables if the type isn't obvious.</a>
-* <a href='/guides/language/effective-dart/design#dont-type-annotate-initialized-local-variables'>DON'T type annotate initialized local variables.</a>
+* <a href='/guides/language/effective-dart/design#dont-type-redundantly-annotate-initialized-local-variables'>DON'T type redundantly annotate initialized local variables.</a>
 * <a href='/guides/language/effective-dart/design#do-annotate-return-types-on-function-declarations'>DO annotate return types on function declarations.</a>
 * <a href='/guides/language/effective-dart/design#do-annotate-parameter-types-on-function-declarations'>DO annotate parameter types on function declarations.</a>
 * <a href='/guides/language/effective-dart/design#dont-annotate-inferred-parameter-types-on-function-expressions'>DON'T annotate inferred parameter types on function expressions.</a>


### PR DESCRIPTION
Realized that I dropped an important qualifier when I revamped the typing guidelines.