### PR TITLE
Restrict test_api dependency to fix browser test failures

### DIFF
--- a/examples/create_libraries/pubspec.yaml
+++ b/examples/create_libraries/pubspec.yaml
@@ -8,3 +8,4 @@ environment:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.8
+  test_api: ">=0.4.0 <0.4.6"

--- a/examples/html/pubspec.yaml
+++ b/examples/html/pubspec.yaml
@@ -10,5 +10,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.17.8
+  test_api: ">=0.4.0 <0.4.6"
   lints: ^1.0.0
   examples_util: {path: ../util}

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -10,3 +10,4 @@ dev_dependencies:
     path: ../util
   lints: ^1.0.0
   test: ^1.17.8
+  test_api: ">=0.4.0 <0.4.6"


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/3636