### PR TITLE
Flesh out mentions of 'subscript' operators

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1710,7 +1710,7 @@ You can implement many of these [operators as class members](#_operators).
 |--------------------------+------------------------------------------------|
 |Description               | Operator                                       |
 |--------------------------|------------------------------------------------|
-| unary postfix            | <code><em>expr</em>++</code>    <code><em>expr</em>--</code>    `()`    `[]`    `.`    `?.` |
+| unary postfix            | <code><em>expr</em>++</code>    <code><em>expr</em>--</code>    `()`    `[]`    `?[]`    `.`    `?.` |
 | unary prefix             | <code>-<em>expr</em></code>    <code>!<em>expr</em></code>    <code>~<em>expr</em></code>    <code>++<em>expr</em></code>    <code>--<em>expr</em></code>      <code>await <em>expr</em></code>    |
 | multiplicative           | `*`    `/`    `%`    `~/`                      |
 | additive                 | `+`    `-`                                     |
@@ -2175,13 +2175,14 @@ and you can't construct a cascade on `void`.
 
 You've seen most of the remaining operators in other examples:
 
-|----------+-------------------------------------------|
-| Operator | Name                 |          Meaning   |
-|-----------+------------------------------------------|
-| `()`     | Function application | Represents a function call
-| `[]`     | List access          | Refers to the value at the specified index in the list
-| `.`      | Member access        | Refers to a property of an expression; example: `foo.bar` selects property `bar` from expression `foo`
-| `?.`     | Conditional member access | Like `.`, but the leftmost operand can be null; example: `foo?.bar` selects property `bar` from expression `foo` unless `foo` is null (in which case the value of `foo?.bar` is null)
+|----------+---------------------------------------------------|
+| Operator | Name                         | Meaning            |
+|-----------+--------------------------------------------------|
+| `()`     | Function application         | Represents a function call
+| `[]`     | Subscript access             | Represents a call to the overridable `[]` operator; example: `fooList[1]` passes the int `1` to `fooList` to access the element at index `1`
+| `?[]`    | Conditional subscript access | Like `[]`, but the leftmost operand can be null; example: `fooList?[1]` passes the int `1` to `fooList` to access the element at index `1` unless `fooList` is null (in which case the expression evaluates to null)
+| `.`      | Member access                | Refers to a property of an expression; example: `foo.bar` selects property `bar` from expression `foo`
+| `?.`     | Conditional member access    | Like `.`, but the leftmost operand can be null; example: `foo?.bar` selects property `bar` from expression `foo` unless `foo` is null (in which case the value of `foo?.bar` is null)
 {:.table .table-striped}
 
 For more information about the `.`, `?.`, and `..` operators, see


### PR DESCRIPTION
- Adds mentions to the null-aware "subscript" operator (`?[]`)
- Slightly expand the mention of the `[]` operator beyond just lists.

Might need some help on wordsmithing as I wasn't sure the best way to discuss an operator which technically has no official designated purpose at least according to the spec. 

Closes #3657 