### PR TITLE
Fix link to "Into to Dart for Java Developers" codelab

### DIFF
--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -10,7 +10,7 @@ no download required!
 ## General
 
 <img src="/codelabs/images/from-java-to-dart.png" width="150px" alt="Bicycle image from codelab" align="right">
-### [Intro to Dart for Java Developers](https://codelabs.developers.google.com/codelabs/from-java-to-dart/)
+### [Intro to Dart for Java Developers](https://developers.google.com/codelabs/from-java-to-dart)
 
 Use DartPad to explore how
 Dart makes writing apps easy and fun.


### PR DESCRIPTION
Side note, it's a bit strange the previous link stopped working(at least without a redirect). @domesticmouse Did something accidentally change with your recent fixes? Seems like other codelabs still exist at the `codelabs.` subdomain. Maybe this should be fixed on that end, but either way we can adjust the link here until that change can occur. 

Closes #3660