### PR TITLE
Uploaded packages can actually be 100 MB large

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -46,7 +46,7 @@ are a few additional requirements for uploading a package:
   You must also have the legal right to
   redistribute anything that you upload as part of your package.
 
-* Your package must be less than 10 MB large after gzip compression. If
+* Your package must be less than 100 MB large after gzip compression. If
   it's too large, consider splitting it into multiple packages, or cutting down
   on the number of included resources or examples.
 


### PR DESCRIPTION
This is defined at https://github.com/dart-lang/pub-dev/blob/f32b6e586983bc2ef11e76133e6f6378692d9604/app/lib/package/upload_signer_service.dart#L62