### PR TITLE
Remove linkcheck exclude for main.css

### DIFF
--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -2,7 +2,3 @@
 
 # Skip links used by example web apps
 localhost:(404\d|8080)
-
-# FIXME(Temporary): linkcheck seems to be intermittently failing when accessing main.css
-# https://github.com/dart-lang/site-www/issues/1107
-/assets/main(-[0-9a-f]+)?.css


### PR DESCRIPTION
I cannot reproduce the last issue and after some investigation it seems Linkcheck added a guard against the issue faced in https://github.com/filiph/linkcheck/commit/011ce655653c0f94bb6f522ef92f486fc835a513