### PR TITLE
Update authors with information on how to find list of contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,4 @@
 # This is a list of some of the Dart website's contributors.
-#
-# This does not necessarily list everyone who has contributed code,
-# especially since many employees of one corporation may be contributing.
 # To see the full list of contributors, see the revision history in
 # source control with a command like: git shortlog -sne
 #

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,11 @@
-# Below is a list of people and organizations that have contributed
-# to the Dart www site. Names should be added to the list like so:
+# This is a list of some of the Dart website's contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control with a command like: git shortlog -sne
+#
+# Names should be added to the list like so:
 #
 #   Name/Organization <email address>
 


### PR DESCRIPTION
This presents a git command rather than the [list of contributors](https://github.com/dart-lang/site-www/graphs/contributors) on the GitHub website as that only shows the top 100 contributors.

Closes https://github.com/dart-lang/site-www/issues/3332