### PR TITLE
Switch from X-Frame-Options to CSP frame-ancestors to allow DartPad as an ancestor

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,17 +10,10 @@
         ]
       },
       {
-      "source": "**",
-      "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" }
-      ]
-      },
-      {
         "source": "**",
         "headers": [
-          { "key": "Content-Security-Policy", "value":  "default-src 'self' https:; script-src 'self' 'unsafe-eval' 'sha256-cTJIwsgB4Xj1loi9AdzTWk3GZ5Kx0NremLhkGfw9zWc=' 'sha256-acZJdbnwXvMNQmfri3ENcArTn+GH3sY664c1uY0xxpg=' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://gstatic.com https://*.gstatic.com https://dartpad.dev https://*.dartpad.dev https://youtube.com https://*.youtube.com https://fonts.googleapis.com https://doubleclick.net https://*.doubleclick.net https://google.com https://*.google.com https://storage.googleapis.com; object-src 'none'; base-uri 'none'; style-src 'self' https: 'unsafe-inline'"},
+          { "key": "Content-Security-Policy", "value":  "default-src 'self' https:; script-src 'self' 'unsafe-eval' 'sha256-cTJIwsgB4Xj1loi9AdzTWk3GZ5Kx0NremLhkGfw9zWc=' 'sha256-acZJdbnwXvMNQmfri3ENcArTn+GH3sY664c1uY0xxpg=' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://gstatic.com https://*.gstatic.com https://dartpad.dev https://*.dartpad.dev https://youtube.com https://*.youtube.com https://fonts.googleapis.com https://doubleclick.net https://*.doubleclick.net https://google.com https://*.google.com https://storage.googleapis.com; object-src 'none'; base-uri 'none'; style-src 'self' https: 'unsafe-inline'; frame-ancestors 'self' https://dartpad.dev https://*.dartpad.dev"},
           { "key": "Referrer-Policy", "value":  "strict-origin-when-cross-origin"},
-          { "key": "X-Frame-Options", "value":  "SAMEORIGIN"},
           { "key": "X-Content-Type-Options", "value":  "nosniff"},
           { "key": "X-XSS-Protection", "value": "1; mode=block"}
         ]

--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,13 @@
         "headers": [
           { "key": "Access-Control-Allow-Origin", "value": "*" }
         ]
-    },
+      },
+      {
+      "source": "**",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "https://dartpad.dev" }
+      ]
+      },
       {
         "source": "**",
         "headers": [

--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,7 @@
       {
       "source": "**",
       "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "https://dartpad.dev" }
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
       ]
       },
       {


### PR DESCRIPTION
This does not fix all of the DartPad issues, but according to MDN: `X-Frame-Options` is obsoleted by  the `frame-ancestors` directive. Switching to that also allows us to specify DartPad as supported as an ancestor. 