### PR TITLE
Auto include and analyze futures error handling guide

### DIFF
--- a/examples/futures/analysis_options.yaml
+++ b/examples/futures/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../analysis_options.yaml

--- a/examples/futures/bin/mixing_errors_problematic.dart
+++ b/examples/futures/bin/mixing_errors_problematic.dart
@@ -8,8 +8,8 @@ import 'mixing_errors_util.dart';
 
 // #docregion parse
 Future<int> parseAndRead(Map<String, dynamic> data) {
-  final fileName = obtainFileName(data); // Could throw.
-  final file = File(fileName);
+  final filename = obtainFilename(data); // Could throw.
+  final file = File(filename);
   return file.readAsString().then((contents) {
     return parseFileData(contents); // Could throw.
   });
@@ -26,7 +26,7 @@ void main() {
 
 // Program Output:
 //   Unhandled exception:
-//   <error from obtainFileName>
+//   <error from obtainFilename>
 //   ...
 // #enddocregion main
 

--- a/examples/futures/bin/mixing_errors_problematic.dart
+++ b/examples/futures/bin/mixing_errors_problematic.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: strict_raw_type, unused_local_variable
+
+import 'dart:io';
+
+import 'package:examples_util/ellipsis.dart';
+
+import 'mixing_errors_util.dart';
+
+// #docregion parse
+Future<int> parseAndRead(Map<String, dynamic> data) {
+  final fileName = obtainFileName(data); // Could throw.
+  final file = File(fileName);
+  return file.readAsString().then((contents) {
+    return parseFileData(contents); // Could throw.
+  });
+}
+// #enddocregion parse
+
+// #docregion main
+void main() {
+  parseAndRead(data).catchError((e) {
+    print('Inside catchError');
+    print(e);
+  });
+}
+
+// Program Output:
+//   Unhandled exception:
+//   <error from obtainFileName>
+//   ...
+// #enddocregion main
+
+// #docregion fragile
+Future fragileFunc() {
+  return Future.sync(() {
+    final x = someFunc(); // Unexpectedly throws in some rare cases.
+    var y = 10 / x; // x should not equal 0.
+    ellipsis();
+  });
+}
+// #enddocregion fragile

--- a/examples/futures/bin/mixing_errors_solution.dart
+++ b/examples/futures/bin/mixing_errors_solution.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'mixing_errors_util.dart';
+
+// #docregion parse
+Future<int> parseAndRead(Map<String, dynamic> data) {
+  return Future.sync(() {
+    final fileName = obtainFileName(data); // Could throw.
+    final file = File(fileName);
+    return file.readAsString().then((contents) {
+      return parseFileData(contents); // Could throw.
+    });
+  });
+}
+// #enddocregion parse
+
+// #docregion main
+void main() {
+  parseAndRead(data).catchError((e) {
+    print('Inside catchError');
+    print(e);
+  });
+}
+
+// Program Output:
+//   Inside catchError
+//   <error from obtainFileName>
+// #enddocregion main

--- a/examples/futures/bin/mixing_errors_solution.dart
+++ b/examples/futures/bin/mixing_errors_solution.dart
@@ -5,8 +5,8 @@ import 'mixing_errors_util.dart';
 // #docregion parse
 Future<int> parseAndRead(Map<String, dynamic> data) {
   return Future.sync(() {
-    final fileName = obtainFileName(data); // Could throw.
-    final file = File(fileName);
+    final filename = obtainFilename(data); // Could throw.
+    final file = File(filename);
     return file.readAsString().then((contents) {
       return parseFileData(contents); // Could throw.
     });
@@ -24,5 +24,5 @@ void main() {
 
 // Program Output:
 //   Inside catchError
-//   <error from obtainFileName>
+//   <error from obtainFilename>
 // #enddocregion main

--- a/examples/futures/bin/mixing_errors_util.dart
+++ b/examples/futures/bin/mixing_errors_util.dart
@@ -1,0 +1,7 @@
+int parseFileData(String contents) => 42;
+
+String obtainFileName(Map<String, dynamic> data) => 'file name';
+
+final Map<String, dynamic> data = {};
+
+int someFunc() => 42;

--- a/examples/futures/bin/mixing_errors_util.dart
+++ b/examples/futures/bin/mixing_errors_util.dart
@@ -1,6 +1,6 @@
 int parseFileData(String contents) => 42;
 
-String obtainFileName(Map<String, dynamic> data) => 'file name';
+String obtainFilename(Map<String, dynamic> data) => 'file name';
 
 final Map<String, dynamic> data = {};
 

--- a/examples/futures/lib/early_error_handlers.dart
+++ b/examples/futures/lib/early_error_handlers.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: dead_code
+
+import 'package:examples_util/ellipsis.dart';
+import 'package:futures_examples/util.dart';
+
+// #docregion (bad)
+void mainBad() {
+  Future<Object> future = funcThatThrows();
+
+  // BAD: Too late to handle funcThatThrows() exception.
+  Future.delayed(const Duration(milliseconds: 500), () {
+    future.then(ellipsis()).catchError(ellipsis());
+  });
+}
+// #enddocregion (bad)
+
+// #docregion (good)
+void mainGood() {
+  Future.delayed(const Duration(milliseconds: 500), () {
+    funcThatThrows().then(ellipsis()).catchError(ellipsis()); // We get here.
+  });
+}
+// #enddocregion (good)

--- a/examples/futures/lib/early_error_handlers.dart
+++ b/examples/futures/lib/early_error_handlers.dart
@@ -3,7 +3,7 @@
 import 'package:examples_util/ellipsis.dart';
 import 'package:futures_examples/util.dart';
 
-// #docregion (bad)
+// #docregion bad
 void mainBad() {
   Future<Object> future = funcThatThrows();
 
@@ -12,12 +12,12 @@ void mainBad() {
     future.then(ellipsis()).catchError(ellipsis());
   });
 }
-// #enddocregion (bad)
+// #enddocregion bad
 
-// #docregion (good)
+// #docregion good
 void mainGood() {
   Future.delayed(const Duration(milliseconds: 500), () {
     funcThatThrows().then(ellipsis()).catchError(ellipsis()); // We get here.
   });
 }
-// #enddocregion (good)
+// #enddocregion good

--- a/examples/futures/lib/long_chain.dart
+++ b/examples/futures/lib/long_chain.dart
@@ -1,0 +1,22 @@
+Future<String> one() => Future.value('from one');
+Future<String> two() => Future.error('error from two');
+Future<String> three() => Future.value('from three');
+Future<String> four() => Future.value('from four');
+
+void main() {
+  one() // Future completes with "from one".
+      .then((_) => two()) // Future completes with two()'s error.
+      .then((_) => three()) // Future completes with two()'s error.
+      .then((_) => four()) // Future completes with two()'s error.
+      .then((value) => value.length) // Future completes with two()'s error.
+      .catchError((e) {
+    print('Got error: $e'); // Finally, callback fires.
+    return 42; // Future completes with 42.
+  }).then((value) {
+    print('The value is $value');
+  });
+}
+
+// Output of this program:
+//   Got error: error from two
+//   The value is 42

--- a/examples/futures/lib/simple.dart
+++ b/examples/futures/lib/simple.dart
@@ -1,0 +1,94 @@
+// ignore_for_file: dead_code, invalid_return_type_for_catch_error, one_member_abstracts
+
+import 'dart:async';
+
+import 'package:examples_util/ellipsis.dart';
+import 'package:futures_examples/util.dart';
+
+void simpleCallbacks() {
+  {
+    // #docregion then-catch
+    myFunc().then(processValue).catchError(handleError);
+    // #enddocregion then-catch
+  }
+
+  {
+    // #docregion comprehensive-errors
+    myFunc().then((value) {
+      doSomethingWith(value);
+      ellipsis();
+      throw Exception('Some arbitrary error');
+    }).catchError(handleError);
+    // #enddocregion comprehensive-errors
+  }
+
+  {
+    // #docregion throws-then-catch
+    funcThatThrows().then(successCallback, onError: (e) {
+      handleError(e); // Original error.
+      anotherFuncThatThrows(); // Oops, new error.
+    }).catchError(handleError); // Error from within then() handled.
+    // #enddocregion throws-then-catch
+  }
+
+  {
+    dynamic connectToServer() {}
+
+    const myUrl = 'https://dart.dev';
+
+    // #docregion connect-server
+    final server = connectToServer();
+    server
+        .post(myUrl, fields: const {'name': 'Dash', 'profession': 'mascot'})
+        .then(handleResponse)
+        .catchError(handleError)
+        .whenComplete(server.close);
+    // #enddocregion connect-server
+  }
+}
+
+abstract class FakeFuture<T> {
+  // #docregion future-then
+  Future<R> then<R>(FutureOr<R> Function(T value) onValue, {Function? onError});
+  // #enddocregion future-then
+
+  // #docregion future-catch-error
+  Future<T> catchError(Function onError, {bool Function(Object error)? test});
+  // #enddocregion future-catch-error
+}
+
+// #docregion auth-response
+void main() {
+  handleAuthResponse(const {'username': 'dash', 'age': 3})
+      .then((_) => ellipsis())
+      .catchError(handleFormatException, test: (e) => e is FormatException)
+      .catchError(handleAuthorizationException,
+          test: (e) => e is AuthorizationException);
+}
+// #enddocregion auth-response
+
+String doSomethingWith(dynamic value) {
+  return 'value';
+}
+
+Future<Object> anotherFuncThatThrows() {
+  throw Exception('Also threw an exception');
+}
+
+Future<Object> handleResponse() => Future.value('Response');
+
+Object successCallback(dynamic value) async {
+  return '';
+}
+
+Future<Object> myFunc() => Future.value('42');
+
+Future<Object> handleAuthResponse(Map<String, dynamic> data) {
+  return Future.value('Response');
+}
+
+void handleFormatException(Object exception) {}
+
+void handleAuthorizationException(Object exception) {}
+
+class AuthorizationException implements Exception {}

--- a/examples/futures/lib/util.dart
+++ b/examples/futures/lib/util.dart
@@ -1,0 +1,13 @@
+String processValue(dynamic value) {
+  return 'value';
+}
+
+Future<Object> funcThatThrows() {
+  throw Exception('Threw an exception');
+}
+
+Future<String> handleError(dynamic error) {
+  return Future.value('value');
+}
+
+void printErrorMessage() {}

--- a/examples/futures/lib/when_complete.dart
+++ b/examples/futures/lib/when_complete.dart
@@ -1,0 +1,43 @@
+import 'package:examples_util/ellipsis.dart';
+import 'package:futures_examples/util.dart';
+
+// #docregion with-error
+void withErrorMain() {
+  funcThatThrows()
+      // Future completes with an error
+      .then((_) => print("Won't reach here"))
+      // Future completes with the same error
+      .whenComplete(() => print('Reaches here'))
+      // Future completes with the same error
+      .then((_) => print("Won't reach here"))
+      // Error is handled here
+      .catchError(handleError);
+}
+// #enddocregion with-error
+
+// #docregion with-object
+void withObjectMain() {
+  funcThatThrows()
+      // Future completes with an error.
+      .then((_) => ellipsis())
+      .catchError((e) {
+    handleError(e);
+    printErrorMessage();
+    return someObject; // Future completes with someObject
+  }).whenComplete(() => print('Done!')); // Future completes with someObject
+}
+// #enddocregion with-object
+
+// #docregion when-complete-error
+void whenCompleteError() {
+  funcThatThrows()
+      // Future completes with a value.
+      .catchError(handleError)
+      // Future completes with an error.
+      .whenComplete(() => throw Exception('New error'))
+      // Error is handled.
+      .catchError(handleError);
+}
+// #enddocregion when-complete-error
+
+final Never someObject = ellipsis();

--- a/examples/futures/lib/when_complete.dart
+++ b/examples/futures/lib/when_complete.dart
@@ -4,13 +4,13 @@ import 'package:futures_examples/util.dart';
 // #docregion with-error
 void withErrorMain() {
   funcThatThrows()
-      // Future completes with an error
+      // Future completes with an error:
       .then((_) => print("Won't reach here"))
-      // Future completes with the same error
+      // Future completes with the same error:
       .whenComplete(() => print('Reaches here'))
-      // Future completes with the same error
+      // Future completes with the same error:
       .then((_) => print("Won't reach here"))
-      // Error is handled here
+      // Error is handled here:
       .catchError(handleError);
 }
 // #enddocregion with-error
@@ -18,7 +18,7 @@ void withErrorMain() {
 // #docregion with-object
 void withObjectMain() {
   funcThatThrows()
-      // Future completes with an error.
+      // Future completes with an error:
       .then((_) => ellipsis())
       .catchError((e) {
     handleError(e);
@@ -31,11 +31,11 @@ void withObjectMain() {
 // #docregion when-complete-error
 void whenCompleteError() {
   funcThatThrows()
-      // Future completes with a value.
+      // Future completes with a value:
       .catchError(handleError)
-      // Future completes with an error.
+      // Future completes with an error:
       .whenComplete(() => throw Exception('New error'))
-      // Error is handled.
+      // Error is handled:
       .catchError(handleError);
 }
 // #enddocregion when-complete-error

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -1,0 +1,13 @@
+name: futures_examples
+description: dart.dev futures and error handling examples.
+version: 0.0.1
+
+environment:
+  sdk: '>=2.13.0 <3.0.0'
+
+dependencies:
+  examples_util: {path: ../util}
+
+dev_dependencies:
+  lints: ^1.0.0
+  test: ^1.17.8

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -1,6 +1,7 @@
 name: futures_examples
 description: dart.dev futures and error handling examples.
 version: 0.0.1
+publish_to: none
 
 environment:
   sdk: '>=2.13.0 <3.0.0'

--- a/examples/futures/test/futures_test.dart
+++ b/examples/futures/test/futures_test.dart
@@ -2,7 +2,7 @@ import 'package:futures_examples/long_chain.dart' as long_chain;
 import 'package:test/test.dart';
 
 void main() {
-  test('long chain full', () {
+  test('long future chain prints', () {
     expect(() async {
       long_chain.main();
       await Future.delayed(Duration(milliseconds: 500));

--- a/examples/futures/test/futures_test.dart
+++ b/examples/futures/test/futures_test.dart
@@ -1,0 +1,11 @@
+import 'package:futures_examples/long_chain.dart' as long_chain;
+import 'package:test/test.dart';
+
+void main() {
+  test('long chain full', () {
+    expect(() async {
+      long_chain.main();
+      await Future.delayed(Duration(milliseconds: 500));
+    }, prints('Got error: error from two\nThe value is 42\n'));
+  });
+}

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -383,7 +383,7 @@ void main() {
 function has a lot of code packed into it, chances are that you could be doing
 something dangerous without realizing it:
 
-<?code-excerpt "futures/bin/mixing_errors_problematic.dart (fragile) replace="/ellipsis\(\);/.../g;"?>
+<?code-excerpt "futures/bin/mixing_errors_problematic.dart (fragile)" replace="/ellipsis\(\);/.../g;"?>
 ```dart
 Future fragileFunc() {
   return Future.sync(() {

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -229,7 +229,7 @@ handled by `catchError()`.  Because `catchError()`'s Future completes with
 void main() {
   funcThatThrows()
       // Future completes with an error.
-      .then((_) => ellipsis())
+      .then((_) => ...)
       .catchError((e) {
     handleError(e);
     printErrorMessage();
@@ -268,7 +268,7 @@ this code:
 ```dart
 void main() {
   Future<Object> future = funcThatThrows();
-  
+
   // BAD: Too late to handle funcThatThrows() exception.
   Future.delayed(const Duration(milliseconds: 500), () {
     future.then(...).catchError(...);
@@ -286,7 +286,7 @@ The problem goes away if `funcThatThrows()` is called within the
 ```dart
 void main() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    funcThatThrows().then(...).catchError(..)); // We get here.
+    funcThatThrows().then(...).catchError(...); // We get here.
   });
 }
 ```

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -224,7 +224,7 @@ In the code below, `then()`'s Future completes with an error, which is now
 handled by `catchError()`.  Because `catchError()`'s Future completes with
 `someObject`, `whenComplete()`'s Future completes with that same object.
 
-<?code-excerpt "futures/lib/when_complete.dart (with-object)" replace="/ellipsis()/.../g; /withObjectMain/main/g; "?>
+<?code-excerpt "futures/lib/when_complete.dart (with-object)" replace="/ellipsis\(\)/.../g; /withObjectMain/main/g; "?>
 ```dart
 void main() {
   funcThatThrows()
@@ -264,7 +264,7 @@ this avoids scenarios where a Future completes with an error, the error
 handler is not yet attached, and the error accidentally propagates. Consider
 this code:
 
-<?code-excerpt "futures/lib/early_error_handlers.dart (bad)" replace="/ellipsis()/.../g; /mainBad/main/g;"?>
+<?code-excerpt "futures/lib/early_error_handlers.dart (bad)" replace="/ellipsis\(\)/.../g; /mainBad/main/g;"?>
 ```dart
 void main() {
   Future<Object> future = funcThatThrows();
@@ -282,7 +282,7 @@ In the code above, `catchError()` is not registered until half a second after
 The problem goes away if `funcThatThrows()` is called within the
 `Future.delayed()` callback:
 
-<?code-excerpt "futures/lib/early_error_handlers.dart (good)" replace="/ellipsis()/.../g; /mainGood/main/g;"?>
+<?code-excerpt "futures/lib/early_error_handlers.dart (good)" replace="/ellipsis\(\)/.../g; /mainGood/main/g;"?>
 ```dart
 void main() {
   Future.delayed(const Duration(milliseconds: 500), () {

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -209,13 +209,13 @@ In the code below, `then()`'s Future completes with an error, so
 ```dart
 void main() {
   funcThatThrows()
-      // Future completes with an error
+      // Future completes with an error:
       .then((_) => print("Won't reach here"))
-      // Future completes with the same error
+      // Future completes with the same error:
       .whenComplete(() => print('Reaches here'))
-      // Future completes with the same error
+      // Future completes with the same error:
       .then((_) => print("Won't reach here"))
-      // Error is handled here
+      // Error is handled here:
       .catchError(handleError);
 }
 ```
@@ -228,7 +228,7 @@ handled by `catchError()`.  Because `catchError()`'s Future completes with
 ```dart
 void main() {
   funcThatThrows()
-      // Future completes with an error.
+      // Future completes with an error:
       .then((_) => ...)
       .catchError((e) {
     handleError(e);
@@ -247,11 +247,11 @@ completes with that error:
 ```dart
 void main() {
   funcThatThrows()
-      // Future completes with a value.
+      // Future completes with a value:
       .catchError(handleError)
-      // Future completes with an error.
+      // Future completes with an error:
       .whenComplete(() => throw Exception('New error'))
-      // Error is handled.
+      // Error is handled:
       .catchError(handleError);
 }
 ```
@@ -301,8 +301,8 @@ errors from leaking out. Consider this code:
 <?code-excerpt "futures/bin/mixing_errors_problematic.dart (parse)"?>
 ```dart
 Future<int> parseAndRead(Map<String, dynamic> data) {
-  final fileName = obtainFileName(data); // Could throw.
-  final file = File(fileName);
+  final filename = obtainFilename(data); // Could throw.
+  final file = File(filename);
   return file.readAsString().then((contents) {
     return parseFileData(contents); // Could throw.
   });
@@ -310,13 +310,13 @@ Future<int> parseAndRead(Map<String, dynamic> data) {
 ```
 
 Two functions in that code could potentially throw synchronously:
-`obtainFileName()` and `parseFileData()`. Because `parseFileData()` executes
+`obtainFilename()` and `parseFileData()`. Because `parseFileData()` executes
 inside a `then()` callback, its error does not leak out of the function.
 Instead, `then()`'s Future completes with `parseFileData()`'s error, the error
 eventually completes `parseAndRead()`'s Future, and the error can be
 successfully handled by `catchError()`.
 
-But `obtainFileName()` is not called within a `then()` callback; if _it_
+But `obtainFilename()` is not called within a `then()` callback; if _it_
 throws, a synchronous error propagates:
 
 <?code-excerpt "futures/bin/mixing_errors_problematic.dart (main)"?>
@@ -330,7 +330,7 @@ void main() {
 
 // Program Output:
 //   Unhandled exception:
-//   <error from obtainFileName>
+//   <error from obtainFilename>
 //   ...
 ```
 
@@ -348,8 +348,8 @@ callback:
 ```dart
 Future<int> parseAndRead(Map<String, dynamic> data) {
   return Future.sync(() {
-    final fileName = obtainFileName(data); // Could throw.
-    final file = File(fileName);
+    final filename = obtainFilename(data); // Could throw.
+    final file = File(filename);
     return file.readAsString().then((contents) {
       return parseFileData(contents); // Could throw.
     });
@@ -376,7 +376,7 @@ void main() {
 
 // Program Output:
 //   Inside catchError
-//   <error from obtainFileName>
+//   <error from obtainFilename>
 ```
 
 `Future.sync()` makes your code resilient against uncaught exceptions. If your

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -56,15 +56,13 @@ The next few sections give examples of this pattern.
 The following example deals with throwing an exception from within `then()`'s
 callback and demonstrates `catchError()`'s versatility as an error handler:
 
-<?code-excerpt "futures/lib/simple.dart (comprehensive-errors)" replace="/ellipsis()/.../g;"?>
+<?code-excerpt "futures/lib/simple.dart (comprehensive-errors)" replace="/ellipsis\(\);/.../g;"?>
 ```dart
-myFunc()
-  .then((value) {
-    doSomethingWith(value);
-    ...
-    throw Exception('Some arbitrary error');
-  })
-  .catchError(handleError);
+myFunc().then((value) {
+  doSomethingWith(value);
+  ...
+  throw Exception('Some arbitrary error');
+}).catchError(handleError);
 ```
 
 If `myFunc()`'s Future completes with a value, `then()`'s callback fires. If
@@ -166,14 +164,14 @@ Given the complex workflow, `handleAuthResponse()` could generate various
 errors and exceptions, and you should handle them differently. Here's
 how you can use `test` to do that:
 
-<?code-excerpt "futures/lib/simple.dart (auth-response)" replace="/ellipsis()/.../g;"?>
+<?code-excerpt "futures/lib/simple.dart (auth-response)" replace="/ellipsis\(\)/.../g;"?>
 ```dart
 void main() {
   handleAuthResponse(const {'username': 'dash', 'age': 3})
-          .then((_) => ...)
-          .catchError(handleFormatException, test: (e) => e is FormatException)
-          .catchError(handleAuthorizationException,
-              test: (e) => e is AuthorizationException);
+      .then((_) => ...)
+      .catchError(handleFormatException, test: (e) => e is FormatException)
+      .catchError(handleAuthorizationException,
+          test: (e) => e is AuthorizationException);
 }
 ```
 
@@ -207,7 +205,7 @@ easiest to understand through examples.
 In the code below, `then()`'s Future completes with an error, so
 `whenComplete()`'s Future also completes with that error.
 
-<?code-excerpt "futures/lib/simple.dart (auth-response)" replace="/withErrorMain/main/g; "?>
+<?code-excerpt "futures/lib/when_complete.dart (with-error)" replace="/withErrorMain/main/g; "?>
 ```dart
 void main() {
   funcThatThrows()
@@ -226,7 +224,7 @@ In the code below, `then()`'s Future completes with an error, which is now
 handled by `catchError()`.  Because `catchError()`'s Future completes with
 `someObject`, `whenComplete()`'s Future completes with that same object.
 
-<?code-excerpt "futures/lib/simple.dart (with-object)" replace="/ellipsis()/.../g; /withObjectMain/main/g; "?>
+<?code-excerpt "futures/lib/when_complete.dart (with-object)" replace="/ellipsis()/.../g; /withObjectMain/main/g; "?>
 ```dart
 void main() {
   funcThatThrows()
@@ -245,7 +243,7 @@ void main() {
 If `whenComplete()`'s callback throws an error, then `whenComplete()`'s Future
 completes with that error:
 
-<?code-excerpt "futures/lib/simple.dart (when-complete-error)" replace="/whenCompleteError/main/g; "?>
+<?code-excerpt "futures/lib/when_complete.dart (when-complete-error)" replace="/whenCompleteError/main/g; "?>
 ```dart
 void main() {
   funcThatThrows()
@@ -325,7 +323,7 @@ throws, a synchronous error propagates:
 ```dart
 void main() {
   parseAndRead(data).catchError((e) {
-    print("Inside catchError");
+    print('Inside catchError');
     print(e);
   });
 }
@@ -371,7 +369,7 @@ With code wrapped within `Future.sync()`, `catchError()` can handle all errors:
 ```dart
 void main() {
   parseAndRead(data).catchError((e) {
-    print("Inside catchError");
+    print('Inside catchError');
     print(e);
   });
 }
@@ -385,7 +383,7 @@ void main() {
 function has a lot of code packed into it, chances are that you could be doing
 something dangerous without realizing it:
 
-<?code-excerpt "futures/bin/mixing_errors_problematic.dart (fragile) replace="/ellipsis();/.../g;"?>
+<?code-excerpt "futures/bin/mixing_errors_problematic.dart (fragile) replace="/ellipsis\(\);/.../g;"?>
 ```dart
 Future fragileFunc() {
   return Future.sync(() {


### PR DESCRIPTION
This implements snippet auto inclusion and analysis for the futures error handling guide. Not much testing is currently added, but the set up is there to implement relatively easy in follow up work.

As part of this, some snippets were adjusted for recommended lints and dart format.

Closes https://github.com/dart-lang/site-www/issues/3526

**Staged _(Updated 9/5/21)_:** https://parlough-dart-dev.web.app/