### PR TITLE
Document .pubignore

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -210,22 +210,27 @@ Here's how to transfer a package to a verified publisher:
 
 ## What files are published?
 
-**All files** in your package are included in the published package, with
-the following exceptions:
+**All files** in your local package root folder are included in the published
+package, with the following exceptions:
 
-* Any `packages` directories.
-* Your package's [lockfile](/tools/pub/glossary#lockfile).
-* If you aren't using Git, all _hidden_ files (that is,
-  files whose names begin with `.`).
-* If you're using Git, any files ignored by your `.gitignore` file.
+ * Any _hidden_ files or folders (that is, files whose names begin with `.`).
+ * Any `packages/` directories.
+ * Files and folders ignored by `.pubignore` (or `.gitignore`).
 
-{% comment %}
-PENDING: Here only to make it easy to find the packages discussion: packages-dir.html
-{% endcomment %}
+`.gitignore` can be used to ignore additional files. If you want different
+ignore rules for `git` and `dart pub publish`, you may overrule the `.gitignore`
+file in a given folder by creating a `.pubignore` file.
 
-Be sure to delete any files you don't want to include (or add them to
-`.gitignore`). `dart pub publish` lists all files that it's going to publish
-before uploading your package,
+{{site.alert.note}}
+  The `.pubignore` files uses the [`.gitignore` format][git-ignore-format], and
+  multiple `.gitignore` and `.pubignore` files may exist across sub-folders of a
+  package. `dart pub publish` only reads the `.gitignore` file from a folder if
+  the folder does not contain a `.pubignore` file.
+{{site.alert.end}}
+
+Be sure to delete any files you don't want to include (or add them to a
+`.gitignore` or `.pubignore` file). `dart pub publish` lists all files that
+it's going to publish before uploading your package,
 so examine the list carefully before completing your upload.
 
 ## Uploaders
@@ -349,3 +354,4 @@ For more information, see the reference pages for the following `pub` commands:
 [pubspec]: /tools/pub/pubspec
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html
 [verified publisher]: /tools/pub/verified-publishers
+[git-ignore-format]: https://git-scm.com/docs/gitignore#_pattern_format

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -210,28 +210,37 @@ Here's how to transfer a package to a verified publisher:
 
 ## What files are published?
 
-**All files** in your local package root folder are included in the published
-package, with the following exceptions:
+**All files** under the package root directory are
+included in the published package,
+with the following exceptions:
 
- * Any _hidden_ files or folders (that is, files whose names begin with `.`).
- * Any `packages/` directories.
- * Files and folders ignored by `.pubignore` (or `.gitignore`).
+ * Any _hidden_ files or directories —
+   that is, files with names that begin with dot (`.`)
+ * Any directories with the name `packages`
+ * Files and directories ignored by a `.pubignore` or `.gitignore` file
 
-`.gitignore` can be used to ignore additional files. If you want different
-ignore rules for `git` and `dart pub publish`, you may overrule the `.gitignore`
-file in a given folder by creating a `.pubignore` file.
-
-{{site.alert.note}}
-  The `.pubignore` files uses the [`.gitignore` format][git-ignore-format], and
-  multiple `.gitignore` and `.pubignore` files may exist across sub-folders of a
-  package. `dart pub publish` only reads the `.gitignore` file from a folder if
-  the folder does not contain a `.pubignore` file.
+{{site.alert.version-note}}
+  Support for `.pubignore` files was added in Dart 2.14.
 {{site.alert.end}}
 
-Be sure to delete any files you don't want to include (or add them to a
-`.gitignore` or `.pubignore` file). `dart pub publish` lists all files that
-it's going to publish before uploading your package,
-so examine the list carefully before completing your upload.
+If you want different ignore rules for `git` and `dart pub publish`,
+then overrule the `.gitignore` file in a given directory by
+creating a `.pubignore` file.
+(If a directory contains both a `.pubignore` file and a `.gitignore` file,
+then  `dart pub publish` doesn't read that directory's `.gitignore` file.)
+The format of `.pubignore` files is the same as the
+[`.gitignore` file format][git-ignore-format].
+
+To avoid publishing unwanted files,
+follow these practices:
+
+* Either delete any files that you don't want to include,
+  or add them to a `.pubignore`  or `.gitignore` file.
+* When uploading your package,
+  carefully examine the list of files that
+  `dart pub publish` says it's going to publish.
+  Cancel the upload if any undesired files appear in that list.
+
 
 ## Uploaders
 


### PR DESCRIPTION
Fixing https://github.com/dart-lang/site-www/issues/3399


Note: `.pubignore` support is set to ship in 2.14