### PR TITLE
Update sidenav wrt pub and dartfmt

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -213,6 +213,8 @@
           permalink: /tools/dart-fix
         - title: dart format 
           permalink: /tools/dart-format
+        - title: dart pub
+          permalink: /tools/pub/cmd
         - title: dart2js (prod JS)
           permalink: /tools/dart2js
         - title: dartaotruntime
@@ -221,10 +223,6 @@
           permalink: /tools/dartdevc
         - title: dartdoc
           permalink: /tools/dartdoc
-        - title: dartfmt
-          permalink: /tools/dartfmt
-        - title: pub
-          permalink: /tools/pub/cmd
         - title: Experiment flags
           permalink: /tools/experiment-flags
     - title: Other command-line tools

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -1,5 +1,5 @@
 ---
-title: The pub tool
+title: dart pub
 description: The command-line interface for pub, a package management tool for Dart.
 ---
 


### PR DESCRIPTION
- Remove redundant `dartfmt` entry
- Rename `pub` to `dart pub`