### PR TITLE
Reference Sitemap.xml in robots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ build:
 
 # Overwrite robots.txt with production version
 write-prod-robots:
-	@echo "User-agent: *\nDisallow:" > _site/robots.txt
+	@echo "User-agent: *\nDisallow:\n\nSitemap: https://dart.dev/sitemap.xml" \
+    		> _site/robots.txt
 
 # Deploy locally
 deploy:


### PR DESCRIPTION
This only affects the production deploy, so you won't see it functional on the staged deploy.

I ran the Make command locally to verify correct output though:

```txt
User-agent: *
Disallow:

Sitemap: https://dart.dev/sitemap.xml
```

Fixes #3762