### PR TITLE
Link to command_line sample

### DIFF
--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -583,5 +583,3 @@ see the [command_line][] sample.
 
 If you're interested in server-side programming,
 check out the [next tutorial](/tutorials/server/httpserver).
-
-

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -577,9 +577,11 @@ and the [args]({{argsAPI}}/args-library.html) package.
 For another example of a command line app, 
 see the [command_line][] sample.
 
+[command_line]: https://github.com/dart-lang/samples/tree/master/command_line
+
 ## What next?
 
 If you're interested in server-side programming,
 check out the [next tutorial](/tutorials/server/httpserver).
 
-[command_line]: https://github.com/dart-lang/samples/tree/master/command_line
+

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -575,7 +575,7 @@ consult to the API reference for
 and the [args]({{argsAPI}}/args-library.html) package.  
 
 For another example of a command line app, 
-see the [command_line][command_line] sample.
+see the [command_line][] sample.
 
 ## What next?
 

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -572,7 +572,9 @@ For more classes, functions, and properties,
 consult to the API reference for
 [dart:io,]({{ioAPI}}/dart-io-library.html)
 [dart:convert,]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html)
-and the [args]({{argsAPI}}/args-library.html) package.
+and the [args]({{argsAPI}}/args-library.html) package.  
+
+For an example of a command line app, see the [command_line](https://github.com/dart-lang/samples/tree/master/command_line) sample.
 
 ## What next?
 

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -574,9 +574,12 @@ consult to the API reference for
 [dart:convert,]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html)
 and the [args]({{argsAPI}}/args-library.html) package.  
 
-For an example of a command line app, see the [command_line](https://github.com/dart-lang/samples/tree/master/command_line) sample.
+For another example of a command line app, 
+see the [command_line][command_line] sample.
 
 ## What next?
 
 If you're interested in server-side programming,
 check out the [next tutorial](/tutorials/server/httpserver).
+
+[command_line]: https://github.com/dart-lang/samples/tree/master/command_line


### PR DESCRIPTION
This adds a link to the command_line sample in the command line tutorial doc. I'm happy to make any requested changes.

Fixes one part of #3221 