### PR TITLE
added documentation for dart pub add/remove

### DIFF
--- a/src/_guides/packages.md
+++ b/src/_guides/packages.md
@@ -194,16 +194,6 @@ the pub package manager.
 The `dart pub` tool provides the following subcommands:
 
 {% include pub-subcommands.md %}
-<!-- * [`cache`][]
-* [`deps`][]
-* [`downgrade`][]
-* [`get`][]
-* [`global`][]
-* [`outdated`][]
-* [`publish`][]
-* [`run`][]
-* [`upgrade`][]
-* [`uploader`][] -->
 
 For an overview of all the `dart pub` subcommands,
 see the [pub tool documentation](/tools/pub/cmd).
@@ -214,13 +204,3 @@ see the [pub tool documentation](/tools/pub/cmd).
 you might encounter when using pub.
 
 [Dart-savvy IDEs]: /tools#ides-and-editors
-<!-- [`cache`]: /tools/pub/cmd/pub-cache
-[`deps`]: /tools/pub/cmd/pub-deps
-[`downgrade`]: /tools/pub/cmd/pub-downgrade
-[`get`]: /tools/pub/cmd/pub-get
-[`global`]: /tools/pub/cmd/pub-global
-[`outdated`]: /tools/pub/cmd/pub-outdated
-[`publish`]: /tools/pub/cmd/pub-lish
-[`run`]: /tools/pub/cmd/pub-run
-[`upgrade`]: /tools/pub/cmd/pub-upgrade
-[`uploader`]: /tools/pub/cmd/pub-uploader -->

--- a/src/_guides/packages.md
+++ b/src/_guides/packages.md
@@ -193,7 +193,8 @@ the pub package manager.
 
 The `dart pub` tool provides the following subcommands:
 
-* [`cache`][]
+{% include pub-subcommands.md %}
+<!-- * [`cache`][]
 * [`deps`][]
 * [`downgrade`][]
 * [`get`][]
@@ -202,7 +203,7 @@ The `dart pub` tool provides the following subcommands:
 * [`publish`][]
 * [`run`][]
 * [`upgrade`][]
-* [`uploader`][]
+* [`uploader`][] -->
 
 For an overview of all the `dart pub` subcommands,
 see the [pub tool documentation](/tools/pub/cmd).
@@ -213,7 +214,7 @@ see the [pub tool documentation](/tools/pub/cmd).
 you might encounter when using pub.
 
 [Dart-savvy IDEs]: /tools#ides-and-editors
-[`cache`]: /tools/pub/cmd/pub-cache
+<!-- [`cache`]: /tools/pub/cmd/pub-cache
 [`deps`]: /tools/pub/cmd/pub-deps
 [`downgrade`]: /tools/pub/cmd/pub-downgrade
 [`get`]: /tools/pub/cmd/pub-get
@@ -222,4 +223,4 @@ you might encounter when using pub.
 [`publish`]: /tools/pub/cmd/pub-lish
 [`run`]: /tools/pub/cmd/pub-run
 [`upgrade`]: /tools/pub/cmd/pub-upgrade
-[`uploader`]: /tools/pub/cmd/pub-uploader
+[`uploader`]: /tools/pub/cmd/pub-uploader -->

--- a/src/_includes/pub-subcommands.md
+++ b/src/_includes/pub-subcommands.md
@@ -1,0 +1,13 @@
+<ul>
+  <li><a href="/tools/pub/cmd/pub-add"><code>add</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-cache"><code>cache</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-deps"><code>deps</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-downgrade"><code>downgrade</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-get"><code>get</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-global"><code>global</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-outdated"><code>outdated</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-lish"><code>publish</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-remove"><code>remove</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-upgrade"><code>upgrade</code></a></li>
+  <li><a href="/tools/pub/cmd/pub-uploader"><code>uploader</code></a></li>
+</ul>

--- a/src/_includes/pub-subcommands.md
+++ b/src/_includes/pub-subcommands.md
@@ -1,13 +1,11 @@
-<ul>
-  <li><a href="/tools/pub/cmd/pub-add"><code>add</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-cache"><code>cache</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-deps"><code>deps</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-downgrade"><code>downgrade</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-get"><code>get</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-global"><code>global</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-outdated"><code>outdated</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-lish"><code>publish</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-remove"><code>remove</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-upgrade"><code>upgrade</code></a></li>
-  <li><a href="/tools/pub/cmd/pub-uploader"><code>uploader</code></a></li>
-</ul>
+* [`add`](/tools/pub/cmd/pub-add)
+* [`cache`](/tools/pub/cmd/pub-cache)
+* [`deps`](/tools/pub/cmd/pub-deps)
+* [`downgrade`](/tools/pub/cmd/pub-downgrade)
+* [`get`](/tools/pub/cmd/pub-get)
+* [`global`](/tools/pub/cmd/pub-global)
+* [`outdated`](/tools/pub/cmd/pub-outdated)
+* [`publish`](/tools/pub/cmd/pub-lish)
+* [`remove`](/tools/pub/cmd/pub-remove)
+* [`upgrade`](/tools/pub/cmd/pub-upgrade)
+* [`uploader`](/tools/pub/cmd/pub-uploader)

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -41,6 +41,7 @@ see [Troubleshooting Pub](/tools/pub/troubleshoot).
 
 Detailed documentation exists for each of the following pub subcommands:
 
+* [`add`](/tools/pub/cmd/pub-add)
 * [`cache`](/tools/pub/cmd/pub-cache)
 * [`deps`](/tools/pub/cmd/pub-deps)
 * [`downgrade`](/tools/pub/cmd/pub-downgrade)
@@ -48,6 +49,7 @@ Detailed documentation exists for each of the following pub subcommands:
 * [`global`](/tools/pub/cmd/pub-global)
 * [`outdated`](/tools/pub/cmd/pub-outdated)
 * [`publish`](/tools/pub/cmd/pub-lish)
+* [`remove`](/tools/pub/cmd/pub-remove)
 * [`upgrade`](/tools/pub/cmd/pub-upgrade)
 * [`uploader`](/tools/pub/cmd/pub-uploader)
 

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -43,17 +43,6 @@ Detailed documentation exists for each of the following pub subcommands:
 
 {% include pub-subcommands.md %}
 
-<!-- * [`add`](/tools/pub/cmd/pub-add)
-* [`cache`](/tools/pub/cmd/pub-cache)
-* [`deps`](/tools/pub/cmd/pub-deps)
-* [`downgrade`](/tools/pub/cmd/pub-downgrade)
-* [`get`](/tools/pub/cmd/pub-get)
-* [`global`](/tools/pub/cmd/pub-global)
-* [`outdated`](/tools/pub/cmd/pub-outdated)
-* [`publish`](/tools/pub/cmd/pub-lish)
-* [`remove`](/tools/pub/cmd/pub-remove)
-* [`upgrade`](/tools/pub/cmd/pub-upgrade)
-* [`uploader`](/tools/pub/cmd/pub-uploader) -->
 ## Overview of subcommands
 
 Pub's subcommands fall into the following categories:

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -41,7 +41,9 @@ see [Troubleshooting Pub](/tools/pub/troubleshoot).
 
 Detailed documentation exists for each of the following pub subcommands:
 
-* [`add`](/tools/pub/cmd/pub-add)
+{% include pub-subcommands.md %}
+
+<!-- * [`add`](/tools/pub/cmd/pub-add)
 * [`cache`](/tools/pub/cmd/pub-cache)
 * [`deps`](/tools/pub/cmd/pub-deps)
 * [`downgrade`](/tools/pub/cmd/pub-downgrade)
@@ -51,9 +53,7 @@ Detailed documentation exists for each of the following pub subcommands:
 * [`publish`](/tools/pub/cmd/pub-lish)
 * [`remove`](/tools/pub/cmd/pub-remove)
 * [`upgrade`](/tools/pub/cmd/pub-upgrade)
-* [`uploader`](/tools/pub/cmd/pub-uploader)
-
-
+* [`uploader`](/tools/pub/cmd/pub-uploader) -->
 ## Overview of subcommands
 
 Pub's subcommands fall into the following categories:

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -12,21 +12,27 @@ $ dart pub add <package>[:<constraint>] [options]
 
 This command adds the specified package to the pubspec as a dependency,
 and then gets the dependency.
-
 For example, the following command is equivalent to
-editing `pubspec.yaml` (adding `http: ^0.12.1` under `dependencies`)
+editing `pubspec.yaml` to add the `http` package,
 and then calling `dart pub get`:
 
 ```terminal
-$ dart pub add http:^0.12.1
+$ dart pub add http
 ```
 
-By default, `dart pub add` gets the package from pub.dev.
-You can use options to specify other
-[dependency sources](/tools/pub/dependencies#dependency-sources) —
-Git repos, the Flutter SDK, alternate package servers, or
-a path within your local file system.
+By default, `dart pub add` uses the
+latest stable version of the package from pub.dev.
+For example, if 0.13.1 is the latest stable version of the `http` package,
+then `dart pub add http` adds
+`http: ^0.13.1` under `dependencies` in the pubspec.
 
+To add a [dev dependency][], use the `--dev` option:
+
+[dev dependency]: /tools/pub/dependencies#dev-dependencies
+
+```terminal
+$ dart pub add --dev test
+```
 
 ## Options
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -1,0 +1,54 @@
+---
+title: dart pub add
+description: Use dart pub add to add dependecies to pubspec.yaml.
+toc: false
+---
+
+_Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
+
+```
+$ dart pub add <package> [options]
+```
+Example:
+
+```
+$ dart pub add http:0.12.1
+```
+
+## Options
+
+For options that apply to all pub commands, see
+[Global options](/tools/pub/cmd#global-options).
+
+<dl>
+    <dt><code>-h, --help</code></dt>
+        <dd>Print this usage information.</dd>
+    <dt><code>-d, --dev</code></dt>
+        <dd>Adds package to the development dependencies instead.</dd>
+    <dt><code>--git-url</code></dt>
+        <dd>Git URL of the package.
+        </dd>
+        {% prettify nocode tag=pre+code %}
+        $ dart pub add package-name --git-url package-git-url
+        {% endprettify %} 
+    <dt><code>--git-ref</code></dt>
+        <dd>Git branch or commit to be retrieved</dd>
+        {% prettify nocode tag=pre+code %}
+        $ dart pub add package-name --git-url package-git-url --git-ref=branch-name
+        {% endprettify %}
+    <dt><code>--git-path</code></dt>
+    <dd>Path of git package in repository</dd>
+    <dt><code>--hosted-url </code></dt>
+    <dd>URL of package host server</dd>
+    <dt><code>--path</code></dt>
+    <dd>Local path.</dd>
+    <dt><code>--sdk</code></dt>
+    <dd>SDK source for package.</dd>
+    <dt><code>--[no-]offline</code></dt>
+    <dd>Use cached packages instead of accessing the network.</dd>
+    <dt><code>-n, --dry-run</code></dt>
+    <dd>Report what dependencies would change but don't change any.</dd>
+    <dt><code>--[no-]precompile</code></dt>
+    <dd>Precompile executables in immediate dependencies.</dd>
+
+</dl>

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -1,19 +1,32 @@
 ---
 title: dart pub add
-description: Use dart pub add to add dependecies to pubspec.yaml.
+description: Use dart pub add to add a dependency.
 toc: false
 ---
 
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 ```
-$ dart pub add <package> [options]
+$ dart pub add <package>[:<constraint>] [options]
 ```
-Example:
 
+This command adds the specified package to the pubspec as a dependency,
+and then gets the dependency.
+
+For example, the following command is equivalent to
+editing `pubspec.yaml` (adding `http: ^0.12.1` under `dependencies`)
+and then calling `dart pub get`:
+
+```terminal
+$ dart pub add http:^0.12.1
 ```
-$ dart pub add http:0.12.1
-```
+
+By default, `dart pub add` gets the package from pub.dev.
+You can use options to specify other
+[dependency sources](/tools/pub/dependencies#dependency-sources) —
+Git repos, the Flutter SDK, alternate package servers, or
+a path within your local file system.
+
 
 ## Options
 
@@ -21,34 +34,37 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 <dl>
-    <dt><code>-h, --help</code></dt>
-        <dd>Print this usage information.</dd>
     <dt><code>-d, --dev</code></dt>
-        <dd>Adds package to the development dependencies instead.</dd>
-    <dt><code>--git-url</code></dt>
-        <dd>Git URL of the package.
+        <dd>Adds the package as a dev dependency,
+        instead of as a regular dependency.</dd>
+    <dt><code>--git-url=<var>git_repo_url</var></code></dt>
+        <dd>Depends on the package in the
+        <a href="/tools/pub/dependencies#git-packages">specified Git repo</a>.
         </dd>
         {% prettify nocode tag=pre+code %}
-        $ dart pub add package-name --git-url package-git-url
-        {% endprettify %} 
-    <dt><code>--git-ref</code></dt>
-        <dd>Git branch or commit to be retrieved</dd>
-        {% prettify nocode tag=pre+code %}
-        $ dart pub add package-name --git-url package-git-url --git-ref=branch-name
+        $ dart pub add http --git-url=https://github.com/my/http.git
         {% endprettify %}
-    <dt><code>--git-path</code></dt>
-    <dd>Path of git package in repository</dd>
-    <dt><code>--hosted-url </code></dt>
-    <dd>URL of package host server</dd>
-    <dt><code>--path</code></dt>
-    <dd>Local path.</dd>
-    <dt><code>--sdk</code></dt>
-    <dd>SDK source for package.</dd>
+    <dt><code>--git-ref=<var>branch_or_commit</var></code></dt>
+        <dd>With <code>--git-url</code>,
+        depends on the specified branch or commit of a Git repo.</dd>
+        {% prettify nocode tag=pre+code %}
+        $ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
+        {% endprettify %}
+    <dt><code>--git-path=<var>directory_path</var></code></dt>
+    <dd>With <code>--git-url</code>,
+    specifies the location of a package within a Git repo.</dd>
+    <dt><code>--hosted-url=<var>package_server_url</var></code></dt>
+    <dd>Depends on the package server at the specified URL.</dd>
+    <dt><code>--path=<var>directory_path</var></code></dt>
+    <dd>Depends on a locally stored package.</dd>
+    <dt><code>--sdk=<var>sdk_name</var></code></dt>
+    <dd>Depends on a package that's shipped with the specified SDK
+    (example: <code>--sdk=flutter</code>).</dd>
     <dt><code>--[no-]offline</code></dt>
-    <dd>Use cached packages instead of accessing the network.</dd>
+    <dd>Uses cached packages instead of the network.</dd>
     <dt><code>-n, --dry-run</code></dt>
-    <dd>Report what dependencies would change but don't change any.</dd>
+    <dd>Reports which dependencies would change, but doesn't change any.</dd>
     <dt><code>--[no-]precompile</code></dt>
-    <dd>Precompile executables in immediate dependencies.</dd>
+    <dd>Precompiles executables in immediate dependencies (true by default).</dd>
 
 </dl>

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -1,6 +1,6 @@
 ---
 title: dart pub remove
-description: Use dart pub remove to remove a dependecy.
+description: Use dart pub remove to remove a dependency.
 toc: false
 ---
 
@@ -13,10 +13,8 @@ $ dart pub remove <package> [options]
 This command removes the specified package from the pubspec as a dependency.
 
 For example, the following command is equivalent to
-editing `pubspec.yaml` (removing `http: ^0.12.1` under `dependencies`)
+editing `pubspec.yaml` (removing `http` from `dependencies` or `dev_dependencies`)
 and then calling `dart pub get`:
-
-Example:
 
 ```
 $ dart pub remove http

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -1,6 +1,6 @@
 ---
 title: dart pub remove
-description: Use dart pub remove to remove dependecies from pubspec.yaml.
+description: Use dart pub remove to remove a dependecy.
 toc: false
 ---
 
@@ -9,6 +9,12 @@ _Remove_ is one of the commands of the [pub tool](/tools/pub/cmd).
 ```
 $ dart pub remove <package> [options]
 ```
+
+This command removes the specified package from the pubspec as a dependency.
+
+For example, the following command is equivalent to
+editing `pubspec.yaml` (removing `http: ^0.12.1` under `dependencies`)
+and then calling `dart pub get`:
 
 Example:
 
@@ -22,13 +28,10 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 <dl>
-    <dt><code>-h, --help</code></dt>
-        <dd>Print this usage information.</dd>
     <dt><code>--[no-]offline</code></dt>
-    <dd>Use cached packages instead of accessing the network.</dd>
+    <dd>Uses cached packages instead of the network.</dd>
     <dt><code>-n, --dry-run</code></dt>
-    <dd>Report what dependencies would change but don't change any.</dd>
+    <dd>Reports which dependencies would change, but doesn't change any.</dd>
     <dt><code>--[no-]precompile</code></dt>
-    <dd>Precompile executables in immediate dependencies.</dd>
-
+    <dd>Precompiles executables in immediate dependencies (true by default).</dd>
 </dl>

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -1,0 +1,34 @@
+---
+title: dart pub remove
+description: Use dart pub remove to remove dependecies from pubspec.yaml.
+toc: false
+---
+
+_Remove_ is one of the commands of the [pub tool](/tools/pub/cmd).
+
+```
+$ dart pub remove <package> [options]
+```
+
+Example:
+
+```
+$ dart pub remove http
+```
+
+## Options
+
+For options that apply to all pub commands, see
+[Global options](/tools/pub/cmd#global-options).
+
+<dl>
+    <dt><code>-h, --help</code></dt>
+        <dd>Print this usage information.</dd>
+    <dt><code>--[no-]offline</code></dt>
+    <dd>Use cached packages instead of accessing the network.</dd>
+    <dt><code>-n, --dry-run</code></dt>
+    <dd>Report what dependencies would change but don't change any.</dd>
+    <dt><code>--[no-]precompile</code></dt>
+    <dd>Precompile executables in immediate dependencies.</dd>
+
+</dl>


### PR DESCRIPTION
I am actually very new to open source and this will be my very first PR so any review, suggestion, advice or changes are welcomed.

So there was an [issue](https://github.com/flutter/flutter/issues/79646) on the flutter repository where someone said that documentation of `dart pub add` and `flutter pub add` are not available and the it was suggested to update the related websites.

I will try to add more documentation for other new sub command of  `dart pub`.