### PR TITLE
Set html background color

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -31,6 +31,10 @@ $font-weight-light-bold: ($font-weight-normal + $font-weight-bold)/2;
 /* -----------------------------------------
   Global
   ----------------------------------------- */
+html {
+  background-color: $site-color-header;
+}
+
 body {
   font-family: $font-family-base;
   font-size: $font-size-base;


### PR DESCRIPTION
This sets the background color for overscrolling on mac os to be the same as the header and footer instead of the default white. The background for the remainder of the body remains white because the `body` tag has its own `background-color: white` declaration.

Before:

<img width="1680" alt="Screen Shot 2021-06-11 at 1 53 28 PM" src="https://user-images.githubusercontent.com/511342/121729660-b7b9c680-cabc-11eb-9bd8-65e0e5df6703.png">

After:

<img width="1680" alt="Screen Shot 2021-06-11 at 1 56 09 PM" src="https://user-images.githubusercontent.com/511342/121729798-dcae3980-cabc-11eb-967a-e153f5e4c46e.png">
