### PR TITLE
Updated book page with post null-safety section (closes #3209)

### DIFF
--- a/src/_data/books-dart2.yml
+++ b/src/_data/books-dart2.yml
@@ -5,12 +5,3 @@
   cover: quick-start-guide.jpg
   link: "https://www.apress.com/gp/book/9781484255612"
   desc: "Get started with Dart and learn to program. You'll gain the basics and be ready to move to the next level: web and mobile apps."
-- title: 'Dart Apprentice'
-  authors:
-    - Jonathan Sande
-    - Matt Galloway
-  publisher: raywenderlich
-  cover: dart-apprentice.png
-  link: "https://www.raywenderlich.com/books/dart-apprentice"
-  desc: "Dart Apprentice will teach you all the basic concepts you need to master this language. Follow along the easily and thoroughly explained concepts and you will be building Dart applications in a breeze."
-

--- a/src/_data/books-dart3.yml
+++ b/src/_data/books-dart3.yml
@@ -1,0 +1,8 @@
+- title: 'Dart Apprentice'
+  authors:
+    - Jonathan Sande
+    - Matt Galloway
+  publisher: raywenderlich
+  cover: dart-apprentice.png
+  link: "https://www.raywenderlich.com/books/dart-apprentice/v1.1/"
+  desc: "Dart Apprentice will teach you all the basic concepts you need to master this language. Follow along the easily and thoroughly explained concepts and you will be building Dart applications in a breeze."

--- a/src/resources/books.md
+++ b/src/resources/books.md
@@ -10,6 +10,24 @@ If you find another Dart book that might be helpful, please
 [let us know.](https://github.com/dart-lang/site-www/issues)
 
 
+{% for book in site.data.books-dart3 %}
+<div class="book-img-with-details row">
+<a href="{{book.link}}" title="{{book.title}}" class="col-sm-3 no-automatic-external">
+  <img src="{% asset 'cover/{{book.cover}}' @path %}" alt="{{book.title}}"/>
+</a>
+<div class="details col-sm-9" markdown="1">
+### [{{book.title}}]({{book.link}})
+{:.title}
+
+by {{book.authors | array_to_sentence_string}}
+{:.authors.h4}
+
+{{book.desc}}
+</div>
+</div>
+{% endfor %}
+
+
 ## Dart books preceding null safety
 
 The following books cover Dart versions preceding the release of [null safety][].


### PR DESCRIPTION
 To reflect Dart Apprentice having been updated for null safety:
 
 1. Created a file `books-dart3.yml` to house book details for this post- null safety section.
 2. Moved Dart Apprentice to it (as it got updated for null safety)
 3. Used this in `books.md`