### PR TITLE
Temporarily disable sdk-files-up-to-date workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,18 +78,18 @@ jobs:
       - run: ${{ matrix.task }}
         continue-on-error: ${{ matrix.experimental }}
 
-  sdk-files-up-to-date:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push'
-      && github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v2
-      - run: mkdir -p $TMP
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - run: ./tool/check-diagnostics.sh
+#  sdk-files-up-to-date:
+#    runs-on: ubuntu-latest
+#    if: |
+#      github.event_name == 'push'
+#      && github.ref == 'refs/heads/master'
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: mkdir -p $TMP
+#      - uses: dart-lang/setup-dart@v1.0
+#        with:
+#          sdk: stable
+#      - run: ./tool/check-diagnostics.sh
 
   deploy:
     needs: test


### PR DESCRIPTION
There's unfortunately no great way to allow an individual workflow to fail while not failing the entire build, at least as far as I can tell. You could continue after a step fails, but the workflow will still show up as green even if this action occurred, limiting the usefulness. See https://github.com/actions/toolkit/issues/399 for a request about allowing particular jobs to fail but not break the build/PR checks.

I set it up this way as it was the easiest way to indicate that the files are outdated but not interrupt pull requests or deployments. Since we want the build to show up as green though, I'll need to identify another solution. Perhaps with a GitHub action creating an issue or pull request. For now, until I identify the best path forward, I'll disable the job so the build can remain green.

Fixes #3203