### PR TITLE
Update GitHub rate limiting link on DartPad troubleshooting page

### DIFF
--- a/src/tools/dartpad/troubleshoot.md
+++ b/src/tools/dartpad/troubleshoot.md
@@ -33,7 +33,7 @@ then try the following:
   (in these cases, **dart.dev** and **flutter.dev**, respectively).
 
 * If you repeatedly reload a page that contains embedded DartPads, 
-  then you might run into [GitHub rate limiting.](https://developer.github.com/v3/#rate-limiting)
+  then you might run into [GitHub rate limiting.][]
   Within 60 minutes, you should be able to reload the page and see code in the embedded DartPads.
 
 Although DartPad doesn't use cookies, it does rely on local storage,
@@ -49,6 +49,7 @@ Try [dartpad.cn.](https://dartpad.cn)
 If you have any other problems when using DartPad,
 [create an issue on GitHub.][new-issue]
 
+[GitHub rate limiting.]: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
 [browser]: /faq#q-what-browsers-do-you-support-as-javascript-compilation-targets
 [chrome-cookies]: https://support.google.com/chrome/answer/95647
 [new-issue]: https://github.com/dart-lang/dart-pad/issues/new


### PR DESCRIPTION
The previous link redirected to a generic REST API page without any rate limit information. This modifies the link to the new rate limiting section for the REST API. 