### PR TITLE
Reference 2.14 as SDK version for the site

### DIFF
--- a/examples/analysis/pubspec.yaml
+++ b/examples/analysis/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/analysis_alt/pubspec.yaml
+++ b/examples/analysis_alt/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/examples/async_await/pubspec.yaml
+++ b/examples/async_await/pubspec.yaml
@@ -2,7 +2,7 @@ name: async_await
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/basics/pubspec.yaml
+++ b/examples/basics/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev null-safety examples.
 version: 0.0.1
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/examples/build_runner_usage/pubspec.yaml
+++ b/examples/build_runner_usage/pubspec.yaml
@@ -2,7 +2,7 @@ name: build_runner_usage
 description: dart.dev build_runner example code.
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   args: ^2.2.0

--- a/examples/create_libraries/pubspec.yaml
+++ b/examples/create_libraries/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/examples/extension_methods/pubspec.yaml
+++ b/examples/extension_methods/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/examples/fetch_data/pubspec.yaml
+++ b/examples/fetch_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Fetch data example
 version: 0.0.1
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.0

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/html/pubspec.yaml
+++ b/examples/html/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 0.0.1
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   html: any

--- a/examples/iterables/pubspec.yaml
+++ b/examples/iterables/pubspec.yaml
@@ -2,7 +2,7 @@ name: iterables_examples
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/non_promotion/pubspec.yaml
+++ b/examples/non_promotion/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev non-promotion examples.
 version: 0.0.1
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/examples/null_safety_codelab/pubspec.yaml
+++ b/examples/null_safety_codelab/pubspec.yaml
@@ -2,7 +2,7 @@ name: null_safety_codelab_examples
 description: dart.dev example code for null safety codelab
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/type_system/pubspec.yaml
+++ b/examples/type_system/pubspec.yaml
@@ -2,7 +2,7 @@ name: type_system_examples
 description: dart.dev type system examples.
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example utilities.
 version: 0.0.2
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
   lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: site_www
 homepage: https://dart.dev
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.0

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.13.4"
+    "vers": "2.14.2"
   }
 }

--- a/tool/dart_tools/pubspec.yaml
+++ b/tool/dart_tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tools
 description: Dart-based tools for site-www
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   path: ^1.8.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: site_scripts
 description: Utility scripts
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   crypto: ^3.0.1


### PR DESCRIPTION
We already were using 2.14 for the misc examples, so update the documented version as well as the minimum SDK for other examples.