### PR TITLE
Add `--recursive` option for safer side

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ submodule-cloning techniques:
   this command from the repo root:<br>
 
   ```console
-  $ git submodule update --init
+  $ git submodule update --init --recursive
   ```
 
 > IMPORTANT:
 > Whenever you update your repo, update the submodule as well:<br>
-> `git pull; git submodule update --init`
+> `git pull; git submodule update --init --recursive`
 
 ### 3. Run installation scripts
 


### PR DESCRIPTION
I got the `--recursive` meaning wrong in dart-lang/site-www#3349.
It is not recursive in means of submodule present in depth deeper than
the repo root but actually the submodules present in the submodules.

Currently no submodules contains nested submodules but it is safer to
add `--recursive` option.