### PR TITLE
Update nullable type parameter code example

### DIFF
--- a/null_safety_examples/null_safety_codelab/bin/more_nullable_types.dart
+++ b/null_safety_examples/null_safety_codelab/bin/more_nullable_types.dart
@@ -1,6 +1,6 @@
 void main() {
   List<String> aListOfStrings = ['one', 'two', 'three'];
-  List<String?> aNullableListOfStrings = [];
+  List<String>? aNullableListOfStrings;
   List<String?> aListOfNullableStrings = ['one', null, 'three'];
 
   print('aListOfStrings is $aListOfStrings.');

--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -74,11 +74,11 @@ Type parameters for generics can also be nullable or non-nullable. Try using
 question marks to correct the type declarations of `aNullableListOfStrings` and
 `aListOfNullableStrings`:
 
-<?code-excerpt "../null_safety_examples/null_safety_codelab/bin/more_nullable_types.dart" replace="/String\?/String/g"?>
+<?code-excerpt "../null_safety_examples/null_safety_codelab/bin/more_nullable_types.dart" replace="/String\?/String/g;/String>\?/String>/g"?>
 ```dart:run-dartpad:ga_id-nullable_type_generics:null_safety-true
 void main() {
   List<String> aListOfStrings = ['one', 'two', 'three'];
-  List<String> aNullableListOfStrings = [];
+  List<String> aNullableListOfStrings;
   List<String> aListOfNullableStrings = ['one', null, 'three'];
 
   print('aListOfStrings is $aListOfStrings.');


### PR DESCRIPTION
Original motivation from https://github.com/dart-lang/site-www/pull/3157:

> The third exercise in the null safety codelab was assigning a value to `aNullableListOfStrings`, and as a result that variable wasn't functioning as it should in the exercise.  
>
> `aNullableListOfStrings` and `aListOfNullableStrings` are intended (at least back when I did the snippets) to teach people that both `List<String>?` and `List<String?>` are valid, but used for different things. If `aNullableListOfStrings` is assigned a value, you never need to change its type to `List<String>?` to make the analyzer happy, so that bit of learning opportunity is lost.

@RedBrogdon I believe this is what you were going for. The correct example also had the nullability suffix in the wrong place, so I adjusted that as well.

