### PR TITLE
Documenting `false_secrets` in `pubspec.yaml`

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -146,7 +146,7 @@
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
-      { "source": "/go/false-leaks", "destination": "/tools/pub/pubspec#false_leaks", "type": 301 },
+      { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },

--- a/firebase.json
+++ b/firebase.json
@@ -146,6 +146,7 @@
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
+      { "source": "/go/false-leaks", "destination": "/tools/pub/pubspec#false_leaks", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -70,6 +70,11 @@ A pubspec can have the following fields:
 : Optional. Specify where to publish a package.
   [_Learn more._](#publish_to)
 
+`false_leaks`
+: Optional. Specify git-ignore style patterns for files to ignore when warning
+  against potential leak of secrets before publishing.
+  [_Learn more._](#false_leaks)
+
 Pub ignores all other fields,
 
 <aside class="alert alert-info" markdown="1">
@@ -272,6 +277,38 @@ publish_to: none
 {% endprettify %}
 
 
+### False_leaks
+
+When publishing leak detection on the client will abort publishing if it finds
+potential leaks of secret credentials, API keys and cryptographic keys in files
+to be published.
+While detection of possible secrets relies on advanced heuristics using regular
+expressions and entropy thresholds, the detection is not perfect.
+If the leak detection reports a _false positive_ you can specify a list of
+[git-ignore patterns][git-ignore-format] under `false_leaks` in `pubspec.yaml`.
+
+The leak detection will ignore any files matching a pattern in `false_leaks`.
+The example below ignores the file `lib/src/file_with_hardcoded_api_key.dart`
+and all `.pem` files in the `test/localhost_certificates/` folder. Starting a
+[git-ignore pattern][git-ignore-format] with slash `/` ensures that is it only
+considered relative to the root folder.
+
+{% prettify yaml tag=pre+code %}
+false_leaks:
+ - /lib/src/file_with_hardcoded_api_key.dart
+ - /test/localhost_certificates/*.pem
+{% endprettify %}
+
+{{site.alert.version-note}}
+  Leak detection will never prevent all leaks. It's your responsibility to
+  manage your credentials, prevent accidental leaks, and revoke credentials
+  that are accidentally leaked.
+
+  You cannot rely on leak detection prevent leaks, it will only detect a
+  limited set of common patterns, and is only intended to mitigate common
+  mistakes.
+{{site.alert.end}}
+
 ### SDK constraints
 
 A package can indicate which versions of its dependencies it supports, but
@@ -348,3 +385,4 @@ accidentally install packages that need Flutter.
 
 [pubsite]: {{site.pub}}
 [semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html
+[git-ignore-format]: https://git-scm.com/docs/gitignore#_pattern_format

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -1,5 +1,6 @@
 ---
 title: The pubspec file
+description: Reference guide for the fields in pubspec.yaml.
 ---
 
 Every [pub package](/guides/packages) needs some metadata so it can specify its
@@ -71,8 +72,8 @@ A pubspec can have the following fields:
   [_Learn more._](#publish_to)
 
 `false_secrets`
-: Optional. Specify git-ignore style patterns for files to ignore when warning
-  against potential leak of secrets before publishing.
+: Optional. Specify files to ignore when conducting a pre-publishing search
+  for potential leaks of secrets.
   [_Learn more._](#false_secrets)
 
 Pub ignores all other fields,
@@ -279,35 +280,46 @@ publish_to: none
 
 ### False_secrets
 
-When publishing leak detection on the client will abort publishing if it finds
-potential leaks of secret credentials, API keys and cryptographic keys in files
-to be published.
-While detection of possible secrets relies on advanced heuristics using regular
-expressions and entropy thresholds, the detection is not perfect.
-If the leak detection reports a _false positive_ you can specify a list of
-[git-ignore patterns][git-ignore-format] under `false_secrets` i
-`pubspec.yaml`.
+When you try to [publish a package][],
+pub conducts a search for potential leaks of
+secret credentials, API keys, or cryptographic keys.
+If pub detects a potential leak in a file that would be published,
+then pub warns you and refuses to publish the package.
 
-The leak detection will ignore any files matching a pattern in `false_secrets`.
-The example below ignores the file `lib/src/file_with_hardcoded_api_key.dart`
-and all `.pem` files in the `test/localhost_certificates/` folder. Starting a
-[git-ignore pattern][git-ignore-format] with slash `/` ensures that is it only
-considered relative to the root folder.
+Leak detection isn't perfect.
+To avoid false positives,
+you can tell pub not to search for leaks in certain files,
+using [`gitignore` patterns][] under
+`false_secrets` in the pubspec.
+
+[`gitignore` patterns]: https://git-scm.com/docs/gitignore#_pattern_format
+
+For example, the following entry causes pub not to look for leaks in
+the file `lib/src/hardcoded_api_key.dart`
+and in all `.pem` files in the `test/localhost_certificates/` directory:
+
+[publish a package]: /tools/pub/publishing
 
 {% prettify yaml tag=pre+code %}
 false_secrets:
- - /lib/src/file_with_hardcoded_api_key.dart
+ - /lib/src/hardcoded_api_key.dart
  - /test/localhost_certificates/*.pem
 {% endprettify %}
 
-{{site.alert.version-note}}
-  Leak detection will never prevent all leaks. It's your responsibility to
-  manage your credentials, prevent accidental leaks, and revoke credentials
-  that are accidentally leaked.
+Starting a `gitgnore` pattern with slash (`/`) ensures that
+the pattern is considered relative to the package's root directory.
 
-  You cannot rely on leak detection prevent leaks, it will only detect a
-  limited set of common patterns, and is only intended to mitigate common
-  mistakes.
+{{site.alert.warn}}
+  **Don't rely on leak detection.**
+  It uses a limited set of patterns
+  to detect common mistakes.
+  You're responsible for managing your credentials,
+  preventing accidental leaks, and
+  revoking credentials that are accidentally leaked.
+{{site.alert.end}}
+
+{{site.alert.version-note}}
+  Support for the `false_secrets` field was added in Dart 2.15.
 {{site.alert.end}}
 
 ### SDK constraints
@@ -386,4 +398,3 @@ accidentally install packages that need Flutter.
 
 [pubsite]: {{site.pub}}
 [semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html
-[git-ignore-format]: https://git-scm.com/docs/gitignore#_pattern_format

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -306,7 +306,7 @@ false_secrets:
  - /test/localhost_certificates/*.pem
 {% endprettify %}
 
-Starting a `gitgnore` pattern with slash (`/`) ensures that
+Starting a `gitignore` pattern with slash (`/`) ensures that
 the pattern is considered relative to the package's root directory.
 
 {{site.alert.warn}}

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -70,10 +70,10 @@ A pubspec can have the following fields:
 : Optional. Specify where to publish a package.
   [_Learn more._](#publish_to)
 
-`false_leaks`
+`false_secrets`
 : Optional. Specify git-ignore style patterns for files to ignore when warning
   against potential leak of secrets before publishing.
-  [_Learn more._](#false_leaks)
+  [_Learn more._](#false_secrets)
 
 Pub ignores all other fields,
 
@@ -277,7 +277,7 @@ publish_to: none
 {% endprettify %}
 
 
-### False_leaks
+### False_secrets
 
 When publishing leak detection on the client will abort publishing if it finds
 potential leaks of secret credentials, API keys and cryptographic keys in files
@@ -285,16 +285,17 @@ to be published.
 While detection of possible secrets relies on advanced heuristics using regular
 expressions and entropy thresholds, the detection is not perfect.
 If the leak detection reports a _false positive_ you can specify a list of
-[git-ignore patterns][git-ignore-format] under `false_leaks` in `pubspec.yaml`.
+[git-ignore patterns][git-ignore-format] under `false_secrets` i
+`pubspec.yaml`.
 
-The leak detection will ignore any files matching a pattern in `false_leaks`.
+The leak detection will ignore any files matching a pattern in `false_secrets`.
 The example below ignores the file `lib/src/file_with_hardcoded_api_key.dart`
 and all `.pem` files in the `test/localhost_certificates/` folder. Starting a
 [git-ignore pattern][git-ignore-format] with slash `/` ensures that is it only
 considered relative to the root folder.
 
 {% prettify yaml tag=pre+code %}
-false_leaks:
+false_secrets:
  - /lib/src/file_with_hardcoded_api_key.dart
  - /test/localhost_certificates/*.pem
 {% endprettify %}


### PR DESCRIPTION
Implementation on `pub` client: https://github.com/dart-lang/pub/pull/3049.

--------

Many of the patterns and heuristics for detection of leaks are adopted from [How Bad Can It Git?](https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf) and [awslabs/git-secrets](https://github.com/awslabs/git-secrets).
We could perhaps consider mentioning these in the documentation, to help people better understand what kind of heuristics is employed for leak detection.

--------

This won't ship until Dart 2.15, I'm not planning to sneak in new features right before the window closes.