### PR TITLE
Remove most outdated version notes

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -348,11 +348,6 @@ You can also [disable specific rules][disable individual rules]
 for all files or
 [change the severity of rules][].
 
-{{site.alert.version-note}}
-  As of Dart 2.8, you can't stop error rules from being applied to
-  individual files or lines of code.
-{{site.alert.end}}
-
 
 ### Excluding files
 

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -85,7 +85,7 @@ class C { ... }
 
 {% include linter-rule-mention.html rule="camel_case_extensions" %}
 
-Like types, extensions should capitalize the first letter of each word
+Like types, [extensions][] should capitalize the first letter of each word
 (including the first word),
 and use no separators.
 
@@ -97,12 +97,7 @@ extension MyFancyList<T> on List<T> { ... }
 extension SmartIterable<T> on Iterable<T> { ... }
 {% endprettify %}
 
-{{site.alert.version-note}}
-  Extensions are a Dart 2.7 language feature.
-  For details, see the [extensions design document.][]
-{{site.alert.end}}
-
-[extensions design document.]: https://github.com/dart-lang/language/blob/master/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
+[extensions]: /guides/language/extension-methods
 
 ### DO name libraries, packages, directories, and source files using `lowercase_with_underscores`. {#do-name-libraries-and-source-files-using-lowercase_with_underscores}
 

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -8,7 +8,6 @@ You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
 
-
 <iframe width="560" height="315"
   src="https://www.youtube.com/embed/D3j0OSfT9ZI"
   frameborder="0"

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -8,7 +8,6 @@ You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
 
-[minimum SDK constraint]: /tools/pub/pubspec#sdk-constraints
 
 <iframe width="560" height="315"
   src="https://www.youtube.com/embed/D3j0OSfT9ZI"

--- a/src/_guides/language/extension-methods.md
+++ b/src/_guides/language/extension-methods.md
@@ -8,11 +8,6 @@ You might use extension methods without even knowing it.
 For example, when you use code completion in an IDE,
 it suggests extension methods alongside regular methods.
 
-{{site.alert.version-note}}
-  To use extension methods in a package,
-  the pubspec must have a [minimum SDK constraint][] of at least 2.7.0.
-{{site.alert.end}}
-
 [minimum SDK constraint]: /tools/pub/pubspec#sdk-constraints
 
 <iframe width="560" height="315"

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2691,10 +2691,6 @@ var p1 = new Point(2, 2);
 var p2 = new Point.fromJson({'x': 1, 'y': 2});
 ```
 
-{{site.alert.version-note}}
-  The `new` keyword became optional in Dart 2.
-{{site.alert.end}}
-
 Some classes provide [constant constructors](#constant-constructors).
 To create a compile-time constant using a constant constructor,
 put the `const` keyword before the constructor name:
@@ -2749,10 +2745,6 @@ var b = ImmutablePoint(1, 1); // Does NOT create a constant
 
 assert(!identical(a, b)); // NOT the same instance!
 ```
-
-{{site.alert.version-note}}
-  The `const` keyword became optional within a constant context in Dart 2.
-{{site.alert.end}}
 
 
 ### Getting an object's type

--- a/src/codelabs/async-await.md
+++ b/src/codelabs/async-await.md
@@ -338,11 +338,6 @@ An `async` function runs synchronously until the first
 `await` keyword. This means that within an `async` function body, all
 synchronous code before the first `await` keyword executes immediately.
 
-{{site.alert.version-note}}
-  Before Dart 2.0, an `async` function returned immediately, without executing
-  any code within the `async` function body.
-{{site.alert.end}}
-
 ### Example: Execution within async functions
 Run the following example to see how execution proceeds within an `async`
 function body. What do you think the output will be?

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -19,6 +19,9 @@ If you aren't sure which tools you need, **get the Flutter SDK.**
 
 [General-purpose tools]: #general-purpose-tools
 
+{{site.alert.note}}
+The Flutter SDK includes the full Dart SDK.
+{{site.alert.end}}
 
 ## General-purpose tools
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -20,7 +20,7 @@ If you aren't sure which tools you need, **get the Flutter SDK.**
 [General-purpose tools]: #general-purpose-tools
 
 {{site.alert.note}}
-The Flutter SDK includes the full Dart SDK.
+  The Flutter SDK includes the full Dart SDK.
 {{site.alert.end}}
 
 ## General-purpose tools

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -19,10 +19,6 @@ If you aren't sure which tools you need, **get the Flutter SDK.**
 
 [General-purpose tools]: #general-purpose-tools
 
-{{site.alert.version-note}}
-  As of Flutter 1.21, the Flutter SDK includes the full Dart SDK.
-{{site.alert.end}}
-
 
 ## General-purpose tools
 

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -16,10 +16,6 @@ and get advice on how to update them.
 include using the most recent stable package versions,
 so you can get the latest bug fixes and improvements.
 
-{{site.alert.version-note}}
-  The `dart pub outdated` command was introduced in Dart 2.8.
-{{site.alert.end}}
-
 ## Overview
 
 Here's how you can use `dart pub outdated` to help you

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -15,12 +15,12 @@ To learn about other tools you can use for Dart development, see
 the [Dart tools](/tools) page.
 
 {{site.alert.version-note}}
-  As of Flutter 1.21, the Flutter SDK includes the full Dart SDK.
   This site's documentation and examples use
   {% if site.data.pkg-vers.SDK.channel == 'dev' %} the **dev channel** {% endif -%}
   version [{{site.data.pkg-vers.SDK.vers}}][site SDK version]{:.no-automatic-external}
   of the **Dart SDK**.
-</aside>
+{{site.alert.end}}
+
 {% comment %}
   IMPORTANT: After each release, EDIT src/_data/pkg-vers.json
   to update the SDK version number.


### PR DESCRIPTION
With this change I kept the version notes about the old versions of the `dart` tools for now as their deprecation is pretty recent and I still see a fair bit of usage of the old commands in the wild. Do you think those should be removed now as well @kwalrath?

Fixes https://github.com/dart-lang/site-www/issues/2174