### PR TITLE
Updating null safety codelab example

### DIFF
--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -78,7 +78,7 @@ question marks to correct the type declarations of `aNullableListOfStrings` and
 ```dart:run-dartpad:ga_id-nullable_type_generics:null_safety-true
 void main() {
   List<String> aListOfStrings = ['one', 'two', 'three'];
-  List<String> aNullableListOfStrings = [];
+  List<String> aNullableListOfStrings;
   List<String> aListOfNullableStrings = ['one', null, 'three'];
 
   print('aListOfStrings is $aListOfStrings.');


### PR DESCRIPTION
The third exercise in the null safety codelab was assigning a value to `aNullableListOfStrings`, and as a result that variable wasn't functioning as it should in the exercise.

`aNullableListOfStrings` and `aListOfNullableStrings` are intended (at least back when I did the snippets) to teach people that both `List<String>?` and `List<String?>` are valid, but used for different things. If `aNullableListOfStrings` is assigned a value, you never need to change its type to `List<String>?` to make the analyzer happy, so that bit of learning opportunity is lost.