### PR TITLE
google-cloud page: add links to HTTP server docs and samples

### DIFF
--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -9,6 +9,9 @@ Dart servers can use many
 often with the help of pre-packaged [Docker images][]
 that the Dart team maintains.
 
+For information about creating HTTP servers with Dart, see the
+[Write HTTP servers page](/tutorials/server/httpserver).
+
 For information about other Google APIs (including Firebase)
 that you might want to use from Dart code,
 see the [Google APIs page](/guides/google-apis).
@@ -19,9 +22,8 @@ You can use Cloud Run's flexible container support,
 combined with Dart's Docker images,
 to run server-side Dart code.
 
-One example of a Dart server that uses Cloud Run is dartbug.com,
-the redirect service for Dart issues and bugs.
-You can find its source code in the [dart-lang/dartbug.com repo][].
+For examples of Dart servers implemented to run on Cloud Run, see the
+[dart-lang/samples repo][].
 
 For more information about using Cloud Run, see the documentation for
 [building and deploying a service in other languages][cr].
@@ -45,16 +47,16 @@ For more information, see the [GKE overview][].
 
 ## App Engine
 
-The App Engine support for Dart is incomplete and experimental,
-so we recommend that you **use Cloud Run** instead of App Engine
-to run new server-side Dart code.
-If you _do_ use App Engine,
-you might also want to use the [`appengine` package][].
+[App Engine][] support for Dart is incomplete,
+so we recommend that you **use Cloud Run** instead of App Engine for new
+server-side Dart code.
+If you _want_ to use App Engine, consider using the [`appengine` package][].
 
 
+[App Engine]: https://cloud.google.com/appengine
 [`appengine` package]: {{site.pub-pkg}}/appengine
 [ce]: https://cloud.google.com/compute/docs/containers
 [cr]: https://cloud.google.com/run/docs/quickstarts/build-and-deploy/other
-[dart-lang/dartbug.com repo]: https://github.com/dart-lang/dartbug.com
+[dart-lang/samples repo]: https://github.com/dart-lang/samples/tree/master/server
 [Docker images]: https://hub.docker.com/r/google/dart
 [GKE overview]: https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview

--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -57,6 +57,6 @@ If you _want_ to use App Engine, consider using the [`appengine` package][].
 [`appengine` package]: {{site.pub-pkg}}/appengine
 [ce]: https://cloud.google.com/compute/docs/containers
 [cr]: https://cloud.google.com/run/docs/quickstarts/build-and-deploy/other
-[dart-lang/samples repo]: https://github.com/dart-lang/samples/tree/master/server
+[server examples]: https://github.com/dart-lang/samples/tree/master/server
 [Docker images]: https://hub.docker.com/r/google/dart
 [GKE overview]: https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview

--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -22,8 +22,8 @@ You can use Cloud Run's flexible container support,
 combined with Dart's Docker images,
 to run server-side Dart code.
 
-For examples of Dart servers implemented to run on Cloud Run, see the
-[dart-lang/samples repo][].
+Examples of Dart servers implemented to run on Cloud Run are
+[in the dart-lang/samples/repo][server examples].
 
 For more information about using Cloud Run, see the documentation for
 [building and deploying a service in other languages][cr].

--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -8,7 +8,6 @@ Dart servers can use many
 [Google Cloud products](https://cloud.google.com/products),
 often with the help of pre-packaged [Docker images][]
 that the Dart team maintains.
-
 For information about creating HTTP servers with Dart, see the
 [Write HTTP servers page](/tutorials/server/httpserver).
 

--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -20,7 +20,6 @@ see the [Google APIs page](/guides/google-apis).
 You can use Cloud Run's flexible container support,
 combined with Dart's Docker images,
 to run server-side Dart code.
-
 Examples of Dart servers implemented to run on Cloud Run are
 [in the dart-lang/samples/repo][server examples].
 


### PR DESCRIPTION
Drop link to dartbug – the code is not well documented
Clarify the App Engine bits
