### PR TITLE
Improve clarity of example warnings on customizing static analysis page

### DIFF
--- a/null_safety_examples/analysis/analyzer-results.txt
+++ b/null_safety_examples/analysis/analyzer-results.txt
@@ -1,14 +1,7 @@
 Analyzing analysis...
 
-  error - A value of type 'dynamic' can't be assigned to a variable of type 'String' at lib/assignment.dart:11:14 - (invalid_assignment)
-          Try changing the type of the variable, or casting the right-hand type to 'String'.
-  error - A value of type 'String' can't be assigned to a variable of type 'int' at lib/assignment.dart:19:11 - (invalid_assignment)
-          Try changing the type of the variable, or casting the right-hand type to 'int'.
-  error - A value of type 'String' can't be assigned to a variable of type 'int' at lib/assignment.dart:26:11 - (invalid_assignment)
-          Try changing the type of the variable, or casting the right-hand type to 'int'.
-  error - Const variables must be initialized with a constant value at lib/assignment.dart:34:13 - (const_initialized_with_non_constant_value)
-          Try changing the initializer to be a constant expression.
-   info - Avoid empty statements at lib/lint.dart:9:19 - (empty_statements)
-   info - Close instances of `dart.core.Sink` at lib/lint.dart:16:7 - (close_sinks)
+   error - lib/assignment.dart:10:14 - A value of type 'dynamic' can't be assigned to a variable of type 'String'. Try changing the type of the variable, or casting the right-hand type to 'String'. - invalid_assignment
+   info - lib/lint.dart:9:19 - Avoid empty statements. - empty_statements
+   info - lib/lint.dart:16:7 - Close instances of `dart.core.Sink`. - close_sinks
 
-6 issues found.
+3 issues found.

--- a/null_safety_examples/analysis/lib/assignment.dart
+++ b/null_safety_examples/analysis/lib/assignment.dart
@@ -1,13 +1,13 @@
 // #docregion ignore_for_file
-// ignore_for_file: unused_import, unused_local_variable
+// ignore_for_file: unused_import, unused_local_variable, duplicate_ignore
 // #enddocregion ignore_for_file
-// ignore_for_file: stable, beta, dev, invalid_assignment
 
 import 'package:examples_util/ellipsis.dart';
 
 String downcastExample() {
   // #docregion implicit-downcast
   dynamic o = ellipsis<String>();
+  // ignore_for_file: stable, beta, dev, invalid_assignment
   String s = o; // Implicit downcast
   String s2 = s.substring(1);
   // #enddocregion implicit-downcast

--- a/null_safety_examples/analysis/lib/lint.dart
+++ b/null_safety_examples/analysis/lib/lint.dart
@@ -13,6 +13,6 @@ void increment() {
 
 void controller() {
   // #docregion close_sinks
-  var _controller = StreamController<String>();
+  var controller = StreamController<String>();
   // #enddocregion close_sinks
 }

--- a/null_safety_examples/util/lib/ellipsis.dart
+++ b/null_safety_examples/util/lib/ellipsis.dart
@@ -1,3 +1,3 @@
 dynamic blockEllipsis; // Use as replace="/=. blockEllipsis;/{ ... }/g"
-Never ellipsis<T>() =>
+dynamic ellipsis<T>() =>
     throw Exception('!'); // Use as replace="/ellipsis;?/.../g"

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -27,17 +27,20 @@ made its way into an `if` statement:
 
 <blockquote class="ml-3" markdown="1">
 <?code-excerpt "../null_safety_examples/analysis/lib/lint.dart (empty_statements)" replace="/(if .*?)(;)/$1[!$2!]/g"?>
-{% prettify dart class="linenums:10 analyzer"%}
+{% prettify dart class="linenums:8 analyzer"%}
 void increment() {
   if (count < 10) [!;!]
   count++;
 }
 {% endprettify %}
 
+If properly configured, the analyzer points to the semicolon and
+produces the following warning:
+
 {:.console-output}
-<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="empty_statements" replace="/.( • )(lib|test)\/\w+\.dart:\d+:\d+/$1example.dart:11/g"?>
+<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="empty_statements" replace="/lib\/lint.dart/example.dart/g"?>
 ```nocode
-info - Avoid empty statements at lib/lint.dart:9:19 - (empty_statements)
+info - lib/lint.dart:9:19 - Avoid empty statements. - empty_statements
 ```
 </blockquote>
 
@@ -45,15 +48,15 @@ The analyzer can also help you find more subtle problems.
 For example, perhaps you've forgotten to close a sink method:
 
 <blockquote class="ml-3" markdown="1">
-<?code-excerpt "../null_safety_examples/analysis/lib/lint.dart (close_sinks)" replace="/(_c.*?)(;)/[!$1!]$2/g"?>
-{% prettify dart class="linenums:11 analyzer"%}
-var [!_controller = StreamController<String>()!];
+<?code-excerpt "../null_safety_examples/analysis/lib/lint.dart (close_sinks)" replace="/(contr.*?)(;)/[!$1!]$2/g"?>
+{% prettify dart class="analyzer"%}
+var [!controller = StreamController<String>()!];
 {% endprettify %}
 
 {:.console-output}
-<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="close_sinks" replace="/.( • )(lib|test)\/\w+\.dart:\d+:\d+/$1example.dart:11/g"?>
+<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="close_sinks" replace="/-(.*?):(.*?):(.*?)-/-/g"?>
 ```nocode
-info - Close instances of `dart.core.Sink` at lib/lint.dart:16:7 - (close_sinks)
+info - Close instances of `dart.core.Sink`. - close_sinks
 ```
 </blockquote>
 
@@ -179,9 +182,9 @@ String s2 = s.substring(1);
 {% endprettify %}
 
 {:.console-output}
-<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="/'dynamic' can't be assigned to a variable of type 'String'/" replace="/. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+<?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="/'dynamic' can't be assigned to a variable of type 'String'/"  replace="/. Try.*'String'. / /g; /-(.*?):(.*?):(.*?)-/-/g"?>
 ```nocode
-error - A value of type 'dynamic' can't be assigned to a variable of type 'String' at lib/assignment.dart:11:14 - (invalid_assignment)
+error - A value of type 'dynamic' can't be assigned to a variable of type 'String' - invalid_assignment
 ```
 
 {{site.alert.version-note}}
@@ -289,13 +292,6 @@ linter:
     - prefer_single_quotes
     - sort_child_properties_last
 ```
-
-{% comment %}
-Brian expressed concern about including this:
-In future, related lint rules may be coalesced into meta rules. See
-[Issue 99: Meta linter rules](https://github.com/dart-lang/linter/issues/288)
-for more information.
-{% endcomment %}
 
 
 ### Disabling individual rules

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -3,6 +3,8 @@ title: Customizing static analysis
 description: Use an analysis options file and code comments to customize static analysis.
 ---
 
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+
 <style>
 li.L0, li.L1, li.L2, li.L3,
 li.L5, li.L6, li.L7, li.L8, li.L9 {
@@ -40,7 +42,7 @@ produces the following warning:
 {:.console-output}
 <?code-excerpt "../null_safety_examples/analysis/analyzer-results.txt" retain="empty_statements" replace="/lib\/lint.dart/example.dart/g"?>
 ```nocode
-info - lib/lint.dart:9:19 - Avoid empty statements. - empty_statements
+info - example.dart:9:19 - Avoid empty statements. - empty_statements
 ```
 </blockquote>
 
@@ -382,7 +384,7 @@ To suppress more than one rule, use a comma-separated list:
 
 <?code-excerpt "../null_safety_examples/analysis/lib/assignment.dart (ignore_for_file)"?>
 ```dart
-// ignore_for_file: unused_import, unused_local_variable
+// ignore_for_file: unused_import, unused_local_variable, duplicate_ignore
 ```
 
 


### PR DESCRIPTION
Some minor cleanup to only keep the important information in the examples and warnings. Also will help properly enabling analysis checks in the future.