### PR TITLE
Remove redunant type annotation in fancy list examples

### DIFF
--- a/null_safety_examples/extension_methods/lib/fancylist.dart
+++ b/null_safety_examples/extension_methods/lib/fancylist.dart
@@ -2,7 +2,7 @@
 extension MyFancyList<T> on List<T> {
   int get doubleLength => length * 2;
   List<T> operator -() => reversed.toList();
-  List<List<T>> split(int at) => <List<T>>[sublist(0, at), sublist(at)];
+  List<List<T>> split(int at) => [sublist(0, at), sublist(at)];
 }
 // #enddocregion
 

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -239,7 +239,7 @@ with a getter, an operator, and a method:
 extension MyFancyList<T> on List<T> {
   int get doubleLength => length * 2;
   List<T> operator -() => reversed.toList();
-  List<List<T>> split(int at) => <List<T>>[sublist(0, at), sublist(at)];
+  List<List<T>> split(int at) => [sublist(0, at), sublist(at)];
 }
 ```
 


### PR DESCRIPTION
This matches Effective Dart and helps encourages best practices. Fixes #3130

Thanks for catching this @dark-chocolate :)