### PR TITLE
Cleanup and add clarifications to DartPad pages

### DIFF
--- a/src/resources/dartpad-best-practices.md
+++ b/src/resources/dartpad-best-practices.md
@@ -585,7 +585,7 @@ think through the entire process versus just being handed the solution.*”
 As long as you get the return correct,
 being able to write how you write it is nice.*”
 
-[DartPad]: http://dartpad.dev
+[DartPad]: https://dartpad.dev
 [new dp issue]: https://github.com/dart-lang/dart-pad/issues/new
 [dart.dev DP docs]:/tools/dartpad
 [dart-lang/dart-pad]: https://github.com/dart-lang/dart-pad
@@ -595,7 +595,7 @@ being able to write how you write it is nice.*”
 [Content guidelines: Content handbook for web.dev]: https://web.dev/handbook#content-guidelines
 [Other editorial resources]: https://developers.google.com/style/resources
 [guided discovery learning]: https://thinkeracademy.com/guided-discovery-learning/
-[Mayer, Richard E., 2004]: http://www.csun.edu/learningnet/TeachScience/UPimages/1/12/MayerThreeStrikesAP04.pdf
+[Mayer, Richard E., 2004]: https://www.csun.edu/learningnet/TeachScience/UPimages/1/12/MayerThreeStrikesAP04.pdf
 [Kim, Ada S., and Amy J. Ko., 2017]: https://faculty.washington.edu/ajko/papers/Kim2017CodingTutorialEvaluation.pdf
 [transfer of learning]: https://en.wikipedia.org/wiki/Transfer_of_learning
 [Asynchronous programming: futures, async, await]: /codelabs/async-await

--- a/src/resources/dartpad-best-practices.md
+++ b/src/resources/dartpad-best-practices.md
@@ -585,7 +585,7 @@ think through the entire process versus just being handed the solution.*”
 As long as you get the return correct,
 being able to write how you write it is nice.*”
 
-[DartPad]: https://dartpad.dev
+[DartPad]: {{site.dartpad}}
 [new dp issue]: https://github.com/dart-lang/dart-pad/issues/new
 [dart.dev DP docs]:/tools/dartpad
 [dart-lang/dart-pad]: https://github.com/dart-lang/dart-pad

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -3,7 +3,7 @@ title: DartPad
 description: The tool that lets you interactively play with Dart in a browser.
 ---
 
-DartPad is an [open source](https://github.com/dart-lang/dart-pad) tool
+DartPad is an [open source tool](https://github.com/dart-lang/dart-pad)
 that lets you play with the Dart language in any modern browser.
 Many pages in this site — especially [codelabs](/codelabs) —
 have [embedded DartPads](#embedding).
@@ -28,11 +28,12 @@ DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. It doesn't support those marked native
 platform, and it doesn't support [deferred loading][].
 
-If you are using Flutter, DartPad also supports the `package:flutter` libraries
-which are supported on the web platform.
+In Flutter mode, you can also use the `package:flutter` libraries
+that are supported on the web platform.
 
-It doesn't currently support using packages from the [pub.dev]({{site.pub}}) 
-package repository. This request is being tracked in [issue 901][].
+DartPad doesn't currently support using packages from the [pub.dev]({{site.pub}}) 
+package repository.
+(To find the status of package support, see [issue 901][].)
 
 ## Getting started
 
@@ -102,7 +103,7 @@ To create a simple command-line app, use **New Pad**.
 
 The language features and APIs that DartPad supports depend on the
 **Dart SDK** version that DartPad is currently using.
-You can find the active SDK's version at the bottom right of DartPad.
+You can find this SDK version at the bottom right of DartPad.
 
 ## Embedding DartPad in web pages {#embedding}
 

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -25,9 +25,8 @@ Here's what DartPad looks like when configured to run Dart:
 ## Library support
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
-multi-platform and web platform. When using Flutter,
-DartPad also supports the `package:flutter` libraries that are supported
-on the web.
+multi-platform and web platform. When writing Flutter apps,
+DartPad also supports the `package:flutter` libraries.
 
 DartPad doesn't support [deferred loading][] or any other libraries. 
 For example, DartPad doesn't support using packages from 

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -19,20 +19,20 @@ the [DartPad site (dartpad.dev)][DartPad]{:target="_blank" rel="noopener"}.
 
 Here's what DartPad looks like when configured to run Dart:
 
-<img src="{% asset dartpad-hello.png @path %}" alt="Showcases what a Hello World application looks like in DartPad" />
+<img src="{% asset dartpad-hello.png @path %}" alt="Showcases what a Hello World app looks like in DartPad" />
 
 
 ## Library support
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. When writing Flutter apps,
-DartPad supports the `package:flutter`
+DartPad also supports the `package:flutter`
 and `dart:ui` libraries.
 
 DartPad doesn't support [deferred loading][] or any other libraries. 
 For example, DartPad doesn't support using packages from 
 the [pub.dev]({{site.pub}}) package repository. 
-(To find the status of package support, see [issue 901][].)
+(Package support might change; for details, see [issue 901][].)
 
 ## Getting started
 

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -3,13 +3,12 @@ title: DartPad
 description: The tool that lets you interactively play with Dart in a browser.
 ---
 
-DartPad is an open-source tool that
-lets you play with the Dart language in any modern browser.
+DartPad is an [open source](https://github.com/dart-lang/dart-pad) tool
+that lets you play with the Dart language in any modern browser.
 Many pages in this site — especially [codelabs](/codelabs) —
 have [embedded DartPads](#embedding).
-To get a DartPad as big as your browser window, go to the
-<a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad
-site (dartpad.dev).</a>
+To open DartPad as a standalone web page, 
+visit the [DartPad][] site.
 
 {{site.alert.tip}}
   If you're in China, try [dartpad.cn.](https://dartpad.cn)
@@ -18,7 +17,7 @@ site (dartpad.dev).</a>
   tips](/tools/dartpad/troubleshoot).
 {{site.alert.end}}
 
-Here's what DartPad looks like:
+Here's what DartPad looks like when configured to run Dart:
 
 <img src="{% asset dartpad-hello.png @path %}" alt="DartPad Hello World" />
 
@@ -29,92 +28,81 @@ DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. It doesn't support those marked native
 platform, and it doesn't support [deferred loading][].
 
-It also doesn't support using packages from the [pub.dev]({{site.pub}}) package
-repository.
+If you are using Flutter, DartPad also supports the `package:flutter` libraries
+which are supported on the web platform.
+
+It doesn't currently support using packages from the [pub.dev]({{site.pub}}) 
+package repository. This request is being tracked in [issue 901][].
 
 ## Getting started
 
 To get familiar with DartPad,
-try running some samples and then creating a simple command-line app.
+try running some samples and creating a simple command-line app.
 
 
-### Open DartPad, and run a sample {#step-1-open-and-run}
+### Open DartPad and run a sample {#step-1-open-and-run}
 
-<ol markdown="1">
-  <li markdown="1">
-  Go to <a href="{{site.dartpad}}" target="_blank" rel="noopener">DartPad.</a>
+1. Go to [DartPad][].  
+   
+   Dart code appears on the left, and 
+   a place for the output appears on the right.
+  
 
-  Dart code appears on the left, and
-  a place for the output appears on the right.
-  </li>
-
-  <li markdown="1">
-  Choose a Flutter sample such as **Sunflower**,
-  using the **Samples** list at the upper right.
-
-  The rendered output appears to the right.
-  </li>
-
-</ol>
+2. Choose a Flutter sample such as **Sunflower**, 
+   using the **Samples** list at the upper right.  
+   
+   The rendered output appears to the right.
 
 
 ### Create a command-line app {#step-2-server}
 
 To create a simple command-line app, use **New Pad**.
 
-<ol markdown="1">
-  <li markdown="1">
-  Click the **New Pad** button,
-  and confirm that you want to discard changes to the current pad.
+1. Click the **New Pad** button,
+   and confirm that you want to discard changes to the current pad.
+   
 
-  </li>
+2. Click the Dart logo, make sure that **HTML** support is disabled,
+   and then click **Create**.
+   
 
-  <li markdown="1">
-  Click the Dart logo, make sure that **HTML** support is disabled,
-  and then click **Create**.
-  </li>
+3. Change the code. For example, change the `main()` function
+   to contain this code:  
+   
+   <!-- library-tour/string-tests/bin/main.dart -->
+   {% prettify dart tag=pre+code %}
+   for (var char in 'hello'.split('')) {
+     print(char);
+   }
+   {% endprettify %}  
+   
+   As you type, DartPad shows hints, documentation,
+   and autocomplete suggestions.
+   
 
-  <li markdown="1">
-  Change the code. For example, change the `main()` function
-  to contain this code:
+4. Click the **Format** button.  
+   
+   DartPad uses the [Dart formatter](/tools/dart-format)
+   to ensure that your code has proper indentation, white space,
+   and line wrapping.
+   
 
-<!-- library-tour/string-tests/bin/main.dart -->
-{% prettify dart tag=pre+code %}
-for (var char in 'hello'.split('')) {
-  print(char);
-}
-{% endprettify %}
+5. Run your app.
+   
 
-  As you type, DartPad shows hints, documentation,
-  and autocomplete suggestions.
-  </li>
+6. If you didn't happen to have any bugs while you were entering the code,
+   try introducing a bug.  
 
-  <li markdown="1">
-  Click the **Format** button.
-  DartPad uses the [Dart formatter](https://github.com/dart-lang/dart_style#readme)
-  to ensure that your code has proper indentation, white space, and line wrapping.
-  </li>
-
-  <li markdown="1">
-  Run your app.
-  </li>
-
-  <li markdown="1">
-  If you didn't happen to have any bugs while you were entering the code,
-  try introducing a bug.
-
-  For example, if you change `split` to `spit`,
-  you get warnings at the bottom right of the window.
-  If you run the app, a compilation error appears in the console.
-  </li>
-</ol>
+   For example, if you change `split` to `spit`,
+   you get warnings at the bottom right of the window.
+   If you run the app, a compilation error appears in the console.
 
 
 ## Checking Dart version info
 
 The language features and APIs that DartPad supports depend on the
-**Dart SDK** version that DartPad is based on.
-You can find the SDK version at the bottom right of DartPad.
+**Dart SDK** version that DartPad is currently using.
+You can find the active SDK's version at the bottom right of DartPad.
 
 ## Embedding DartPad in web pages {#embedding}
 
@@ -130,7 +118,9 @@ For more information about how to use embedded DartPads, see
 For technical details on embedding DartPads, see the
 [DartPad embedding guide.][]
 
+[DartPad]: {{site.dartpad}}
 [best practices for using DartPad in tutorials]: /resources/dartpad-best-practices
 [DartPad embedding guide.]: https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide
 [deferred loading]: /guides/language/language-tour#lazily-loading-a-library
 [futures codelab]: /codelabs/async-await
+[issue 901]: https://github.com/dart-lang/dart-pad/issues/901

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -26,7 +26,8 @@ Here's what DartPad looks like when configured to run Dart:
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
 multi-platform and web platform. When writing Flutter apps,
-DartPad also supports the `package:flutter` libraries.
+DartPad supports the `package:flutter`
+and `dart:ui` libraries.
 
 DartPad doesn't support [deferred loading][] or any other libraries. 
 For example, DartPad doesn't support using packages from 

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -8,7 +8,7 @@ that lets you play with the Dart language in any modern browser.
 Many pages in this site — especially [codelabs](/codelabs) —
 have [embedded DartPads](#embedding).
 To open DartPad as a standalone web page, 
-visit the [DartPad][]{:target="_blank"} site.
+visit the [DartPad][]{:target="_blank" rel="noopener"} site.
 
 {{site.alert.tip}}
   If you're in China, try [dartpad.cn.](https://dartpad.cn)
@@ -42,7 +42,7 @@ try running some samples and creating a simple command-line app.
 
 ### Open DartPad and run a sample {#step-1-open-and-run}
 
-1. Go to [DartPad][]{:target="_blank"}.  
+1. Go to [DartPad][]{:target="_blank" rel="noopener"}.  
    
    Dart code appears on the left, and 
    a place for the output appears on the right.

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -7,8 +7,8 @@ DartPad is an [open source tool](https://github.com/dart-lang/dart-pad)
 that lets you play with the Dart language in any modern browser.
 Many pages in this site — especially [codelabs](/codelabs) —
 have [embedded DartPads](#embedding).
-To open DartPad as a standalone web page, 
-visit the [DartPad][]{:target="_blank" rel="noopener"} site.
+To open DartPad as a standalone web page, visit 
+the [DartPad site (dartpad.dev)][DartPad]{:target="_blank" rel="noopener"}.
 
 {{site.alert.tip}}
   If you're in China, try [dartpad.cn.](https://dartpad.cn)
@@ -19,20 +19,19 @@ visit the [DartPad][]{:target="_blank" rel="noopener"} site.
 
 Here's what DartPad looks like when configured to run Dart:
 
-<img src="{% asset dartpad-hello.png @path %}" alt="DartPad Hello World" />
+<img src="{% asset dartpad-hello.png @path %}" alt="Showcases what a Hello World application looks like in DartPad" />
 
 
 ## Library support
 
 DartPad supports `dart:*` [core libraries](/guides/libraries) marked as
-multi-platform and web platform. It doesn't support those marked native
-platform, and it doesn't support [deferred loading][].
+multi-platform and web platform. When using Flutter,
+DartPad also supports the `package:flutter` libraries that are supported
+on the web.
 
-In Flutter mode, you can also use the `package:flutter` libraries
-that are supported on the web platform.
-
-DartPad doesn't currently support using packages from the [pub.dev]({{site.pub}}) 
-package repository.
+DartPad doesn't support [deferred loading][] or any other libraries. 
+For example, DartPad doesn't support using packages from 
+the [pub.dev]({{site.pub}}) package repository. 
 (To find the status of package support, see [issue 901][].)
 
 ## Getting started

--- a/src/tools/dartpad/index.md
+++ b/src/tools/dartpad/index.md
@@ -8,7 +8,7 @@ that lets you play with the Dart language in any modern browser.
 Many pages in this site — especially [codelabs](/codelabs) —
 have [embedded DartPads](#embedding).
 To open DartPad as a standalone web page, 
-visit the [DartPad][] site.
+visit the [DartPad][]{:target="_blank"} site.
 
 {{site.alert.tip}}
   If you're in China, try [dartpad.cn.](https://dartpad.cn)
@@ -42,7 +42,7 @@ try running some samples and creating a simple command-line app.
 
 ### Open DartPad and run a sample {#step-1-open-and-run}
 
-1. Go to [DartPad][].  
+1. Go to [DartPad][]{:target="_blank"}.  
    
    Dart code appears on the left, and 
    a place for the output appears on the right.

--- a/src/tools/dartpad/privacy.md
+++ b/src/tools/dartpad/privacy.md
@@ -4,7 +4,7 @@ description: How Google uses the source code that you enter into DartPad.
 toc: false
 ---
 
-DartPad is a free, open-source service to help developers learn about the Dart
+DartPad is a free, open source service to help developers learn about the Dart
 language and libraries. Source code entered into DartPad may be sent to servers
 running in Google Cloud Platform to be analyzed for errors/warnings, compiled to
 JavaScript, and returned to the browser.


### PR DESCRIPTION
The goal was to add some clarifications around packages in DartPad while also cleaning up the rest of the page.

Accomplishes:
- Clarifies what packages are supported in DartPad.
- Updates "open-source" to "open source" to match Google style guide
- Use Markdown links instead of HTML ones
- Use Markdown formatting for lists instead of HTML
- Updates various links to https

Closes #2259 and fixes #2090