### PR TITLE
Update get-dart.md

### DIFF
--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -24,6 +24,7 @@ any of the following are true:
   For example, you might have a continuous integration (CI)
   setup that requires Dart but not Flutter.
 
+**Flutter is built with a particular Dart SDK, and can only be used with a given version of that SDK.**
 
 ## Installing the Dart SDK {#install}
 


### PR DESCRIPTION
Added 'Flutter is built with a particular Dart SDK, and can only be used with a given version of that SDK.'
(reference: https://github.com/flutter/flutter/issues/62790#issuecomment-668201880 )