### PR TITLE
Update version mentions on SDK tool version page

### DIFF
--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.13.0"
+    "vers": "2.13.4"
   }
 }

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -43,7 +43,7 @@ directory that has these command-line tools:
 : The API documentation generator.
 
 {{site.alert.note}}
-  The 2.10 Dart SDK also contains `dart2js`, `dart2native`, `dartanalyzer`,
+  The 2.13 Dart SDK also contains `dart2js`, `dart2native`, `dartanalyzer`,
   `dartdevc`, `dartfmt`, and `pub` commands.
   However, as of 2.10 the `dart` tool provides a unified interface
   to their functionality.


### PR DESCRIPTION
- Updates the listed SDK version since it's best for users to use the latest stable release and its what the CI uses.
- Updates the note about tools still being included to 2.13 as they still are present.