### PR TITLE
Clarification in example for 'Type test operators' section

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1899,7 +1899,7 @@ runtime.
 {:.table .table-striped}
 
 The result of `obj is T` is true if `obj` implements the interface
-specified by `T`. For example, `obj is Object` is always true.
+specified by `T`. For example, `obj is Object` is always true (if `obj != null`).
 
 Use the `as` operator to cast an object to a particular type if and only if
 you are sure that the object is of that type. Example:


### PR DESCRIPTION
Clarified example `obj is Object` when `null` is assigned to `obj`