### PR TITLE
Remove `--remote` option from `git submodule update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ submodule-cloning techniques:
   this command from the repo root:<br>
 
   ```console
-  $ git submodule update --init --remote
+  $ git submodule update --init
   ```
 
 > IMPORTANT:
 > Whenever you update your repo, update the submodule as well:<br>
-> `git pull; git submodule update --init --remote`
+> `git pull; git submodule update --init`
 
 ### 3. Run installation scripts
 


### PR DESCRIPTION
[`--remote`][1] option will pull the `site-shared` remote master branch 
HEAD and not the current branch's recorded SHA-1.

Also, in the case of `flutter/website` repo, instead of `--remote` 
option [`--recursive`][2] option is appropriate because it has 
`examples/codelabs` submodule in the depth deeper than the root of the repo.

[1]: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---remote
[2]: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---recursive