### PR TITLE
Fix sorting in firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -138,6 +138,7 @@
       { "source": "/go/data-driven-fixes", "destination": "https://github.com/flutter/flutter/wiki/Data-driven-Fixes", "type": 301 },
       { "source": "/go/dot-packages-deprecation", "destination": "https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/package-config-file-v2.md", "type": 301 },
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
+      { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
       { "source": "/go/ffi", "destination": "/guides/libraries/c-interop", "type": 301 },
       { "source": "/go/flutter-upper-bound-deprecation", "destination": "https://github.com/flutter/flutter/issues/68143", "type": 301 },
       { "source": "/go/non-promo-property", "destination": "/tools/non-promotion-reasons#property-or-this", "type": 301 },
@@ -148,7 +149,6 @@
       { "source": "/go/sdk-constraint", "destination": "https://dart.dev/tools/pub/pubspec#sdk-constraints", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
-      { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
 
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/get-started", "destination": "/overview", "type": 301 },


### PR DESCRIPTION
Fix CI failure:

```
Run ./tool/firebase-checks.sh
Resolving dependencies...
Changed 13 dependencies!
Error: The firebase.json file's redirects are not sorted by source:
Starting with: {source: /go/ffi, destination: /guides/libraries/c-interop, type: 301}
Error: Process completed with exit code 1.
```

https://github.com/dart-lang/site-www/runs/4457198341?check_suite_focus=true
