### PR TITLE
Deploy to live using GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,12 @@ jobs:
         run: dart pub get
       - run: ./tool/shared/write-ci-info.sh -v
       - run: ./tool/build.sh
-      - run: ./tool/shared/deploy.sh --robots ok default
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_DEV }}'
+          projectId: dart-dev
+          channelId: live
 
   deploy_preview:
     needs: test


### PR DESCRIPTION
Stop using `deploy.sh` as that requires a token we'd rather not have.

This uses the same GitHub Action we use for deploying to Firebase Preview for PRs.

Based on:
https://github.com/FirebaseExtended/action-hosting-deploy/blob/main/README.md#deploy-to-your-live-channel-on-merge