### PR TITLE
Fix errors in FAQ question about List.filled

### DIFF
--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -262,8 +262,7 @@ _jellyCounts = List<int>.filled(jellyMax + 1, 0); // List initialized with fille
 
 If you are setting the elements of the list via an index, or you are populating
 each element of the list with a distinct value, you should instead use the
-[`generate`](https://api.dart.dev/stable/dart-core/List/List.generate.html)
-constructor to build the list.
+list literal syntax to build the list.
 
 {:.bad}
 {% prettify dart tag=pre+code %}
@@ -275,7 +274,10 @@ for (var i = 0; i <= jellyMax; i++) {
 
 {:.good}
 {% prettify dart tag=pre+code %}
-_jellyPoints = List<Vec2D>.generate(jellyMax + 1, (i) => Vec2D()); // List initialized with generate constructor
+_jellyPoints = [
+  for (var i = 0; i <= jellyMax; i++)
+    Vec2D() // Each list element is a distinct Vec2D
+];
 {% endprettify %}
 
 ## What happened to the default List constructor?

--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -262,7 +262,8 @@ _jellyCounts = List<int>.filled(jellyMax + 1, 0); // List initialized with fille
 
 If you are setting the elements of the list via an index, or you are populating
 each element of the list with a distinct value, you should instead use the
-[`generate`](https://api.dart.dev/stable/dart-core/List/List.generate.html) constructor to build the list.
+[`generate`](https://api.dart.dev/stable/dart-core/List/List.generate.html)
+constructor to build the list.
 
 {:.bad}
 {% prettify dart tag=pre+code %}

--- a/src/null-safety/faq.md
+++ b/src/null-safety/faq.md
@@ -238,7 +238,7 @@ It is typically a code smell to end up with nullable code like this:
 
 {:.bad}
 {% prettify dart tag=pre+code %}
-List?<Foo?> fooList; // fooList can contain null values
+List<Foo?> fooList; // fooList can contain null values
 {% endprettify %}
 
 This implies `fooList` might contain null values. This might happen if you are
@@ -249,20 +249,33 @@ use the [`filled`](https://api.dart.dev/stable/dart-core/List/List.filled.html) 
 
 {:.bad}
 {% prettify dart tag=pre+code %}
-_jellyPoints = List<Vec2D>(jellyMax + 1);
+_jellyCounts = List<int?>(jellyMax + 1);
 for (var i = 0; i <= jellyMax; i++) {
-  _jellyPoints[i] = Vec2D(); // List initalized with the same value
+  _jellyCounts[i] = 0; // List initalized with the same value
 }
 {% endprettify %}
 
 {:.good}
 {% prettify dart tag=pre+code %}
-_jellyPoints = List<Vec2D>.filled(jellyMax + 1, Vec2D()); // List initialized with filled constructor
+_jellyCounts = List<int>.filled(jellyMax + 1, 0); // List initialized with filled constructor
 {% endprettify %}
 
-If you are setting the elements of the list via an index, you should instead use
-the `add` function to build the list. That is less error-prone and more
-readable.
+If you are setting the elements of the list via an index, or you are populating
+each element of the list with a distinct value, you should instead use the
+[`generate`](https://api.dart.dev/stable/dart-core/List/List.generate.html) constructor to build the list.
+
+{:.bad}
+{% prettify dart tag=pre+code %}
+_jellyPoints = List<Vec2D?>(jellyMax + 1);
+for (var i = 0; i <= jellyMax; i++) {
+  _jellyPoints[i] = Vec2D(); // Each list element is a distinct Vec2D
+}
+{% endprettify %}
+
+{:.good}
+{% prettify dart tag=pre+code %}
+_jellyPoints = List<Vec2D>.generate(jellyMax + 1, (i) => Vec2D()); // List initialized with generate constructor
+{% endprettify %}
 
 ## What happened to the default List constructor?
 


### PR DESCRIPTION
There was a syntax error (`List?<Foo?>`).  Also the example talked about initializing a list with the same value when in fact the "bad" example was initializing each element of the list with a different value.  This change fixes the syntax error and splits the one example into two (one using `List.filled`, for when there really is the same value, and the other using `List.generate`).