### PR TITLE
Fix links for site.pub-pkg and braces

### DIFF
--- a/src/_articles/archive/zones.md
+++ b/src/_articles/archive/zones.md
@@ -750,7 +750,7 @@ stack_trace
 : With the stack_trace library's
   [Chain class]({{site.pub-api}}/stack_trace/latest/stack_trace/Chain-class.html)
   you can get better stack traces for asynchronously executed code.
-  See the [stack_trace package]({{site.pub}}/packages/stack_trace)
+  See the [stack_trace package]({{site.pub-pkg}}/stack_trace)
   at the pub.dev site for more information.
 
 
@@ -766,7 +766,7 @@ The task_interceptor example
   without yielding to the event loop.
 
 The source code for the stack_trace package
-: The [stack_trace package]({{site.pub}}/packages/stack_trace)
+: The [stack_trace package]({{site.pub-pkg}}/stack_trace)
   uses zones to form chains of stack traces
   for debugging asynchronous code.
   Zone features used include error handling, zone-local values, and callbacks.

--- a/src/_guides/json.md
+++ b/src/_guides/json.md
@@ -17,13 +17,13 @@ The following libraries and packages are useful across Dart platforms:
   Converters for both JSON and UTF-8
   (the character encoding that JSON requires).
 
-* [package:json_serializable]({{site.pub}}/packages/json_serializable)<br>
+* [package:json_serializable]({{site.pub-pkg}}/json_serializable)<br>
   An easy-to-use code generation package.
   When you add some metadata annotations
   and use the builder provided by this package,
   the Dart build system generates serialization and deserialization code for you.
 
-* [package:built_value]({{site.pub}}/packages/built_value)<br>
+* [package:built_value]({{site.pub-pkg}}/built_value)<br>
   A powerful, opinionated alternative to json_serializable.
 
 

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -59,7 +59,7 @@ info - Close instances of `dart.core.Sink` at lib/lint.dart:16:7 - (close_sinks)
 
 In the Dart ecosystem,
 the Dart Analysis Server and other tools use the
-[analyzer package]({{site.pub}}/packages/analyzer)
+[analyzer package]({{site.pub-pkg}}/analyzer)
 to perform static analysis.
 
 You can customize static analysis to look for a variety of potential
@@ -79,7 +79,7 @@ use the analyzer package to evaluate your code.
 This document explains how to customize the behavior of the analyzer
 using either an analysis options file or comments in Dart source code. If you want to
 add static analysis to your tool, see the
-[analyzer package]({{site.pub}}/packages/analyzer) docs and the
+[analyzer package]({{site.pub-pkg}}/analyzer) docs and the
 [Analysis Server API Specification.](https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/doc/api.html)
 
 {{site.alert.note}}
@@ -356,7 +356,7 @@ for all files or
 ### Excluding files
 
 To exclude files from static analysis, use the `exclude:` analyzer option. You
-can list individual files, or use [glob]({{site.pub}}/packages/glob) syntax:
+can list individual files, or use [glob]({{site.pub-pkg}}/glob) syntax:
 
 <?code-excerpt "analysis_alt/analysis_options.yaml (exclude)" plaster="none"?>
 ```yaml
@@ -481,7 +481,7 @@ Use the following resources to learn more about static analysis in Dart:
 * [Dart's type system][type-system]
 * [Dart linter](https://github.com/dart-lang/linter#linter-for-dart)
 * [Dart linter rules][linter rules]
-* [analyzer package]({{site.pub}}/packages/analyzer)
+* [analyzer package]({{site.pub-pkg}}/analyzer)
 
 [analysis_option_deprecated]: {{site.pub-api}}/analyzer/latest/analyzer/AnalysisOptionsWarningCode/ANALYSIS_OPTION_DEPRECATED-constant.html
 [analyzer error codes]: https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/lib/error/error.dart

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1797,10 +1797,10 @@ The main exception to this rule is when working with existing APIs that use
 so, when using a value from one of these APIs, it's often a good idea to cast it
 to a more precise type before accessing members.
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
 In code that hasn't been migrated to null safety yet, use `Object` to accept
 values of all types, including `null`.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ### DO use `Future<void>` as the return type of asynchronous members that do not produce values.
@@ -2068,9 +2068,9 @@ class Person {
 }
 {% endprettify %}
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
 In code that has not been migrated to null safety yet, the `Object` type
 annotation permits `null`. Even so, Dart will never call your `==` method and
 pass `null` to it, so you don't need to handle `null` inside the body of the
 method.
-{{ site.alert.end }}
+{{site.alert.end}}

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -391,7 +391,7 @@ You are allowed to use most [markdown][] formatting in your doc comments and
 dartdoc will process it accordingly using the [markdown package.][]
 
 [markdown]: https://daringfireball.net/projects/markdown/
-[markdown package.]: {{site.pub}}/packages/markdown
+[markdown package.]: {{site.pub-pkg}}/markdown
 
 There are tons of guides out there already to introduce you to Markdown. Its
 universal popularity is why we chose it. Here's just a quick example to give you

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -336,7 +336,7 @@ To keep the preamble of your file tidy, we have a prescribed order that
 directives should appear in. Each "section" should be separated by a blank line.
 
 A single linter rule handles all the ordering guidelines:
-[directives_ordering.]({{ site.lints }}/directives_ordering.html)
+[directives_ordering.]({{site.lints}}/directives_ordering.html)
 
 
 ### DO place "dart:" imports before other imports.

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -24,11 +24,11 @@ environment:
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [language versioning section]: #language-versioning
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   For a peek into current features being
   discussed, investigated, and added to the Dart language,
   see the [language funnel][] tracker in the Dart language GitHub repo.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## Changes in each release

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -8,10 +8,10 @@ You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   To use extension methods in a package,
   the pubspec must have a [minimum SDK constraint][] of at least 2.7.0.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [minimum SDK constraint]: /tools/pub/pubspec#sdk-constraints
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -404,10 +404,10 @@ void main() {
 }
 ```
 
-{{ site.alert.warn }}
+{{site.alert.warn}}
   If you fail to initialize a `late` variable,
   a runtime error occurs when the variable is used.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 When you mark a variable as `late` but initialize it at its declaration,
 then the initializer runs the first time the variable is used.
@@ -1329,10 +1329,10 @@ to specify named parameters:
 void enableFlags({bool? bold, bool? hidden}) {...}
 ```
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   If a parameter is optional but can't be `null`,
   provide a [default value](#default-parameter-values).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 Although named parameters are a kind of optional parameter,
 you can annotate them with `required` to indicate
@@ -1497,7 +1497,7 @@ void main(List<String> arguments) {
 }
 ```
 
-You can use the [args library]({{site.pub}}/packages/args) to
+You can use the [args library]({{site.pub-pkg}}/args) to
 define and parse command-line arguments.
 
 ### Functions as first-class objects
@@ -2120,9 +2120,9 @@ querySelector('#confirm') // Get an object.
   ..onClick.listen((e) => window.alert('Confirmed!'));
 ```
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   The `?..` syntax was introduced in 2.12.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 The previous code is equivalent to the following:
 

--- a/src/_guides/language/numbers.md
+++ b/src/_guides/language/numbers.md
@@ -13,7 +13,7 @@ This page has details about the differences
 between native and web number implementations,
 and how to write code so that those differences don't matter.
 
-{{ site.alert.secondary }}
+{{site.alert.secondary}}
   **Number implementations in Dart and other languages**
 
   Dart has always allowed platform-specific representations
@@ -27,7 +27,7 @@ and how to write code so that those differences don't matter.
   were originally designed to strictly follow IEEE 754 on all platforms,
   but this constraint was loosened almost immediately for efficiency reasons
   (`strictfp` is required for exact coherence).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## Dart number representation
@@ -98,13 +98,13 @@ both `int` and `double`.
 <img src="{% asset number-platform-specific.svg @path %}" alt="Implementation classes vary by platform; for JavaScript, the class that implements int also implements double">
 
 
-{{ site.alert.note }}
+{{site.alert.note}}
   Dart represents `int` and `double` in
   a few different ways for efficiency,
   but these implementation classes (in blue, above) are hidden.
   In general, you can ignore the platform-specific types,
   and think of `int` and `double` as concrete types. 
-{{ site.alert.end }}
+{{site.alert.end}}
 
 An `int` on the web is represented as
 a double-precision floating-point value with no fractional part.
@@ -126,10 +126,10 @@ When arithmetic results differ, as described in this section,
 the behavior is **platform specific**
 and **subject to change**.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   Any platform-specific behavior that this page describes might change to be
   less surprising, more consistent, or more performant.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ### Precision

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -36,11 +36,11 @@ calling a C library.
 The hello_world example has the following files:
 
 | **Source file** | **Description** |
-| [hello.dart]({{ page.hw}}/hello.dart) | A Dart file that uses the `hello_world()` function from a C library. |
-| [pubspec.yaml]({{ page.hw}}/pubspec.yaml) | The usual Dart [pubspec](/tools/pub/pubspec), with a lower bounds on the SDK that's at least 2.6. |
-| [hello_library/hello.h]({{ page.hw}}/hello_library/hello.h) | Declares the `hello_world()` function. |
-| [hello_library/hello.c]({{ page.hw}}/hello_library/hello.c) | A C file that imports `hello.h` and defines the `hello_world()` function. |
-| [hello_library/CMakeLists.txt]({{ page.hw}}/hello_library/CMakeLists.txt) | A CMake build file for compiling the C code into a dynamic library. |
+| [hello.dart]({{page.hw}}/hello.dart) | A Dart file that uses the `hello_world()` function from a C library. |
+| [pubspec.yaml]({{page.hw}}/pubspec.yaml) | The usual Dart [pubspec](/tools/pub/pubspec), with a lower bounds on the SDK that's at least 2.6. |
+| [hello_library/hello.h]({{page.hw}}/hello_library/hello.h) | Declares the `hello_world()` function. |
+| [hello_library/hello.c]({{page.hw}}/hello_library/hello.c) | A C file that imports `hello.h` and defines the `hello_world()` function. |
+| [hello_library/CMakeLists.txt]({{page.hw}}/hello_library/CMakeLists.txt) | A CMake build file for compiling the C code into a dynamic library. |
 {:.table .table-striped }
 
 {% comment %}
@@ -82,7 +82,7 @@ Hello World
 
 ### Using dart:ffi
 
-The [`hello.dart` file]({{ page.hw}}/hello.dart)
+The [`hello.dart` file]({{page.hw}}/hello.dart)
 illustrates the steps for using dart:ffi to call a C function:
 
 1. Import dart:ffi.
@@ -164,7 +164,7 @@ depends on your platform and the type of library.
 For details, see the following:
 
 * [Flutter dart:ffi page][binding]
-* [dart:ffi examples]({{ page.samples }})
+* [dart:ffi examples]({{page.samples}})
 
 ## Generating FFI bindings with `package:ffigen`
 
@@ -178,8 +178,8 @@ binding generator to automatically create FFI wrappers from C header files.
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 [ffi issue]: https://github.com/dart-lang/sdk/issues/34452
 [hello_world]: {{page.hw}}
-[primitives]: {{ page.samples }}/primitives
-[structs]: {{ page.samples }}/structs
-[sqlite]: {{ page.sqlite }}
-[mini tutorial.]: {{ page.sqlite }}/docs/sqlite-tutorial.md
-[ffigen]: {{ site.pub }}/packages/ffigen
+[primitives]: {{page.samples}}/primitives
+[structs]: {{page.samples}}/structs
+[sqlite]: {{page.sqlite}}
+[mini tutorial.]: {{page.sqlite}}/docs/sqlite-tutorial.md
+[ffigen]: {{site.pub-pkg}}/ffigen

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -177,7 +177,7 @@ binding generator to automatically create FFI wrappers from C header files.
 [binding]: https://flutter.dev/docs/development/platform-integration/c-interop
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 [ffi issue]: https://github.com/dart-lang/sdk/issues/34452
-[hello_world]: {{ page.hw }}
+[hello_world]: {{page.hw}}
 [primitives]: {{ page.samples }}/primitives
 [structs]: {{ page.samples }}/structs
 [sqlite]: {{ page.sqlite }}

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -281,7 +281,7 @@ we recommend sharing it on the [pub.dev site.]({{site.pub}})
 To publish or update the library,
 use [pub publish](/tools/pub/cmd/pub-lish),
 which uploads your package and creates or updates its page.
-For example, see the page for the [shelf package.]({{site.pub}}/packages/shelf)
+For example, see the page for the [shelf package.]({{site.pub-pkg}}/shelf)
 See [Publishing a package](/tools/pub/publishing)
 for details on how to prepare your package for publishing.
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1658,11 +1658,11 @@ as well as platform-specific libaries like the
 and the [Flutter libraries.][docs.flutter]
 
 You can get yet more libraries by using the [pub package manager](/guides/packages). The
-[collection,]({{site.pub}}/packages/collection)
-[crypto,]({{site.pub}}/packages/crypto)
-[http,]({{site.pub}}/packages/http)
-[intl,]({{site.pub}}/packages/intl) and
-[test]({{site.pub}}/packages/test) libraries are just a
+[collection,]({{site.pub-pkg}}/collection)
+[crypto,]({{site.pub-pkg}}/crypto)
+[http,]({{site.pub-pkg}}/http)
+[intl,]({{site.pub-pkg}}/intl) and
+[test]({{site.pub-pkg}}/test) libraries are just a
 sampling of what you can install using pub.
 
 To learn more about the Dart language, see the

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -43,11 +43,11 @@ quickly scan the README when deciding whether to try your package.
 A good README catches the reader's attention and
 shows that your package is worth trying.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   The package README is used in multiple ways.
   For example, its content appears not only in the package page on pub.dev,
   but also in [dartdoc][]-produced API reference documentation.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 Although this page features the [`in_app_purchase`][] package README,
 yours might not need to be as large or detailed.
@@ -131,14 +131,14 @@ adding visual content made the `in_app_purchase` package page look informative a
 
 {% asset libraries/package-page-example-iap.png alt="in_app_purchase readme without and with images" class="screenshot" %}
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   When adding visual content,
   use absolute URLs for the files
   to make the images reliably appear,
   no matter where the README is published.
   One place to host your images is in the repository itself,
   like `in_app_purchase` does.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ### 3. Use lists to present important information {#tip3}

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -53,7 +53,7 @@ Although your tests partly depend on the platform your code is intended
 for&mdash;Flutter, the web, or server-side, for example&mdash;the
 following packages are useful across Dart platforms:
 
-* [package:test]({{site.pub}}/packages/test)<br>
+* [package:test]({{site.pub-pkg}}/test)<br>
   Provides a standard way of writing tests in Dart. You can use the test
   package to:
     * Write single tests, or groups of tests.
@@ -68,7 +68,7 @@ following packages are useful across Dart platforms:
       multiple files or an entire package.
 
 
-* [package:mockito]({{site.pub}}/packages/mockito)<br>
+* [package:mockito]({{site.pub-pkg}}/mockito)<br>
   Provides a way to create
   [mock objects,](https://en.wikipedia.org/wiki/Mock_object)
   easily configured for use in fixed scenarios, and to verify
@@ -102,10 +102,10 @@ applications:
 
 * [Testing]({{site.angulardart}}/guide/testing)(a page
   in the AngularDart guide)<br>
-  How to use the [angular_test]({{site.pub}}/packages/angular_test)
+  How to use the [angular_test]({{site.pub-pkg}}/angular_test)
   package to test AngularDart components and subsystems.
   <!-- More pages are coming! -->
-* [package:webdriver]({{site.pub}}/packages/webdriver)<br>
+* [package:webdriver]({{site.pub-pkg}}/webdriver)<br>
   A Dart package for interfacing with
   [WebDriver](https://www.w3.org/TR/webdriver/) servers.
 

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -176,9 +176,9 @@ We published the following articles on the [Dart blog:][Dart blog]
 We also improved the blog navigation,
 adding **announcement** and **archive** tabs, plus a link to dart.dev.
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   All articles in the Dart blog are free to read.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 </div>
 

--- a/src/_includes/article_summary.html
+++ b/src/_includes/article_summary.html
@@ -1,3 +1,3 @@
-<h4><a href="{{ article.url }}" title="{{ article.title }}">{{ article.title }}</a></h4>
+<h4><a href="{{article.url}}" title="{{article.title}}">{{article.title}}</a></h4>
 <em class="muted">{{ article.original-date | default: article.date | date: '%B %Y' }}&nbsp;{% if article.original-date %}(updated: {{ article.date | date: '%B %Y' }}){% endif %}</em>
-<p>{{ article.description }}</p>
+<p>{{article.description}}</p>

--- a/src/_includes/author.html
+++ b/src/_includes/author.html
@@ -1,13 +1,13 @@
 <article class="author">
   {% if page.rel.me or page.author.twitter %}
     <section class="author-follow">
-      <h2>Follow {{ page.author.fname }}</h2>
+      <h2>Follow {{page.author.fname}}</h2>
       <ul>
         {% if page.rel.me %}
-          <li><a rel="me" href="{{ page.rel.me }}">+{{ page.author.fname }} {{ page.author.lname }}</a></li>
+          <li><a rel="me" href="{{page.rel.me}}">+{{page.author.fname}} {{page.author.lname}}</a></li>
         {% endif %}
         {% if page.author.twitter %}
-          <li><a href="http://twitter.com/{{ page.author.twitter }}">@{{ page.author.twitter }}</a></li>
+          <li><a href="http://twitter.com/{{page.author.twitter}}">@{{page.author.twitter}}</a></li>
         {% endif %}
       </ul>
     </section>
@@ -15,7 +15,7 @@
 
   <section class="author-bio">
     <h2>Bio</h2>
-    {{ bio }}
+    {{bio}}
   </section>
 
   {% assign empty_list = true %}
@@ -28,7 +28,7 @@
     <h2>On this site</h2>
     <ul>
       {% endif %}
-      <li><a href="{{ article_url }}">{{ article.title }}</a></li>
+      <li><a href="{{article_url}}">{{article.title}}</a></li>
     {% endif %}
   {% endfor %}
   {% if empty_list == false %}

--- a/src/_includes/capture_output.html
+++ b/src/_includes/capture_output.html
@@ -1,1 +1,1 @@
-<h3>Here ya go: {{ test }}</h3>
+<h3>Here ya go: {{test}}</h3>

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -17,13 +17,13 @@ which (as of Flutter 1.21) includes the full Dart SDK.
   Use [Chocolatey](https://chocolatey.org) to install a stable release of
   the Dart SDK.
 
-{{ site.alert.important }}
+{{site.alert.important}}
   These commands require administrator privileges.
   If you need help on starting an administrator-level command prompt,
   try a search like
   <em><a href="https://www.google.com/search?q=cmd+admin"
   target="blank">cmd admin</a>.</em>
-{{ site.alert.end }}
+{{site.alert.end}}
 
 To install the Dart SDK:
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -12,7 +12,7 @@
   <!-- End Google Tag Manager -->
   {% assign desc = page.description | default: page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 -%}
   <meta name="description" content="{{desc}}">
-  <title>{% if page.short-title %}{{ page.short-title }}{% else %}{{ page.title }}{% endif %} | {{ site.title }}</title>
+  <title>{% if page.short-title %}{{page.short-title}}{% else %}{{page.title}}{% endif %} | {{site.title}}</title>
 
   <!-- Favicon / Touch Icons -->
   <link rel="icon" sizes="64x64" href="/assets/shared/dart/icon/64.png">
@@ -24,11 +24,11 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@dart_lang" />
-  <meta name="twitter:title" content="{{ page.title }}" />
+  <meta name="twitter:title" content="{{page.title}}" />
   <meta name="twitter:description" content="{{desc}}" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="{{ page.title }}" />
+  <meta property="og:title" content="{{page.title}}" />
   <meta property="og:description" content="{{desc}}" />
   <meta property="og:url" content="{{ page.url | absolute_url }}" />
   {% assign og_image_path = page.og_image | default: layout.og_image | default: '/assets/shared/dart-logo-for-shares.png' -%}

--- a/src/_includes/linter-rule.html
+++ b/src/_includes/linter-rule.html
@@ -1,6 +1,6 @@
 {:.linter-rule}
 {% if include.rule %}
-Linter rule: <a href="{{ site.lints }}/{{ include.rule }}.html">{{ include.rule }}</a>
+Linter rule: <a href="{{site.lints}}/{{include.rule}}.html">{{include.rule}}</a>
 {% else %}
-Linter rules: <a href="{{ site.lints }}/{{ include.rule1 }}.html">{{ include.rule1 }},</a> <a href="{{ site.lints }}/{{ include.rule2 }}.html">{{ include.rule2 }}</a>
+Linter rules: <a href="{{site.lints}}/{{include.rule1}}.html">{{include.rule1}},</a> <a href="{{site.lints}}/{{include.rule2}}.html">{{include.rule2}}</a>
 {% endif %}

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -2,8 +2,8 @@
 
 <nav id="mainnav" class="site-header">
   <div id="menu-toggle"><i class="icon icon-menu"></i></div>
-  <a href="/" class="brand" title="{{ site.title }}">
-    <img src="{% asset shared/dart/logo+text/horizontal/white.svg @path %}" alt="{{ site.title }}">
+  <a href="/" class="brand" title="{{site.title}}">
+    <img src="{% asset shared/dart/logo+text/horizontal/white.svg @path %}" alt="{{site.title}}">
   </a>
   <ul class="navbar">
     {%- comment -%}

--- a/src/_includes/navigation-sub.html
+++ b/src/_includes/navigation-sub.html
@@ -3,12 +3,12 @@
   <ul>
     <li class="previous">
       {% if page.prevpage.url %}
-        <a href="{{ page.prevpage.url }}">&lang;&nbsp;&nbsp;{{ page.prevpage.title }}</a>
+        <a href="{{page.prevpage.url}}">&lang;&nbsp;&nbsp;{{page.prevpage.title}}</a>
       {% endif %}
     </li>
     <li class="next">
       {% if page.nextpage.url %}
-        <a href="{{ page.nextpage.url }}">{{ page.nextpage.title }}&nbsp;&nbsp;&rang;</a>
+        <a href="{{page.nextpage.url}}">{{page.nextpage.title}}&nbsp;&nbsp;&rang;</a>
       {% endif %}
     </li>
   </ul>

--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -25,6 +25,6 @@
       <span class="{{include.id}}__toggle toc-toggle-up"><i class="fas fa-chevron-up fa-m"></i></span>
     {% endif %}
   </header>
-  {{ toc }}
+  {{toc}}
 </div>
 {% endunless %}

--- a/src/_includes/not-null-safe.md
+++ b/src/_includes/not-null-safe.md
@@ -1,5 +1,5 @@
-{{ site.alert.info }}
+{{site.alert.info}}
   This page hasn't yet been updated to reflect
   [sound null safety](/null-safety),
   which was introduced in Dart 2.12.
-{{ site.alert.end }}
+{{site.alert.end}}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <body class="{{ page.layout }}{% if page.toc == false %} hide_toc{% endif %}{% if page.obsolete == true %} obsolete{% endif %}{% if site.show_banner == true %} show_banner{% endif %}">
+  <body class="{{page.layout}}{% if page.toc == false %} hide_toc{% endif %}{% if page.obsolete == true %} obsolete{% endif %}{% if site.show_banner == true %} show_banner{% endif %}">
     {% include gtags.html %}
     {% include page-header.html %}
     {% include navigation-side.html %}
@@ -15,7 +15,7 @@
           {% endif -%}
           <div>
             {% include shared/page-github-links.html %}
-            <h1>{{ page.title }}</h1>
+            <h1>{{page.title}}</h1>
           </div>
           {% include navigation-toc.html id='site-toc--inline' collapsible=true %}
           {{ content | inject_anchors }}

--- a/src/_layouts/error.html
+++ b/src/_layouts/error.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <body class="{{ page.layout }} hide_toc">
+  <body class="{{page.layout}} hide_toc">
     {% include gtags.html %}
     {% include page-header.html %}
     {% include navigation-side.html %}
     <main id="page-content">
       <div class="content">
-        {{ content }}
+        {{content}}
       </div>
     </main>
     {% include page-footer.html %}

--- a/src/_layouts/homepage.html
+++ b/src/_layouts/homepage.html
@@ -6,7 +6,7 @@
     {% include page-header.html %}
     {% include navigation-side.html %}
     <main id="page-content">
-      {{ content }}
+      {{content}}
     </main>
     {% include page-footer.html %}
   </body>

--- a/src/_layouts/tutorial.html
+++ b/src/_layouts/tutorial.html
@@ -6,12 +6,12 @@ layout: default
     <h4>What's the point?</h4>
     <ul>
       {% for point in page.points %}
-      <li>{{ point }}</li>
+      <li>{{point}}</li>
       {% endfor %}
     </ul>
   </div>
 {% endif %}
-{{ content }}
+{{content}}
 
 {% comment %}
   {% if page.examples %}
@@ -21,10 +21,10 @@ layout: default
         {% for example in page.examples %}
         <li>
           {% if example.url %}
-            <a href="{{ example.url }}"
-              target="_blank" rel="noopener">{{ example.title }}</a>
+            <a href="{{example.url}}"
+              target="_blank" rel="noopener">{{example.title}}</a>
           {% else %}
-            {{ example.title }}
+            {{example.title}}
           {% endif %}
         </li>
         {% endfor %}

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -111,7 +111,7 @@ which is available at the [pub.dev site]({{site.pub}}).
 
     {: type="a"}
      1. Go to [vector_math's entry on the Package
-        site.]({{site.pub}}/packages/vector_math)
+        site.]({{site.pub-pkg}}/vector_math)
      2. Click the **Installing** tab.
      3. Copy the **vector_math** line from the sample **dependencies** entry.
         The entry should look something like this:
@@ -269,7 +269,7 @@ use the `package:` prefix.
 
    {: type="a"}
    1. Go to [vector_math's entry on the Package
-      site.]({{site.pub}}/packages/vector_math)
+      site.]({{site.pub-pkg}}/vector_math)
    2. Click the **Installing** tab.
    3. Copy the **import** line. It should look something like this:
 

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -153,7 +153,7 @@ is present, a line number is displayed before each line.
 
 ## Parsing command-line arguments
 
-The [args package]({{site.pub}}/packages/args) provides
+The [args package]({{site.pub-pkg}}/args) provides
 parser support for transforming command-line arguments
 into a set of options, flags, and additional values.
 Import the package's

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -66,12 +66,12 @@ This command creates a small Dart app that has the following:
   information about which [packages](/guides/packages) the app depends on
   and which versions of those packages are required.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   Under the hood, `dart create` runs [`dart pub get`][], which
   scans the generated pubspec file and downloads dependencies.
   If you add other dependencies to your pubspec file,
   then run `dart pub get` to download them.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [`dart pub get`]: /tools/pub/cmd/pub-get
 

--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -733,7 +733,7 @@ _Example files for this section:_
 
 For some higher-level building blocks,
 we recommend that you try the
-[http_server]({{site.pub}}/packages/http_server)
+[http_server]({{site.pub-pkg}}/http_server)
 pub package,
 which contains a set of classes that,
 together with the HttpServer class in the `dart:io` library,
@@ -990,7 +990,7 @@ for further details about the classes and libraries discussed in this tutorial.
 [dart:io]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/dart-io-library.html
 [Encoding]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/Encoding-class.html
 [Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
-[http_server]: {{site.pub}}/packages/http_server
+[http_server]: {{site.pub-pkg}}/http_server
 [HttpClient]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/HttpClient-class.html
 [HttpClientRequest]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/HttpClientRequest-class.html
 [HttpClientResponse]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-io/HttpClientResponse-class.html

--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -95,11 +95,11 @@ If you're sure that an expression with a nullable type isn't null, you can use a
 expression, you tell Dart that the value won't be null, and
 that it's safe to assign it to a non-nullable variable.
 
-{{ site.alert.warn }}
+{{site.alert.warn}}
   If you're wrong, **Dart throws an exception at run-time**. This makes the
   `!` operator unsafe, so don't use it unless you're very sure that the
   expression isn't null.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### Exercise: Null assertion
 
@@ -301,13 +301,13 @@ void main() {
 }
 ```
 
-{{ site.alert.info }}
+{{site.alert.info}}
   **Fun fact:**
   After you add `late` to the declaration of `_cache`, if you move the
   `_computeValue` function into the `CachedValueProvider` class the code
   still works! Initialization expressions for `late` fields can use instance
   methods in their initializers.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## What's next?

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -71,10 +71,10 @@ The Dart SDK is supported on Windows, Linux, and macOS.
 * **Supported versions:** Recent Linux versions, but only Ubuntu 16.04 is tested.
 * **Supported architectures:** x64, ia32, arm, arm64.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   The arm support requires glibc 2.23 or newer due to a
   [dynamic linker bug](https://sourceware.org/bugzilla/show_bug.cgi?id=14341).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### macOS
 

--- a/src/map.html
+++ b/src/map.html
@@ -9,16 +9,16 @@ permalink: /map
 {% for document in site.pages %}
   {% if document.url and document.url != '/404' %}
   <li>
-    <a href="{{ document.url }}">{{ document.title | xml_escape }}</a><br>
-    <small>{{ document.url }}</small>
+    <a href="{{document.url}}">{{ document.title | xml_escape }}</a><br>
+    <small>{{document.url}}</small>
   </li>
   {% endif %}
 {% endfor %}
 {% for document in site.documents %}
   {% if document.url %}
   <li>
-    <a href="{{ document.url }}">{{ document.title | xml_escape }}</a><br>
-    <small>{{ document.url }}</small>
+    <a href="{{document.url}}">{{ document.title | xml_escape }}</a><br>
+    <small>{{document.url}}</small>
   </li>
   {% endif %}
 {% endfor %}

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -16,11 +16,11 @@ Here are the basic steps for migrating each package that you own:
    [**publish**](#step5-publish) the null-safe version
    as a **prerelease** version.
 
-{{ site.alert.info }}
+{{site.alert.info}}
   **Migrating an app is technically the same as migrating a package.**
   Before migrating an app,
   make sure that all of your dependencies are ready.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 For an informal look at the experience of using the migration tool, watch this video:
 
@@ -45,7 +45,7 @@ For example, if you predict that a function will take a nullable parameter but
 the package migrates it to be non-nullable,
 then passing a nullable argument becomes a compile error.
 
-{{ site.alert.info }}
+{{site.alert.info}}
   **You can — and should — migrate your package before
   packages that depend on it are migrated.**
   Your null-safe package is usable by packages and apps that
@@ -53,7 +53,7 @@ then passing a nullable argument becomes a compile error.
   as long as they use Dart 2.12 or later.
   For example, the Dart and Flutter core libraries are null safe,
   and they're still usable by apps that haven't migrated to null safety.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 This section tells you how to
 check and update your package's dependencies,
@@ -86,7 +86,7 @@ then you can start migrating.
 Otherwise, use the **Resolvable** column to find
 null-safe releases, if they exist.
 
-{{ site.alert.info }}
+{{site.alert.info}}
   **Why do all dependencies need to support null safety?**
   When all of an app's direct dependencies support null safety,
   you can _run the app_ with sound null safety.
@@ -94,7 +94,7 @@ null-safe releases, if they exist.
   you can _run tests_ with sound null safety.
   You might also need null-safe dev dependencies for other reasons,
   such as code generation.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 Here's an example of the output for a simple package.
 The green checkmarked version for each package supports null safety:
@@ -108,7 +108,7 @@ If any of your package's dependencies _don't_ yet support null safety,
 we encourage you to reach out to the package owner.
 You can find contact details on the package page on [pub.dev][].
 
-[pub.dev]: {{ site.pub }}
+[pub.dev]: {{site.pub}}
 
 
 ### Update dependencies
@@ -138,10 +138,10 @@ You have two options for migrating:
   which can make most of the easily predictable changes for you.
 * [Migrate your code by hand.](#migrating-by-hand)
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   For additional help while migrating code, check the
   [null safety FAQ][].
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [nullable type]: /null-safety#creating-variables
 [required]: /null-safety/understanding-null-safety#required-named-parameters

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -24,11 +24,11 @@ with the goal of helping you decide when to migrate to null safety.
 After the conceptual discussion are instructions for migrating incrementally,
 followed by details on testing and running mixed-version programs.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   We recommend that, if possible, you wait for dependencies to migrate
   before you migrate your package.
   For details, see the [migration guide][].
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [migration guide]: /null-safety/migration-guide
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -105,12 +105,12 @@ class Point {
 }
 ```
 
-{{ site.alert.info }}
+{{site.alert.info}}
   This example is running in an embedded [DartPad](/tools/dartpad).
   You can also
   <a href="{{site.dartpad}}/4d688b6e468fb4c53d312250f557ec5c"
   target="_blank">open this example in its own window</a>.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 
 ## Dart: The libraries {#libraries}

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -21,9 +21,9 @@ A playlist of Google-produced videos,
 ranging from 5-minute talks on Dart asynchrony support
 to the Dart session from Google I/O 2019.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{ page.dart-playlist-id }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{page.dart-playlist-id}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-[Playlist: Dart videos](https://www.youtube.com/playlist?list={{ page.dart-playlist-id }})
+[Playlist: Dart videos](https://www.youtube.com/playlist?list={{page.dart-playlist-id}})
 
 
 <!-- Smartherd playlist -->
@@ -31,6 +31,6 @@ to the Dart session from Google I/O 2019.
 
 A community-provided series of tutorial videos about the Dart language.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{ page.smartherd-playlist-id }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{page.smartherd-playlist-id}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-[Playlist: Dart tutorial for beginners](https://www.youtube.com/playlist?list={{ page.smartherd-playlist-id }})
+[Playlist: Dart tutorial for beginners](https://www.youtube.com/playlist?list={{page.smartherd-playlist-id}})

--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -249,11 +249,11 @@ produces deployable JavaScript.
 The [`webdev serve`][] command uses `dartdevc` by default, but you can switch
 to producing deployable JavaScript by using the `--release` flag.
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   Although we expect the `js` subcommand to replace the `dart2js` command,
   as of Dart 2.12 `js` is missing
   some of the more advanced flags available in `dart2js`.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 For more information, see the [`dart2js` documentation](/tools/dart2js).
 

--- a/src/tools/dart-format.md
+++ b/src/tools/dart-format.md
@@ -20,9 +20,9 @@ under the current directory's `bin`, `lib`, and `test` directories:
 $ dart format bin lib test
 ```
 
-{{ site.alert.warn }}
+{{site.alert.warn}}
   By default, `dart format` **overwrites** the Dart files.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 If you don't want to overwrite the files,
 add the `-o` flag.

--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -33,14 +33,14 @@ $ dart pub outdated
 $ dart pub upgrade
 ```
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   Before Dart 2.10, the `dart` command was used only to run the
   [Dart VM][dart-vm].
   You can still use it that way, but
   now the command has more functionality.
   Over time, we expect the `dart` command to replace
   most existing commands in the Dart SDK.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 The following table shows which commands you can use with the `dart` tool.
 

--- a/src/tools/dart-vm.md
+++ b/src/tools/dart-vm.md
@@ -6,13 +6,13 @@ description: "The reference page for using 'dart' to run command-line apps."
 You can use the _dart_ tool (`bin/dart`) to run Dart command-line apps such as
 server-side scripts, programs, and servers.
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   As of Dart 2.10, the `dart` command has more functionality
   than just running the Dart VM.
   Instead of using `dart` as described on this page,
   we recommend using `dart run`.
   For details, see [the `dart` tool page][dart-tool].
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [dart-tool]: /tools/dart-tool
 

--- a/src/tools/dartpad/troubleshoot.md
+++ b/src/tools/dartpad/troubleshoot.md
@@ -4,7 +4,7 @@ description: Common problems with using DartPad
 ---
 
 This page describes solutions to problems that might occur when
-you're trying to use DartPad, whether at [dartpad.dev]({{ site.dartpad }})
+you're trying to use DartPad, whether at [dartpad.dev]({{site.dartpad}})
 or in a page that has embedded DartPads.
 For an overview of DartPad, see the
 [DartPad page](/tools/dartpad).

--- a/src/tools/non-promotion-reasons.md
+++ b/src/tools/non-promotion-reasons.md
@@ -4,10 +4,10 @@ description: Solutions for cases where you know more about a field's type than D
 toc: false
 ---
 
-{{ site.alert.warn}}
+{{site.alert.warn}}
   **This page is under construction**
   ([issue #2940][]).
-{{ site.alert.end}}
+{{site.alert.end}}
 
 This page will have information to help you understand
 why type promotion failures occur,

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -25,13 +25,13 @@ on the [Flutter website]({{site.flutter}}).
 [flutter-cli]: {{site.flutter}}/docs/reference/flutter-cli
 [dart-cli]: /tools/dart-tool
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   The `dart pub` command debuted in Dart 2.10.
   Although you might still find examples of
   using the standalone `pub` command instead of
   `dart pub` or `flutter pub`,
   the standalone `pub` command is deprecated.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 If you encounter problems using the pub tool,
 see [Troubleshooting Pub](/tools/pub/troubleshoot).

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -122,10 +122,10 @@ Also updates `pubspec.yaml` with the new constraints.
 
 [`dart pub outdated`]: /tools/pub/cmd/pub-outdated
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   Commit the `pubspec.yaml` file before running this command,
   so that you can undo the changes if necessary.
-{{ site.alert.end }}
+{{site.alert.end}}
 To check which dependencies will be upgraded,
 you can use `dart pub upgrade --major-versions --dry-run`.
 
@@ -138,10 +138,10 @@ ignoring any upper-bound constraint in the `pubspec.yaml` file.
 Also updates `pubspec.yaml` with the new constraints.
 This command is similar to `--major-versions`.
 
-{{ site.alert.tip }}
+{{site.alert.tip}}
   Commit the `pubspec.yaml` file before running this command,
   so that you can undo the changes if necessary.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 ### `--offline`
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -369,7 +369,7 @@ Every package should have tests. With pub, the convention is
 that these go in a `test` directory (or some directory inside it if you like)
 and have `_test` at the end of their file names.
 
-Typically, these use the [test]({{site.pub}}/packages/test)
+Typically, these use the [test]({{site.pub-pkg}}/test)
 package.
 
 {% prettify none tag=pre+code %}

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -132,7 +132,7 @@ doesn't start with digits and isn't a
 
 Try to pick a name that is clear, terse, and not already in use.
 A quick search of packages on the
-[pub.dev site]({{site.pub}}/packages)
+[pub.dev site]({{site.pub-pkg}})
 to make sure that nothing else is using your name is recommended.
 
 ### Version
@@ -162,7 +162,7 @@ The description should be relatively short&mdash;60 to 180 characters&mdash;and
 tell a casual reader what they might want to know about your package.
 
 Think of the description as the sales pitch for your package. Users see it
-when they [browse for packages.]({{site.pub}}/packages)
+when they [browse for packages.]({{site.pub-pkg}})
 The description is plain text: no markdown or HTML.
 
 ### Author/authors
@@ -285,12 +285,12 @@ and uses the same
 [version constraint](/tools/pub/dependencies#version-constraints) syntax as
 dependencies.
 
-{{ site.alert.version-note }}
+{{site.alert.version-note}}
   For a package to use a feature introduced after 2.0,
   its pubspec must have a lower constraint that's at least
   the version when the feature was introduced.
   For details, see the [language evolution page][].
-{{ site.alert.end }}
+{{site.alert.end}}
 
 [language evolution page]: /guides/language/evolution
 

--- a/src/tools/sdk/_windows.md
+++ b/src/tools/sdk/_windows.md
@@ -1,12 +1,12 @@
 You can install the Dart SDK using [Chocolatey.][Chocolatey]
 
-{{ site.alert.important }}
+{{site.alert.important}}
 These commands require administrator privileges.
 If you need help on starting an administrator-level command prompt,
 try a search like
 <em><a href="https://www.google.com/search?q=cmd+admin"
   target="blank">cmd admin</a>.</em>
-{{ site.alert.end }}
+{{site.alert.end}}
 
 To install the Dart SDK:
 

--- a/src/tools/sdk/archive/_archives_table.html
+++ b/src/tools/sdk/archive/_archives_table.html
@@ -1,11 +1,11 @@
 <form class="form-inline">
   <div class="form-group select">
-    <label for="{{ include.channel }}-versions">Version:</label>
-    <select id="{{ include.channel }}-versions"></select>
+    <label for="{{include.channel}}-versions">Version:</label>
+    <select id="{{include.channel}}-versions"></select>
   </div>
   <div class="form-group select">
-    <label for="{{ include.channel }}-os">OS:</label>
-    <select id="{{ include.channel }}-os">
+    <label for="{{include.channel}}-os">OS:</label>
+    <select id="{{include.channel}}-os">
       <option value="all">All</option>
       <option value="macos" id="{{include.channel}}-macos" class="macos-option">macOS</option>
       <option value="linux" id="{{include.channel}}-linux" class="linux-option">Linux</option>
@@ -13,7 +13,7 @@
     </select>
   </div>
 </form>
-<table id="{{ include.channel }}" class="table">
+<table id="{{include.channel}}" class="table">
   <thead>
     <tr>
       <th>Version</th>

--- a/src/tools/sdk/archive/index.md
+++ b/src/tools/sdk/archive/index.md
@@ -53,9 +53,9 @@ and they're likely to contain bugs.
 Main channel builds are suitable only for
 experimental development use, not for production use.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   Main channel builds are unsigned.
-{{ site.alert.end }}
+{{site.alert.end}}
 
 To download a main channel build, use a
 [main channel URL](#main-channel-url-scheme).
@@ -98,6 +98,6 @@ Example:
 https://storage.googleapis.com/dart-archive/channels/be/raw/latest/sdk/dartsdk-windows-x64-release.zip
 {% endprettify %}
 
-{{ site.alert.note }}
+{{site.alert.note}}
   Main channel builds are unsigned.
-{{ site.alert.end }}
+{{site.alert.end}}

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -42,14 +42,14 @@ directory that has these command-line tools:
 [`dartdoc`](/tools/dartdoc)
 : The API documentation generator.
 
-{{ site.alert.note }}
+{{site.alert.note}}
   The 2.10 Dart SDK also contains `dart2js`, `dart2native`, `dartanalyzer`,
   `dartdevc`, `dartfmt`, and `pub` commands.
   However, as of 2.10 the `dart` tool provides a unified interface
   to their functionality.
   We recommend that you transition to using
   [the `dart` tool](/tools/dart-tool).
-{{ site.alert.end }}
+{{site.alert.end}}
 
 For more information about the SDK, see its
 [README file.](https://github.com/dart-lang/sdk/blob/master/README.dart-sdk)


### PR DESCRIPTION
A response to #1324

Changes all instances of `{{site.pub}}/packages` to `{{site.pub-pkg}}`.

In addition, changes all double-curly-brace notation around singular objects in `src` so they have no space inside them. Changing multiple-object double-curly-brace notations could be an option in the future. 

This is all meant to clean up the backend and promote consistent style in the future.