### PR TITLE
Added a mention to Flutter Web.

### DIFF
--- a/src/_includes/web-tutorials.md
+++ b/src/_includes/web-tutorials.md
@@ -18,7 +18,7 @@ These tutorials cover topics relevant to Dart web apps.
     <p> Delete elements from the web page. </p>
   </div>
   <div class="card">
-    <h3><a href="https://flutter.dev/docs/get-started/codelab-web">Use Flutter Web</a></h3>
+    <h3><a href="{{site.flutter}}/docs/get-started/codelab-web">Use Flutter Web</a></h3>
     <p>Write your first Flutter app on the web.</p>
   </div>
 </div>


### PR DESCRIPTION
As suggest by @parlough, I have added a mention to Flutter Web in the Tutorials: web apps.

Closes https://github.com/dart-lang/site-www/issues/3509