### PR TITLE
Fix the xOrigin and yOrigin const declaration location

### DIFF
--- a/null_safety_examples/misc/lib/language_tour/classes/point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point.dart
@@ -2,10 +2,11 @@
 // #docregion class-with-distanceTo
 import 'dart:math';
 
+// #docregion named-constructor
 const double xOrigin = 0;
 const double yOrigin = 0;
 
-// #docregion constructor-initializer, named-constructor
+// #docregion constructor-initializer
 class Point {
   double x = 0;
   double y = 0;

--- a/null_safety_examples/misc/lib/language_tour/classes/point.dart
+++ b/null_safety_examples/misc/lib/language_tour/classes/point.dart
@@ -2,11 +2,12 @@
 // #docregion class-with-distanceTo
 import 'dart:math';
 
+// #enddocregion class-with-distanceTo
 // #docregion named-constructor
 const double xOrigin = 0;
 const double yOrigin = 0;
 
-// #docregion constructor-initializer
+// #docregion class-with-distanceTo, constructor-initializer
 class Point {
   double x = 0;
   double y = 0;

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2904,6 +2904,9 @@ or to provide extra clarity:
 
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/classes/point.dart (named-constructor)" replace="/Point\.\S*/[!$&!]/g" plaster="none"?>
 {% prettify dart tag=pre+code %}
+const double xOrigin = 0;
+const double yOrigin = 0;
+
 class Point {
   double x = 0;
   double y = 0;
@@ -3163,9 +3166,6 @@ instance method:
 <?code-excerpt "../null_safety_examples/misc/lib/language_tour/classes/point.dart (class-with-distanceTo)" plaster="none"?>
 ```dart
 import 'dart:math';
-
-const double xOrigin = 0;
-const double yOrigin = 0;
 
 class Point {
   double x = 0;


### PR DESCRIPTION
The organization of these values caused confusion as they were used in an early section but then declared in a later section that didn't even use them.

Fixes #3197