### PR TITLE
angulardart.dev -> angulardart.xyz

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ port: 4000
 
 dart-site: '' 
 prev-url: https://v1-dartlang-org.firebaseapp.com
-angulardart: https://angulardart.dev
+angulardart: https://angulardart.xyz
 dart_vm:  /server
 flutter:  https://flutter.dev
 dart_api: https://api.dart.dev

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -207,11 +207,9 @@ closingWindow // Returns a bool or a window?
 showPopup     // Sounds like it shows the popup.
 {% endprettify %}
 
-**Exception:** Input properties in [Angular][] components sometimes use
+**Exception:** Input properties in [AngularDart][] components sometimes use
 imperative verbs for boolean setters because these setters are invoked in
 templates, not from other Dart code.
-
-[angular]: {{site.angulardart}}
 
 
 ### CONSIDER omitting the verb for a named boolean *parameter*.
@@ -270,7 +268,7 @@ overwhelmingly need to use. Choosing the positive case would force them to
 negate the property with `!` everywhere. Instead, it may be better to use the
 negative case for that property.
 
-**Exception:** Properties accessed in [Angular][]
+**Exception:** Properties accessed in [AngularDart][]
 templates are often better in the negative form because the property is used to
 *hide* or *disable* content.
 
@@ -935,12 +933,10 @@ you want to add. Objects shouldn't generally expose more state than they need
 to. If you have some piece of an object's state that can be modified but not
 exposed in the same way, use a method instead.
 
-**Exception:** An [Angular][] component class may expose setters that are
+**Exception:** An [AngularDart][] component class may expose setters that are
 invoked from a template to initialize the component. Often, these setters are
 not intended to be invoked from Dart code and don't need a corresponding getter.
 (If they are used from Dart code, they *should* have a getter.)
-
-[angular]: {{site.angulardart}}
 
 
 ### AVOID using runtime type tests to fake overloading.
@@ -2074,3 +2070,6 @@ annotation permits `null`. Even so, Dart will never call your `==` method and
 pass `null` to it, so you don't need to handle `null` inside the body of the
 method.
 {{site.alert.end}}
+
+
+[AngularDart]: {{site.angulardart}}

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -7,14 +7,15 @@ Software testing, an important part of app development, helps verify that
 your app is working correctly before you release it.
 This Dart testing guide outlines several types of testing, and points
 you to where you can learn how to test your
-[mobile,]({{site.flutter}}) [web](/web),
+[Flutter]({{site.flutter}}), [web](/web),
 and [server-side apps and scripts](/server).
 
 <aside class="alert alert-info" markdown="1">
 **Terminology: widget vs. component**<br>
-Flutter, an SDK for building apps for iOS and Android, defines its
-GUI elements as _widgets_. AngularDart, a web app framework,
-defines its GUI elements as _components_.
+Flutter, a UI toolkit for building apps for any device,
+defines its GUI elements as _widgets_.
+Some frameworks, such as AngularDart,
+define GUI elements as _components_.
 This doc uses **component** (except when explicitly discussing Flutter),
 but both terms refer to the same concept.
 </aside>
@@ -40,7 +41,7 @@ encounter when using Dart technologies:
 
 * _Integration_ and _end-to-end_ tests verify the behavior of
   an entire app, or a large chunk of an app. An integration test
-  generally runs on a real device or OS simulator (for mobile)
+  generally runs on a simulated or real device
   or on a browser (for the web) and consists of two pieces:
   the app itself, and the test app that puts
   the app through its paces. An integration test often measures performance,
@@ -100,14 +101,13 @@ Use the following resources to learn more about testing Flutter apps:
 Use the following resources to learn more about testing Dart web
 applications:
 
+* [package:webdriver]({{site.pub-pkg}}/webdriver)<br>
+  A Dart package for interfacing with
+  [WebDriver](https://www.w3.org/TR/webdriver/) servers.
 * [Testing]({{site.angulardart}}/guide/testing)(a page
   in the AngularDart guide)<br>
   How to use the [angular_test]({{site.pub-pkg}}/angular_test)
   package to test AngularDart components and subsystems.
-  <!-- More pages are coming! -->
-* [package:webdriver]({{site.pub-pkg}}/webdriver)<br>
-  A Dart package for interfacing with
-  [WebDriver](https://www.w3.org/TR/webdriver/) servers.
 
 ## Other tools and resources
 

--- a/src/_tutorials/web/low-level-html/connect-dart-html.md
+++ b/src/_tutorials/web/low-level-html/connect-dart-html.md
@@ -8,7 +8,7 @@ nextpage:
 
 This tutorial is the first of a series on
 basic, low-level web programming with the dart:html library.
-If you use a web framework like [AngularDart,]({{site.angulardart}})
+If you use a web framework,
 some of these concepts might be useful,
 but you might not need to use the dart:html library at all.
 

--- a/src/_tutorials/web/low-level-html/index.md
+++ b/src/_tutorials/web/low-level-html/index.md
@@ -6,16 +6,18 @@ toc: false
 
 {% comment %} [PENDING: improve this intro. reuse text in other tutorial index pages.] {% endcomment %}
 
-Web pages are programmed in HTML and represented within the browser as a tree structure
-called the DOM (Document Object Model). Dart apps can modify the DOM programatically,
-thus dynamically changing the web page. First, learn now to connect Dart and HTML.
+Web pages are programmed in HTML and represented within the browser
+as a tree structure called the DOM (Document Object Model).
+Dart apps can modify the DOM programatically,
+thus dynamically changing the web page.
+First, learn now to connect Dart and HTML.
 Then learn how to add, move, and remove DOM elements.
 
 <aside class="alert alert-info" markdown="1">
   **Note:**
   These tutorials cover basic, low-level web programming
   with the dart:html library.
-  If you use a web framework like [AngularDart,]({{site.angulardart}})
+  If you use a web framework,
   the concepts in these tutorials might be useful,
   but you might not need to use the dart:html library at all.
   For information about frameworks for Dart web apps,

--- a/src/faq.md
+++ b/src/faq.md
@@ -262,9 +262,9 @@ has some tips for specific browsers.
 ### Q. What web frameworks can I use with Dart?
 
 You can use the low-level HTML API defined by core libraries such as dart:html,
-or you can use a framework such as [AngularDart][]. You can also use
-[Flutter for web][] to bring your existing Flutter applications or new ones
-to the browser.
+or you can choose from many [web packages](/web/libraries#web-packages).
+You can also use the [Flutter framework]({{site.flutter}}),
+which has [web support]({{site.flutter}}/web)
 
 ### Q. Will the Dart VM get into Chrome?
 
@@ -442,16 +442,10 @@ if either of those lists is used.
 
 
 [ppwsize]: https://work.j832.com/2012/11/excited-to-see-dart2js-minified-output.html
-[sourcemaps]: https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
 [package:js]: {{site.pub-pkg}}/js
-[AngularDart]: {{site.angulardart}}
-[Polymer Dart]: https://github.com/dart-archive/polymer-dart/wiki
 [dart2js]: /tools/dart2js
 [dart compile]: /tools/dart-compile
 [dart analyze]: /tools/dart-analyze
 [dartdevc]: /tools/dartdevc
-[chrome.dart]: https://github.com/dart-gde/chrome.dart
-[fixallthethings]: https://hyperboleandahalf.blogspot.com/2010/06/this-is-why-ill-never-be-adult.html
 [typescript]: {{site.news}}/2012/10/the-dart-team-welcomes-typescript.html
 [webdev]: /tools/webdev
-[Flutter for web]: {{site.flutter}}/web

--- a/src/tools/dartdevc/index.md
+++ b/src/tools/dartdevc/index.md
@@ -2,6 +2,7 @@
 title: "dartdevc: The Dart dev compiler"
 short-title: dartdevc
 description: Fast, modular compilation of Dart code to JavaScript.
+toc: false
 ---
 
 The Dart development compiler _(dartdevc_, also known as _DDC)_
@@ -11,7 +12,7 @@ lets you run and debug your Dart web app in the Chrome browser.
   **Note:**
   The dartdevc compiler is for _development_ only.
   Continue to use [dart2js](/tools/dart2js)
-  to compile for [deployment]({{site.angulardart}}/guide/deployment).
+  to compile for deployment.
 </aside>
 
 Unlike dart2js,

--- a/src/tools/pub/obsolete.md
+++ b/src/tools/pub/obsolete.md
@@ -5,33 +5,17 @@ toc: false
 ---
 
 As of Dart 2, pub no longer supports `pub build`, `pub serve`, or transformers.
-They're replaced by the **build system**, which includes the **build_runner** tool.
+They're replaced by the **build system**,
+which includes the **build_runner** tool.
 
 For information about building and serving apps in Dart 2, see the following:
 
-* Web development:
-  * [Setup for Angular development (v5)]({{site.angulardart}}/guide/setup)
-  * [Deployment (v5)]({{site.angulardart}}/guide/deployment)
-  * [Web-specific build_runner documentation](/tools/build_runner)
-* General:
-  * [Build system](https://github.com/dart-lang/build)
-  * [Build system documents,](https://github.com/dart-lang/build/tree/master/docs) including
-    [getting started with build_runner](https://github.com/dart-lang/build/blob/master/docs/getting_started.md#getting-started-with-build_runner)
-
-If you use Dart 1.x for web development, see the following:
-
-* [Setup for Angular development (v4)]({{site.angulardart}}/guide/setup)
-* [Deployment (v4)]({{site.angulardart}}/guide/deployment)
-
-If you maintain a transformer, see the following:
-
-* [Assets and Transformers]({{site.prev-url}}/tools/pub/assets-and-transformers)
-  in the [archived Dart site]({{site.prev-url}})
-* [Writing a Pub Transformer]({{site.prev-url}}/tools/pub/transformers)
-  in the [archived Dart site]({{site.prev-url}})
+* [build_runner documentation](/tools/build_runner)
+* [Build system documents](https://github.com/dart-lang/build/tree/master/docs),
+  including
+  [getting started with build_runner](https://github.com/dart-lang/build/blob/master/docs/getting_started.md#getting-started-with-build_runner)
 
 For help in switching from Dart 1.x to Dart 2, see the Dart 2 migration guides:
 
 * [Language and core library migration guide](/dart-2#migration)
 * [Web app migration guide](/web/dart-2)
-* [Barback/transformer migration guide](https://github.com/dart-lang/build/blob/master/docs/from_barback_transformer.md)

--- a/src/tools/pub/obsolete.md
+++ b/src/tools/pub/obsolete.md
@@ -1,6 +1,7 @@
 ---
 title: Obsolete pub features
 description: As of Dart 2, pub no longer supports pub build/serve or transformers.
+toc: false
 ---
 
 As of Dart 2, pub no longer supports `pub build`, `pub serve`, or transformers.

--- a/src/tools/webdev.md
+++ b/src/tools/webdev.md
@@ -150,7 +150,7 @@ $ webdev build --output web:build
 
 ### build_runner test {#test}
 
-Use the `build_runner test` command to run your app's [component tests][]:
+Use the `build_runner test` command to run your app's component tests:
 
 ```
 $ dart pub run build_runner test [build_runner options] -- -p <platform> [test options]
@@ -201,7 +201,6 @@ Also see the following pages:
 [build_runner]: /tools/build_runner
 [build_runner test]: #test
 [build_web_compilers]: {{site.pub-pkg}}/build_web_compilers
-[component tests]: {{site.angulardart}}/guide/testing/component
 [Dart DevTools]: /tools/dart-devtools
 [dart2js]: /tools/dart2js
 [dart2js options.]: /tools/dart2js#options

--- a/src/web/dart-2.md
+++ b/src/web/dart-2.md
@@ -16,8 +16,6 @@ These changes are necessary because of the following:
   - A **new build system** replaces `pub build`, `pub serve`, pub transformers.
 - Dart 2 [language and library changes.][dart-2]
 
-See also: [Angular Migration Guide v4 to v5]({{site.angulardart}}/note/migrating-to-v5)
-
 
 ## Tools
 
@@ -36,13 +34,14 @@ Here are the highlights:
 
 To migrate to Dart 2, you'll need to edit your web app's project files:
 
-- `pubspec.yaml`, [see details below.](#pubspec)
+- `pubspec.yaml`. [See details below.](#pubspec)
 - HTML files with `<script src="foo.dart"...>` elements,
   such as `web/index.html`. [See details below.](#web-index-html)
 - Dart code, due to changes in the [Dart language and libraries.][dart-2]
 
-For complete examples of migrated apps, compare the `4.x` and `master` branches
-of any one of the [angular-examples][] apps, such as these:
+For complete examples of migrating apps,
+look at the files changed between the `4.x` and `master` branches
+of the following apps:
 
 - [Quickstart][angular-examples/quickstart]
 - [Tour of Heroes, part 5][angular-examples/toh-5]
@@ -64,8 +63,8 @@ Make these changes to your `pubspec.yaml` file:
   - <del>`dart_to_js_script_rewriter`</del>
   - <del>`test/pub_serve`</del>
 
-For example, here is a diff of
-[angular-examples/quickstart/pubspec.yaml][]
+For example, look at the the differences in
+the [Quickstart example's pubspec][angular-examples/quickstart/pubspec.yaml]
 with these changes applied.
 
 <a id="web-index-html"></a>
@@ -78,22 +77,19 @@ You'll need to make these changes:
 - Replace <del>`<script defer src="foo.dart" type="application/dart"></script>`</del> by<br>
   `<script defer src="foo.dart.js"></script>`
 
-Here is a diff of
-[angular-examples/quickstart/web/index.html][]
+For example, look at the the differences in the [Quickstart example's
+web/index.html page][angular-examples/quickstart/web/index.html]
 with these changes applied.
 
 ## Additional resources
 
-- [Dart 2 Updates:][dart-2]
-  Information about changes in Dart 2, and how to migrate your code from Dart 1.x.
-- [Changelog][Documentation changelog]:
-  Lists changes made to this site's documentation and examples.
+The [Dart 2 migration guide][dart-2] has
+information about changes in Dart 2, and how to migrate your code from Dart 1.x.
 
-[angular-examples]: https://github.com/angular-examples
-[angular-examples/quickstart]: https://github.com/angular-examples/quickstart/compare/4.x...master
-[angular-examples/quickstart/pubspec.yaml]: https://github.com/angular-examples/quickstart/compare/4.x...master#diff-4
-[angular-examples/quickstart/web/index.html]: https://github.com/angular-examples/quickstart/compare/4.x...master#diff-6
-[angular-examples/toh-5]: https://github.com/angular-examples/toh-5/compare/4.x...master
+[angular-examples/quickstart]: https://github.com/googlearchive/quickstart/compare/4.x...master
+[angular-examples/quickstart/pubspec.yaml]: https://github.com/googlearchive/quickstart/compare/4.x...master#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25
+[angular-examples/quickstart/web/index.html]: https://github.com/googlearchive/quickstart/compare/4.x...master#diff-8f62b6ced28d3396b501d2e89a2e7cb761d16cd7dc977aebece03d4a5da5c24e
+[angular-examples/toh-5]: https://github.com/googlearchive/toh-5/compare/4.x...master
 [build]: https://github.com/dart-lang/build
 [dart-2]: /dart-2
 [dartdevc]: /tools/dartdevc

--- a/src/web/index.md
+++ b/src/web/index.md
@@ -19,8 +19,11 @@ and [interoperability for calling JavaScript][interop] from Dart.
 You have the option of using Dart web with a higher-level web app framework.
 Several web apps at Google
 (including the [Google Ads front end formerly known as AdWords][AdWords])
-are built using [AngularDart.][]
-Many apps that support both web and mobile are built
+are built using [AngularDart][],
+which is available outside Google as an
+[open source, community-maintained framework][AD community].
+
+Many apps that support web and mobile or desktop are built
 using [Flutter][] and [Flutter web][] support.
 AngularDart,
 Flutter web support,
@@ -39,7 +42,8 @@ and other web app frameworks for Dart are powered by the Dart web platform.
 </p>
 
 [AdWords]: {{site.news}}/2016/03/the-new-adwords-ui-uses-dart-we-asked.html
-[AngularDart.]: {{site.angulardart}}
+[AngularDart]: {{site.angulardart}}
+[AD community]: https://groups.google.com/a/dartlang.org/g/announce/c/Kz84KNBcf3U
 [core libraries]: /guides/libraries#web-platform-libraries
 [DOM]: /tutorials/web/low-level-html/connect-dart-html
 [Flutter]: {{site.flutter}}

--- a/src/web/index.md
+++ b/src/web/index.md
@@ -17,16 +17,9 @@ access to the [DOM (Document Object Model)][DOM],
 and [interoperability for calling JavaScript][interop] from Dart.
 
 You have the option of using Dart web with a higher-level web app framework.
-Several web apps at Google
-(including the [Google Ads front end formerly known as AdWords][AdWords])
-are built using [AngularDart][],
-which is available outside Google as an
-[open source, community-maintained framework][AD community].
-
-Many apps that support web and mobile or desktop are built
+Many apps that support web plus mobile or desktop are built
 using [Flutter][] and [Flutter web][] support.
-AngularDart,
-Flutter web support,
+Flutter web support
 and other web app frameworks for Dart are powered by the Dart web platform.
 
 <p class="text-center">
@@ -41,9 +34,6 @@ and other web app frameworks for Dart are powered by the Dart web platform.
   <em>Flutter Gallery, running in a web browser</em>
 </p>
 
-[AdWords]: {{site.news}}/2016/03/the-new-adwords-ui-uses-dart-we-asked.html
-[AngularDart]: {{site.angulardart}}
-[AD community]: https://groups.google.com/a/dartlang.org/g/announce/c/Kz84KNBcf3U
 [core libraries]: /guides/libraries#web-platform-libraries
 [DOM]: /tutorials/web/low-level-html/connect-dart-html
 [Flutter]: {{site.flutter}}

--- a/src/web/libraries.md
+++ b/src/web/libraries.md
@@ -6,13 +6,10 @@ description: Libraries and packages that can help you write Dart web apps.
 
 The [Dart SDK][] contains [dart:html][] and other libraries
 that provide low-level web APIs.
-You can supplement or replace these APIs using
-[web packages,][web packages]
-such as those in the [AngularDart][] framework.
+You can supplement or replace these APIs using web packages.
 
 [Dart SDK]: /tools/sdk
 [dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html/dart-html-library.html
-[web packages]: {{site.pub}}/web
 
 
 ## SDK libraries
@@ -38,8 +35,11 @@ that provide low-level web APIs.
 
 ## Web packages
 
-Many [packages](/guides/packages) support web development with Dart. Here
-are a few:
+Many [packages](/guides/packages) support web development with Dart.
+In particular, the [Flutter framework][flutter] has [web support][flutter-web],
+in addition to mobile, desktop, and embedded device support.
+
+Here are a few packages that are web-specific:
 
 |-----------------+---------------------------------+--------------------------|
 | Library         | Packages                        | Notes                    |
@@ -52,6 +52,10 @@ are a few:
 | Vue             | [vue][]                         | Bindings for the Vue.js library. |
 {:.table .table-striped}
 
+
+[flutter]: {{site.flutter}}
+[flutter-web]: {{site.flutter}}/web
+[AngularDart]: {{site.angulardart}}
 [js]: {{site.pub-pkg}}/js
 [JavaScript interoperability]: /web/js-interop
 [md_core,]: {{site.pub-pkg}}/m4d_core
@@ -60,19 +64,8 @@ are a few:
 [vue]: {{site.pub-pkg}}/vue
 [react]: {{site.pub-pkg}}/react
 
-To find more libraries that support writing web apps, search for
-[web packages.][web packages]
-
-{% comment %}
-Check out these pages:
-
-https://github.com/TheBosZ/dartins
-https://medium.com/@thebosz/creating-a-dart-to-javascript-interop-library-c97da204c34a#.up26ibqyb
-{% endcomment %}
+To find more libraries that support writing web apps, search pub.dev for
+[web packages][].
 
 
----
-
-Also see the [FAQ.](/faq)
-
-[AngularDart]: {{site.angulardart}}
+[web packages]: {{site.pub}}/web


### PR DESCRIPTION
Fixes #3378 

The community has started updating the AngularDart docs, as we were hoping they would (see https://angulardart.xyz and #3378 for details). How about we point to the community site?

Staged:
https://kw-dartlang-3.web.app/web

Btw, a lot of pages still refer to AngularDart. The following ones use the `{{site.angulardart}}` macro (and thus would now point to angulardart.xyz):

/web (as listed above)
/tools/dartdevc
/tools/webdev
/tools/pub/obsolete
/tutorials/web/low-level-html
/tutorials/web/low-level-html/connect-dart-html
/web/dart-2
/web/libraries
/faq
/guides/json
/guides/language/effective-dart/design
/guides/testing


