### PR TITLE
Standardize pub page options formatting and wording

### DIFF
--- a/src/_includes/tools/pub-option-no-offline.md
+++ b/src/_includes/tools/pub-option-no-offline.md
@@ -1,0 +1,5 @@
+By default, pub connects to the network
+to retrieve hosted packages (`--no-offline`).
+To use cached packages instead, use `--offline`.
+For details,
+see [Getting while offline](/tools/pub/cmd/pub-get#getting-while-offline).

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -143,14 +143,17 @@ to make it directly available from the command line.
 Several command-line options work with all of the pub subcommands.
 These include:
 
-`--help` or `-h`
-: Print usage information.
+### `--help` or `-h`
 
-`--trace`
-: Print debugging information when an error occurs.
+Print usage information.
 
-`--verbosity=<level>`
-: The specified level determines the amount of information that is displayed:
+### `--trace`
+
+Print debugging information when an error occurs.
+
+### `--verbosity=`_`<level>`_
+
+The specified level determines the amount of information that is displayed:
 
 * `all`
 : Show all output, including internal tracing messages.
@@ -164,5 +167,6 @@ These include:
 * `solver`
 : Show steps during version resolution.
 
-`-verbose` or `-v`
-: Equivalent to `--verbosity=all`.
+### `-verbose` or `-v`
+
+Equivalent to `--verbosity=all`.

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -145,11 +145,11 @@ These include:
 
 ### `--help` or `-h`
 
-Print usage information.
+Prints usage information.
 
 ### `--trace`
 
-Print debugging information when an error occurs.
+Prints debugging information when an error occurs.
 
 ### `--verbosity=`_`<level>`_
 

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -170,3 +170,8 @@ The specified level determines the amount of information that is displayed:
 ### `-verbose` or `-v`
 
 Equivalent to `--verbosity=all`.
+
+### `--directory=<dir>` or `-C <dir>`
+
+Runs the command in the specified directory.
+

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -156,16 +156,16 @@ Prints debugging information when an error occurs.
 The specified level determines the amount of information that is displayed:
 
 * `all`
-: Show all output, including internal tracing messages.
+: Shows all output, including internal tracing messages.
 
 * `io`
-: Show I/O operations.
+: Shows I/O operations.
 
 * `normal`
-: Show errors, warnings, and user messages.
+: Shows errors, warnings, and user messages.
 
 * `solver`
-: Show steps during version resolution.
+: Shows steps during version resolution.
 
 ### `-verbose` or `-v`
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -79,9 +79,7 @@ Depends on a package that's shipped with the specified SDK
 
 ### `--[no-]offline`
 
-By default, pub connects to the network
-to retrieve hosted packages (`--no-offline`).
-To use cached packages instead, use `--offline`.
+{% include tools/pub-option-no-offline.md %}
 
 ### `-n, --dry-run`
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -80,7 +80,7 @@ Depends on a package that's shipped with the specified SDK
 ### `--[no-]offline`
 
 By default, pub connects to the network
-to add hosted packages (`--no-offline`).
+to retrieve hosted packages (`--no-offline`).
 To use cached packages instead, use `--offline`.
 
 ### `-n, --dry-run`

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -79,7 +79,9 @@ Depends on a package that's shipped with the specified SDK
 
 ### `--[no-]offline`
 
-Uses cached packages instead of the network.
+By default, pub connects to the network
+to add hosted packages (`--no-offline`).
+To use cached packages instead, use `--offline`.
 
 ### `-n, --dry-run`
 
@@ -88,7 +90,9 @@ but doesn't change any.
 
 ### `--[no-]precompile`
 
-Precompiles executables in immediate dependencies (`true` by default).
+By default, pub precompiles executables
+in immediate dependencies (`--precompile`).
+To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -5,7 +5,7 @@ description: Use dart pub add to add a dependency.
 
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-```
+```nocode
 $ dart pub add <package>[:<constraint>] [options]
 ```
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub add
 description: Use dart pub add to add a dependency.
-toc: false
 ---
 
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -21,10 +20,10 @@ $ dart pub add http
 ```
 
 By default, `dart pub add` uses the
-latest stable version of the package from pub.dev.
-For example, if 0.13.1 is the latest stable version of the `http` package,
+latest stable version of the package from the [pub.dev site]({{site.pub}}).
+For example, if 0.13.3 is the latest stable version of the `http` package,
 then `dart pub add http` adds
-`http: ^0.13.1` under `dependencies` in the pubspec.
+`http: ^0.13.3` under `dependencies` in the pubspec.
 
 To add a [dev dependency][], use the `--dev` option:
 
@@ -39,38 +38,59 @@ $ dart pub add --dev test
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-<dl>
-    <dt><code>-d, --dev</code></dt>
-        <dd>Adds the package as a dev dependency,
-        instead of as a regular dependency.</dd>
-    <dt><code>--git-url=<var>git_repo_url</var></code></dt>
-        <dd>Depends on the package in the
-        <a href="/tools/pub/dependencies#git-packages">specified Git repo</a>.
-        </dd>
-        {% prettify nocode tag=pre+code %}
-        $ dart pub add http --git-url=https://github.com/my/http.git
-        {% endprettify %}
-    <dt><code>--git-ref=<var>branch_or_commit</var></code></dt>
-        <dd>With <code>--git-url</code>,
-        depends on the specified branch or commit of a Git repo.</dd>
-        {% prettify nocode tag=pre+code %}
-        $ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
-        {% endprettify %}
-    <dt><code>--git-path=<var>directory_path</var></code></dt>
-    <dd>With <code>--git-url</code>,
-    specifies the location of a package within a Git repo.</dd>
-    <dt><code>--hosted-url=<var>package_server_url</var></code></dt>
-    <dd>Depends on the package server at the specified URL.</dd>
-    <dt><code>--path=<var>directory_path</var></code></dt>
-    <dd>Depends on a locally stored package.</dd>
-    <dt><code>--sdk=<var>sdk_name</var></code></dt>
-    <dd>Depends on a package that's shipped with the specified SDK
-    (example: <code>--sdk=flutter</code>).</dd>
-    <dt><code>--[no-]offline</code></dt>
-    <dd>Uses cached packages instead of the network.</dd>
-    <dt><code>-n, --dry-run</code></dt>
-    <dd>Reports which dependencies would change, but doesn't change any.</dd>
-    <dt><code>--[no-]precompile</code></dt>
-    <dd>Precompiles executables in immediate dependencies (true by default).</dd>
+### `-d, --dev`
 
-</dl>
+Adds the package as a dev dependency,
+instead of as a regular dependency.
+
+### `--git-url=`_`<git_repo_url>`_
+
+Depends on the package in the
+[specified Git repository](/tools/pub/dependencies#git-packages).
+
+```terminal
+$ dart pub add http --git-url=https://github.com/my/http.git
+```
+
+### `--git-ref=`_`<branch_or_commit>`_
+
+With `--git-url`, depends on the specified branch or commit of a Git repo.
+
+```terminal
+$ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
+```
+
+### `--git-path=`_`<directory_path>`_
+
+With `--git-url`, specifies the location of a package within a Git repo.
+
+### `--hosted-url=`_`<package_server_url>`_
+
+Depends on the package server at the specified URL.
+
+### `--path=`_`<directory_path>`_
+
+Depends on a locally stored package.
+
+### `--sdk=`_`<sdk_name>`_
+
+Depends on a package that's shipped with the specified SDK
+(example: `--sdk=flutter`).
+
+### `--[no-]offline`
+
+Uses cached packages instead of the network.
+
+### `-n, --dry-run`
+
+Reports which dependencies would change,
+but doesn't change any.
+
+### `--[no-]precompile`
+
+Precompiles executables in immediate dependencies (`true` by default).
+
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -29,16 +29,16 @@ You can perform a clean reinstallation of all packages in your system cache:
 $ dart pub cache repair
 ```
 
-This is useful if the packages in your system cache
-were somehow changed or broken.
+This command can be useful when packages in your system cache
+are somehow changed or broken.
 
 For example, some editors make it easy to find implementation files
 for packages in the system cache,
 and you might accidentally edit one of those files.
 
-## Clear the global system cache
+## Clearing the global system cache
 
-You can clear the entire system cache:
+You can empty the entire system cache:
 
 ```terminal
 $ dart pub cache clear

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -5,7 +5,7 @@ description: Use dart pub cache to manage your system cache.
 
 _Cache_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-```
+```nocode
 $ dart pub cache add <package> [--version <constraint>] [--all]
 $ dart pub cache repair
 ```

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -51,15 +51,14 @@ For options that apply to all pub commands, see
 
 ### `--all`
 
-Optional for `dart pub cache add`.
-
-Installs all matching versions of a library.
+Use `dart pub cache add --all` 
+to install all matching versions of a library.
 
 ### `--version `_`<constraint>`_
 
-Optional for `dart pub cache add`.
-
-Installs the best version matching the specified constraint. For example:
+Use with `dart pub cache add`
+to install the version best matching the specified constraint. 
+For example:
 
 ```terminal
 $ dart pub cache add http --version "0.12.2"

--- a/src/tools/pub/cmd/pub-cache.md
+++ b/src/tools/pub/cmd/pub-cache.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub cache
 description: Use dart pub cache to manage your system cache.
-toc: false
 ---
 
 _Cache_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -13,41 +12,62 @@ $ dart pub cache repair
 
 The `dart pub cache` command works with the
 [system cache](/tools/pub/glossary#system-cache).
-To add new packages to your cache, use `dart pub cache add`.
-To perform a clean reinstall of the packages in your system cache,
-use `dart pub cache repair`.
+
+## Adding a package to the system cache
+
+You can manually add a package to your system cache:
+
+```terminal
+$ dart pub cache add <package>
+```
+
+## Reinstalling all packages in the system cache
+
+You can perform a clean reinstallation of all packages in your system cache:
+
+```terminal
+$ dart pub cache repair
+```
+
+This is useful if the packages in your system cache
+were somehow changed or broken.
+
+For example, some editors make it easy to find implementation files
+for packages in the system cache,
+and you might accidentally edit one of those files.
+
+## Clear the global system cache
+
+You can clear the entire system cache:
+
+```terminal
+$ dart pub cache clear
+```
 
 ## Options
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-<dl>
-<dt><code>add &lt;package&gt;</code></dt>
-<dd>Installs a library in your cache.</dd>
+### `--all`
 
-<dt><code>--all</code></dt>
-<dd>Optional. Use with <code>dart pub cache add</code> to install all
-matching versions of a library.</dd>
+Optional for `dart pub cache add`.
 
-<dt><code>--version &lt;constraint&gt;</code></dt>
-<dd>Optional. Use with <code>dart pub cache add</code> to install the best
-version matching the specified constraint. For example:
+Installs all matching versions of a library.
 
-{% prettify nocode tag=pre+code %}
+### `--version `_`<constraint>`_
+
+Optional for `dart pub cache add`.
+
+Installs the best version matching the specified constraint. For example:
+
+```terminal
 $ dart pub cache add http --version "0.12.2"
-{% endprettify %}
+```
 
-If <code>--version</code> is omitted, pub installs the best of all known
-versions.</dd>
+If `--version` is omitted, pub installs the best of all known versions.
 
-<dt><code>repair</code></dt>
-<dd>It's possible for packages in your pub cache to change or break.
-For example, some editors make it easy to find implementation files for
-packages in the pub cache, and you might accidentally edit one of those files.
-The <code>dart pub cache repair</code> command performs a clean reinstall of all
-hosted and git packages in the system cache.</dd>
-
-<aside class="alert alert-info" markdown="1">
-  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -65,8 +65,9 @@ default format.
 
 ### `--[no-]dev`
 
-Prints all package dependencies, including dev dependencies. 
-Dev dependencies are included by default.
+By default, prints all dependencies, 
+including dev dependencies (`--dev`).
+To remove dev dependencies, use `--no-dev`.
 
 ### `--executables`
 

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub deps
 description: Use dart pub deps to print a dependency graph for a package.
-toc: false
 ---
 
 _Deps_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -22,11 +21,11 @@ The dependency information is printed as a tree by default.
 For example, the pubspec for the markdown_converter example specifies
 the following dependencies:
 
-{% prettify yaml tag=pre+code %}
+```yaml
 dependencies:
   barback: ^0.15.2
   markdown: ^0.7.2
-{% endprettify %}
+```
 
 Here's an example of the `dart pub deps` output for markdown_converter:
 
@@ -50,8 +49,9 @@ markdown_converter 0.0.0
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`--style=<style>` or `-s <style>`
-: The specified style determines the output format:
+### `--style=<style>` or `-s <style>`
+
+The specified style determines the output format:
 
 * `tree`
 : Prints dependency information as a tree. This is the 
@@ -63,18 +63,20 @@ default format.
 * `compact`
 : Prints dependency information as a compact list.
 
+### `--[no-]dev`
 
-`--dev`
-: Prints all package dependencies, including dev dependencies. Dev 
-dependencies are included by default.
+Prints all package dependencies, including dev dependencies. 
+Dev dependencies are included by default.
 
-`--no-dev`
-: Prints all package dependencies, excluding dev dependencies. 
+### `--executables`
 
-`--executables`
-: Prints all available executables.
+Prints all available executables.
 
-<aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+### `--json`
+
+Generates output in JSON format.
+
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -5,9 +5,9 @@ description: Use dart pub deps to print a dependency graph for a package.
 
 _Deps_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify none tag=pre+code %}
-$ dart pub deps [--style=<style>] [--dev] [--no-dev] [--executables]
-{% endprettify %}
+```nocode
+$ dart pub deps [--style=<style>] [--[no-]-dev] [--executables]
+```
 
 This command prints the dependency graph for a package.
 The graph includes both the

--- a/src/tools/pub/cmd/pub-deps.md
+++ b/src/tools/pub/cmd/pub-deps.md
@@ -6,7 +6,7 @@ description: Use dart pub deps to print a dependency graph for a package.
 _Deps_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 ```nocode
-$ dart pub deps [--style=<style>] [--[no-]-dev] [--executables]
+$ dart pub deps [--style=<style>] [--[no-]dev] [--executables]
 ```
 
 This command prints the dependency graph for a package.

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -5,9 +5,9 @@ description: Use dart pub downgrade to get the lowest versions of all dependenci
 
 _Downgrade_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify sh tag=pre+code %}
+```nocode
 $ dart pub downgrade [--[no-]offline] [-n|--dry-run] [dependencies...] 
-{% endprettify %}
+```
 
 Without any additional arguments, `dart pub downgrade` gets the lowest versions of
 all the dependencies listed in the [`pubspec.yaml`](/tools/pub/pubspec) file

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -105,14 +105,17 @@ available.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`--[no-]offline`
-: By default, pub connects to the network to check for hosted 
+### `--[no-]offline`
+
+By default, pub connects to the network to check for hosted 
 dependencies (`--no-offline`). To use cached packages instead, use `--offline`.
 
-`--dry-run` or `-n`
-: Report what dependencies would change but don't change any.
+### `--dry-run` or `-n`
+
+Reports what dependencies would change but doesn't change any.
 
 
-<aside class="alert alert-info" markdown="1">
-  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -107,8 +107,9 @@ For options that apply to all pub commands, see
 
 ### `--[no-]offline`
 
-By default, pub connects to the network to check for hosted 
-dependencies (`--no-offline`). To use cached packages instead, use `--offline`.
+By default, pub connects to the network
+to check for hosted dependencies (`--no-offline`). 
+To use cached packages instead, use `--offline`.
 
 ### `--dry-run` or `-n`
 

--- a/src/tools/pub/cmd/pub-downgrade.md
+++ b/src/tools/pub/cmd/pub-downgrade.md
@@ -107,9 +107,7 @@ For options that apply to all pub commands, see
 
 ### `--[no-]offline`
 
-By default, pub connects to the network
-to check for hosted dependencies (`--no-offline`). 
-To use cached packages instead, use `--offline`.
+{% include tools/pub-option-no-offline.md %}
 
 ### `--dry-run` or `-n`
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -58,18 +58,14 @@ By default, pub creates a `.packages` file
 that maps from package names to location URIs.
 Before the `.packages` file, pub used to create `packages` directories.
 
-<aside class="alert alert-info" markdown="1">
-**Note:** Don't check the generated `.packages` file,
-`packages` directories (if present), or
-`.dart_tool` directory into your repo;
-add them to your repo's `.gitignore` file.
-For more information, see
-[What Not to Commit](/guides/libraries/private-files).
-{% comment %}
-PENDING: here just to make it easy to find discussions of `packages`...
-{% include packages-dir.html %}
-{% endcomment %}
-</aside>
+{{site.alert.note}}
+  Don't check the generated `.packages` file,
+  `packages` directories (if present), or
+  `.dart_tool` directory into your repo;
+  add them to your repo's `.gitignore` file.
+  For more information, 
+  see [What not to commit](/guides/libraries/private-files).
+{{site.alert.end}}
 
 For more information, see the
 [package specification file proposal.](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md#proposal)

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -142,16 +142,18 @@ Reports the dependencies that would be changed,
 but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
 
-### `--offline`
+### `--[no-]offline`
 
-Uses cached packages rather than downloading
-from the network.
+By default, pub connects to the network
+to retrieve hosted packages (`--no-offline`).
+To use cached packages instead, use `--offline`.
 For details, see [Getting while offline](#getting-while-offline).
 
-### `--precompile`
+### `--[no-]precompile`
 
-Creates snapshots of the
-project's executables in direct dependencies.
+By default, pub precompiles executables
+in immediate dependencies (`--precompile`).
+To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -136,15 +136,15 @@ run [`dart pub upgrade`](/tools/pub/cmd/pub-upgrade) to upgrade to a later versi
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
+### `--[no-]offline`
+
+{% include tools/pub-option-no-offline.md %}
+
 ### `--dry-run` or `-n`
 
 Reports the dependencies that would be changed,
 but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
-
-### `--[no-]offline`
-
-{% include tools/pub-option-no-offline.md %}
 
 ### `--[no-]precompile`
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -31,9 +31,9 @@ this command creates a `.packages` file.
 Once the dependencies are acquired, they may be referenced in Dart code.
 For example, if a package depends on `test`:
 
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:test/test.dart';
-{% endprettify %}
+```
 
 When `dart pub get` gets new dependencies, it writes a
 [lockfile](/tools/pub/glossary#lockfile) to ensure that future
@@ -157,7 +157,7 @@ For details, see [Getting while offline](#getting-while-offline).
 Creates snapshots of the
 project's executables in direct dependencies.
 
-<aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -144,10 +144,7 @@ want to analyze updates before making them.
 
 ### `--[no-]offline`
 
-By default, pub connects to the network
-to retrieve hosted packages (`--no-offline`).
-To use cached packages instead, use `--offline`.
-For details, see [Getting while offline](#getting-while-offline).
+{% include tools/pub-option-no-offline.md %}
 
 ### `--[no-]precompile`
 

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -5,9 +5,9 @@ description: Use dart pub get to retrieve the dependencies used by your Dart app
 
 _Get_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify nocode tag=pre+code %}
-$ dart pub get [args]
-{% endprettify %}
+```
+$ dart pub get [options]
+```
 
 This command gets all the dependencies listed in the
 [`pubspec.yaml`](/tools/pub/pubspec) file in the current working

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -135,7 +135,7 @@ may vary for different versions of Windows.
 
 You can now directly invoke the command:
 
-{% prettify none tag=pre+code %}
+{% prettify nocode tag=pre+code %}
 $ cd web_project
 $ [!webdev serve!]
 {% endprettify %}

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -213,10 +213,8 @@ For options that apply to all pub commands, see
 
 ### `<constraint>`
 
-Optional for `dart pub global activate`. 
-
-The constraint allows you to pull in a specific version of the package. 
-
+Use `dart pub global activate <package> <constraint>` 
+to specify a specific version of the package. 
 For example, the following command pulls
 the 0.6.0 version of the `markdown` package:
 

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -29,7 +29,7 @@ package that your package depends on, see [dart run](/tools/dart-run).
 ## Activating a package
 
 ```nocode
-dart pub global activate [--noexecutables] [--executable=<name>] [--overwrite] <package> [constraint]
+dart pub global activate [--noexecutables] [--executable=<name>] [--overwrite] <package> [version-constraint]
 ```
 
 Activate a package when you want to be able to run
@@ -211,9 +211,9 @@ Use `list` to list all currently active packages.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-### `<constraint>`
+### `[version-constraint]`
 
-Use `dart pub global activate <package> <constraint>` 
+Use `dart pub global activate <package> [version-constraint]` 
 to specify a specific version of the package. 
 For example, the following command pulls
 the 0.6.0 version of the `markdown` package:
@@ -229,15 +229,15 @@ constraint. For example:
 $ dart pub global activate foo <3.0.0
 ```
 
-### `--executable=<name>` or `-x<name>`
+### `--executable=<name>` or `-x <name>`
 
-Optional for `dart pub global activate`.
-
-Adds the specified executable to your PATH.
+Use with `dart pub global activate`
+to add the specified executable to your PATH.
 You can pass more than one of these flags.
 
-For example, the following command adds `bar` and `baz` (but not
-any other executables that `foo` might define) to your PATH.
+For example, the following command adds `bar` and `baz`,
+(but not any other executables that `foo` might define) 
+to your PATH.
 
 ```terminal
 $ dart pub global activate foo -x bar -x baz
@@ -245,19 +245,18 @@ $ dart pub global activate foo -x bar -x baz
 
 ### `--no-executables`
 
-Optional for `dart pub global activate`.
-
-Globally activates the package
-but doesn't put any executables in `bin`. 
+Use `dart pub global activate <package> --no-executables`
+to globally activate the specified package,
+but not put any executables in `bin`. 
 You have to use `dart pub global run` to run any executables.
 
 ### `--overwrite`
 
-Optional for `dart pub global activate`.
+Use `dart pub global activate <package> --overwrite`
+to overwrite any previously activated global executables
+with the same name. If you don't specify this flag,
+the preexisting executable will not be replaced.
 
-Normally, if executables from two global packages have a name collision, 
-the preexisting executable wins. If you specify this flag,
-the new executable overwrites the previously activated executable.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -47,7 +47,7 @@ constraint.  See the [constraint](#options) flag for usage examples.
 ### Activating a package on the pub.dev site
 
 ```terminal
-$ dart pub global activate <pub.dartlang package>
+$ dart pub global activate <pub.dev package>
 ```
 
 Specify a package on the pub.dev site to activate it. For example:
@@ -115,10 +115,10 @@ $ webdev serve
 Verify that the `bin` directory for the system cache is in your path.
 The following `PATH` variable, on macOS, includes the system cache:
 
-{% prettify none tag=pre+code %}
+```terminal
 $ echo $PATH
 /Users/<user>/homebrew/bin:/usr/local/bin:/usr/bin:/bin:[!/Users/<user>/.pub-cache/bin!]
-{% endprettify %}
+```
 
 If this directory is missing from your `PATH`,
 locate the file for your platform and add it.
@@ -171,12 +171,12 @@ entry of the pubspec file.  For example, the following pubspec file
 identifies `bin/helloworld.dart` as an executable for the helloworld
 package:
 
-{% prettify yaml tag=pre+code %}
+```yaml
 name: helloworld
 
 executables:
   helloworld:
-{% endprettify %}
+```
 
 Failing to list a script under the `executables` tag reduces the script's
 usability: unlisted scripts can be executed using `dart pub global run`, but not
@@ -211,49 +211,60 @@ Use `list` to list all currently active packages.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`<constraint>`
-: Optional for `dart pub global activate`. The constraint allows you to pull
-  in a specific version of the package. For example,
-  the following command pulls the 0.6.0 version of the `markdown`
-  package:
+### `<constraint>`
 
-  ```terminal
-  $ dart pub global activate markdown 0.6.0
-  ```
+Optional for `dart pub global activate`. 
 
-  If you specify a range, pub picks the best version that meets that
-  constraint. For example:
+The constraint allows you to pull in a specific version of the package. 
 
-  ```terminal
-  $ dart pub global activate foo <3.0.0
-  ```
+For example, the following command pulls
+the 0.6.0 version of the `markdown` package:
 
-`--executable=<name>` or `-x<name>`
-: Optional for `dart pub global activate`.
-  Adds the specified executable to your PATH.
-  You can pass more than one of these flags.
-  For example, the following command adds `bar` and `baz` (but not
-  any other executables that `foo` might define) to your PATH.
+```terminal
+$ dart pub global activate markdown 0.6.0
+```
 
-  ```terminal
-  $ dart pub global activate foo -x bar -x baz
-  ```
+If you specify a range, pub picks the best version that meets that
+constraint. For example:
 
-`--no-executables`
-: Optional for `dart pub global activate`.
-  Globally activates the package but doesn't put any
-  executables in `bin`. You have to use `dart pub global run` to
-  run any executables.
+```terminal
+$ dart pub global activate foo <3.0.0
+```
 
-`--overwrite`
-: Optional for `dart pub global activate`.
-  Normally, if executables from two global packages have a name
-  collision, the preexisting executable wins. If you specify this flag,
-  the new executable overwrites the previously activated executable.
+### `--executable=<name>` or `-x<name>`
 
-<aside class="alert alert-info" markdown="1">
-  *Problems?* See [Troubleshooting pub](/tools/pub/troubleshoot).
-</aside>
+Optional for `dart pub global activate`.
+
+Adds the specified executable to your PATH.
+You can pass more than one of these flags.
+
+For example, the following command adds `bar` and `baz` (but not
+any other executables that `foo` might define) to your PATH.
+
+```terminal
+$ dart pub global activate foo -x bar -x baz
+```
+
+### `--no-executables`
+
+Optional for `dart pub global activate`.
+
+Globally activates the package
+but doesn't put any executables in `bin`. 
+You have to use `dart pub global run` to run any executables.
+
+### `--overwrite`
+
+Optional for `dart pub global activate`.
+
+Normally, if executables from two global packages have a name collision, 
+the preexisting executable wins. If you specify this flag,
+the new executable overwrites the previously activated executable.
+
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}
 
 [system cache]: /tools/pub/glossary#system-cache
 [webdev]: /tools/webdev

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -229,6 +229,13 @@ constraint. For example:
 $ dart pub global activate foo <3.0.0
 ```
 
+### `--no-executables`
+
+Use `dart pub global activate <package> --no-executables`
+to globally activate the specified package,
+but not put any executables in `bin`.
+You have to use `dart pub global run` to run any executables.
+
 ### `--executable=<name>` or `-x <name>`
 
 Use with `dart pub global activate`
@@ -242,13 +249,6 @@ to your PATH.
 ```terminal
 $ dart pub global activate foo -x bar -x baz
 ```
-
-### `--no-executables`
-
-Use `dart pub global activate <package> --no-executables`
-to globally activate the specified package,
-but not put any executables in `bin`. 
-You have to use `dart pub global run` to run any executables.
 
 ### `--overwrite`
 

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -5,9 +5,9 @@ description: Use dart pub publish to publish your Dart package to the pub.dev si
 
 _Publish_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify nocode tag=pre+code %}
+```nocode
 $ dart pub publish [options]
-{% endprettify %}
+```
 
 This command publishes your package on the
 [pub.dev site]({{site.pub}}) for anyone to download and depend

--- a/src/tools/pub/cmd/pub-lish.md
+++ b/src/tools/pub/cmd/pub-lish.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub publish
 description: Use dart pub publish to publish your Dart package to the pub.dev site.
-toc: false
 ---
 
 _Publish_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -37,7 +36,8 @@ In the event of warnings, your package *is* uploaded.
 To ensure that your package has no warnings before uploading,
 either don't use `--force`, or use `--dry-run` first.
 
-<aside class="alert alert-info" markdown="1">
-  *Problems?* See [Troubleshooting pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}
 

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -207,9 +207,11 @@ Generates output in JSON format.
 
 ### `--[no-]color`
 
-By default, uses color when printing to a terminal (`--color`),
-otherwise doesn't use color (`--no-color`).
-To not include color when printing to a terminal, use `--no-color`.
+Adds color to the output for emphasis (`--color`). 
+The default depends on whether you're using this command at a terminal.
+At a terminal, `--color` is the default, 
+otherwise, `--no-color` is the default. 
+Use `--no-color` to disable color in all environments.
 
 ### `--[no-]up-to-date`
 

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -201,10 +201,6 @@ so that each package uses the versions in the **Resolvable** column.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-### `--json`
-
-Generates output in JSON format.
-
 ### `--[no-]color`
 
 Adds color to the output for emphasis (`--color`). 
@@ -213,11 +209,21 @@ At a terminal, `--color` is the default,
 otherwise, `--no-color` is the default. 
 Use `--no-color` to disable color in all environments.
 
-### `--[no-]up-to-date`
+### `--[no-]dependency-overrides`
 
-By default, doesn't include dependencies that
-are at the latest version (`--no-up-to-date`).
-To include up-to-date dependencies, use `--up-to-date`.
+By default, accounts for [`dependency_overrides`][]
+when resolving package constraints (`--dependency-overrides`).
+To not consider overrides, use `--no-dependency_overrides`.
+
+### `--[no-]dev-dependencies`
+
+By default, accounts for [dev dependencies][dev dependency]
+when resolving package constraints (`--dev-dependencies`).
+To not consider dev dependencies, use `--no-dev-dependencies`.
+
+### `--json`
+
+Generates output in JSON format.
 
 ### `--[no-]prereleases`
 
@@ -225,23 +231,18 @@ By default, includes prereleases
 when determining the last package versions (`--prereleases`).
 To not consider preleases, use `--no-prereleases`.
 
-### `--[no-]dev-dependencies`
-
-By default, accounts for [dev dependencies][dev dependency] 
-when resolving package constraints (`--dev-dependencies`).
-To not consider dev dependencies, use `--no-dev-dependencies`.
-
-### `--[no-]dependency-overrides`
-
-By default, accounts for [`dependency_overrides`][] 
-when resolving package constraints (`--dependency-overrides`).
-To not consider overrides, use `--no-dependency_overrides`.
-
 ### `--[no-]transitive`
 
-By default, doesn't include [transitive dependencies][] 
+By default, doesn't include [transitive dependencies][]
 as part of the output (`--no-transitive`).
 To include transitive dependencies, use `--transitive`.
+
+### `--[no-]up-to-date`
+
+By default, doesn't include dependencies that
+are at the latest version (`--no-up-to-date`).
+To include up-to-date dependencies, use `--up-to-date`.
+
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -233,13 +233,13 @@ To not consider dev dependencies, use `--no-dev-dependencies`.
 
 By default, accounts for [`dependency_overrides`][] 
 when resolving package constraints (`--dependency-overrides`).
-To not consider overrides, use `dependency_overrides`.
+To not consider overrides, use `--no-dependency_overrides`.
 
 ### `--[no-]transitive`
 
 By default, doesn't include [transitive dependencies][] 
 as part of the output (`--no-transitive`).
-To include transitive dependencies, use `--no-transitive`.
+To include transitive dependencies, use `--transitive`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -6,9 +6,9 @@ diff2html: true
 
 _Outdated_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify nocode tag=pre+code %}
+```nocode
 $ dart pub outdated [options]
-{% endprettify %}
+```
 
 Use `dart pub outdated` to identify out-of-date [package dependencies][]
 and get advice on how to update them.

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -201,36 +201,55 @@ so that each package uses the versions in the **Resolvable** column.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-`--json`
-: Use this option to generate output in JSON format.
+### `--json`
 
-`--[no-]color`
-: Use this option to change whether the output uses color for emphasis.
-  The default depends on whether you're using this command at a terminal.
-  At a terminal, `--color` is the default;
-  otherwise, `--no-color` is the default.
+Generates output in JSON format.
 
-`--[no-]up-to-date`
-: Use `--up-to-date` to make the output include dependencies that
-  are already at the latest version.
-  The default is `--no-up-to-date`, which saves space.
+### `--[no-]color`
 
-`--[no-]prereleases`
-: Use `--prereleases` to include prereleases when determining
-  the latest package versions.
-  By default, prerelease versions aren't considered.
+Controls whether the output uses color for emphasis.
+The default depends on whether you're using this command at a terminal.
 
-`--[no-]dev-dependencies`
-: Use `--no-dev-dependencies` to ignore [dev dependencies][dev dependency].
+At a terminal, `--color` is the default;
+otherwise, `--no-color` is the default.
 
-`--[no-]dependency-overrides`
-: Use `--no-dependency-overrides` to ignore [`dependency_overrides`][]
-  when resolving package constraints.
+### `--[no-]up-to-date`
 
-<aside class="alert alert-info" markdown="1">
-**Problems?**
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+Makes the output include dependencies that 
+are already at the latest version.
+
+The default is `--no-up-to-date`, which saves space.
+
+### `--[no-]prereleases`
+
+Includes prereleases when determining the latest package versions.
+
+By default, prerelease versions aren't considered.
+
+### `--[no-]dev-dependencies`
+
+Accounts for [dev dependencies][dev dependency] 
+when resolving package constraints.
+
+By default, dev dependencies are accounted for.
+
+### `--[no-]dependency-overrides`
+
+Accounts for [`dependency_overrides`][] 
+when resolving package constraints.
+
+By default, dependency overrides are accounted for.
+
+### `--[no-]transitive`
+
+Shows [transitive dependencies][] as part of the output.
+
+By default, transitive dependencies are not included.
+
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}
 
 [`args`]: {{site.pub-pkg}}/args
 [best practices]: /tools/pub/dependencies#best-practices

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -207,44 +207,39 @@ Generates output in JSON format.
 
 ### `--[no-]color`
 
-Controls whether the output uses color for emphasis.
-The default depends on whether you're using this command at a terminal.
-
-At a terminal, `--color` is the default;
-otherwise, `--no-color` is the default.
+By default, uses color when printing to a terminal (`--color`),
+otherwise doesn't use color (`--no-color`).
+To not include color when printing to a terminal, use `--no-color`.
 
 ### `--[no-]up-to-date`
 
-Makes the output include dependencies that 
-are already at the latest version.
-
-The default is `--no-up-to-date`, which saves space.
+By default, doesn't include dependencies that
+are at the latest version (`--no-up-to-date`).
+To include up-to-date dependencies, use `--up-to-date`.
 
 ### `--[no-]prereleases`
 
-Includes prereleases when determining the latest package versions.
-
-By default, prerelease versions aren't considered.
+By default, includes prereleases
+when determining the last package versions (`--prereleases`).
+To not consider preleases, use `--no-prereleases`.
 
 ### `--[no-]dev-dependencies`
 
-Accounts for [dev dependencies][dev dependency] 
-when resolving package constraints.
-
-By default, dev dependencies are accounted for.
+By default, accounts for [dev dependencies][dev dependency] 
+when resolving package constraints (`--dev-dependencies`).
+To not consider dev dependencies, use `--no-dev-dependencies`.
 
 ### `--[no-]dependency-overrides`
 
-Accounts for [`dependency_overrides`][] 
-when resolving package constraints.
-
-By default, dependency overrides are accounted for.
+By default, accounts for [`dependency_overrides`][] 
+when resolving package constraints (`--dependency-overrides`).
+To not consider overrides, use `dependency_overrides`.
 
 ### `--[no-]transitive`
 
-Shows [transitive dependencies][] as part of the output.
-
-By default, transitive dependencies are not included.
+By default, doesn't include [transitive dependencies][] 
+as part of the output (`--no-transitive`).
+To include transitive dependencies, use `--no-transitive`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -26,9 +26,7 @@ For options that apply to all pub commands, see
 
 ### `--[no-]offline`
 
-By default, pub connects to the network
-to retrieve hosted packages (`--no-offline`).
-To use cached packages instead, use `--offline`.
+{% include tools/pub-option-no-offline.md %}
 
 ### `-n, --dry-run`
 

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub remove
 description: Use dart pub remove to remove a dependency.
-toc: false
 ---
 
 _Remove_ is one of the commands of the [pub tool](/tools/pub/cmd).
@@ -25,11 +24,20 @@ $ dart pub remove http
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-<dl>
-    <dt><code>--[no-]offline</code></dt>
-    <dd>Uses cached packages instead of the network.</dd>
-    <dt><code>-n, --dry-run</code></dt>
-    <dd>Reports which dependencies would change, but doesn't change any.</dd>
-    <dt><code>--[no-]precompile</code></dt>
-    <dd>Precompiles executables in immediate dependencies (true by default).</dd>
-</dl>
+### `--[no-]offline`
+
+Uses cached packages instead of the network.
+
+### `-n, --dry-run`
+
+Reports which dependencies would change, 
+but doesn't change any.
+
+### `--[no-]precompile`
+
+Precompiles executables in immediate dependencies (`true` by default).
+
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -26,7 +26,9 @@ For options that apply to all pub commands, see
 
 ### `--[no-]offline`
 
-Uses cached packages instead of the network.
+By default, pub connects to the network
+to retrieve hosted packages (`--no-offline`).
+To use cached packages instead, use `--offline`.
 
 ### `-n, --dry-run`
 
@@ -35,7 +37,9 @@ but doesn't change any.
 
 ### `--[no-]precompile`
 
-Precompiles executables in immediate dependencies (`true` by default).
+By default, pub precompiles executables
+in immediate dependencies (`--precompile`).
+To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -5,7 +5,7 @@ description: Use dart pub remove to remove a dependency.
 
 _Remove_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-```
+```nocode
 $ dart pub remove <package> [options]
 ```
 
@@ -15,7 +15,7 @@ For example, the following command is equivalent to
 editing `pubspec.yaml` (removing `http` from `dependencies` or `dev_dependencies`)
 and then calling `dart pub get`:
 
-```
+```terminal
 $ dart pub remove http
 ```
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -104,7 +104,7 @@ run `dart pub upgrade` again to upgrade to a later version.
 ## Options
 
 The `dart pub upgrade` command supports the
-[`dart pub get` options](/tools/pub/cmd/pub-get#options).
+[`dart pub get` options](/tools/pub/cmd/pub-get#options), and more.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -154,7 +154,7 @@ For details, see [Upgrading while offline](#upgrading-while-offline).
 Creates snapshots of the
 project's executables in direct dependencies.
 
-<aside class="alert alert-info" markdown="1">
-*Problems?*
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -108,26 +108,21 @@ The `dart pub upgrade` command supports the
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
+### `--[no-]offline`
+
+{% include tools/pub-option-no-offline.md %}
+
 ### `--dry-run` or `-n`
 
 Reports the dependencies that would be changed,
 but doesn't make the changes. This is useful if you
 want to analyze updates before making them.
 
-### `--major-versions`
+### `--[no-]precompile`
 
-Gets the packages that [`dart pub outdated`][] lists as _resolvable_,
-ignoring any upper-bound constraint in the `pubspec.yaml` file.
-Also updates `pubspec.yaml` with the new constraints.
-
-[`dart pub outdated`]: /tools/pub/cmd/pub-outdated
-
-{{site.alert.tip}}
-  Commit the `pubspec.yaml` file before running this command,
-  so that you can undo the changes if necessary.
-{{site.alert.end}}
-To check which dependencies will be upgraded,
-you can use `dart pub upgrade --major-versions --dry-run`.
+By default, pub precompiles executables
+in immediate dependencies (`--precompile`).
+To prevent precompilation, use `--no-precompile`.
 
 ### `--null-safety`
 
@@ -138,20 +133,27 @@ ignoring any upper-bound constraint in the `pubspec.yaml` file.
 Also updates `pubspec.yaml` with the new constraints.
 This command is similar to `--major-versions`.
 
+### `--major-versions`
+
+Gets the packages that [`dart pub outdated`][] lists as _resolvable_,
+ignoring any upper-bound constraint in the `pubspec.yaml` file.
+Also updates `pubspec.yaml` with the new constraints.
+
+[`dart pub outdated`]: /tools/pub/cmd/pub-outdated
+
+{{site.alert.tip}}
+Commit the `pubspec.yaml` file before running this command,
+so that you can undo the changes if necessary.
+{{site.alert.end}}
+
+To check which dependencies will be upgraded,
+you can use `dart pub upgrade --major-versions --dry-run`.
+
 {{site.alert.tip}}
   Commit the `pubspec.yaml` file before running this command,
   so that you can undo the changes if necessary.
 {{site.alert.end}}
 
-### `--[no-]offline`
-
-{% include tools/pub-option-no-offline.md %}
-
-### `--[no-]precompile`
-
-By default, pub precompiles executables
-in immediate dependencies (`--precompile`).
-To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -143,16 +143,18 @@ This command is similar to `--major-versions`.
   so that you can undo the changes if necessary.
 {{site.alert.end}}
 
-### `--offline`
+### `--[no-]offline`
 
-Uses cached packages rather than downloading
-from the network.
-For details, see [Upgrading while offline](#upgrading-while-offline).
+By default, pub connects to the network
+to retrieve hosted packages (`--no-offline`).
+To use cached packages instead, use `--offline`.
+For details, see [Getting while offline](#getting-while-offline).
 
-### `--precompile`
+### `--[no-]precompile`
 
-Creates snapshots of the
-project's executables in direct dependencies.
+By default, pub precompiles executables
+in immediate dependencies (`--precompile`).
+To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -145,10 +145,7 @@ This command is similar to `--major-versions`.
 
 ### `--[no-]offline`
 
-By default, pub connects to the network
-to retrieve hosted packages (`--no-offline`).
-To use cached packages instead, use `--offline`.
-For details, see [Getting while offline](#getting-while-offline).
+{% include tools/pub-option-no-offline.md %}
 
 ### `--[no-]precompile`
 

--- a/src/tools/pub/cmd/pub-upgrade.md
+++ b/src/tools/pub/cmd/pub-upgrade.md
@@ -5,9 +5,9 @@ description: Use dart pub upgrade to get the latest versions of all dependencies
 
 _Upgrade_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify nocode tag=pre+code %}
-$ dart pub upgrade [args] [dependencies]
-{% endprettify %}
+```nocode
+$ dart pub upgrade [options] [dependencies]
+```
 
 Like [`dart pub get`](/tools/pub/cmd/pub-get),
 `dart pub upgrade` gets dependencies.

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -11,9 +11,9 @@ description: Use dart pub uploader to add or remove uploaders for your Dart pack
 
 _Uploader_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
-{% prettify nocode tag=pre+code %}
+```nocode
 $ dart pub uploader [options] {add/remove} <email>
-{% endprettify %}
+```
 
 This command allows
 [uploaders](/tools/pub/glossary#uploader) of a

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -1,7 +1,6 @@
 ---
 title: dart pub uploader
 description: Use dart pub uploader to add or remove uploaders for your Dart package on the pub.dev site.
-toc: false
 ---
 
 {{site.alert.tip}}
@@ -61,6 +60,11 @@ Google Apps email address for any new uploaders.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
+
+### `--package=`_`<package name>`_
+
+Specifies which package to modify the uploaders for. 
+Defaults to the package in the current directory.
 
 {{site.alert.info}}
   *Problems?*

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -62,6 +62,7 @@ Google Apps email address for any new uploaders.
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
-<aside class="alert alert-info" markdown="1">
-  *Problems?* See [Troubleshooting Pub](/tools/pub/troubleshoot).
-</aside>
+{{site.alert.info}}
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+{{site.alert.end}}


### PR DESCRIPTION
- Standardizes options from definition lists to h3s
- Works to better standardize wording of option descriptions
- Moves some options to their own h2s as subcommands
- Adds some missing options
- Makes some minor format modifications
- Standardizes the inclusion and formatting of the troubleshooting pub aside

**Staged:** https://parlough-dart-dev.web.app/ _(Updated 08/27/21)_

Closes https://github.com/dart-lang/site-www/issues/1256