### PR TITLE
Switch to ignore rather than ignore_for_file for tracked analysis issues

### DIFF
--- a/examples/analysis/lib/assignment.dart
+++ b/examples/analysis/lib/assignment.dart
@@ -7,7 +7,7 @@ import 'package:examples_util/ellipsis.dart';
 String downcastExample() {
   // #docregion implicit-downcast
   dynamic o = ellipsis<String>();
-  // ignore_for_file: stable, beta, dev, invalid_assignment
+  // ignore: stable, beta, dev, invalid_assignment
   String s = o; // Implicit downcast
   String s2 = s.substring(1);
   // #enddocregion implicit-downcast

--- a/examples/analysis/lib/lint.dart
+++ b/examples/analysis/lib/lint.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 int count = 0;
 // #docregion empty_statements
 void increment() {
-  // ignore_for_file: stable, beta, dev,  empty_statements
+  // ignore: stable, beta, dev,  empty_statements
   if (count < 10) ;
   count++;
 }
@@ -13,7 +13,7 @@ void increment() {
 
 void controller() {
   // #docregion close_sinks
-  // ignore_for_file: stable, beta, dev, close_sinks
+  // ignore: stable, beta, dev, close_sinks
   var controller = StreamController<String>();
   // #enddocregion close_sinks
 }

--- a/examples/misc/lib/language_tour/classes/employee.dart
+++ b/examples/misc/lib/language_tour/classes/employee.dart
@@ -35,7 +35,7 @@ void main() {
   // Instance of 'Employee'
   // #enddocregion super
   // #docregion emp-is-Person
-  // ignore_for_file: stable, beta, dev, unnecessary_type_check
+  // ignore: stable, beta, dev, unnecessary_type_check
   if (employee is Person) {
     // Type check
     employee.firstName = 'Bob';

--- a/examples/misc/lib/language_tour/typedefs/misc.dart
+++ b/examples/misc/lib/language_tour/typedefs/misc.dart
@@ -15,6 +15,6 @@ typedef Compare<T> = int Function(T a, T b);
 int sort(int a, int b) => a - b;
 
 void main() {
-  // ignore_for_file: stable, beta, dev, unnecessary_type_check
+  // ignore: stable, beta, dev, unnecessary_type_check
   assert(sort is Compare<int>); // True!
 }

--- a/examples/misc/lib/language_tour/variables.dart
+++ b/examples/misc/lib/language_tour/variables.dart
@@ -107,9 +107,9 @@ void miscDeclAnalyzedButNotTested() {
       // #docregion const-dart-25
       const Object i = 3; // Where i is a const Object with an int value...
       const list = [i as int]; // Use a typecast.
-      // ignore_for_file: stable, beta, dev, unnecessary_type_check
+      // ignore: stable, beta, dev, unnecessary_type_check
       const map = {if (i is int) i: 'int'}; // Use is and collection if.
-      // ignore_for_file: stable, beta, dev, unnecessary_type_check
+      // ignore: stable, beta, dev, unnecessary_type_check
       const set = {if (list is List<int>) ...list}; // ...and a spread.
       // #enddocregion const-dart-25
     }

--- a/examples/misc/lib/library_tour/core/collections.dart
+++ b/examples/misc/lib/library_tour/core/collections.dart
@@ -1,7 +1,7 @@
 void miscDeclAnalyzedButNotTested() {
   var fruits = <String>[];
-  // ignore_for_file: stable, dev, argument_type_not_assignable, unused_local_variable
   // #docregion List-of-String
+  // ignore: stable, beta, dev, argument_type_not_assignable, unused_local_variable
   fruits.add(5); // Error: 'int' can't be assigned to 'String'
   // #enddocregion List-of-String
 }

--- a/examples/misc/test/language_tour/generics_test.dart
+++ b/examples/misc/test/language_tour/generics_test.dart
@@ -26,7 +26,7 @@ void main() {
       // #docregion generic-collections
       var names = <String>[];
       names.addAll(['Seth', 'Kathy', 'Lars']);
-      // ignore_for_file: stable, beta, dev, unnecessary_type_check
+      // ignore: stable, beta, dev, unnecessary_type_check
       print(names is List<String>); // true
       // #enddocregion generic-collections
     }

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -272,7 +272,7 @@ void main() {
 
       fruits.add('apples');
       var fruit = fruits[0];
-      // ignore_for_file: stable, beta, dev, unnecessary_type_check
+      // ignore: stable, beta, dev, unnecessary_type_check
       assert(fruit is String);
       // #enddocregion List-of-String
     });
@@ -486,7 +486,7 @@ void main() {
       var loudTeas =
           teas.map((tea) => tea.toUpperCase()).toList();
       // #enddocregion toList
-      // ignore_for_file: stable, beta, dev, unnecessary_type_check
+      // ignore: stable, beta, dev, unnecessary_type_check
       expect(loudTeas is List, isTrue);
     });
 

--- a/examples/type_system/lib/bounded/instantiate_to_bound.dart
+++ b/examples/type_system/lib/bounded/instantiate_to_bound.dart
@@ -3,7 +3,7 @@ import 'my_collection.dart';
 void cannotRunThis() {
   // #docregion undefined_method
   var c = C(Iterable.empty()).collection;
-  // ignore_for_file: stable, beta, dev, undefined_method
+  // ignore: stable, beta, dev, undefined_method
   c.add(2); //!analysis-issue
   // #enddocregion undefined_method
 }

--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -12,7 +12,7 @@ void _samplesFromCommonProblemsPage() {
   {
     // #docregion canvas-undefined
     var canvas = querySelector('canvas')!;
-    // ignore_for_file: stable, beta, dev, undefined_getter
+    // ignore: stable, beta, dev, undefined_getter
     canvas.context2D.lineTo(x, y); //!analysis-issue
     // #enddocregion canvas-undefined
   }
@@ -35,7 +35,7 @@ void _samplesFromCommonProblemsPage() {
     // #docregion inferred-collection-types
     // Inferred as Map<String, int>
     var map = {'a': 1, 'b': 2, 'c': 3};
-    // ignore_for_file: stable, beta, dev, invalid_assignment
+    // ignore: stable, beta, dev, invalid_assignment
     map['d'] = 1.5; //!analysis-issue
     // #enddocregion inferred-collection-types
   }
@@ -56,7 +56,7 @@ abstract class NumberAdder {
 }
 
 class MyAdder extends NumberAdder {
-  // ignore_for_file: stable, beta, dev, invalid_override
+  // ignore: stable, beta, dev, invalid_override
   @override
   num add(int a, int b) => a + b;
 }
@@ -76,7 +76,7 @@ class Superclass<T> {
 
 class Subclass extends Superclass {
   @override
-  // ignore_for_file: stable, beta, dev, invalid_override
+  // ignore: stable, beta, dev, invalid_override
   void method(int param) {/* ... */}
 }
 // #enddocregion type-arguments
@@ -93,7 +93,7 @@ class _HoneyBadger extends Animal {
   final String _name;
   // #docregion super-goes-last
   _HoneyBadger(Eats food, String name)
-      // ignore_for_file: stable, beta, dev, invalid_super_invocation
+      // ignore: stable, beta, dev, invalid_super_invocation
       : super(food),
         _name = name {/* ... */}
 // #enddocregion super-goes-last
@@ -113,7 +113,7 @@ class HoneyBadger extends Animal {
 void funcFail() {
   // #docregion func-fail
   void filterValues(bool Function(dynamic) filter) {}
-  // ignore_for_file: stable, beta, dev, argument_type_not_assignable
+  // ignore: stable, beta, dev, argument_type_not_assignable
   filterValues((String x) => x.contains('Hello'));
   // #enddocregion func-fail
 }

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -23,14 +23,14 @@ void _miscDeclAnalyzedButNotTested() {
       var list = [];
       list.add(1);
       list.add('2');
-      // ignore_for_file: stable, beta, dev, argument_type_not_assignable
+      // ignore: stable, beta, dev, argument_type_not_assignable
       printInts(list); //!analysis-issue
     }
     // #enddocregion opening-example
 
     void testAnalysis() {
       // #docregion static-analysis-enabled
-      // ignore_for_file: stable, beta, dev, invalid_assignment
+      // ignore: stable, beta, dev, invalid_assignment
       bool b = [0][0];
       // #enddocregion static-analysis-enabled
     }
@@ -41,7 +41,7 @@ void _miscDeclAnalyzedButNotTested() {
     Map<String, dynamic> arguments = {'argA': 'hello', 'argB': 42};
     // #enddocregion type-inference-1-orig
 
-    // ignore_for_file: stable, beta, dev, argument_type_not_assignable
+    // ignore: stable, beta, dev, argument_type_not_assignable
     arguments[1] = null;
 
     // #docregion type-inference-2-orig
@@ -57,7 +57,7 @@ void _miscDeclAnalyzedButNotTested() {
     var arguments = {'argA': 'hello', 'argB': 42}; // Map<String, Object>
     // #enddocregion type-inference-1
 
-    // ignore_for_file: stable, beta, dev, argument_type_not_assignable
+    // ignore: stable, beta, dev, argument_type_not_assignable
     arguments[1] = 100;
 
     // #docregion type-inference-2
@@ -79,7 +79,7 @@ void _miscDeclAnalyzedButNotTested() {
   {
     // #docregion local-var-type-inference-error
     var x = 3; // x is inferred as an int.
-    // ignore_for_file: stable, beta, dev, stable, dev, invalid_assignment
+    // ignore: stable, beta, dev, stable, dev, invalid_assignment
     x = 4.0; //!analysis-issue
     // #enddocregion local-var-type-inference-error
   }
@@ -103,7 +103,7 @@ void _miscDeclAnalyzedButNotTested() {
     var ints = listOfDouble.map((x) => x.toInt());
     // #enddocregion type-arg-inference
 
-    // ignore_for_file: stable, beta, dev, invalid_assignment
+    // ignore: stable, beta, dev, invalid_assignment
     listOfDouble[0] = '';
   }
 
@@ -115,7 +115,7 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion MaineCoon-Cat-err
-    // ignore_for_file: stable, beta, dev, invalid_cast_new_expr, invalid_assignment
+    // ignore: stable, beta, dev, invalid_cast_new_expr, invalid_assignment
     MaineCoon c = Cat();
     // #enddocregion MaineCoon-Cat-err
   }
@@ -140,7 +140,7 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion generic-type-assignment-Animal
-    // ignore_for_file: stable, beta, dev, invalid_assignment
+    // ignore: stable, beta, dev, invalid_assignment
     List<Cat> myCats = <Animal>[];
     // #enddocregion generic-type-assignment-Animal
   }

--- a/examples/type_system/test/strong_test.dart
+++ b/examples/type_system/test/strong_test.dart
@@ -116,7 +116,7 @@ void main() {
 
 // #docregion downcast-check
 void assumeStrings(dynamic objects) {
-  // ignore_for_file: stable, beta, dev, invalid_assignment
+  // ignore: stable, beta, dev, invalid_assignment
   List<String> strings = objects; // Runtime downcast check
   String string = strings[0]; // Expect a String value
   // #enddocregion downcast-check

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -3,7 +3,7 @@ title: Customizing static analysis
 description: Use an analysis options file and code comments to customize static analysis.
 ---
 
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore: (stable|beta|dev)[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore: (stable|beta|dev)[^\n]+\n/$1\n/g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
 
 <style>
 li.L0, li.L1, li.L2, li.L3,

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -3,7 +3,7 @@ title: Customizing static analysis
 description: Use an analysis options file and code comments to customize static analysis.
 ---
 
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
 
 <style>
 li.L0, li.L1, li.L2, li.L3,

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4,7 +4,7 @@ description: A tour of all the major Dart language features.
 short-title: Language tour
 js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
 ---
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; / *\/\/\s+ignore:[^\n]+//g; /([A-Z]\w*)\d\b/$1/g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; / *\/\/\s+ignore:[^\n]+//g; /([A-Z]\w*)\d\b/$1/g"?>
 
 This page shows you how to use each major Dart feature, from
 variables and operators to classes and libraries, with the assumption

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -2,7 +2,7 @@
 title: Fixing common type problems
 description: Common type issues you may have and how to fix them.
 ---
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; /. • (lib|test)\/\w+\.dart:\d+:\d+//g"?>
 <?code-excerpt plaster="none"?>
 <?code-excerpt path-base="type_system"?>
 

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -2,7 +2,7 @@
 title: The Dart type system
 description: Why and how to write sound Dart code.
 ---
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /([A-Z]\w*)\d\b/$1/g; /\b(main)\d\b/$1/g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /([A-Z]\w*)\d\b/$1/g; /\b(main)\d\b/$1/g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
 <?code-excerpt path-base="type_system"?>
 
 The Dart language is type safe: it uses a combination of static type checking

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -3,7 +3,7 @@ title: A tour of the core libraries
 description: Learn about the major features in Dart's libraries.
 short-title: Library tour
 ---
-<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /\n? *\/\/\s+ignore:[^\n]+//g"?>
+<?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
 <?code-excerpt plaster="none"?>
 
 This page shows you how to use the major features in Dart’s core libraries.


### PR DESCRIPTION
Adds the previously used replaces for `ignore` to the affected files. They are quite large but I wanted to stay consistent in handling all cases for these files. Since in the analysis options explanation, we want some of the ignore statements, I've added a specifier to look for one of the SDK channels.

Fixes #3591