### PR TITLE
Update typedef example comment

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
+++ b/null_safety_examples/misc/lib/language_tour/typedefs/sorted_collection_2.dart
@@ -7,7 +7,7 @@ class SortedCollection {
   SortedCollection(this.compare);
 }
 
-// Initial, broken implementation.
+// Now matching the defined function type.
 int sort(Object a, Object b) => 0;
 
 void main() {

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4390,7 +4390,7 @@ class SortedCollection {
   SortedCollection(this.compare);
 }
 
-// Initial, broken implementation.
+// Now matching the defined function type.
 int sort(Object a, Object b) => 0;
 
 void main() {


### PR DESCRIPTION
### Context

The example in question is explaining how typedef works.

In the first  example we have:
``` 
  ...
  Function compare;
  ...
  SortedCollection(int f(Object a, Object b)) : compare = f;
  ...
  // Initial, broken implementation.
  int sort(Object a, Object b) => 0;
```

In the following example we have:
```
typedef Compare = int Function(Object a, Object b);
...
Compare compare;
...
// Initial, broken implementation.
int sort(Object a, Object b) => 0;
```

### Proposal

My proposed changes changes the comment of the typedef example from:

`// Initial, broken implementation.` to `// Now matching the defined function type.`