### PR TITLE
Add note about requiring clean analysis for dartdoc

### DIFF
--- a/src/tools/dartdoc.md
+++ b/src/tools/dartdoc.md
@@ -12,8 +12,8 @@ which can contain markdown formatting.
 For guidance on writing doc comments,
 see the [documentation part of Effective Dart][effective doc].
 {{site.alert.note}}
-To generate documentation, your package must pass [dart analyze][]
-without errors.
+  To generate documentation, your package must pass [dart analyze][]
+  without errors.
 {{site.alert.end}}
 
 Run `dartdoc` from the root directory of your package. For example:

--- a/src/tools/dartdoc.md
+++ b/src/tools/dartdoc.md
@@ -22,6 +22,7 @@ Documenting my_app...
 Success! Docs generated into /Users/me/projects/my_app/doc/api
 ```
 
+To work correctly, your package must [analyze][] without errors.
 By default, the documentation files are static HTML files,
 placed in the `doc/api` directory.
 To view the rendered documentation, you need an HTTP server.
@@ -40,6 +41,7 @@ $ dartdoc --help
 
 [documentation comments]: /guides/language/language-tour#documentation-comments
 [effective doc]: /guides/language/effective-dart/documentation
+[analyze]: /tools/dart-analyze
 [dartdoc package.]: {{site.pub-pkg}}/dartdoc
 
 {% comment %}

--- a/src/tools/dartdoc.md
+++ b/src/tools/dartdoc.md
@@ -11,6 +11,10 @@ by using [documentation comments][],
 which can contain markdown formatting.
 For guidance on writing doc comments,
 see the [documentation part of Effective Dart][effective doc].
+{{site.alert.note}}
+To generate documentation, your package must pass [dart analyze][]
+without errors.
+{{site.alert.end}}
 
 Run `dartdoc` from the root directory of your package. For example:
 
@@ -22,7 +26,6 @@ Documenting my_app...
 Success! Docs generated into /Users/me/projects/my_app/doc/api
 ```
 
-To work correctly, your package must [analyze][] without errors.
 By default, the documentation files are static HTML files,
 placed in the `doc/api` directory.
 To view the rendered documentation, you need an HTTP server.
@@ -41,7 +44,7 @@ $ dartdoc --help
 
 [documentation comments]: /guides/language/language-tour#documentation-comments
 [effective doc]: /guides/language/effective-dart/documentation
-[analyze]: /tools/dart-analyze
+[dart analyze]: /tools/dart-analyze
 [dartdoc package.]: {{site.pub-pkg}}/dartdoc
 
 {% comment %}


### PR DESCRIPTION
Fixes dart-lang/dartdoc#2722.

README is already updated for dartdoc, this closes the loop by updating the main site.