### PR TITLE
Fix information about mirrors in Flutter link

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -197,7 +197,7 @@ Inside or outside of Google, every Flutter app uses Dart.
 [DDC]: https://github.com/dart-lang/sdk/tree/master/pkg/dev_compiler#dev_compiler
 [strong mode]: /guides/language/type-system
 [Dart's type system]: /guides/language/type-system
-[Flutter no mirrors]: {{site.flutter}}/faq/#does-flutter-come-with-a-reflectionmirrors-system
+[Flutter no mirrors]: {{site.flutter}}/faq/#does-flutter-come-with-a-reflection--mirrors-system
 
 ---
 


### PR DESCRIPTION
The broken link lead to the top of the page due to not finding the anchor: https://flutter.dev/docs/resources/faq#does-flutter-come-with-a-reflectionmirrors-system

The updated link correctly leads to the proper header: https://flutter.dev/docs/resources/faq#does-flutter-come-with-a-reflection--mirrors-system