### PR TITLE
Use a rolling policy for Linux version support

### DIFF
--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -68,7 +68,7 @@ The Dart SDK is supported on Windows, Linux, and macOS.
 
 ### Linux
 
-* **Supported versions:** Recent Linux versions, but only Ubuntu 16.04 is tested.
+* **Supported versions:** [Debian stable] and [Ubuntu LTS] under standard support.
 * **Supported architectures:** x64, ia32, arm, arm64.
 
 {{ site.alert.note }}
@@ -129,6 +129,8 @@ or by [downloading the SDK as a zip file][].
 [build the SDK from source]: https://github.com/dart-lang/sdk/wiki/Building
 [Dart libraries]: /guides/libraries/library-tour
 [downloading the SDK as a zip file]: /tools/sdk/archive
+[Debian stable]: https://www.debian.org/releases
+[Ubuntu LTS]: https://wiki.ubuntu.com/Releases
 [flutter]: https://flutter.dev/docs/get-started/install
 [site SDK version]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/{{site.data.pkg-vers.SDK.vers}}/index.html
 [a package manager]: https://github.com/dart-lang/sdk/wiki/Installing-beta-and-dev-releases-with-brew,-choco,-and-apt-get


### PR DESCRIPTION
In practice, we tend to support only Debian stable (docker, debian images) and Ubuntu LTS (under standard support). We've consistently had to upgrade to those versions when they get released. Other Linux versions often do work, but Ubuntu LTS is where we have most test and benchmark coverage, Debian is where we have at least some coverage through builds for the debian package, our sysroot and the docker images (at least we know "Hello World!" works).

Other Linux versions/distributions probably work if relatively recent, but we really don't know.

Having a rolling policy depending on the Debian and Ubuntu allows us to proactively roll our infrastructure forward before these distributions sunset our currently supported versions.