### PR TITLE
Attempt at refactoring retraction example

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -343,10 +343,19 @@ Before retracting a package,
 consider publishing a new version instead.
 Retracting a package causes churn and can have a negative impact on package users.
 
-For example, if your package version contains a minor bug, then retraction is
-probably not needed. On the other hand, if you accidentally publish a major
-version or a version with wrong or missing dependency constraints,
-then retraction might be the right solution.
+If you accidentally publish a new version with a _missing dependency constraint_,
+or a _dependency constraint that is too lax_, retracting the package version is
+often the only solution. As publishing a newer version of your package is
+insufficient to stop the _version solver_ from picking the old version, which may
+in some cases be the only solution. Thus, by retracting the package version with
+incorrect dependency constraints you force users to _upgrade other dependencies_
+or get a _dependency conflict_.
+
+However, if your package merely contains a minor bug, then retraction is
+probably not necessary. Publishing a newer version with the bug fixed and an
+description of the fixed bug in `CHANGELOG.md` makes it easy for users to
+understand what happened. And publishing a newer version is less disruptive to
+package users.
 
 {{site.alert.version-note}}
   Package retraction was introduced in Dart 2.15.

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -343,19 +343,23 @@ Before retracting a package,
 consider publishing a new version instead.
 Retracting a package causes churn and can have a negative impact on package users.
 
-If you accidentally publish a new version with a _missing dependency constraint_,
-or a _dependency constraint that is too lax_, retracting the package version is
-often the only solution. As publishing a newer version of your package is
-insufficient to stop the _version solver_ from picking the old version, which may
-in some cases be the only solution. Thus, by retracting the package version with
-incorrect dependency constraints you force users to _upgrade other dependencies_
-or get a _dependency conflict_.
+If you accidentally publish a new version with either
+a _missing dependency constraint_
+or a _dependency constraint that is too lax_, 
+then retracting the package version might be the only solution.
+Publishing a newer version of your package is
+insufficient to stop the version solver from picking the old version,
+which might be the only version pub can choose.
+By retracting the package version that has
+incorrect dependency constraints, you force users to either
+upgrade other dependencies or get a dependency conflict.
 
-However, if your package merely contains a minor bug, then retraction is
-probably not necessary. Publishing a newer version with the bug fixed and an
-description of the fixed bug in `CHANGELOG.md` makes it easy for users to
-understand what happened. And publishing a newer version is less disruptive to
-package users.
+However, if your package merely contains a minor bug,
+then retraction is probably not necessary.
+Publishing a newer version with the bug fixed and a
+description of the fixed bug in `CHANGELOG.md`
+helps users to understand what happened.
+And publishing a newer version is less disruptive to package users.
 
 {{site.alert.version-note}}
   Package retraction was introduced in Dart 2.15.


### PR DESCRIPTION
This attempts to put the positive case before the negative case, in example of when to do and not to do package retraction.

_Staged: https://kw-www-dartlang-1.web.app/tools/pub/publishing#retract_

I'm not sure it's better... it's also possible that we should just write out a few examples in expandable `<details><summary>` fields... or possible we should write a separate page explaining example of when we think retraction is a good idea.
I'm not sure it's useful, ultimately it's up to the package author anyways, all we make here are guidelines -- if you've shipped a sufficiently bad bug, well then maybe you do want to pull out all of the tools at your disposal such as retraction.

/cc @mit-mit, @szakarias, @kevmoo following [discussion here](https://github.com/dart-lang/site-www/pull/3680#discussion_r764381584).