### PR TITLE
Move up most important language resources

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -26,6 +26,10 @@
 - title: Language
   expanded: false
   children:
+    - title: Tour
+      permalink: /guides/language/language-tour
+    - title: Type system
+      permalink: /guides/language/type-system
     - title: Effective Dart
       expanded: false
       children:
@@ -73,10 +77,6 @@
       permalink: /guides/language/evolution
     - title: Specification
       permalink: /guides/language/spec
-    - title: Tour
-      permalink: /guides/language/language-tour
-    - title: Type system
-      permalink: /guides/language/type-system
 
 - title: Core libraries
   expanded: false


### PR DESCRIPTION
The tour and type system docs are critical resources for any new Dart developer. This moves them to top of the left-nav to signal that.