### PR TITLE
Update Google privacy policy links and make https

### DIFF
--- a/src/_includes/page-footer.html
+++ b/src/_includes/page-footer.html
@@ -7,8 +7,8 @@
         <ul class="menu">
           <li><a href="/terms">Terms</a></li>
           <li><a href="/security">Security</a></li>
-          <li><a href="http://www.google.com/intl/en/policies/privacy/" class="no-automatic-external">Privacy</a></li>
-          <li>Site&nbsp;<a href="http://creativecommons.org/licenses/by/4.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;4.0</a></li>
+          <li><a href="https://policies.google.com/privacy" class="no-automatic-external">Privacy</a></li>
+          <li>Site&nbsp;<a href="https://creativecommons.org/licenses/by/4.0/" class="no-automatic-external">CC&nbsp;BY&nbsp;4.0</a></li>
           <li>
             <a href="{{site.repo.this}}"
                title="This site's source is on GitHub."

--- a/src/tools/dartpad/privacy.md
+++ b/src/tools/dartpad/privacy.md
@@ -15,5 +15,5 @@ example, we may use the source code to help offer better code completion
 suggestions. The raw source code is deleted after no more than 60 days.
 
 Learn more about Google's [privacy
-policy.](https://www.google.com/policies/privacy/) We look forward to your
+policy.](https://policies.google.com/privacy) We look forward to your
 [feedback.](https://github.com/dart-lang/dart-pad/issues)


### PR DESCRIPTION
- Updates the Google privacy policy links
- Makes the privacy policy and Creative Commons links in the footer `https`