### PR TITLE
[Effective Dart] Update tear-off rule to mention constructor tear-offs.

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -159,9 +159,24 @@ void miscDeclAnalyzedButNotTested() {
 
   (Iterable names) {
     // #docregion use-tear-off
-    names.forEach((name) {
-      print(name);
+    var charCodes = [68, 97, 114, 116];
+    var buffer = StringBuffer();
+
+    // Function:
+    charCodes.forEach((code) {
+      print(code);
     });
+
+    // Method:
+    charCodes.forEach((code) {
+      buffer.write(code);
+    });
+
+    // Named constructor:
+    var strings = charCodes.map((code) => String.fromCharCode(code));
+
+    // Unnamed constructor:
+    var buffers = charCodes.map((code) => StringBuffer(code));
     // #enddocregion use-tear-off
   };
 

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -160,7 +160,20 @@ void miscDeclAnalyzedButNotTested() {
 
   (Iterable names) {
     // #docregion use-tear-off
-    names.forEach(print);
+    var charCodes = [68, 97, 114, 116];
+    var buffer = StringBuffer();
+
+    // Function:
+    charCodes.forEach(print);
+
+    // Method:
+    charCodes.forEach(buffer.write);
+
+    // Named constructor:
+    var strings = charCodes.map(String.fromCharCode);
+
+    // Unnamed constructor:
+    var buffers = charCodes.map(StringBuffer.new);
     // #enddocregion use-tear-off
   };
 

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dev_dependencies:
   args: ^2.2.0

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -892,7 +892,7 @@ void main() {
 {% include linter-rule-mention.md rule="unnecessary_lambdas" %}
 
 When you refer to a function, method, or named constructor but omit the
-parentheses, Dart creates a "tear-off"&mdash;a closure that takes the same
+parentheses, Dart creates a _tear-off_&mdash;a closure that takes the same
 parameters as the function and invokes the underlying function when you call it.
 If all you need is a closure that invokes a named function with the same
 parameters as the closure accepts, don't manually wrap the call in a lambda.

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -891,25 +891,52 @@ void main() {
 
 {% include linter-rule-mention.md rule="unnecessary_lambdas" %}
 
-If you refer to a method on an object but omit the parentheses, Dart gives you
-a "tear-off"&mdash;a closure that takes the same parameters as the method and
-invokes it when you call it.
-
-If you have a function that invokes a method with the same arguments as are
-passed to it, you don't need to manually wrap the call in a lambda.
+When you refer to a function, method, or named constructor but omit the
+parentheses, Dart creates a "tear-off"&mdash;a closure that takes the same
+parameters as the function and invokes the underlying function when you call it.
+If all you need is a closure that invokes a named function with the same
+parameters as the closure accepts, don't manually wrap the call in a lambda.
 
 {:.good}
 <?code-excerpt "usage_good.dart (use-tear-off)"?>
 {% prettify dart tag=pre+code %}
-names.forEach(print);
+var charCodes = [68, 97, 114, 116];
+var buffer = StringBuffer();
+
+// Function:
+charCodes.forEach(print);
+
+// Method:
+charCodes.forEach(buffer.write);
+
+// Named constructor:
+var strings = charCodes.map(String.fromCharCode);
+
+// Unnamed constructor:
+var buffers = charCodes.map(StringBuffer.new);
 {% endprettify %}
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (use-tear-off)"?>
 {% prettify dart tag=pre+code %}
-names.forEach((name) {
-  print(name);
+var charCodes = [68, 97, 114, 116];
+var buffer = StringBuffer();
+
+// Function:
+charCodes.forEach((code) {
+  print(code);
 });
+
+// Method:
+charCodes.forEach((code) {
+  buffer.write(code);
+});
+
+// Named constructor:
+var strings = charCodes.map((code) => String.fromCharCode(code));
+
+// Unnamed constructor:
+var buffers = charCodes.map((code) => StringBuffer(code));
 {% endprettify %}
 
 


### PR DESCRIPTION
Fix #3560.