### PR TITLE
Fix build due to flutter job link change

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -161,7 +161,7 @@
       { "source": "/install", "destination": "/get-dart", "type": 301 },
       { "source": "/install/**", "destination": "/get-dart", "type": 301 },
       { "source": "/install/archive", "destination": "/tools/sdk/archive", "type": 301 },
-      { "source": "/jobs", "destination": "https://flutter.dev/jobs", "type": 301 },
+      { "source": "/jobs", "destination": "https://docs.flutter.dev/jobs", "type": 301 },
       { "source": "/language-tour", "destination": "/guides/language/language-tour", "type": 301 },
       { "source": "/linter/lints/:lint*", "destination": "/tools/linter-rules#:lint", "type": 301 },
       { "source": "/lints", "destination": "/tools/linter-rules", "type": 301 },

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -663,7 +663,7 @@ you don't care about the type, then use `toList()`.
 
 ### DO use `whereType()` to filter a collection by type.
 
-{% include linter-rule-mention.md rule="prefer_iterable_whereType" %}
+{% include linter-rule-mention.md rule="prefer_iterable_wheretype" %}
 
 Let's say you have a list containing a mixture of objects, and you want to get
 just the integers out of it. You could use `where()` like this:

--- a/src/tools/linter-rules.md
+++ b/src/tools/linter-rules.md
@@ -48,8 +48,8 @@ which the following packages provide:
 : Contains the `flutter` rule set,
   which the Flutter team encourages you to use
   in Flutter apps, packages, and plugins.
-  This rule set is a superset of the [`recommended`](#recommended) set,
-  which is itself a superset of the [`core`](#core) set that
+  This rule set is a superset of the [`recommended`](#lints) set,
+  which is itself a superset of the [`core`](#lints) set that
   partially determines the [score]({{site.pub}}/help/scoring) of
   packages uploaded to [pub.dev]({{site.pub}}).
 


### PR DESCRIPTION
We should go over remaining Flutter links to make sure they work as expected and update them to the new locations in a follow-up PR (https://github.com/dart-lang/site-www/issues/3678).