### PR TITLE
Add link to "Writing Package Pages" in sidebar

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -105,6 +105,8 @@
       permalink: /guides/libraries/create-library-packages
     - title: Publishing packages
       permalink: /tools/pub/publishing
+    - title: Writing package pages
+      permalink: /guides/libraries/writing-package-pages
     - title: Package reference
       expanded: false
       children:


### PR DESCRIPTION
Partially works on #3190
Adds the link to the "Writing Package Pages" in the sidebar where it was recommended by @kwalrath 's [comment](https://github.com/dart-lang/site-www/pull/3147#issuecomment-829608551).
I'm not sure where I'd put the other links, so I think this issue should continue to be worked on.