### PR TITLE
Add details for redirecting constructors

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3050,7 +3050,9 @@ void main() {
 
 Sometimes a constructor’s only purpose is to redirect to another
 constructor in the same class. A redirecting constructor’s body is
-empty, with the constructor call appearing after a colon (:).
+empty, with the constructor call appearing after a colon (:). The
+constructor being redirected to must be accessed using the `this`
+keyword.
 
 <?code-excerpt "misc/lib/language_tour/classes/point_redirecting.dart"?>
 ```dart

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3050,9 +3050,9 @@ void main() {
 
 Sometimes a constructor’s only purpose is to redirect to another
 constructor in the same class. A redirecting constructor’s body is
-empty, with the constructor call appearing after a colon (:). The
-constructor being redirected to must be accessed using the `this`
-keyword.
+empty, with the constructor call
+(using `this` instead of the class name)
+appearing after a colon (:).
 
 <?code-excerpt "misc/lib/language_tour/classes/point_redirecting.dart"?>
 ```dart


### PR DESCRIPTION
I thought it was confusing there was no mention of the fact that the redirecting constructor syntax requires accessing the other constructor using `this`. WDYT? I'm totally open to rewording.