### PR TITLE
Fix to Formatting Page

### DIFF
--- a/src/_guides/language/formatting.md
+++ b/src/_guides/language/formatting.md
@@ -18,7 +18,7 @@ For example, here's how to format all the Dart files
 under the current directory's `bin`, `lib`, and `test` directories:
 
 ```terminal
-$ dart format -w bin lib test
+$ dart format bin lib test
 ```
 
 However, dart format can't do it all.


### PR DESCRIPTION
Fixes #3104

Copies over the instructions from the `dart format` page to properly show how to format using the command line. 