### PR TITLE
Placeholder page & go links for non-promotion docs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -137,6 +137,9 @@
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
+      { "source": "/go/non-promo-write", "destination": "/tools/non-promotion-reasons", "type": 301 },
+      { "source": "/go/non-promo-property", "destination": "/tools/non-promotion-reasons", "type": 301 },
+      { "source": "/go/non-promo-this", "destination": "/tools/non-promotion-reasons", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },

--- a/src/tools/non-promotion-reasons.md
+++ b/src/tools/non-promotion-reasons.md
@@ -1,0 +1,45 @@
+---
+title: Fixing type promotion failures
+description: Solutions for cases where you know more about a field's type than Dart can determine.
+toc: false
+---
+
+{{ site.alert.warn}}
+  **This page is under construction**
+  ([issue #2940][]).
+{{ site.alert.end}}
+
+This page will have information to help you understand
+why type promotion failures occur,
+and give tips on how to fix them.
+For example, consider the following code:
+
+```dart
+class C {
+  int? i;                  // (1)
+  f() {
+    if (i == null) return;
+    i.isEven;              // (2)
+  }
+}
+```
+
+The Dart compiler produces an error message for (2)
+that points to (1) and explains that
+`i` can't be promoted to a non-nullable type
+because it's a field.
+The usual fix is to either use `i!`
+or create a local variable
+of type `int` that holds the value of `i`.
+
+Until this page is complete, see the following resources:
+
+* [Working with nullable fields][ns-fields]:
+  A section in [Understanding null safety][].
+* [Discussion in SDK issue #44900][sdk-44900-comment]:
+  A detailed list of reasons why type promotion might fail.
+
+[issue #2940]: https://github.com/dart-lang/site-www/issues/2940
+[sdk-44900-comment]: https://github.com/dart-lang/sdk/issues/44900#issuecomment-807117343
+[ns-fields]: /null-safety/understanding-null-safety#working-with-nullable-fields
+[Understanding null safety]: /null-safety/understanding-null-safety


### PR DESCRIPTION
Contributes to #2940 and https://github.com/dart-lang/sdk/issues/44900.

I'm not sure how to frame this page, so a few questions (which don't necessarily have to be answered definitively before we merge this PR):

* Is everything on this page going to be about promotion from nullable to non-nullable types? Or might we get some visits related to other forms of type promotion?
* What should the title be? What's going to set expectations correctly?
* Where on dart.dev should this page really live? Initially I thought it was like https://dart.dev/tools/diagnostic-messages, but now I'm not sure how tool-tied it is.

Staged:
https://dartlang-org-staging-0.firebaseapp.com/tools/non-promotion-reasons
https://dartlang-org-staging-0.firebaseapp.com/go/non-promo-write
https://dartlang-org-staging-0.firebaseapp.com/go/non-promo-property
https://dartlang-org-staging-0.firebaseapp.com/go/non-promo-this

/cc @bwilkerson @mit-mit @munificent @sfshaza2 