### PR TITLE
Copy edit, reformat security page

### DIFF
--- a/src/security.md
+++ b/src/security.md
@@ -3,33 +3,40 @@ title: Security
 ---
 
 The Dart team takes the security of Dart and the applications
-created with it seriously. This page describes how to report any
-vulnerabilities you may find, and lists best practices to minimize
-the risk of introducing a vulnerability.
+created with it seriously.
+This page describes how to report any vulnerabilities that you find,
+and lists best practices to minimize the risk of introducing a vulnerability.
 
 ## Reporting vulnerabilities
 
-To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
-We use g.co/vulnz for our intake, and do coordination and disclosure
-[on GitHub](https://github.com/dart-lang/)
-(including using GitHub Security Advisory). The Google Security
-Team will respond within 5 working days of your report on g.co/vulnz.
+To report a security issue, use [https://g.co/vulnz][].
+Coordination and disclosure happen in the [dart-lang GitHub repos][repos]
+and the [GitHub Advisory Database][].
+The Google Security Team will respond within 5 working days of
+your report on g.co/vulnz.
 
 For more information about how Google handles security issues, see
-[Google’s security philosophy.](https://www.google.com/about/appsecurity/)
+[Google’s security philosophy][].
 
 ## Best practices
 
 * **Keep current with the latest Dart SDK releases.**
   We regularly update Dart, and these updates may fix security
-  defects discovered in previous versions. Check the Dart
-  [change log](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md)
+  defects discovered in previous versions.
+  Check the [Dart changelog][]
   for security-related updates.
 
 * **Keep your application’s dependencies up to date.**
-  Make sure you [upgrade your package
-  dependencies](/guides/packages#upgrading-a-dependency)
-  to keep the dependencies up to date. Avoid pinning to specific versions
+  Make sure you [upgrade your package dependencies][]
+  to keep the dependencies up to date.
+  Avoid pinning to specific versions
   for your dependencies and, if you do, make sure you check
   periodically to see if your dependencies have had security updates,
-  and update the pin accordingly.
+  and update the version pin accordingly.
+
+[Dart changelog]: https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md
+[GitHub Advisory Database]: https://github.com/advisories
+[Google’s security philosophy]: https://www.google.com/about/appsecurity/
+[https://g.co/vulnz]: https://g.co/vulnz
+[repos]: https://github.com/dart-lang/
+[upgrade your package dependencies]: /guides/packages#upgrading-a-dependency


### PR DESCRIPTION
I don't think I changed the meaning of anything, but the most changed sentence is the second one under **Reporting vulnerabilities**, so please check that. I'd love to add ", respectively" to that sentence — but only if that's correct.