### PR TITLE
Clarify mention of equivalent future in library tour

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1177,9 +1177,11 @@ The `then().catchError()` pattern is the asynchronous version of
 #### Chaining multiple asynchronous methods
 
 The `then()` method returns a Future, providing a useful way to run
-multiple asynchronous functions in a certain order. If the callback
-registered with `then()` returns a Future, `then()` returns an
-equivalent Future. If the callback returns a value of any other type,
+multiple asynchronous functions in a certain order. 
+If the callback registered with `then()` returns a Future, 
+`then()` returns a Future that will be completed
+with the same result as the Future returned from the callback. 
+If the callback returns a value of any other type,
 `then()` creates a new Future that completes with the value.
 
 <?code-excerpt "misc/lib/library_tour/async/future.dart (then-chain)"?>
@@ -1253,7 +1255,6 @@ It uses Stream's `listen()` method
 to subscribe to a list of files,
 passing in a function literal that searches each file or directory.
 
-<!-- OLD dart-tutorials-samples/cmdline/bin/dgrep.dart -->
 <?code-excerpt "misc/lib/library_tour/async/stream.dart (listen)" replace="/listen/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 void main(List<String> arguments) {

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1179,7 +1179,7 @@ The `then().catchError()` pattern is the asynchronous version of
 The `then()` method returns a Future, providing a useful way to run
 multiple asynchronous functions in a certain order. 
 If the callback registered with `then()` returns a Future, 
-`then()` returns a Future that will be completed
+`then()` returns a Future that will complete
 with the same result as the Future returned from the callback. 
 If the callback returns a value of any other type,
 `then()` creates a new Future that completes with the value.


### PR DESCRIPTION
"Equivalent Future" may not have been easily understand, so I tried to elaborate on what that meant. I may have been too verbose in doing so, but I tried to follow what's present in the Dartdoc as it seemed to explain it well. 

Closes https://github.com/dart-lang/site-www/issues/1265