### PR TITLE
Add missing type annotations in Effective Dart examples

### DIFF
--- a/null_safety_examples/misc/lib/effective_dart/docs_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/docs_bad.dart
@@ -3,7 +3,7 @@ import 'package:examples_util/ellipsis.dart';
 
 void miscDeclAnalyzedButNotTested() {
   // #docregion block-comments
-  void greet(name) {
+  void greet(String name) {
     /* Assume we have a valid name. */
     print('Hi, $name!');
   }

--- a/null_safety_examples/misc/lib/effective_dart/docs_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/docs_good.dart
@@ -12,7 +12,7 @@ void miscDeclAnalyzedButNotTested() {
   };
 
   // #docregion block-comments
-  void greet(name) {
+  void greet(String name) {
     // Assume we have a valid name.
     print('Hi, $name!');
   }

--- a/null_safety_examples/misc/lib/effective_dart/style_good.dart
+++ b/null_safety_examples/misc/lib/effective_dart/style_good.dart
@@ -72,7 +72,7 @@ const anArg = null;
 
 // #docregion annotation-type-names
 class Foo {
-  const Foo([arg]);
+  const Foo([Object? arg]);
 }
 
 @Foo(anArg)

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -45,7 +45,7 @@ inline stuff, even TODOs. Even if it's a sentence fragment.
 {:.good}
 <?code-excerpt "docs_good.dart (block-comments)"?>
 {% prettify dart tag=pre+code %}
-void greet(name) {
+void greet(String name) {
   // Assume we have a valid name.
   print('Hi, $name!');
 }
@@ -54,7 +54,7 @@ void greet(name) {
 {:.bad}
 <?code-excerpt "docs_bad.dart (block-comments)"?>
 {% prettify dart tag=pre+code %}
-void greet(name) {
+void greet(String name) {
   /* Assume we have a valid name. */
   print('Hi, $name!');
 }

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -56,7 +56,7 @@ This even includes classes intended to be used in metadata annotations.
 <?code-excerpt "style_good.dart (annotation-type-names)"?>
 {% prettify dart tag=pre+code %}
 class Foo {
-  const Foo([arg]);
+  const Foo([Object? arg]);
 }
 
 @Foo(anArg)


### PR DESCRIPTION
Fixes #3316