### PR TITLE
Introduce a hover/focus style for code within link/anchor tags

### DIFF
--- a/src/_assets/css/_overwrites.scss
+++ b/src/_assets/css/_overwrites.scss
@@ -5,9 +5,16 @@ dd {
   margin-bottom: 15px;
 }
 
-/* Make code-font links look like links. Should also change the hover color. */
-a code {
-  color: $default-link
+a {
+  code {
+    color: $default-link;
+  }
+
+  &:hover, &:focus, &:active {
+    code {
+      color: lighten($default-link, 25%);
+    }
+  }
 }
 
 /* Make links in page footer white, not blue. */


### PR DESCRIPTION
There have been multiple occurrences where inline code blocks within links confuse users as they don't have a focus/hover style.

To remedy this, this PR introduces a custom style where the inline code also lightens by 25% to match the normal link behavior.

**Normal:**
![image](https://user-images.githubusercontent.com/18372958/120242099-b4574d00-c229-11eb-8203-20a55fb5a215.png)

**Hovered:**
![image](https://user-images.githubusercontent.com/18372958/120242117-bf11e200-c229-11eb-9aaf-9d3227991948.png)

