### PR TITLE
LangTour: computing finals, factory constructors, and late final

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2846,8 +2846,9 @@ class ProfileMark {
 If you need to assign the value of a `final` instance variable
 after the constructor body starts, you can use one of the following:
 
-* Use `late final`, but [_be careful_][late-final-ivar].
 * Use a [factory constructor](#factory-constructors).
+* Use `late final`, but [_be careful_][late-final-ivar];
+  a `late final` without an initializer adds a setter to the API.
 
 
 ### Constructors

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2844,7 +2844,7 @@ class ProfileMark {
 }
 ```
 
-If you want to assign the value of a `final` instance variable
+If you need to assign the value of a `final` instance variable
 after the constructor body starts, you can use one of the following:
 
 * Use `late final`, but [_be careful_][late-final-ivar].

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2847,7 +2847,7 @@ If you need to assign the value of a `final` instance variable
 after the constructor body starts, you can use one of the following:
 
 * Use a [factory constructor](#factory-constructors).
-* Use `late final`, but [_be careful_][late-final-ivar];
+* Use `late final`, but [_be careful:_][late-final-ivar]
   a `late final` without an initializer adds a setter to the API.
 
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2845,10 +2845,10 @@ class ProfileMark {
 ```
 
 If you want to assign the value of a `final` instance variable
-after the constructor body starts, you can use `late final`,
-[but _be careful_][late-final-ivar].
+after the constructor body starts, you can use one of the following:
 
-[late-final-ivar]: /guides/language/effective-dart/design#avoid-public-late-final-fields-without-initializers
+* Use `late final`, but [_be careful_][late-final-ivar].
+* Use a [factory constructor](#factory-constructors).
 
 
 ### Constructors
@@ -3115,6 +3115,10 @@ Another use case for factory constructors is
 initializing a final variable using
 logic that can't be handled in the initializer list.
 
+{{site.alert.tip}}
+  Another way to handle late initialization of a final variable
+  is to [use `late final` (carefully!)][late-final-ivar].
+{{site.alert.end}}
 
 In the following example,
 the `Logger` factory constructor returns objects from a cache,
@@ -4629,6 +4633,7 @@ To learn more about Dart's core libraries, see
 [iteration]: /guides/libraries/library-tour#iteration
 [js numbers]: https://stackoverflow.com/questions/2802957/number-of-bits-in-javascript-numbers/2803010#2803010
 [language version]: /guides/language/evolution#language-versioning
+[late-final-ivar]: /guides/language/effective-dart/design#avoid-public-late-final-fields-without-initializers
 [`List`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
 [`Map`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html
 [meta]: {{site.pub-pkg}}/meta


### PR DESCRIPTION
Fixes #267
(maybe)

But we should perhaps update Effective Dart if we make this change.

/cc @natebosch @munificent 

Staged:
https://dart-dev--pr3580-kw-finals-rwmq5v76.web.app/guides/language/language-tour#instance-variables
https://dart-dev--pr3580-kw-finals-rwmq5v76.web.app/guides/language/language-tour#factory-constructors