### PR TITLE
Update Firebase package link on js interop page

### DIFF
--- a/src/web/js-interop.md
+++ b/src/web/js-interop.md
@@ -15,13 +15,13 @@ For help using the `js` package, see the following:
   * [pub.dev site page][js]
   * [API reference][js-api]
 * Packages that use the `js` package:
-  * [firebase_web][] is a good example of providing a Dart-like API
+  * [firebase][] is a good example of providing a Dart-like API
     to a JavaScript library.
   * [sass][] is an example of a more unusual use case: providing a
     way for JavaScript code to call Dart code.
 
 [js]: {{site.pub-pkg}}/js
 [js-api]: {{site.pub-api}}/js
-[firebase_web]: {{site.pub-pkg}}/firebase_web
+[firebase]: {{site.pub-pkg}}/firebase
 [sass]: {{site.pub-pkg}}/sass
 


### PR DESCRIPTION
The original package has been discontinued for a while for this combined package: https://pub.dev/packages/firebase

This page could probably use an expansion, but for now we can at least point users in a more recently updated direction. 