### PR TITLE
Remove holiday/infrastructure update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-**IMPORTANT:** Due to year-end holidays and work on the dart.dev infrastructure, this repository is accepting only simple or crucial pull requests.
-
-Instead of creating a pull request, consider creating an issue (https://github.com/dart-lang/site-www/issues/new/choose) about the desired change.
-
-We expect to return to normal PR handling in mid-January.


### PR DESCRIPTION
🥳 

If desired, we can investigate adding a more permanent PR template to the repository in the future.