### PR TITLE
Update diagnostic messages as of 09/28/21

### DIFF
--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -2644,7 +2644,11 @@ C f(int i) => C(i);
 
 ### const_with_type_parameters
 
+_A constant constructor tearoff can't use a type parameter as a type argument._
+
 _A constant creation can't use a type parameter as a type argument._
+
+_A constant function tearoff can't use a type parameter as a type argument._
 
 #### Description
 
@@ -3090,6 +3094,40 @@ class A {
 class B implements A {
   B([int x = 1]) {}
 }
+{% endprettify %}
+
+### default_value_on_required_parameter
+
+_Required named parameters can't have a default value._
+
+#### Description
+
+The analyzer produces this diagnostic when a named parameter has both the
+`required` modifier and a default value. If the parameter is required, then
+a value for the parameter is always provided at the call sites, so the
+default value can never be used.
+
+#### Examples
+
+The following code generates this diagnostic:
+
+{% prettify dart tag=pre+code %}
+void log({required String [!message!] = 'no message'}) {}
+{% endprettify %}
+
+#### Common fixes
+
+If the parameter is really required, then remove the default value:
+
+{% prettify dart tag=pre+code %}
+void log({required String message}) {}
+{% endprettify %}
+
+If the parameter isn't always required, then remove the `required`
+modifier:
+
+{% prettify dart tag=pre+code %}
+void log({String message = 'no message'}) {}
 {% endprettify %}
 
 ### deferred_import_of_extension
@@ -5281,6 +5319,50 @@ void f() {
 }
 {% endprettify %}
 
+### generic_method_type_instantiation_on_dynamic
+
+_A method tear-off on a receiver whose type is 'dynamic' can't have type
+arguments._
+
+#### Description
+
+The analyzer produces this diagnostic when an instance method is being torn
+off from a receiver whose type is `dynamic`, and the tear-off includes type
+arguments. Because the analyzer can't know how many type parameters the
+method has, or whether it has any type parameters, there's no way it can
+validate that the type arguments are correct. As a result, the type
+arguments aren't allowed.
+
+#### Example
+
+The following code produces this diagnostic because the type of `p` is
+`dynamic` and the tear-off of `m` has type arguments:
+
+{% prettify dart tag=pre+code %}
+void f(dynamic list) {
+  [!list.fold!]<int>;
+}
+{% endprettify %}
+
+#### Common fixes
+
+If you can use a more specific type than `dynamic`, then change the type of
+the receiver:
+
+{% prettify dart tag=pre+code %}
+void f(List<Object> list) {
+  list.fold<int>;
+}
+{% endprettify %}
+
+If you can't use a more specific type, then remove the type arguments:
+
+{% prettify dart tag=pre+code %}
+void f(dynamic list) {
+  list.cast;
+}
+{% endprettify %}
+
 ### getter_not_subtype_setter_types
 
 _The return type of getter '{0}' is '{1}' which isn't a subtype of the type
@@ -6110,6 +6192,48 @@ var e = E.a;
 
 If you intend to use an instance of a class, then use the name of that class in place of the name of the enum.
 
+### instantiate_type_alias_expands_to_type_parameter
+
+_Type aliases that expand to a type parameter can't be instantiated._
+
+#### Description
+
+The analyzer produces this diagnostic when a constructor invocation is
+found where the type being instantiated is a type alias for one of the type
+parameters of the type alias. This isn’t allowed because the value of the
+type parameter is a type rather than a class.
+
+#### Example
+
+The following code produces this diagnostic because it creates an instance
+of `A`, even though `A` is a type alias that is defined to be equivalent to
+a type parameter:
+
+{% prettify dart tag=pre+code %}
+typedef A<T> = T;
+
+void f() {
+  const [!A!]<int>();
+}
+{% endprettify %}
+
+#### Common fixes
+
+Use either a class name or a type alias defined to be a class, rather than
+a type alias defined to be a type parameter:
+
+{% prettify dart tag=pre+code %}
+typedef A<T> = C<T>;
+
+void f() {
+  const A<int>();
+}
+
+class C<T> {
+  const C();
+}
+{% endprettify %}
+
 ### integer_literal_imprecise_as_double
 
 _The integer literal is being used as a double, but can't be represented as a
@@ -6246,6 +6370,57 @@ int v = 0;
 void f() {
 }
 {% endprettify %}
+
+### invalid_annotation_constant_value_from_deferred_library
+
+_Constant values from a deferred library can't be used in annotations._
+
+#### Description
+
+The analyzer produces this diagnostic when a constant defined in a library
+that is imported as a deferred library is referenced in the argument list
+of an annotation. Annotations are evaluated at compile time, and values
+from deferred libraries aren't available at compile time.
+
+For more information, see the language tour's coverage of
+[deferred loading](https://dart.dev/guides/language/language-tour#lazily-loading-a-library).
+
+#### Example
+
+The following code produces this diagnostic because the constant `pi` is
+being referenced in the argument list of an annotation, even though the
+library that defines it is being imported as a deferred library:
+
+{% prettify dart tag=pre+code %}
+import 'dart:math' deferred as math;
+
+class C {
+  const C(double d);
+}
+
+@C([!math.pi!])
+void f () {}
+{% endprettify %}
+
+#### Common fixes
+
+If you need to reference the imported constant, then remove the `deferred`
+keyword:
+
+{% prettify dart tag=pre+code %}
+import 'dart:math' as math;
+
+class C {
+  const C(double d);
+}
+
+@C(math.pi)
+void f () {}
+{% endprettify %}
+
+If the import is required to be deferred and there's another constant that
+is appropriate, then use that constant in place of the constant from the
+deferred library.
 
 ### invalid_annotation_from_deferred_library
 
@@ -6711,7 +6886,7 @@ class C {
 
 ### invalid_modifier_on_setter
 
-_The modifier '{0}' can't be applied to the body of a setter._
+_Setters can't use 'async', 'async*', or 'sync*'._
 
 #### Description
 
@@ -6759,7 +6934,7 @@ _The receiver can't be null, so the null-aware operator '{0}' is unnecessary._
 #### Description
 
 The analyzer produces this diagnostic when a null-aware operator (`?.`,
-`?..`, `?[`, `?..[`, or `...?`) is used on a target that's known to be
+`?..`, `?[`, `?..[`, or `...?`) is used on a receiver that's known to be
 non-nullable.
 
 #### Example
@@ -7098,7 +7273,7 @@ Replace the invalid URI with a valid URI.
 
 ### invalid_use_of_covariant_in_extension
 
-_Can't have modifier '#lexeme' in an extension._
+_Can't have modifier '{0}' in an extension._
 
 #### Description
 
@@ -7159,6 +7334,47 @@ int f(String? x) {
 }
 {% endprettify %}
 
+### invalid_use_of_visible_for_overriding_member
+
+_The member '{0}' can only be used for overriding._
+
+#### Description
+
+The analyzer produces this diagnostic when an instance member that is
+annotated with `visibleForOverriding` is referenced outside the library in
+which it's declared for any reason other than to override it.
+
+#### Example
+
+Given a file named `a.dart` containing the following declaration:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+class A {
+  @visibleForOverriding
+  void a() {}
+}
+{% endprettify %}
+
+The following code produces this diagnostic because the method `m` is being
+invoked even though the only reason it's public is to allow it to be
+overridden:
+
+{% prettify dart tag=pre+code %}
+import 'a.dart';
+
+class B extends A {
+  void b() {
+    [!a!]();
+  }
+}
+{% endprettify %}
+
+#### Common fixes
+
+Remove the invalid use of the member.
+
 ### invalid_visibility_annotation
 
 _The member '{0}' is annotated with '{1}', but this annotation is only
@@ -7202,6 +7418,38 @@ import 'package:meta/meta.dart';
 void someFunction() {}
 
 void f() => someFunction();
+{% endprettify %}
+
+### invalid_visible_for_overriding_annotation
+
+_The declaration '{0}' is annotated with 'visibleForOverriding'. Because '{0}'
+isn't an interface member that could be overridden, the annotation is meaningless._
+
+#### Description
+
+The analyzer produces this diagnostic when anything other than a public
+instance member of a class is annotated with `visibleForOverriding`.
+Because only public instance members can be overridden outside the defining
+library, there's no value to annotating any other declarations.
+
+#### Example
+
+The following code produces this diagnostic because the annotation is on a
+class, and classes can't be overridden:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+[!@visibleForOverriding!]
+class C {}
+{% endprettify %}
+
+#### Common fixes
+
+Remove the annotation:
+
+{% prettify dart tag=pre+code %}
+class C {}
 {% endprettify %}
 
 ### invocation_of_extension_without_call
@@ -7438,7 +7686,7 @@ void f() {
 
 ### late_final_field_with_const_constructor
 
-_Can't have a late final field in a class with a const constructor._
+_Can't have a late final field in a class with a generative const constructor._
 
 #### Description
 
@@ -8187,6 +8435,7 @@ doesn't implement the required constraint.
 #### Example
 
 The following code produces this diagnostic because the mixin `M` requires
+that the class to which it's applied be a subclass of `A`, but `Object`
 isn't a subclass of `A`:
 
 {% prettify dart tag=pre+code %}
@@ -9824,6 +10073,32 @@ g([!f!] v) {}
 
 Replace the name with the name of a type.
 
+### not_binary_operator
+
+_'{0}' isn't a binary operator._
+
+#### Description
+
+The analyzer produces this diagnostic when an operator that can only be
+used as a unary operator is used as a binary operator.
+
+#### Example
+
+The following code produces this diagnostic because the operator `~` can
+only be used as a unary operator:
+
+{% prettify dart tag=pre+code %}
+var a = 5 [!~!] 3;
+{% endprettify %}
+
+#### Common fixes
+
+Replace the operator with the correct binary operator:
+
+{% prettify dart tag=pre+code %}
+var a = 5 - 3;
+{% endprettify %}
+
 ### not_enough_positional_arguments
 
 _{0} positional argument(s) expected, but {1} found._
@@ -10320,6 +10595,41 @@ Remove the question mark from the type:
 {% prettify dart tag=pre+code %}
 mixin M {}
 class C with M {}
+{% endprettify %}
+
+### null_argument_to_non_null_type
+
+_'{0}' shouldn't be called with a null argument for the non-nullable type
+argument '{1}'._
+
+#### Description
+
+The analyzer produces this diagnostic when `null` is passed to either the
+constructor `Future.value` or the method `Completer.complete` when the type
+argument used to create the instance was non-nullable. Even though the type
+system can't express this restriction, passing in a `null` results in a
+runtime exception.
+
+#### Example
+
+The following code produces this diagnostic because `null` is being passed
+to the constructor `Future.value` even though the type argument is the
+non-nullable type `String`:
+
+{% prettify dart tag=pre+code %}
+Future<String> f() {
+  return Future.value([!null!]);
+}
+{% endprettify %}
+
+#### Common fixes
+
+Pass in a non-null value:
+
+{% prettify dart tag=pre+code %}
+Future<String> f() {
+  return Future.value('');
+}
 {% endprettify %}
 
 ### on_repeated
@@ -11245,6 +11555,47 @@ class C {
 }
 {% endprettify %}
 
+### redirect_to_type_alias_expands_to_type_parameter
+
+_A redirecting constructor can't redirect to a type alias that expands to a type
+parameter._
+
+#### Description
+
+The analyzer produces this diagnostic when a redirecting factory
+constructor redirects to a type alias, and the type alias expands to one of
+the type parameters of the type alias. This isn’t allowed because the value
+of the type parameter is a type rather than a class.
+
+#### Example
+
+The following code produces this diagnostic because the redirect to `B<A>`
+is to a type alias whose value is `T`, even though it looks like the value
+should be `A`:
+
+{% prettify dart tag=pre+code %}
+class A implements C {}
+
+typedef B<T> = T;
+
+abstract class C {
+  factory C() = [!B!]<A>;
+}
+{% endprettify %}
+
+#### Common fixes
+
+Use either a class name or a type alias that is defined to be a class
+rather than a type alias defined to be a type parameter:
+
+{% prettify dart tag=pre+code %}
+class A implements C {}
+
+abstract class C {
+  factory C() = A;
+}
+{% endprettify %}
+
 ### referenced_before_declaration
 
 _Local variable '{0}' can't be referenced before it is declared._
@@ -11393,14 +11744,15 @@ class C {
 
 ### return_in_generator
 
-_Can't return a value from a generator function (using the '{0}' modifier)._
+_Can't return a value from a generator function that uses the 'async*' or
+'sync*' modifier._
 
 #### Description
 
 The analyzer produces this diagnostic when a generator function (one whose
-body is marked with either `async*` or `sync*`) uses a `return` statement
-to return a value. In both cases, they should use `yield` instead of
-`return`.
+body is marked with either `async*` or `sync*`) uses either a `return`
+statement to return a value or implicitly returns a value because of using
+`=>`. In any of these cases, they should use `yield` instead of `return`.
 
 #### Example
 
@@ -11413,7 +11765,23 @@ Iterable<int> f() sync* {
 }
 {% endprettify %}
 
+The following code produces this diagnostic because the function `f` is a
+generator and is implicitly returning a value:
+
+{% prettify dart tag=pre+code %}
+Stream<int> f() async* [!=>!] 3;
+{% endprettify %}
+
 #### Common fixes
+
+If the function is using `=>` for the body of the function, then convert it
+to a block function body, and use `yield` to return a value:
+
+{% prettify dart tag=pre+code %}
+Stream<int> f() async* {
+  yield 3;
+}
+{% endprettify %}
 
 If the method is intended to be a generator, then use `yield` to return a
 value:
@@ -11684,6 +12052,52 @@ const bool b = false;
 bool c = a & b;
 {% endprettify %}
 
+### sdk_version_constructor_tearoffs
+
+_Tearing off a constructor requires the 'constructor-tearoffs' language
+feature._
+
+#### Description
+
+The analyzer produces this diagnostic when a constructor tear-off is found
+in code that has an SDK constraint whose lower bound is less than 2.15.
+Constructor tear-offs weren't supported in earlier versions, so this code
+won't be able to run against earlier versions of the SDK.
+
+#### Example
+
+Here's an example of a pubspec that defines an SDK constraint with a lower
+bound of less than 2.15:
+
+```yaml
+environment:
+  sdk: '>=2.9.0 <2.15.0'
+```
+
+In the package that has that pubspec, code like the following produces this
+diagnostic:
+
+{% prettify dart tag=pre+code %}
+var setConstructor = [!Set.identity!];
+{% endprettify %}
+
+#### Common fixes
+
+If you don't need to support older versions of the SDK, then you can
+increase the SDK constraint to allow the operator to be used:
+
+```yaml
+environment:
+  sdk: '>=2.15.0 <2.16.0'
+```
+
+If you need to support older versions of the SDK, then rewrite the code to
+not use constructor tear-offs:
+
+{% prettify dart tag=pre+code %}
+var setConstructor = () => Set.identity();
+{% endprettify %}
+
 ### sdk_version_eq_eq_operator_in_const_context
 
 _Using the operator '==' for non-primitive types wasn't supported until version
@@ -11790,6 +12204,60 @@ the value that would have been bound to `this` as a parameter:
 {% prettify dart tag=pre+code %}
 void sayHello(String s) {
   print('Hello $s');
+}
+{% endprettify %}
+
+### sdk_version_gt_gt_gt_operator
+
+_The operator '>>>' wasn't supported until version 2.14.0, but this code is
+required to be able to run on earlier versions._
+
+#### Description
+
+The analyzer produces this diagnostic when the operator `>>>` is used in
+code that has an SDK constraint whose lower bound is less than 2.14.0. This
+operator wasn't supported in earlier versions, so this code won't be able
+to run against earlier versions of the SDK.
+
+#### Examples
+
+Here's an example of a pubspec that defines an SDK constraint with a lower
+bound of less than 2.14.0:
+
+```yaml
+environment:
+ sdk: '>=2.0.0 <2.15.0'
+```
+
+In the package that has that pubspec, code like the following produces this
+diagnostic:
+
+{% prettify dart tag=pre+code %}
+int x = 3 [!>>>!] 4;
+{% endprettify %}
+
+#### Common fixes
+
+If you don't need to support older versions of the SDK, then you can
+increase the SDK constraint to allow the operator to be used:
+
+```yaml
+environment:
+  sdk: '>=2.14.0 <2.15.0'
+```
+
+If you need to support older versions of the SDK, then rewrite the code to
+not use the `>>>` operator:
+
+{% prettify dart tag=pre+code %}
+int x = logicalShiftRight(3, 4);
+
+int logicalShiftRight(int leftOperand, int rightOperand) {
+  int divisor = 1 << rightOperand;
+  if (divisor == 0) {
+    return 0;
+  }
+  return leftOperand ~/ divisor;
 }
 {% endprettify %}
 
@@ -12518,6 +12986,36 @@ void f(String s) {
   }
 }
 {% endprettify %}
+
+### tearoff_of_generative_constructor_of_abstract_class
+
+_A generative constructor of an abstract class can't be torn off._
+
+#### Description
+
+The analyzer produces this diagnostic when a generative constructor from an
+abstract class is being torn off. This isn't allowed because it isn't valid
+to create an instance of an abstract class, which means that there isn't
+any valid use for the torn off constructor.
+
+#### Example
+
+The following code produces this diagnostic because the constructor `C.new`
+is being torn off and the class `C` is an abstract class:
+
+{% prettify dart tag=pre+code %}
+abstract class C {
+  C();
+}
+
+void f() {
+  [!C.new!];
+}
+{% endprettify %}
+
+#### Common fixes
+
+Tear off the constructor of a concrete class.
 
 ### throw_of_invalid_type
 
@@ -13544,6 +14042,8 @@ an import or re-arrange your code to make the function visible.
 
 ### undefined_getter
 
+_The getter '{0}' isn't defined for the '{1}' function type._
+
 _The getter '{0}' isn't defined for the type '{1}'._
 
 #### Description
@@ -13664,6 +14164,8 @@ void f(p) async { await p; }
 {% endprettify %}
 
 ### undefined_method
+
+_The method '{0}' isn't defined for the '{1}' function type._
 
 _The method '{0}' isn't defined for the type '{1}'._
 
@@ -13825,7 +14327,43 @@ import for the library.
 If the name is wrong, then change it to one of the names that's declared in
 the imported libraries.
 
+### undefined_referenced_parameter
+
+_The parameter '{0}' is not defined by '{1}'._
+
+#### Description
+
+The analyzer produces this diagnostic when an annotation of the form
+`@UnusedResult.unless(parameterDefined: parameterName)` specifies a
+parameter name that isn't defined by the annotated function.
+
+#### Example
+
+The following code produces this diagnostic because the function `f`
+doesn't have a parameter named `b`:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+@UseResult.unless(parameterDefined: [!'b'!])
+int f([int? a]) => a ?? 0;
+{% endprettify %}
+
+#### Common fixes
+
+Change the argument named `parameterDefined` to match the name of one of
+the parameters to the function:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+@UseResult.unless(parameterDefined: 'a')
+int f([int? a]) => a ?? 0;
+{% endprettify %}
+
 ### undefined_setter
+
+_The setter '{0}' isn't defined for the '{1}' function type._
 
 _The setter '{0}' isn't defined for the type '{1}'._
 
@@ -14016,6 +14554,52 @@ dependencies:
   meta: ^1.0.2
 ```
 
+### unnecessary_import
+
+_The import of '{0}' is unnecessary because all of the used elements are also
+provided by the import of '{1}'._
+
+#### Description
+
+The analyzer produces this diagnostic when an import isn't needed because
+all of the names that are imported and referenced within the importing
+library are also visible through another import.
+
+#### Example
+
+Given a file named `a.dart` that contains the following:
+
+{% prettify dart tag=pre+code %}
+class A {}
+{% endprettify %}
+
+And, given a file named `b.dart` that contains the following:
+
+{% prettify dart tag=pre+code %}
+export 'a.dart';
+
+class B {}
+{% endprettify %}
+
+The following code produces this diagnostic because the class `A`, which is
+imported from `a.dart`, is also imported from `b.dart`. Removing the import
+of `a.dart` leaves the semantics unchanged:
+
+{% prettify dart tag=pre+code %}
+import [!'a.dart'!];
+import 'b.dart';
+
+void f(A a, B b) {}
+{% endprettify %}
+
+#### Common fixes
+
+If the import isn't needed, then remove it.
+
+If some of the names imported by this import are intended to be used but
+aren't yet, and if those names aren't imported by other imports, then add
+the missing references to those names.
+
 ### unnecessary_non_null_assertion
 
 _The '!' will have no effect because the receiver can't be null._
@@ -14149,6 +14733,33 @@ If the other operand really can't be `null`, then remove the condition:
 void f(int x) {
   print(x);
 }
+{% endprettify %}
+
+### unnecessary_question_mark
+
+_The '?' is unnecessary because '{0}' is nullable without it._
+
+#### Description
+
+The analyzer produces this diagnostic when either the type `dynamic` or the
+type `Null` is followed by a question mark. Both of these types are
+inherently nullable so the question mark doesn't change the semantics.
+
+#### Example
+
+The following code produces this diagnostic because the question mark
+following `dynamic` isn't necessary:
+
+{% prettify dart tag=pre+code %}
+dynamic[!?!] x;
+{% endprettify %}
+
+#### Common fixes
+
+Remove the unneeded question mark:
+
+{% prettify dart tag=pre+code %}
+dynamic x;
 {% endprettify %}
 
 ### unnecessary_type_check
@@ -14430,14 +15041,23 @@ never read, even if it's written in one or more places.
 
 #### Examples
 
-The following code produces this diagnostic because `_x` isn't referenced
-anywhere in the library:
+The following code produces this diagnostic because the field
+`_originalValue` isn't read anywhere in the library:
 
 {% prettify dart tag=pre+code %}
-class Point {
-  int [!_x!];
+class C {
+  final String [!_originalValue!];
+  final String _currentValue;
+
+  C(this._originalValue) : _currentValue = _originalValue;
+
+  String get value => _currentValue;
 }
 {% endprettify %}
+
+It might appear that the field `_originalValue` is being read in the
+initializer (`_currentValue = _originalValue`), but that is actually a
+reference to the parameter of the same name, not a reference to the field.
 
 #### Common fixes
 
@@ -14543,6 +15163,79 @@ void main() {
 If the variable isn't needed, then remove it.
 
 If the variable was intended to be used, then add the missing code.
+
+### unused_result
+
+_'{0}' should be used. {1}._
+
+_The value of '{0}' should be used._
+
+#### Description
+
+The analyzer produces this diagnostic when a function annotated with
+`useResult` is invoked, and the value returned by that function isn't used.
+The value is considered to be used if a member of the value is invoked, if
+the value is passed to another function, or if the value is assigned to a
+variable or field.
+
+#### Example
+
+The following code produces this diagnostic because the invocation of
+`c.a()` isn't used, even though the method `a` is annotated with
+`useResult`:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+class C {
+  @useResult
+  int a() => 0;
+
+  int b() => 0;
+}
+
+void f(C c) {
+  c.[!a!]();
+}
+{% endprettify %}
+
+#### Common fixes
+
+If you intended to invoke the annotated function, then use the value that
+was returned:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+class C {
+  @useResult
+  int a() => 0;
+
+  int b() => 0;
+}
+
+void f(C c) {
+  print(c.a());
+}
+{% endprettify %}
+
+If you intended to invoke a different function, then correct the name of
+the function being invoked:
+
+{% prettify dart tag=pre+code %}
+import 'package:meta/meta.dart';
+
+class C {
+  @useResult
+  int a() => 0;
+
+  int b() => 0;
+}
+
+void f(C c) {
+  c.b();
+}
+{% endprettify %}
 
 ### unused_shown_name
 
@@ -14665,6 +15358,30 @@ import 'dart:math';
 
 var zero = min(0, 0);
 {% endprettify %}
+
+### use_of_native_extension
+
+_Dart native extensions are deprecated and aren’t available in Dart 2.15._
+
+#### Description
+
+The analyzer produces this diagnostic when a library is imported using the
+`dart-ext` scheme.
+
+#### Example
+
+The following code produces this diagnostic because the native library `x`
+is being imported using a scheme of `dart-ext`:
+
+{% prettify dart tag=pre+code %}
+[!import 'dart-ext:x';!]
+int f() native 'string';
+{% endprettify %}
+
+#### Common fixes
+
+Rewrite the code to use `dart:ffi` as a way of invoking the contents of the
+native library.
 
 ### use_of_void_result
 


### PR DESCRIPTION
I can include links to the primary modified sections once the preview is available.

From a precursory look, everything looks to be in a pretty good state.

If you find any changes you'd like to see, I can make a follow-up CL on the SDK side of things as well.

**Primary additions:**

- [`default_value_on_required_parameter`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#default_value_on_required_parameter)
- [`generic_method_type_instantiation_on_dynamic`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#generic_method_type_instantiation_on_dynamic)
- [`instantiate_type_alias_expands_to_type_parameter`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#instantiate_type_alias_expands_to_type_parameter)
- [`invalid_annotation_constant_value_from_deferred_library`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#invalid_annotation_constant_value_from_deferred_library)
- [`invalid_use_of_visible_for_overriding_member`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#invalid_use_of_visible_for_overriding_member)
- [`invalid_visible_for_overriding_annotation`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#invalid_visible_for_overriding_annotation)
- [`not_binary_operator`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#not_binary_operator)
- [`null_argument_to_non_null_type`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#null_argument_to_non_null_type)
- [`redirect_to_type_alias_expands_to_type_parameter`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#redirect_to_type_alias_expands_to_type_parameter)
- [`sdk_version_constructor_tearoffs`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#sdk_version_constructor_tearoffs)
- [`sdk_version_gt_gt_gt_operator`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#sdk_version_gt_gt_gt_operator)
- [`tearoff_of_generative_constructor_of_abstract_class`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#tearoff_of_generative_constructor_of_abstract_class)
- [`undefined_referenced_parameter`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#undefined_referenced_parameter)
- [`unnecessary_import`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#unnecessary_import)
- [`unnecessary_question_mark`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#unnecessary_question_mark)
- [`unused_result`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#unused_result)
- [`use_of_native_extension`](https://dart-dev--pr3600-analyzer-update-diag-8q8h0lt6.web.app/tools/diagnostic-messages#use_of_native_extension)

Closes https://github.com/dart-lang/site-www/issues/3599