### PR TITLE
Fix and ignore more lint warnings

### DIFF
--- a/null_safety_examples/analysis/lib/assignment.dart
+++ b/null_safety_examples/analysis/lib/assignment.dart
@@ -1,5 +1,5 @@
 // #docregion ignore_for_file
-// ignore_for_file: unused_import, unused_local_variable, duplicate_ignore
+// ignore_for_file: unused_local_variable, duplicate_ignore, dead_code
 // #enddocregion ignore_for_file
 
 import 'package:examples_util/ellipsis.dart';

--- a/null_safety_examples/analysis/lib/lint.dart
+++ b/null_safety_examples/analysis/lib/lint.dart
@@ -1,11 +1,11 @@
-// ignore_for_file: unused_element, unused_local_variable
-// ignore_for_file: stable, beta, dev
+// ignore_for_file: unused_local_variable, duplicate_ignore
 
 import 'dart:async';
 
 int count = 0;
 // #docregion empty_statements
 void increment() {
+  // ignore_for_file: stable, beta, dev,  empty_statements
   if (count < 10) ;
   count++;
 }
@@ -13,6 +13,7 @@ void increment() {
 
 void controller() {
   // #docregion close_sinks
+  // ignore_for_file: stable, beta, dev, close_sinks
   var controller = StreamController<String>();
   // #enddocregion close_sinks
 }

--- a/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
+++ b/null_safety_examples/misc/lib/effective_dart/usage_bad.dart
@@ -4,6 +4,7 @@
 // ignore_for_file: use_rethrow_when_possible, prefer_is_empty, prefer_iterable_wheretype, prefer_initializing_formals, unnecessary_this
 // ignore_for_file: prefer_typing_uninitialized_variables, prefer_collection_literals, unnecessary_cast, strict_raw_type
 // ignore_for_file: avoid_function_literals_in_foreach_calls, prefer_function_declarations_over_variables, always_declare_return_types
+// ignore_for_file: prefer_adjacent_string_concatenation
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
@@ -11,7 +12,7 @@ import 'dart:math';
 import 'usage_good.dart';
 
 class EnableableThing {
-  bool isEnabled;
+  final bool isEnabled;
   EnableableThing(this.isEnabled);
 }
 

--- a/null_safety_examples/misc/lib/language_tour/built_in_types.dart
+++ b/null_safety_examples/misc/lib/language_tour/built_in_types.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, type_annotate_public_apis
+// ignore_for_file: unused_local_variable, type_annotate_public_apis, prefer_single_quotes, prefer_collection_literals
 
 void miscDeclAnalyzedButNotTested() {
   {

--- a/null_safety_examples/misc/test/language_tour/built_in_types_test.dart
+++ b/null_safety_examples/misc/test/language_tour/built_in_types_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: prefer_single_quotes, prefer_typing_uninitialized_variables
+// ignore_for_file: prefer_single_quotes, prefer_typing_uninitialized_variables, prefer_adjacent_string_concatenation
 
 import 'package:test/test.dart';
 
@@ -36,11 +36,11 @@ void main() {
     var s = 'string interpolation';
 
     assert('Dart has $s, which is very handy.' ==
-        'Dart has string interpolation, ' +
+        'Dart has string interpolation, '
             'which is very handy.');
-    assert('That deserves all caps. ' +
+    assert('That deserves all caps. '
             '${s.toUpperCase()} is very handy!' ==
-        'That deserves all caps. ' +
+        'That deserves all caps. '
             'STRING INTERPOLATION is very handy!');
     // #enddocregion string-interpolation
   });

--- a/null_safety_examples/misc/test/library_tour/core_test.dart
+++ b/null_safety_examples/misc/test/library_tour/core_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, prefer_collection_literals
+// ignore_for_file: type_annotate_public_apis, prefer_collection_literals, avoid_function_literals_in_foreach_calls
 import 'package:test/test.dart';
 
 import 'package:examples/library_tour/core/comparable.dart'

--- a/null_safety_examples/non_promotion/lib/non_promotion.dart
+++ b/null_safety_examples/non_promotion/lib/non_promotion.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: expected_executable, missing_statement, unused_local_variable, unused_element
+// ignore_for_file: expected_executable, missing_statement, unused_local_variable, unused_element, prefer_function_declarations_over_variables
 
 class C1 {
   int? i;

--- a/null_safety_examples/util/lib/ellipsis.dart
+++ b/null_safety_examples/util/lib/ellipsis.dart
@@ -1,3 +1,3 @@
 dynamic blockEllipsis; // Use as replace="/=. blockEllipsis;/{ ... }/g"
-dynamic ellipsis<T>() =>
+Never ellipsis<T>() =>
     throw Exception('!'); // Use as replace="/ellipsis;?/.../g"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: site_www
 
-author: Dart Team <misc@dartlang.org>
 homepage: https://dart.dev
 
 environment:

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -374,7 +374,7 @@ add an `ignore_for_file` comment to the file:
 
 <?code-excerpt "../null_safety_examples/analysis/lib/assignment.dart (ignore_for_file)" replace="/, \w+//g"?>
 ```dart
-// ignore_for_file: unused_import
+// ignore_for_file: unused_local_variable
 ```
 
 This acts for the whole file, before or after the comment, and is
@@ -384,7 +384,7 @@ To suppress more than one rule, use a comma-separated list:
 
 <?code-excerpt "../null_safety_examples/analysis/lib/assignment.dart (ignore_for_file)"?>
 ```dart
-// ignore_for_file: unused_import, unused_local_variable, duplicate_ignore
+// ignore_for_file: unused_local_variable, duplicate_ignore, dead_code
 ```
 
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -718,11 +718,11 @@ object’s `toString()` method.
 var s = 'string interpolation';
 
 assert('Dart has $s, which is very handy.' ==
-    'Dart has string interpolation, ' +
+    'Dart has string interpolation, '
         'which is very handy.');
-assert('That deserves all caps. ' +
+assert('That deserves all caps. '
         '${s.toUpperCase()} is very handy!' ==
-    'That deserves all caps. ' +
+    'That deserves all caps. '
         'STRING INTERPOLATION is very handy!');
 ```
 


### PR DESCRIPTION
This brings the remaining warnings almost to those just remaining in the strong examples to be fixed in https://github.com/dart-lang/site-www/pull/3340