### PR TITLE
Update Default parameter values information

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1398,8 +1398,8 @@ assert(say('Bob', 'Howdy', 'smoke signal') ==
 <a id="default-parameters"></a>
 #### Default parameter values
 
-Your function can use `=` to define default values for both named and positional
-parameters. The default values must be compile-time constants.
+Your function can use `=` to define default values for both named and optional
+positional parameters. The default values must be compile-time constants.
 If no default value is provided, the default value is `null`.
 
 Here's an example of setting default values for named parameters:

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1398,8 +1398,8 @@ assert(say('Bob', 'Howdy', 'smoke signal') ==
 <a id="default-parameters"></a>
 #### Default parameter values
 
-Your function can use `=` to define default values for both named and optional
-positional parameters. The default values must be compile-time constants.
+Your function can use `=` to define default values for optional parameters,
+both named and positional. The default values must be compile-time constants.
 If no default value is provided, the default value is `null`.
 
 Here's an example of setting default values for named parameters:


### PR DESCRIPTION
The current text implies that it is possible to define default values for both types of positional parameters (required and optional), as it says: "Your function can use = to define default values for both named and positional parameters.". However, positional parameters can be of 2 types, required and optional, and only the optional ones allow the definition of a default value.

This change is intended to make it clear that only named and optional positional parameters are likely to have default values set.

**IMPORTANT:** Due to year-end holidays and work on the dart.dev infrastructure, this repository is accepting only simple or crucial pull requests.

Instead of creating a pull request, consider creating an issue (https://github.com/dart-lang/site-www/issues/new/choose) about the desired change.

We expect to return to normal PR handling in mid-January.
