### PR TITLE
Patch dev build analysis failure

### DIFF
--- a/examples/misc/analyzer-results-dev.txt
+++ b/examples/misc/analyzer-results-dev.txt
@@ -2,6 +2,13 @@ Analyzing misc...
 
   error - bin/cheatsheet/nullable.dart:7:13 - A value of type 'Null' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/library_tour/core/collections.dart:5:14 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-   info - lib/effective_dart/usage_good.dart:481:9 - Use initializing formals when possible. - prefer_initializing_formals
+  info - lib/effective_dart/usage_good.dart:481:9 - Use initializing formals when possible. - prefer_initializing_formals
+  info - lib/language_tour/classes/employee.dart:39:7 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - lib/language_tour/typedefs/misc.dart:19:10 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - lib/language_tour/variables.dart:111:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - lib/language_tour/variables.dart:113:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - test/language_tour/generics_test.dart:30:13 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - test/library_tour/core_test.dart:276:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+  info - test/library_tour/core_test.dart:490:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
 
-3 issues found.
+10 issues found.

--- a/examples/misc/analyzer-results-dev.txt
+++ b/examples/misc/analyzer-results-dev.txt
@@ -2,13 +2,13 @@ Analyzing misc...
 
   error - bin/cheatsheet/nullable.dart:7:13 - A value of type 'Null' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/library_tour/core/collections.dart:5:14 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  info - lib/effective_dart/usage_good.dart:481:9 - Use initializing formals when possible. - prefer_initializing_formals
-  info - lib/language_tour/classes/employee.dart:39:7 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - lib/language_tour/typedefs/misc.dart:19:10 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - lib/language_tour/variables.dart:111:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - lib/language_tour/variables.dart:113:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - test/language_tour/generics_test.dart:30:13 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - test/library_tour/core_test.dart:276:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
-  info - test/library_tour/core_test.dart:490:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - lib/effective_dart/usage_good.dart:481:9 - Use initializing formals when possible. - prefer_initializing_formals
+   info - lib/language_tour/classes/employee.dart:39:7 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - lib/language_tour/typedefs/misc.dart:19:10 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - lib/language_tour/variables.dart:111:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - lib/language_tour/variables.dart:113:24 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - test/language_tour/generics_test.dart:30:13 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - test/library_tour/core_test.dart:276:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
+   info - test/library_tour/core_test.dart:490:14 - Unnecessary type check; the result is always 'true'. Try correcting the type check, or removing the type check. - unnecessary_type_check
 
 10 issues found.

--- a/examples/misc/lib/language_tour/classes/employee.dart
+++ b/examples/misc/lib/language_tour/classes/employee.dart
@@ -35,6 +35,7 @@ void main() {
   // Instance of 'Employee'
   // #enddocregion super
   // #docregion emp-is-Person
+  // ignore_for_file: stable, beta, dev, unnecessary_type_check
   if (employee is Person) {
     // Type check
     employee.firstName = 'Bob';

--- a/examples/misc/lib/language_tour/typedefs/misc.dart
+++ b/examples/misc/lib/language_tour/typedefs/misc.dart
@@ -15,5 +15,6 @@ typedef Compare<T> = int Function(T a, T b);
 int sort(int a, int b) => a - b;
 
 void main() {
+  // ignore_for_file: stable, beta, dev, unnecessary_type_check
   assert(sort is Compare<int>); // True!
 }

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -107,7 +107,9 @@ void miscDeclAnalyzedButNotTested() {
       // #docregion const-dart-25
       const Object i = 3; // Where i is a const Object with an int value...
       const list = [i as int]; // Use a typecast.
+      // ignore_for_file: stable, beta, dev, unnecessary_type_check
       const map = {if (i is int) i: 'int'}; // Use is and collection if.
+      // ignore_for_file: stable, beta, dev, unnecessary_type_check
       const set = {if (list is List<int>) ...list}; // ...and a spread.
       // #enddocregion const-dart-25
     }

--- a/examples/misc/test/language_tour/generics_test.dart
+++ b/examples/misc/test/language_tour/generics_test.dart
@@ -26,6 +26,7 @@ void main() {
       // #docregion generic-collections
       var names = <String>[];
       names.addAll(['Seth', 'Kathy', 'Lars']);
+      // ignore_for_file: stable, beta, dev, unnecessary_type_check
       print(names is List<String>); // true
       // #enddocregion generic-collections
     }

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -272,6 +272,7 @@ void main() {
 
       fruits.add('apples');
       var fruit = fruits[0];
+      // ignore_for_file: stable, beta, dev, unnecessary_type_check
       assert(fruit is String);
       // #enddocregion List-of-String
     });
@@ -485,6 +486,7 @@ void main() {
       var loudTeas =
           teas.map((tea) => tea.toUpperCase()).toList();
       // #enddocregion toList
+      // ignore_for_file: stable, beta, dev, unnecessary_type_check
       expect(loudTeas is List, isTrue);
     });
 


### PR DESCRIPTION
This is due to this diagnostic being produced in more situations in the latest dev builds.

We use the checks for instructional purposes generally, so should be fine to ignore this hint for now.