### PR TITLE
Update the listed web package examples

### DIFF
--- a/src/web/libraries.md
+++ b/src/web/libraries.md
@@ -42,9 +42,9 @@ in addition to mobile, desktop, and embedded device support.
 Here are a few packages that are web-specific:
 
 |--------------------+---------------------------------+--------------------------|
-| Library            | Packages                        | Notes                    |
+| Library            | Package                         | Notes                    |
 |--------------------|---------------------------------|--------------------------|
-| AngularDart        | angular*                        | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation,]({{site.angulardart}}) [AngularDart Components]({{site.angulardart}}/components) | 
+| AngularDart        | [angular][]                     | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation]({{site.angulardart}}) | 
 | JavaScript interop | [js][]                          | Support for calling JavaScript libraries from Dart code. More info: [JavaScript interoperability][] |
 | Material Design    | [mdc_web][]                     | Bindings for Material Components for the web. |
 | Mustache templates | [mustache_template][]           | Support for the Mustache templating language. |
@@ -52,6 +52,7 @@ Here are a few packages that are web-specific:
 {:.table .table-striped}
 
 
+[angular]: {{site.pub-pkg}}/angular
 [flutter]: {{site.flutter}}
 [flutter-web]: {{site.flutter}}/web
 [AngularDart]: {{site.angulardart}}

--- a/src/web/libraries.md
+++ b/src/web/libraries.md
@@ -41,15 +41,14 @@ in addition to mobile, desktop, and embedded device support.
 
 Here are a few packages that are web-specific:
 
-|-----------------+---------------------------------+--------------------------|
-| Library         | Packages                        | Notes                    |
-|-----------------|---------------------------------|--------------------------|
-| AngularDart     | angular*                        | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation,]({{site.angulardart}}) [AngularDart Components]({{site.angulardart}}/components) | 
-| JavaScript interop | [js][] | Support for calling JavaScript libraries from Dart code. More info: [JavaScript interoperability][] |
-| Material Design | [md_core,][] [m4d_components][] | Basic Material Design components. |
-| Mustache        | [mustache][]                    | Support for the Mustache templating language. |
-| React           | [react][]                       | Bindings for the ReactJS library. |
-| Vue             | [vue][]                         | Bindings for the Vue.js library. |
+|--------------------+---------------------------------+--------------------------|
+| Library            | Packages                        | Notes                    |
+|--------------------|---------------------------------|--------------------------|
+| AngularDart        | angular*                        | Useful for complex apps that support features such as event handling and dependency injection. More info: [AngularDart documentation,]({{site.angulardart}}) [AngularDart Components]({{site.angulardart}}/components) | 
+| JavaScript interop | [js][]                          | Support for calling JavaScript libraries from Dart code. More info: [JavaScript interoperability][] |
+| Material Design    | [mdc_web][]                     | Bindings for Material Components for the web. |
+| Mustache templates | [mustache_template][]           | Support for the Mustache templating language. |
+| React              | [react][]                       | Bindings for the ReactJS library. |
 {:.table .table-striped}
 
 
@@ -58,10 +57,8 @@ Here are a few packages that are web-specific:
 [AngularDart]: {{site.angulardart}}
 [js]: {{site.pub-pkg}}/js
 [JavaScript interoperability]: /web/js-interop
-[md_core,]: {{site.pub-pkg}}/m4d_core
-[m4d_components]: {{site.pub-pkg}}/m4d_components
-[mustache]: {{site.pub-pkg}}/mustache
-[vue]: {{site.pub-pkg}}/vue
+[mdc_web]: {{site.pub-pkg}}/mdc_web
+[mustache_template]: {{site.pub-pkg}}/mustache_template
 [react]: {{site.pub-pkg}}/react
 
 To find more libraries that support writing web apps, search pub.dev for


### PR DESCRIPTION
- Switched the material component libraries which are outdated for [mdc_web](https://pub.dev/packages/mdc_web) which supports null safety (and DartPad uses)
- Switch the mustache library to [mustache_template](https://pub.dev/packages/mustache_template) which supports null safety and dart2js/aot.
- Removed the vue library which hasn't been supported for a while and ["at the moment" is dead](https://github.com/refi64/vuedart/issues/48)
-  Formatted table for easier editing