### PR TITLE
Fix h1 overlapping subnav

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -363,7 +363,7 @@ img {
   }
 }
 #subnav {
-  height: 32px;
+  min-height: 32px;
   line-height: 32px;
   margin-bottom: 10px;
   ul {


### PR DESCRIPTION
Fixes it by allowing the subnav to take on its necessary height if its multiple lines long.

I recommend viewing the preview and verifying pages with the page subnav (back and forward sections at the top, refer to issue) are formatted as you expect. Then do the same by switching to a mobile layout with developer tools.

Fixes #3582