### PR TITLE
Clarify import path recommendations

### DIFF
--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -313,10 +313,17 @@ tests) but you should never import from another package's `lib/src` directory.
 Those files are not part of the package's public API, and they might change in
 ways that could break your code.
 
-When you use libraries from within your own package, even code in `src`, you
-can (and should) still use `package:` to import them. For example:
+When you use libraries from within your own package, you should use:
+ * `package:` when [reaching inside or outside `lib/`](https://dart.dev/guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib) (lint: [_avoid_relative_lib_imports_](https://dart.dev/tools/linter-rules#avoid_relative_lib_imports))
+ * [Prefer relative imports](https://dart.dev/guides/language/effective-dart/usage#prefer-relative-import-paths) otherwise.
+
+For example:
 
 {% prettify dart tag=pre+code %}
+// When importing from lib/beans.dart
+import 'src/beans.dart';
+
+// When importing from test/beans_test.dart
 import 'package:enchilada/src/beans.dart';
 {% endprettify %}
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -313,9 +313,15 @@ tests) but you should never import from another package's `lib/src` directory.
 Those files are not part of the package's public API, and they might change in
 ways that could break your code.
 
-When you use libraries from within your own package, you should use:
- * `package:` when [reaching inside or outside `lib/`](https://dart.dev/guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib) (lint: [_avoid_relative_lib_imports_](https://dart.dev/tools/linter-rules#avoid_relative_lib_imports))
- * [Prefer relative imports](https://dart.dev/guides/language/effective-dart/usage#prefer-relative-import-paths) otherwise.
+How you import libraries from within your own package
+depends on the locations of the libraries:
+
+ * When [reaching inside or outside `lib/`][] (lint: [_avoid_relative_lib_imports_][]), use `package:`.
+ * Otherwise, [prefer relative imports][].
+ 
+ [reaching inside or outside `lib/`]: /guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib
+ [_avoid_relative_lib_imports_]: /tools/linter-rules#avoid_relative_lib_imports
+ [prefer relative imports]: /guides/language/effective-dart/usage#prefer-relative-import-paths
 
 For example:
 

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -316,7 +316,9 @@ ways that could break your code.
 How you import libraries from within your own package
 depends on the locations of the libraries:
 
- * When [reaching inside or outside `lib/`][] (lint: [_avoid_relative_lib_imports_][]), use `package:`.
+ * When [reaching inside or outside `lib/`][]
+   (lint: [_avoid_relative_lib_imports_][]),
+   use `package:`.
  * Otherwise, [prefer relative imports][].
  
  [reaching inside or outside `lib/`]: /guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib


### PR DESCRIPTION
Bring import documentation in line with Effective Dart:
https://dart.dev/guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib