### PR TITLE
Reorder "For loops" examples of the Language Tour

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/control_flow.dart
+++ b/null_safety_examples/misc/lib/language_tour/control_flow.dart
@@ -26,9 +26,11 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion forEach
-    candidates.forEach((candidate) => candidate.interview());
-    // #enddocregion forEach
+    // #docregion collection
+    for (var candidate in candidates) {
+      candidate.interview();
+    }
+    // #enddocregion collection
   }
 
   {

--- a/null_safety_examples/misc/test/language_tour/control_flow_test.dart
+++ b/null_safety_examples/misc/test/language_tour/control_flow_test.dart
@@ -26,14 +26,12 @@ void main() {
     expect(_test, m.prints(['0', '1']));
   });
 
-  test('collection', () {
+  test('forEach', () {
     _test() {
-      // #docregion collection
+      // #docregion forEach
       var collection = [1, 2, 3];
-      for (var x in collection) {
-        print(x); // 1 2 3
-      }
-      // #enddocregion collection
+      collection.forEach(print); // 1 2 3
+      // #enddocregion forEach
     }
 
     expect(_test, m.prints([1, 2, 3]));

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2237,9 +2237,9 @@ callbacks.forEach((c) => c());
 The output is `0` and then `1`, as expected. In contrast, the example
 would print `2` and then `2` in JavaScript.
 
-If the object that you are iterating over is an Iterable (such as List or Set),
-you can use the `for-in` form of [iteration](/guides/libraries/library-tour#iteration)
-if you don't need to know the current iteration counter:
+If the object that you are iterating over is an Iterable (such as List or Set)
+and if you don't need to know the current iteration counter, 
+you can use the `for-in` form of [iteration](/guides/libraries/library-tour#iteration):
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/control_flow.dart (collection)"?>
 ```dart

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2237,24 +2237,23 @@ callbacks.forEach((c) => c());
 The output is `0` and then `1`, as expected. In contrast, the example
 would print `2` and then `2` in JavaScript.
 
-If the object that you are iterating over is an Iterable, you can use the
-[forEach()][] method. Using `forEach()` is a good option if you don’t need to
-know the current iteration counter:
+If the object that you are iterating over is an Iterable (such as List or Set),
+you can use the `for-in` form of [iteration](/guides/libraries/library-tour#iteration)
+if you don't need to know the current iteration counter:
 
-<?code-excerpt "../null_safety_examples/misc/lib/language_tour/control_flow.dart (forEach)"?>
+<?code-excerpt "../null_safety_examples/misc/lib/language_tour/control_flow.dart (collection)"?>
 ```dart
-candidates.forEach((candidate) => candidate.interview());
+for (var candidate in candidates) {
+  candidate.interview();
+}
 ```
 
-Iterable classes such as List and Set also support the `for-in` form of
-[iteration](/guides/libraries/library-tour#iteration):
+Iterable classes also have a [forEach()][] method as another option:
 
-<?code-excerpt "../null_safety_examples/misc/test/language_tour/control_flow_test.dart (collection)"?>
+<?code-excerpt "../null_safety_examples/misc/test/language_tour/control_flow_test.dart (forEach)"?>
 ```dart
 var collection = [1, 2, 3];
-for (var x in collection) {
-  print(x); // 1 2 3
-}
+collection.forEach(print); // 1 2 3
 ```
 
 


### PR DESCRIPTION
The "For loops" section of the Language Tour described
`Iterable.forEach` before `for-in` and suggested `Iterable.forEach`
as a "good option".  This currently is not the recommendation from
Effective Dart, which discourages using `Iterable.forEach` with
anonymous functions.

* Reorder the examples in the "For loops" section to put greater
  emphasis on `for-in`.
* Describe `Iterable.forEach` as "an option" rather than as a "good
  option".
* Adjust the code snippets so that the `Iterable.forEach` example
  follows the Effective Dart guideline by using a tear-off instead
  of an anonymous function.