### PR TITLE
Add a shorter redirect link for diagnostic messages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -93,6 +93,7 @@
       { "source": "/guides/get-started", "destination": "/overview", "type": 301 },
       { "source": "/guides/platforms", "destination": "/overview#platform", "type": 301 },
       { "source": "/platforms", "destination": "/overview#platform", "type": 301 },
+      { "source": "/diagnostics/:code*", "destination": "/tools/diagnostic-messages#:code", "type": 301 },
       { "source": "/docs/language-tour", "destination": "/guides/language/language-tour", "type": 301 },
       { "source": "/docs/library-tour", "destination": "/guides/libraries/library-tour", "type": 301 },
       { "source": "/docs/pub-package-manager", "destination": "/tools/pub", "type": 301 },

--- a/firebase.json
+++ b/firebase.json
@@ -93,6 +93,7 @@
       { "source": "/guides/get-started", "destination": "/overview", "type": 301 },
       { "source": "/guides/platforms", "destination": "/overview#platform", "type": 301 },
       { "source": "/platforms", "destination": "/overview#platform", "type": 301 },
+      { "source": "/diagnostics", "destination": "/tools/diagnostic-messages", "type": 301 },
       { "source": "/diagnostics/:code*", "destination": "/tools/diagnostic-messages#:code", "type": 301 },
       { "source": "/docs/language-tour", "destination": "/guides/language/language-tour", "type": 301 },
       { "source": "/docs/library-tour", "destination": "/guides/libraries/library-tour", "type": 301 },


### PR DESCRIPTION
The following introduces a shorter link for diagnostic messages.

**Example shortened:**
https://parlough-dart-dev-0.web.app/diagnostics/duplicate_shown_name

**Example destination:**
https://parlough-dart-dev-0.web.app/tools/diagnostic-messages#duplicate_shown_name


Staged here:
https://parlough-dart-dev-0.web.app/

Supersedes #3022 