### PR TITLE
Try using Google Sans in banner

### DIFF
--- a/src/_assets/css/_dash.scss
+++ b/src/_assets/css/_dash.scss
@@ -357,6 +357,7 @@ $dash-dartpad-border: #293542;
 
     a {
       color: $site-color-card-link;
+      font-family: $site-font-family-gsans;
 
       &:hover, &:focus, &:active {
         color: darken($site-color-card-link, 20%);

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -274,9 +274,9 @@ img {
 }
 
 .banner__text {
-  font-family: $site-font-family-roboto;
+  font-family: $site-font-family-gsans;
   font-size: 16px;
-  font-weight: 300;
+  font-weight: 400;
   margin-bottom: 0;
   padding-left: 1em;
   padding-right: 1em;


### PR DESCRIPTION
I noticed on my computer, particularly on Linux with a 1440p display, the banner text seemed a bit blurry. Improving the font-weight to 400 helped but then "2.14" looked strange. Switching to Google Sans fixed that issue and improved it overall even more.

It's not as large of a problem on my MacBook Pro. As a side note, flutter.dev also uses Google Sans for its banner.

I'm curious to see what you think. Open the [preview link](https://dart-dev--pr3570-misc-use-google-sans-rzpejl53.web.app/) below and the [live site](https://dart.dev/) next to each other on your computer. Thanks!