### PR TITLE
Update Google AdWords to Google Ads

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -169,7 +169,7 @@ using [Flutter][Flutter], which is powered by the Dart platform.
 
 ### Q. What are some real-world production deployments of Dart?
 
-Google AdWords, AdSense, AdMob, and the Google Assistant all use Dart.
+Google Ads, AdSense, AdMob, and the Google Assistant all use Dart.
 A significant portion of Google's revenue flows through these apps.
 Inside or outside of Google, every Flutter app uses Dart.
 


### PR DESCRIPTION
My understanding is Google AdWords has been completely renamed to Google Ads:

https://en.wikipedia.org/wiki/Google_Ads