### PR TITLE
Adjust bootstrap config import order

### DIFF
--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -1,5 +1,4 @@
-// FIXME(chalin): remove the corresponding import from main.scss before uncommenting the following line:
-// @import 'bootstrap_config_shared';
+@import 'bootstrap_config_shared';
 
 $enable-shadows: true;
 
@@ -24,16 +23,6 @@ $kbd-font-size: 0.75rem;
 $dropdown-divider-bg: #bbbbbb;
 $dropdown-link-active-color: transparent;
 $dropdown-link-active-bg: transparent;
-
-//== Headings
-
-// The following are needed only because _bootstrap_config_shared is not imported in the right order:
-// https://github.com/dart-lang/site-www/issues/2007
-$headings-font-family: $site-font-family-gsans;
-$headings-font-weight: 400;
-
-// Move to _bootstrap_config_shared once #2007 is fixed:
-$headings-color: $site-color-body;
 
 //== Popovers
 

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -4,7 +4,6 @@
 @import 'colors';
 @import 'bootstrap_config';
 @import 'bootstrap';
-@import 'bootstrap_config_shared'; // FIXME(chalin): this should be before the bootstrap import; move to site file.
 @import 'bootstrap_adjust';
 
 @import 'font-awesome-sprockets';


### PR DESCRIPTION
`$headings-color` is not used in the site anymore, so it was safe to remove. As for the other changes, the variables seem to be working properly with the new ordering. I recommend viewing the staged website(or its generated CSS) to see if it matches your expectations, in case I missed something.

Closes #2007