### PR TITLE
Update .analysis_options note

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -92,10 +92,11 @@ add static analysis to your tool, see the
 Place the analysis options file, `analysis_options.yaml`,
 at the root of the package, in the same directory as the pubspec file.
 
-{{site.alert.note}}
-  The conventional name for the analysis options file
-  used to be `.analysis_options` (note the leading dot and missing `.yaml` suffix).
-  Support for the `.analysis_options` name was dropped in Dart 2.8.
+{{site.alert.tip}}
+  The older name for the analysis options file was `.analysis_options`;
+  support for that filename was dropped in Dart 2.8.
+  To upgrade an `.analysis_options` file,
+  just change its name to `analysis_options.yaml`.
 {{site.alert.end}}
 
 Here's a sample analysis options file:

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -92,15 +92,10 @@ add static analysis to your tool, see the
 Place the analysis options file, `analysis_options.yaml`,
 at the root of the package, in the same directory as the pubspec file.
 
-{{site.alert.warn}}
-  **Breaking change:** The conventional name for the analysis options file
+{{site.alert.note}}
+  The conventional name for the analysis options file
   used to be `.analysis_options` (note the leading dot and missing `.yaml` suffix).
-  We expect support for the `.analysis_options` name to go away in a future
-  release, so we recommend that you **rename your `.analysis_options` files to
-  `analysis_options.yaml`.**
-  {% comment %}
-  Tracking issue: https://github.com/dart-lang/sdk/issues/28385
-  {% endcomment %}
+  Support for the `.analysis_options` name was dropped in Dart 2.8.
 {{site.alert.end}}
 
 Here's a sample analysis options file:


### PR DESCRIPTION
Per https://github.com/dart-lang/sdk/issues/28385#issuecomment-857272675, `.analysis_options` hasn't been supported for quite a while. The [CHANGELOG](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md) says support was dropped in 2.8.1.