### PR TITLE
Add language repo link and update old spec link

### DIFF
--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -20,10 +20,12 @@ The Dart 2 language specification is available in PDF format:
 [latest draft]: https://spec.dart.dev/DartLangSpecDraft.pdf
 [LaTeX file]: https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex
 
-New language features are typically described using informal language feature specifications in the dart-lang/language repo:
+New language features are typically described using 
+informal language feature specifications in the [dart-lang/language][] repo:
   * [Accepted informal proposals][]
   * [Drafts of potential features][]
 
+[dart-lang/language]: https://github.com/dart-lang/language
 [Accepted informal proposals]: https://github.com/dart-lang/language/tree/master/accepted
 [Drafts of potential features]: https://github.com/dart-lang/language/tree/master/working
 
@@ -38,5 +40,5 @@ New language features are typically described using informal language feature sp
 The formal Dart 1.x language specification is available from
 the Ecma International website:
 
-* <a href="https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-408.pdf"
+* <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-408/"
    target="_blank" rel="noopener">Dart Programming Language Specification, 4<sup>th</sup> Edition</a>


### PR DESCRIPTION
That old Ecma link doesn't lead to the PDF anymore, so updating the link to what it actually leads to.