### PR TITLE
Fix null safe example to remove error and introduce warning

### DIFF
--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -726,9 +726,9 @@ redundantly check it again for `null`:
 
 ```dart
 // Using null safety:
-checkList(List? list) {
+String checkList(List? list) {
   if (list == null) return 'No list';
-  if (list?.isEmpty) {
+  if (list?.isEmpty ?? false) {
     return 'Empty list';
   }
   return 'Got something';

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -701,8 +701,8 @@ if you wrote something like:
 
 ```dart
 // Using null safety:
-String checkList(List list) {
-  if (list?.isEmpty) {
+String checkList(List<Object> list) {
+  if (list?.isEmpty ?? false) {
     return 'Got nothing';
   }
   return 'Got something';
@@ -726,7 +726,7 @@ redundantly check it again for `null`:
 
 ```dart
 // Using null safety:
-String checkList(List? list) {
+String checkList(List<Object>? list) {
   if (list == null) return 'No list';
   if (list?.isEmpty ?? false) {
     return 'Empty list';


### PR DESCRIPTION
The `list?.isEmpty` evaluates to `bool?` resulting in an error instead of a warning, so this modifies the example to introduce the expected _warning_. 

I'm open to other ways to fix the conditional statement as well!

Also adds the return type to be consistent with the other surrounding examples.

Fixes #3139