### PR TITLE
Fix hard to see scroll bar

### DIFF
--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -30,9 +30,6 @@ $font-weight-light-bold: ($font-weight-normal + $font-weight-bold)/2;
 /* -----------------------------------------
   Global
   ----------------------------------------- */
-html {
-  background-color: $site-color-header;
-}
 
 body {
   font-family: $font-family-base;


### PR DESCRIPTION
This undoes the change in https://github.com/dart-lang/site-www/pull/3327 since the html background color seems to be used for the scrollbar, which I believe is more important to fix than the overscroll background color. There are potentially other options we can explore to improve that but none are super straightforward, so that can be investigated separately if desired.

Fixes #3672