### PR TITLE
Fix concurrency according to `avoid_void_async`

### DIFF
--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -109,7 +109,7 @@ String _readFileSync() {
 Here’s similar code, but with changes (highlighted) to make it asynchronous:
 
 {% prettify dart tag=pre+code %}
-void main() [!async!] {
+[!Future<void>!] main() [!async!] {
   // Read some data.
   final fileData = [!await!] _readFileAsync();
   final jsonData = jsonDecode(fileData);
@@ -312,7 +312,7 @@ This example uses the following isolate-related API:
 Here’s the code for the main isolate:
 
 ```dart
-void main() async {
+Future<void> main() async {
   // Read some data.
   final jsonData = await _parseInBackground();
 


### PR DESCRIPTION
*Holding since the pull requests window is closed.*

According to the [`avoid_void_async` rule](https://dart-lang.github.io/linter/lints/avoid_void_async.html), we might expect the function to be written as `Future<void>`.