### PR TITLE
Allow robots on release deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
         run: dart pub get
       - run: ./tool/shared/write-ci-info.sh -v
       - run: ./tool/build.sh
+      - run: ./tool/before-release.sh
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/tool/before-release.sh
+++ b/tool/before-release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source ./tool/shared/env-set-check.sh
+source ./tool/shared/_robots.sh
+
+# Allow robots on release deploy
+saveAndSetRobotsTxt "ok"


### PR DESCRIPTION
I made the change in a new file here on site-www as to not require larger changes in site-shared and then here as well. 

With the infrastructure update, which reworks deploys, we likely won't need this file anymore and can address this in a more consistent fashion to match flutter/website.

Closes #3755
