### PR TITLE
Add Unofficial Dart Community Discord to community page

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -12,13 +12,15 @@ For details, see our [code of conduct](/code-of-conduct).
 
 ## Stay informed
 
-* [Dart announce]({{site.group}}/d/forum/announce) -
-  Low traffic announcements of new releases, breaking changes,
+[Dart announce]({{site.group}}/d/forum/announce)
+: Low traffic announcements of new releases, breaking changes,
   and other important news. Recommended!
-* [@dart_lang](https://twitter.com/dart_lang) -
-  The official Twitter account.
-* [Dart blog](https://medium.com/dartlang) - 
-  The latest news and insights from a diverse group of Dart users.
+
+[@dart_lang](https://twitter.com/dart_lang)
+: The official Twitter account.
+
+[Dart blog](https://medium.com/dartlang)
+: The latest news and insights from a diverse group of Dart users.
 
 ## Join the conversation
 
@@ -26,29 +28,43 @@ Get answers and connect with Dart developers.
 
 #### Communities
 
-* [StackOverflow](https://stackoverflow.com/tags/dart) -
-  The best place for how-to questions.
-* [Gitter](https://gitter.im/dart-lang/home) -
-  Chat with Dart team and community members.
-* [Dart on Reddit](https://www.reddit.com/r/dartlang)
+[StackOverflow](https://stackoverflow.com/tags/dart)
+: The best place for how-to questions.
+
+[The Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx)
+: Chat with other Dart developers and contributors. 
+  Come get help, help others, work together, and discuss contributions.
+
+[Gitter](https://gitter.im/dart-lang/home)
+: Chat with Dart team and community members.
+
+[Dart on Reddit](https://www.reddit.com/r/dartlang)
+: The subreddit for all things related to Dart.
 
 #### Google Groups
 
-* [General discussions]({{site.group}}/d/forum/misc)
-* [Dart analyzer]({{site.group}}/d/forum/analyzer-discuss)
+[General discussions]({{site.group}}/d/forum/misc)
+: Discuss miscellaneous Dart topics.
+
+[Dart analyzer]({{site.group}}/d/forum/analyzer-discuss)
+: Get help understanding the [Dart analyzer](/tools/dart-analyze).
 
 ## Contribute
 
 Dart is open source. Learn how to
 [contribute to the core SDK.](https://github.com/dart-lang/sdk/blob/master/CONTRIBUTING.md)
 
-* [Dart GitHub repositories](https://github.com/dart-lang/)
+[Dart GitHub repositories](https://github.com/dart-lang/)
+: Track new changes and contribute to various Dart projects.
   * [Core SDK](https://github.com/dart-lang/sdk/)
     ([issue tracker](https://github.com/dart-lang/sdk/issues/))
+  * [The Dart Language](https://github.com/dart-lang/language)
+    ([issue tracker](https://github.com/dart-lang/language/issues))
   * [This site](https://github.com/dart-lang/site-www/)
     ([issue tracker](https://github.com/dart-lang/site-www/issues/))
-* [Dart reviews]({{site.group}}/d/forum/reviews) -
-  High-traffic list of all core SDK code reviews.
+
+[Dart reviews]({{site.group}}/d/forum/reviews)
+: High-traffic list of all core SDK code reviews.
 
 ## Additional community resources
 


### PR DESCRIPTION
I thought I would try starting a community around Dart due to the popularity of the Flutter discords. This way those who have more direct interest in Dart have a more straightforward location to go to for help and discussions. Now they'll have more than one channel :)

_I'm still looking to spread word of the Discord, so this is a first step._

Also updates the pre-existing listings to use the definition syntax.