### PR TITLE
Use correct URL for bundler

### DIFF
--- a/src/tools/pub/versioning.md
+++ b/src/tools/pub/versioning.md
@@ -125,7 +125,7 @@ wiggle room to move our dependencies forward to newer versions. As long as there
 is overlap in their ranges, we can still find a single version that makes them
 both happy.
 
-This is the model that [bundler](https://gembundler.com/) follows,
+This is the model that [bundler](https://bundler.io/) follows,
 and is pub's model too. When you add a dependency in your pubspec,
 you can specify a _range_ of versions that you can accept.
 If the pubspec for `widgets` looked like this:


### PR DESCRIPTION
The URL was incorrectly pointing to a web
site that is not the current site for bundler.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>