### PR TITLE
Update JetBrains plugin page

### DIFF
--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -17,7 +17,7 @@ and find more information when you need it.
 {{site.alert.note}}
   [WebStorm,](https://www.jetbrains.com/webstorm/)
   a JetBrains IDE for client-side development,
-  comes with the Dart plugin pre-installed.  
+  comes with the Dart plugin pre-installed.
 {{site.alert.end}}
 
 ## Getting started
@@ -28,12 +28,12 @@ Then install the Dart plugin and tell it where to find the Dart SDK.
 
 ### Downloading the IDE
 
-Install a JetBrains IDE if you don't already have one.
+Install a JetBrains IDE if you don't already have one. Choose one:
 
-* [Download IntelliJ IDEA.][IDEA]{:target="_blank" rel="noopener"}
-* To try out the latest Dart language features and IntelliJ functionality,
-  [install IntelliJ IDEA EAP.][IDEA EAP]{:target="_blank" rel="noopener"}
-* [Find another Jetbrains product.][Other]{:target="_blank" rel="noopener"}
+* [IntelliJ IDEA][IDEA]{:target="_blank" rel="noopener"}
+* [IntelliJ IDEA EAP][IDEA EAP]{:target="_blank" rel="noopener"}
+  (for early access to the latest Dart language features and IntelliJ functionality)
+* [Another JetBrains product][Other]{:target="_blank" rel="noopener"}
 
 [IDEA]: https://www.jetbrains.com/idea/download/
 [IDEA EAP]: https://www.jetbrains.com/idea/nextversion/

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -3,7 +3,7 @@ title: IntelliJ & Android Studio
 description: Use Dart with a variety of IDEs and editors from JetBrains.
 ---
 
-The Dart plugin adds Dart support to JetBrains IDEs such as
+The [Dart plugin][] adds Dart support to JetBrains IDEs such as
 IntelliJ IDEA and Android Studio.
 IntelliJ IDEA is an intelligent Java IDE
 with support for many other languages and frameworks.
@@ -14,12 +14,11 @@ Whichever JetBrains IDE you choose for Dart development,
 this page has resources to help you get started quickly
 and find more information when you need it.
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
+{{site.alert.note}}
   [WebStorm,](https://www.jetbrains.com/webstorm/)
   a JetBrains IDE for client-side development,
-  comes with the Dart plugin pre-installed.
-</aside>
+  comes with the Dart plugin pre-installed.  
+{{site.alert.end}}
 
 ## Getting started
 
@@ -31,19 +30,20 @@ Then install the Dart plugin and tell it where to find the Dart SDK.
 
 Install a JetBrains IDE if you don't already have one.
 
-* <a href="https://www.jetbrains.com/idea/download/"
-  target="_blank" rel="noopener">Download IntelliJ IDEA</a> or,
-  to try out the latest Dart language features,
-  [install IntelliJ IDEA EAP.](https://confluence.jetbrains.com/display/IDEADEV/EAP)
-* Or <a href="https://www.jetbrains.com/products.html"
-  target="_blank" rel="noopener">find another JetBrains product.</a>
+* [Download IntelliJ IDEA.][IDEA]{:target="_blank" rel="noopener"}
+* To try out the latest Dart language features and IntelliJ functionality,
+  [install IntelliJ IDEA EAP.][IDEA EAP]{:target="_blank" rel="noopener"}
+* [Find another Jetbrains product.][Other]{:target="_blank" rel="noopener"}
 
-<aside class="alert alert-info" markdown="1">
-  **Note:**
+[IDEA]: https://www.jetbrains.com/idea/download/
+[IDEA EAP]: https://www.jetbrains.com/idea/nextversion/
+[Other]: https://www.jetbrains.com/products.html
+
+{{site.alert.note}}
   The Community Edition of IntelliJ IDEA has limited functionality.
   For example, it doesn't directly support debugging web apps.
   It also has very little support for JavaScript, HTML, CSS, and YAML.
-</aside>
+{{site.alert.end}}
 
 
 ### Downloading the Dart SDK
@@ -67,13 +67,15 @@ Here's one way to configure Dart support:
 <li>
   <p>
     Start the IDE, and install the <b>Dart</b> plugin.
-    To find the Dart plugin, from the Welcome screen
-    choose <b>Configure > Plugins</b>,
-    then click <b>Install JetBrains plugin</b>,
-    and then search or scroll down until you find <b>Dart</b>.
-    Once you've installed the Dart plugin, restart the IDE.
   </p>
+
+  <ol type="a">
+    <li>From the Welcome screen, choose <b>Plugins</b>.</li>
+    <li>Search for <b>Dart</b>.</li>
+    <li>Once you've installed the Dart plugin, restart the IDE.</li>
+  </ol>
 </li>
+<br>
 
 <li>
   <p>
@@ -81,8 +83,8 @@ Here's one way to configure Dart support:
   </p>
 
   <ol type="a">
-    <li> From the Welcome screen, click <b>Create New Project</b>. </li>
-    <li> In the next dialog, click <b>Dart</b>.</li>
+    <li>From the Welcome screen, click <b>New Project</b>.</li>
+    <li>In the next dialog, click <b>Dart</b>.</li>
   </ol>
 </li>
 <br>
@@ -98,13 +100,32 @@ Here's one way to configure Dart support:
     <code><em>&lt;dart installation directory></em>/dart/dart-sdk</code>.
   </p>
 
-<aside class="alert alert-info" markdown="1">
-  <b>Note:</b>
-  The <b>Dart SDK</b> path specifies the directory that
-  contains the SDK's `bin` and `lib` directories;
-  the `bin` directory contains tools such as `dart` and `dartdoc`.
-  The IDE ensures that the path is valid.
-</aside>
+  {{site.alert.note}}
+    The **Dart SDK** specifies the directory that
+    contains the SDK's `bin` and `lib` directories;
+    the `bin` directory contains tools such as `dart` and `dartdoc`.
+    The IDE ensures that the path is valid.
+  {{site.alert.end}}
+</li>
+
+<li>
+  <p>
+    Choose a starting template.
+  </p>
+
+  <ol type="a">
+    <li>To enable starting templates, click <b>Generate sample content</b>.</li>
+    <li>Pick your desired template.</li>
+  </ol>
+
+  {{site.alert.info}}
+    The provided templates are supplied and created
+    by [`dart create`](/tools/dart-create).
+  {{site.alert.end}}
+</li>
+
+<li>
+  <p>Click <b>Next</b> and continue project setup.</p>
 </li>
 </ol>
 
@@ -112,29 +133,25 @@ An alternative to Step 2 is to open an existing Dart project,
 and then open its `pubspec.yaml` file or any of its Dart files.
 
 
-{% comment %}
-
-NOTE TO EDITORS OF THIS FILE:
-[PENDING: put instructions here on how to reset to the initial
-IntelliJ experience.
-It probably involves deleting the IDE settings
-by removing a directory.
-
-{% endcomment %}
-
-
 ## Reporting issues
 
-{% include tools/jetbrains-reporting-issues.html %}
+Please report issues and feedback via the official
+[JetBrains issue tracker for Dart.][]
 
+Include details of the expected behavior, the actual behavior,
+and screenshots if appropriate.
+
+[JetBrains issue tracker for Dart.]: https://youtrack.jetbrains.com/issues/WEB?q=Subsystem:%20Dart
 
 ## More information
 
 See the JetBrains website for more information.
 
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/)
-  * [Dart PhpStorm Help](https://www.jetbrains.com/help/phpstorm/dart.html)
+  * [Dart WebStorm Help](https://www.jetbrains.com/help/webstorm/dart.html)
   * [Features](https://www.jetbrains.com/idea/features/)
-  * [Quick start](https://www.jetbrains.com/help/idea/meet-intellij-idea.html)
-* [Dart Plugin by JetBrains](https://plugins.jetbrains.com/plugin/6351)
-* [Eclipse to IntelliJ migration guide](https://www.jetbrains.com/help/idea/eclipse.html)
+  * [Quick start](https://www.jetbrains.com/help/idea/getting-started.html)
+* [Dart Plugin by JetBrains][Dart plugin]
+* [Eclipse to IntelliJ migration guide](https://www.jetbrains.com/help/idea/migrating-from-eclipse-to-intellij-idea.html)
+
+[Dart plugin]: https://plugins.jetbrains.com/plugin/6351-dart/


### PR DESCRIPTION
- Formats and restructures some of the content to utilize our current utilities.
- Updates some moved and/or outdated links
- Update IntelliJ setup instructions for new(er) welcome screen
- Add a mention of `dart create` in relation to templates
- Switch from PhpStorm help to WebStorm help
- Include a link to the plugin earlier on