### PR TITLE
Standardize on Function style for parameters in MyStream example

### DIFF
--- a/null_safety_examples/misc/lib/tutorial/stream_interface.dart
+++ b/null_safety_examples/misc/lib/tutorial/stream_interface.dart
@@ -1,9 +1,5 @@
-// ignore_for_file: annotate_overrides, type_annotate_public_apis, strict_raw_type, use_function_type_syntax_for_parameters
+// ignore_for_file: annotate_overrides, type_annotate_public_apis, strict_raw_type
 import 'dart:async';
-
-// TODO(chalin): I believe that handleError's test argument should be declared
-// as follows, but it isn't: {bool Function(dynamic error) test}.
-// (https://github.com/dart-lang/site-www/issues/3298)
 
 abstract class MyStream<T> implements Stream<T> {
   // #docregion main-stream-members
@@ -43,11 +39,11 @@ abstract class MyStream<T> implements Stream<T> {
   bool get isBroadcast;
 
   Stream<T> asBroadcastStream(
-      {void onListen(StreamSubscription<T> subscription)?,
-      void onCancel(StreamSubscription<T> subscription)?});
+      {void Function(StreamSubscription<T> subscription)? onListen,
+      void Function(StreamSubscription<T> subscription)? onCancel});
 
   // #docregion special-stream-members
-  Stream<T> handleError(Function onError, {bool test(error)?});
+  Stream<T> handleError(Function onError, {bool Function(dynamic error)? test});
   Stream<T> timeout(Duration timeLimit,
       {void Function(EventSink<T> sink)? onTimeout});
   Stream<S> transform<S>(StreamTransformer<T, S> streamTransformer);

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -295,7 +295,7 @@ The `distinct()` function doesn't exist on `Iterable`, but it could have.
 
 <?code-excerpt "../null_safety_examples/misc/lib/tutorial/stream_interface.dart (special-stream-members)"?>
 ```dart
-Stream<T> handleError(Function onError, {bool test(error)?});
+Stream<T> handleError(Function onError, {bool Function(dynamic error)? test});
 Stream<T> timeout(Duration timeLimit,
     {void Function(EventSink<T> sink)? onTimeout});
 Stream<S> transform<S>(StreamTransformer<T, S> streamTransformer);


### PR DESCRIPTION
It seems the SDK code uses the-non Function style for most of its declarations for Streams, but since `use_function_type_syntax_for_parameters` is part of the recommended rule set, we'll stay consistent with that here.

Updating to this is still compatible with the original declaration when used as an @override so everything should be good.

Fixes #3298