### PR TITLE
Add diagnostic messages and linter rules to sidebar

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -253,6 +253,10 @@
         permalink: /guides/language/analysis-options
       - title: Fixing common type problems
         permalink: /guides/language/sound-problems
+      - title: Diagnostic messages
+        permalink: /tools/diagnostic-messages
+      - title: Linter rules
+        permalink: /tools/linter-rules
   - title: Testing & optimization
     children:
       - title: Testing


### PR DESCRIPTION
What do you think about adding these to the sidebar under "Static analysis"?

Closes https://github.com/dart-lang/site-www/issues/3222

