### PR TITLE
Add links to writing-package-pages

### DIFF
--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -120,6 +120,8 @@ rendered as [Markdown][] — on
 the page for your package. This is the perfect place to introduce people to
 your code.
 
+For guidance on how to write a great README, see
+[Writing package pages](/guides/libraries/writing-package-pages).
 
 ## CHANGELOG.md
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -74,6 +74,8 @@ affect how your package's page looks:
 * **README.md:** The `README.md` file
   is the main content featured in your package's page.
   The file's contents are rendered as [Markdown.][Markdown]
+  For guidance on how to write a great README, see
+  [Writing package pages](/guides/libraries/writing-package-pages).
 * **CHANGELOG.md:** Your package's `CHANGELOG.md` file, if found,
   is also featured in a tab on your package's page,
   so that developers can read it right from pub.dev.


### PR DESCRIPTION
Fixes #3190

Staged:
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/publishing#important-files
https://kw-www-dartlang-1.firebaseapp.com/tools/pub/package-layout#readmemd

I grepped src for README. These were the only two mentions that seemed like they should link back to the guidelines.