### PR TITLE
Switch Effective Dart linter rule links to the local versions

### DIFF
--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -367,7 +367,7 @@ previous guidelines state, either:
 
 ### PREFER naming a method `to___()` if it copies the object's state to a new object.
 
-{% include linter-rule-mention.html rule="use_to_and_as_if_applicable" %}
+{% include linter-rule-mention.md rule="use_to_and_as_if_applicable" %}
 
 A *conversion* method is one that returns a new object containing a copy of
 almost all of the state of the receiver but usually in some different form or
@@ -387,7 +387,7 @@ dateTime.toLocal();
 
 ### PREFER naming a method `as___()` if it returns a different representation backed by the original object.
 
-{% include linter-rule-mention.html rule="use_to_and_as_if_applicable" %}
+{% include linter-rule-mention.md rule="use_to_and_as_if_applicable" %}
 
 Conversion methods are "snapshots". The resulting object has its own copy of the
 original object's state. There are other conversion-like methods that return
@@ -558,7 +558,7 @@ you can in a procedural or functional language.
 
 ### AVOID defining a one-member abstract class when a simple function will do.
 
-{% include linter-rule-mention.html rule="one_member_abstracts" %}
+{% include linter-rule-mention.md rule="one_member_abstracts" %}
 
 Unlike Java, Dart has first-class functions, closures, and a nice light syntax
 for using them. If all you need is something like a callback, just use a
@@ -583,7 +583,7 @@ abstract class Predicate<E> {
 
 ### AVOID defining a class that contains only static members.
 
-{% include linter-rule-mention.html rule="avoid_classes_with_only_static_members" %}
+{% include linter-rule-mention.md rule="avoid_classes_with_only_static_members" %}
 
 In Java and C#, every definition *must* be inside a class, so it's common to see
 "classes" that exist only as a place to stuff static members. Other classes are
@@ -697,7 +697,7 @@ comment.
 
 ### DO use `mixin` to define a mixin type.
 
-{% include linter-rule-mention.html rule="prefer_mixin" %}
+{% include linter-rule-mention.md rule="prefer_mixin" %}
 
 Dart originally didn't have a separate syntax for declaring a class intended to
 be mixed in to other classes. Instead, any class that met certain restrictions
@@ -735,7 +735,7 @@ syntax is preferred.
 
 ### AVOID mixing in a type that isn't intended to be a mixin. {#avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin}
 
-{% include linter-rule-mention.html rule="prefer_mixin" %}
+{% include linter-rule-mention.md rule="prefer_mixin" %}
 
 For compatibility, Dart still allows you to mix in classes that aren't defined
 using `mixin`. However, that's risky. If the author of the class doesn't intend
@@ -777,7 +777,7 @@ A member belongs to an object and can be either methods or instance variables.
 
 ### PREFER making fields and top-level variables `final`.
 
-{% include linter-rule-mention.html rule="prefer_final_fields" %}
+{% include linter-rule-mention.md rule="prefer_final_fields" %}
 
 State that is not *mutable*&mdash;that does not change over time&mdash;is
 easier for programmers to reason about. Classes and libraries that minimize the
@@ -894,7 +894,7 @@ dataSet.minimumValue;
 
 ### DO use setters for operations that conceptually change properties.
 
-{% include linter-rule-mention.html rule="use_setters_to_change_properties" %}
+{% include linter-rule-mention.md rule="use_setters_to_change_properties" %}
 
 Deciding between a setter versus a method is similar to deciding between a
 getter versus a method. In both cases, the operation should be "field-like".
@@ -921,7 +921,7 @@ button.visible = false;
 
 ### DON'T define a setter without a corresponding getter.
 
-{% include linter-rule-mention.html rule="avoid_setters_without_getters" %}
+{% include linter-rule-mention.md rule="avoid_setters_without_getters" %}
 
 Users think of getters and setters as visible properties of an object. A
 "dropbox" property that can be written to but not seen is confusing and
@@ -1003,7 +1003,7 @@ empty container, it might make sense to use a nullable type.
 
 ### AVOID returning `this` from methods just to enable a fluent interface.
 
-{% include linter-rule-mention.html rule="avoid_returning_this" %}
+{% include linter-rule-mention.md rule="avoid_returning_this" %}
 
 Method cascades are a better solution for chaining method calls.
 
@@ -1129,7 +1129,7 @@ various cases, but the rough summary is:
 
 ### DO type annotate variables without initializers.
 
-{% include linter-rule-mention.html rule="prefer_typing_uninitialized_variables" %}
+{% include linter-rule-mention.md rule="prefer_typing_uninitialized_variables" %}
 
 The type of a variable&mdash;top-level, local, static field, or instance
 field&mdash;can often be inferred from its initializer. However, if there is no
@@ -1160,7 +1160,7 @@ if (node is Constructor) {
 
 ### DO type annotate fields and top-level variables if the type isn't obvious.
 
-{% include linter-rule-mention.html rule="type_annotate_public_apis" %}
+{% include linter-rule-mention.md rule="type_annotate_public_apis" %}
 
 Type annotations are important documentation for how a library should be used.
 They form boundaries between regions of a program to isolate the source of a
@@ -1215,7 +1215,7 @@ annotations on APIs help *users* of your code, types on private members help
 
 ### DON'T redundantly type annotate initialized local variables.
 
-{% include linter-rule-mention.html rule="omit_local_variable_types" %}
+{% include linter-rule-mention.md rule="omit_local_variable_types" %}
 
 Local variables, especially in modern code where functions tend to be small,
 have very little scope. Omitting the type focuses the reader's attention on the
@@ -1328,7 +1328,7 @@ void sayRepeatedly(message, {count = 2}) {
 
 ### DON'T annotate inferred parameter types on function expressions.
 
-{% include linter-rule-mention.html rule="avoid_types_on_closure_parameters" %}
+{% include linter-rule-mention.md rule="avoid_types_on_closure_parameters" %}
 
 Anonymous functions are almost always immediately passed to a method taking a
 callback of some type.
@@ -1361,7 +1361,7 @@ function's parameters. In those cases, you may need to annotate.
 
 ### DON'T type annotate initializing formals.
 
-{% include linter-rule-mention.html rule="type_init_formals" %}
+{% include linter-rule-mention.md rule="type_init_formals" %}
 
 If a constructor parameter is using `this.` to initialize a field, then the type
 of the parameter is inferred to have the same type as the field.
@@ -1612,7 +1612,7 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
 
 ### DON'T specify a return type for a setter.
 
-{% include linter-rule-mention.html rule="avoid_return_types_on_setters" %}
+{% include linter-rule-mention.md rule="avoid_return_types_on_setters" %}
 
 Setters always return `void` in Dart. Writing the word is pointless.
 
@@ -1631,7 +1631,7 @@ set foo(Foo value) { ... }
 
 ### DON'T use the legacy typedef syntax.
 
-{% include linter-rule-mention.html rule="prefer_generic_function_type_aliases" %}
+{% include linter-rule-mention.md rule="prefer_generic_function_type_aliases" %}
 
 Dart has two notations for defining a named typedef for a function type. The
 original syntax looks like:
@@ -1693,7 +1693,7 @@ it's deprecated.
 
 ### PREFER inline function types over typedefs.
 
-{% include linter-rule-mention.html rule="avoid_private_typedef_functions" %}
+{% include linter-rule-mention.md rule="avoid_private_typedef_functions" %}
 
 In Dart 1, if you wanted to use a function type for a field, variable, or
 generic type argument, you had to first define a typedef for it. Dart 2 supports
@@ -1730,7 +1730,7 @@ that clarity.
 
 ### PREFER using function type syntax for parameters.
 
-{% include linter-rule-mention.html rule="use_function_type_syntax_for_parameters" %}
+{% include linter-rule-mention.md rule="use_function_type_syntax_for_parameters" %}
 
 Dart has a special syntax when defining a parameter whose type is a function.
 Sort of like in C, you surround the parameter's name with the function's return
@@ -1875,7 +1875,7 @@ In Dart, optional parameters can be either positional or named, but not both.
 
 ### AVOID positional boolean parameters.
 
-{% include linter-rule-mention.html rule="avoid_positional_boolean_parameters" %}
+{% include linter-rule-mention.md rule="avoid_positional_boolean_parameters" %}
 
 Unlike other types, booleans are usually used in literal form. Values like
 numbers are usually wrapped in named constants, but we typically pass around
@@ -1996,7 +1996,7 @@ elements to follow.
 
 ### DO override `hashCode` if you override `==`.
 
-{% include linter-rule-mention.html rule="hash_and_equals" %}
+{% include linter-rule-mention.md rule="hash_and_equals" %}
 
 The default hash code implementation provides an *identity* hash&mdash;two
 objects generally only have the same hash code if they are the exact same
@@ -2024,7 +2024,7 @@ you're trying to express.
 
 ### AVOID defining custom equality for mutable classes.
 
-{% include linter-rule-mention.html rule="avoid_equals_and_hash_code_on_mutable_classes" %}
+{% include linter-rule-mention.md rule="avoid_equals_and_hash_code_on_mutable_classes" %}
 
 When you define `==`, you also have to define `hashCode`. Both of those should
 take into account the object's fields. If those fields *change* then that
@@ -2036,7 +2036,7 @@ true.
 
 ### DON'T make the parameter to `==` nullable.
 
-{% include linter-rule-mention.html rule="avoid_null_checks_in_equality_operators" %}
+{% include linter-rule-mention.md rule="avoid_null_checks_in_equality_operators" %}
 
 The language specifies that `null` is equal only to itself, and that the `==`
 method is called only if the right-hand side is not `null`.

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -74,7 +74,7 @@ before a declaration and uses the special `///` syntax that dartdoc looks for.
 
 ### DO use `///` doc comments to document members and types.
 
-{% include linter-rule-mention.html rule="slash_for_doc_comments" %}
+{% include linter-rule-mention.md rule="slash_for_doc_comments" %}
 
 Using a doc comment instead of a regular comment enables [dartdoc][] to find it
 and generate documentation for it.
@@ -104,7 +104,7 @@ up.
 
 ### PREFER writing doc comments for public APIs.
 
-{% include linter-rule-mention.html rule1="package_api_docs" rule2="public_member_api_docs"%}
+{% include linter-rule-mention.md rule1="package_api_docs" rule2="public_member_api_docs"%}
 
 You don't have to document every single library, top-level variable, type, and
 member, but you should document most of them.
@@ -304,7 +304,7 @@ makes an API easier to learn.
 
 ### DO use square brackets in doc comments to refer to in-scope identifiers.
 
-{% include linter-rule-mention.html rule="comment_references" %}
+{% include linter-rule-mention.md rule="comment_references" %}
 
 If you surround things like variable, method, or type names in square brackets,
 then dartdoc looks up the name and links to the relevant API docs. Parentheses

--- a/src/_guides/language/effective-dart/index.md
+++ b/src/_guides/language/effective-dart/index.md
@@ -37,7 +37,7 @@ The Dart analyzer has a linter to help you write good, consistent code.
 If a linter rule exists that can help you follow a guideline,
 then the guideline links to that rule. Here's an example:
 
-{% include linter-rule-mention.html rule="prefer_collection_literals" %}
+{% include linter-rule-mention.md rule="prefer_collection_literals" %}
 
 For help on
 [enabling linter rules](/guides/language/analysis-options#enabling-linter-rules),

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -35,7 +35,7 @@ Identifiers come in three flavors in Dart.
 
 ### DO name types using `UpperCamelCase`.
 
-{% include linter-rule-mention.html rule="camel_case_types" %}
+{% include linter-rule-mention.md rule="camel_case_types" %}
 
 Classes, enum types, typedefs, and type parameters should capitalize the first
 letter of each word (including the first word), and use no separators.
@@ -83,7 +83,7 @@ class C { ... }
 
 ### DO name extensions using `UpperCamelCase`.
 
-{% include linter-rule-mention.html rule="camel_case_extensions" %}
+{% include linter-rule-mention.md rule="camel_case_extensions" %}
 
 Like types, [extensions][] should capitalize the first letter of each word
 (including the first word),
@@ -101,7 +101,7 @@ extension SmartIterable<T> on Iterable<T> { ... }
 
 ### DO name libraries, packages, directories, and source files using `lowercase_with_underscores`. {#do-name-libraries-and-source-files-using-lowercase_with_underscores}
 
-{% include linter-rule-mention.html rule1="library_names" rule2="file_names" %}
+{% include linter-rule-mention.md rule1="library_names" rule2="file_names" %}
 <!-- source for rules (update these if you update the guideline):
 https://github.com/dart-lang/linter/blob/master/lib/src/rules/library_names.dart
 https://github.com/dart-lang/linter/blob/master/lib/src/rules/file_names.dart -->
@@ -138,7 +138,7 @@ import 'SliderMenu.dart';
 
 ### DO name import prefixes using `lowercase_with_underscores`.
 
-{% include linter-rule-mention.html rule="library_prefixes" %}
+{% include linter-rule-mention.md rule="library_prefixes" %}
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (import-as)" replace="/(package):examples[^']*/$1:angular_components\/angular_components/g"?>
@@ -161,7 +161,7 @@ import 'package:js/js.dart' as JS;
 
 ### DO name other identifiers using `lowerCamelCase`.
 
-{% include linter-rule-mention.html rule="non_constant_identifier_names" %}
+{% include linter-rule-mention.md rule="non_constant_identifier_names" %}
 
 Class members, top-level definitions, variables, parameters, and named
 parameters should capitalize the first letter of each word *except* the first
@@ -182,7 +182,7 @@ void align(bool clearItems) {
 
 ### PREFER using `lowerCamelCase` for constant names.
 
-{% include linter-rule-mention.html rule="constant_identifier_names" %}
+{% include linter-rule-mention.md rule="constant_identifier_names" %}
 
 In new code, use `lowerCamelCase` for constant variables, including enum values.
 
@@ -336,7 +336,7 @@ A single linter rule handles all the ordering guidelines:
 
 ### DO place "dart:" imports before other imports.
 
-{% include linter-rule-mention.html rule="directives_ordering" %}
+{% include linter-rule-mention.md rule="directives_ordering" %}
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
@@ -351,7 +351,7 @@ import 'package:foo/foo.dart';
 
 ### DO place "package:" imports before relative imports.
 
-{% include linter-rule-mention.html rule="directives_ordering" %}
+{% include linter-rule-mention.md rule="directives_ordering" %}
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
@@ -365,7 +365,7 @@ import 'util.dart';
 
 ### DO specify exports in a separate section after all imports.
 
-{% include linter-rule-mention.html rule="directives_ordering" %}
+{% include linter-rule-mention.md rule="directives_ordering" %}
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (export)"?>
@@ -387,7 +387,7 @@ import 'src/foo_bar.dart';
 
 ### DO sort sections alphabetically.
 
-{% include linter-rule-mention.html rule="directives_ordering" %}
+{% include linter-rule-mention.md rule="directives_ordering" %}
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
@@ -448,7 +448,7 @@ to produce beautiful code.
 
 ### AVOID lines longer than 80 characters.
 
-{% include linter-rule-mention.html rule="lines_longer_than_80_chars" %}
+{% include linter-rule-mention.md rule="lines_longer_than_80_chars" %}
 
 Readability studies show that long lines of text are harder to read because your
 eye has to travel farther when moving to the beginning of the next line. This is
@@ -474,7 +474,7 @@ shorter ones can alter the program.
 
 ### DO use curly braces for all flow control statements. {#do-use-curly-braces-for-all-flow-control-structures}
 
-{% include linter-rule-mention.html rule="curly_braces_in_flow_control_structures" %}
+{% include linter-rule-mention.md rule="curly_braces_in_flow_control_structures" %}
 
 Doing so avoids the [dangling else][] problem.
 

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -60,7 +60,7 @@ part of my_library;
 
 ### DON'T import libraries that are inside the `src` directory of another package.
 
-{% include linter-rule-mention.html rule="implementation_imports" %}
+{% include linter-rule-mention.md rule="implementation_imports" %}
 
 The `src` directory under `lib` [is specified][package guide] to contain
 libraries private to the package's own implementation. The way package
@@ -76,7 +76,7 @@ theoretically non-breaking point release of that package could break your code.
 
 ### DON'T allow an import path to reach into or out of `lib`.
 
-{% include linter-rule-mention.html rule="avoid_relative_lib_imports" %}
+{% include linter-rule-mention.md rule="avoid_relative_lib_imports" %}
 
 A `package:` import lets you access
 a library inside a package's `lib` directory
@@ -129,7 +129,7 @@ import libraries from other places in the package.
 
 ### PREFER relative import paths.
 
-{% include linter-rule-mention.html rule="prefer_relative_imports" %}
+{% include linter-rule-mention.md rule="prefer_relative_imports" %}
 
 Whenever the previous rule doesn't come into play, follow this one.
 When an import does *not* reach across `lib`, prefer using relative imports.
@@ -181,7 +181,7 @@ import 'test_utils.dart'; // Relative within 'test' is fine.
 
 ### DON'T explicitly initialize variables to `null`.
 
-{% include linter-rule-mention.html rule="avoid_init_to_null" %}
+{% include linter-rule-mention.md rule="avoid_init_to_null" %}
 
 If a variable has a non-nullable type, Dart reports a compile error if you try
 to use it before it has been definitely initialized. If the variable is
@@ -224,7 +224,7 @@ Item? bestDeal(List<Item> cart) {
 
 ### DON'T use an explicit default value of `null`.
 
-{% include linter-rule-mention.html rule="avoid_init_to_null" %}
+{% include linter-rule-mention.md rule="avoid_init_to_null" %}
 
 If you make a nullable parameter optional but don't give it a default value, the
 language implicitly uses `null` as the default, so there's no need to write it.
@@ -418,7 +418,7 @@ Here are some best practices to keep in mind when composing strings in Dart.
 
 ### DO use adjacent strings to concatenate string literals.
 
-{% include linter-rule-mention.html rule="prefer_adjacent_string_concatenation" %}
+{% include linter-rule-mention.md rule="prefer_adjacent_string_concatenation" %}
 
 If you have two string literals&mdash;not values, but the actual quoted literal
 form&mdash;you do not need to use `+` to concatenate them. Just like in C and
@@ -442,7 +442,7 @@ raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
 
 ### PREFER using interpolation to compose strings and values.
 
-{% include linter-rule-mention.html rule="prefer_interpolation_to_compose_strings" %}
+{% include linter-rule-mention.md rule="prefer_interpolation_to_compose_strings" %}
 
 If you're coming from other languages, you're used to using long chains of `+`
 to build a string out of literals and other values. That does work in Dart, but
@@ -462,7 +462,7 @@ it's almost always cleaner and shorter to use interpolation:
 
 ### AVOID using curly braces in interpolation when not needed.
 
-{% include linter-rule-mention.html rule="unnecessary_brace_in_string_interps" %}
+{% include linter-rule-mention.md rule="unnecessary_brace_in_string_interps" %}
 
 If you're interpolating a simple identifier not immediately followed by more
 alphanumeric text, the `{}` should be omitted.
@@ -486,7 +486,7 @@ The following best practices apply to collections.
 
 ### DO use collection literals when possible.
 
-{% include linter-rule-mention.html rule="prefer_collection_literals" %}
+{% include linter-rule-mention.md rule="prefer_collection_literals" %}
 
 Dart has three core collection types: List, Map, and Set. The Map and Set
 classes have unnamed constructors like most classes do. But because these
@@ -550,7 +550,7 @@ arguments.addAll(filePaths
 
 ### DON'T use `.length` to see if a collection is empty.
 
-{% include linter-rule-mention.html rule1="prefer_is_empty" rule2="prefer_is_not_empty" %}
+{% include linter-rule-mention.md rule1="prefer_is_empty" rule2="prefer_is_not_empty" %}
 
 The [Iterable][] contract does not require that a collection know its length or
 be able to provide it in constant time. Calling `.length` just to see if the
@@ -578,7 +578,7 @@ if (!words.isEmpty) return words.join(' ');
 
 ### AVOID using `Iterable.forEach()` with a function literal.
 
-{% include linter-rule-mention.html rule="avoid_function_literals_in_foreach_calls" %}
+{% include linter-rule-mention.md rule="avoid_function_literals_in_foreach_calls" %}
 
 `forEach()` functions are widely used in JavaScript because the built in
 `for-in` loop doesn't do what you usually want. In Dart, if you want to iterate
@@ -663,7 +663,7 @@ you don't care about the type, then use `toList()`.
 
 ### DO use `whereType()` to filter a collection by type.
 
-{% include linter-rule-mention.html rule="prefer_iterable_whereType" %}
+{% include linter-rule-mention.md rule="prefer_iterable_whereType" %}
 
 Let's say you have a list containing a mixture of objects, and you want to get
 just the integers out of it. You could use `where()` like this:
@@ -857,7 +857,7 @@ involving functions.
 
 ### DO use a function declaration to bind a function to a name.
 
-{% include linter-rule-mention.html rule="prefer_function_declarations_over_variables" %}
+{% include linter-rule-mention.md rule="prefer_function_declarations_over_variables" %}
 
 Modern languages have realized how useful local nested functions and closures
 are. It's common to have a function defined inside another one. In many cases,
@@ -889,7 +889,7 @@ void main() {
 
 ### DON'T create a lambda when a tear-off will do.
 
-{% include linter-rule-mention.html rule="unnecessary_lambdas" %}
+{% include linter-rule-mention.md rule="unnecessary_lambdas" %}
 
 If you refer to a method on an object but omit the parentheses, Dart gives you
 a "tear-off"&mdash;a closure that takes the same parameters as the method and
@@ -915,7 +915,7 @@ names.forEach((name) {
 
 ### DO use `=` to separate a named parameter from its default value.
 
-{% include linter-rule-mention.html rule="prefer_equal_for_default_values" %}
+{% include linter-rule-mention.md rule="prefer_equal_for_default_values" %}
 
 For legacy reasons, Dart allows both `:` and `=` as the default value separator
 for named parameters. For consistency with optional positional parameters, use
@@ -1050,7 +1050,7 @@ variables). The following best practices apply to an object's members.
 
 ### DON'T wrap a field in a getter and setter unnecessarily.
 
-{% include linter-rule-mention.html rule="unnecessary_getters_setters" %}
+{% include linter-rule-mention.md rule="unnecessary_getters_setters" %}
 
 In Java and C#, it's common to hide all fields behind getters and setters (or
 properties in C#), even if the implementation just forwards to the field. That
@@ -1086,7 +1086,7 @@ class Box {
 
 ### PREFER using a `final` field to make a read-only property.
 
-{% include linter-rule-mention.html rule="unnecessary_getters_setters" %}
+{% include linter-rule-mention.md rule="unnecessary_getters_setters" %}
 
 If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.
@@ -1115,7 +1115,7 @@ don't reach for that until you need to.
 
 ### CONSIDER using `=>` for simple members.
 
-{% include linter-rule-mention.html rule="prefer_expression_function_bodies" %}
+{% include linter-rule-mention.md rule="prefer_expression_function_bodies" %}
 
 In addition to using `=>` for function expressions, Dart also lets you define
 members with it. That style is a good fit for simple members that just calculate
@@ -1170,7 +1170,7 @@ set x(num value) => center = Point(value, center.y);
 
 ### DON'T use `this.` except to redirect to a named constructor or to avoid shadowing. {#dont-use-this-when-not-needed-to-avoid-shadowing}
 
-{% include linter-rule-mention.html rule="unnecessary_this" %}
+{% include linter-rule-mention.md rule="unnecessary_this" %}
 
 JavaScript requires an explicit `this.` to refer to members on the object whose
 method is currently being executed, but Dart&mdash;like C++, Java, and
@@ -1308,7 +1308,7 @@ The following best practices apply to declaring constructors for a class.
 
 ### DO use initializing formals when possible.
 
-{% include linter-rule-mention.html rule="prefer_initializing_formals" %}
+{% include linter-rule-mention.md rule="prefer_initializing_formals" %}
 
 Many fields are initialized directly from a constructor parameter, like:
 
@@ -1384,7 +1384,7 @@ performance.
 
 ### DO use `;` instead of `{}` for empty constructor bodies.
 
-{% include linter-rule-mention.html rule="empty_constructor_bodies" %}
+{% include linter-rule-mention.md rule="empty_constructor_bodies" %}
 
 In Dart, a constructor with an empty body can be terminated with just a
 semicolon. (In fact, it's required for const constructors.)
@@ -1409,7 +1409,7 @@ class Point {
 
 ### DON'T use `new`.
 
-{% include linter-rule-mention.html rule="unnecessary_new" %}
+{% include linter-rule-mention.md rule="unnecessary_new" %}
 
 Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
 clear because factory constructors mean a `new` invocation may still not
@@ -1451,7 +1451,7 @@ Widget build(BuildContext context) {
 
 ### DON'T use `const` redundantly.
 
-{% include linter-rule-mention.html rule="unnecessary_const" %}
+{% include linter-rule-mention.md rule="unnecessary_const" %}
 
 In contexts where an expression *must* be constant, the `const` keyword is
 implicit, doesn't need to be written, and shouldn't. Those contexts are any
@@ -1497,7 +1497,7 @@ best practices apply to catching and throwing exceptions.
 
 ### AVOID catches without `on` clauses.
 
-{% include linter-rule-mention.html rule="avoid_catches_without_on_clauses" %}
+{% include linter-rule-mention.md rule="avoid_catches_without_on_clauses" %}
 
 A catch clause with no `on` qualifier catches *anything* thrown by the code in
 the try block. [Pokémon exception handling][pokemon] is very likely not what you
@@ -1540,7 +1540,7 @@ one of the core Exception classes or some other type.
 
 ### DON'T explicitly catch `Error` or types that implement it.
 
-{% include linter-rule-mention.html rule="avoid_catching_errors" %}
+{% include linter-rule-mention.md rule="avoid_catching_errors" %}
 
 This follows from the above. Since an Error indicates a bug in your code, it
 should unwind the entire callstack, halt the program, and print a stack trace so
@@ -1553,7 +1553,7 @@ and fix the code that is causing it to be thrown in the first place.
 
 ### DO use `rethrow` to rethrow a caught exception.
 
-{% include linter-rule-mention.html rule="use_rethrow_when_possible" %}
+{% include linter-rule-mention.md rule="use_rethrow_when_possible" %}
 
 If you decide to rethrow an exception, prefer using the `rethrow` statement
 instead of throwing the same exception object using `throw`.

--- a/src/_includes/linter-rule-mention.html
+++ b/src/_includes/linter-rule-mention.html
@@ -1,6 +1,0 @@
-{:.linter-rule}
-{% if include.rule %}
-Linter rule: <a href="{{site.lints}}/{{include.rule}}.html">{{include.rule}}</a>
-{% else %}
-Linter rules: <a href="{{site.lints}}/{{include.rule1}}.html">{{include.rule1}},</a> <a href="{{site.lints}}/{{include.rule2}}.html">{{include.rule2}}</a>
-{% endif %}

--- a/src/_includes/linter-rule-mention.md
+++ b/src/_includes/linter-rule-mention.md
@@ -1,0 +1,6 @@
+{:.linter-rule}
+{% if include.rule %}
+Linter rule: [{{include.rule}}](/tools/linter-rules#{{include.rule}})
+{% else %}
+Linter rules: [{{include.rule1}}](/tools/linter-rules#{{include.rule1}}), [{{include.rule2}}](/tools/linter-rules#{{include.rule2}})
+{% endif %}


### PR DESCRIPTION
What do you think about switching these linter rule links to the local version? Allows users to stay on the same website.

For example, this guide:

![image](https://user-images.githubusercontent.com/18372958/130138881-74af084f-835e-43d3-b432-432f166ee465.png)

Will link to: https://dart.dev/tools/linter-rules#camel_case_extensions

Instead of: https://dart-lang.github.io/linter/lints/camel_case_extensions.html

Staged at https://kw-dartlang-3.web.app. E.g. [before](https://dart.dev/guides/language/effective-dart/style#do-name-extensions-using-uppercamelcase), [after](https://kw-dartlang-3.web.app/guides/language/effective-dart/style#do-name-extensions-using-uppercamelcase)