### PR TITLE
Update docs to use dart doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -221,6 +221,7 @@
       { "source": "/tools/dart2aot", "destination": "/tools/dart-compile", "type": 301 },
       { "source": "/tools/dart2native", "destination": "/tools/dart-compile", "type": 301 },
       { "source": "/tools/dartanalyzer", "destination": "/tools/dart-analyze", "type": 301 },
+      { "source": "/tools/dartdoc", "destination": "/tools/dart-doc", "type": 301 },
       { "source": "/tools/dartdocgen{,/**}", "destination": "https://github.com/dart-lang/dartdoc#dartdoc", "type": 301 },
       { "source": "/tools/dartfmt", "destination": "/tools/dart-format", "type": 301 },
       { "source": "/tools/dartium?(.html)", "destination": "/web/dart-2#tools", "type": 301 },

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -218,6 +218,8 @@
           permalink: /tools/dart-compile
         - title: dart create
           permalink: /tools/dart-create
+        - title: dart doc
+          permalink: /tools/dart-doc
         - title: dart fix 
           permalink: /tools/dart-fix
         - title: dart format 
@@ -230,8 +232,6 @@
           permalink: /tools/dart-test
         - title: dartaotruntime
           permalink: /tools/dartaotruntime
-        - title: dartdoc
-          permalink: /tools/dartdoc
         - title: Experiment flags
           permalink: /tools/experiment-flags
     - title: Other command-line tools

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4606,7 +4606,7 @@ to the docs for the `feed` method,
 and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
-[documentation generation tool, dartdoc.](/tools/dartdoc)
+[documentation generation tool, dartdoc.](/tools/dart-doc)
 For an example of generated documentation, see the [Dart API
 documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
 your comments, see

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -411,7 +411,7 @@ You’re the only person who can provide the information that the reader needs.
 
 [Awesome README]: https://github.com/matiassingers/awesome-readme
 [Badges]: https://github.com/badges/shields#readme
-[dartdoc]: /tools/dartdoc
+[dartdoc]: /tools/dart-doc
 [How to write a great README for your GitHub project]: https://dbader.org/blog/write-a-great-readme-for-your-github-project
 [`in_app_purchase`]: {{site.pub-pkg}}/in_app_purchase
 [in its repo]: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase/doc

--- a/src/tools/dart-doc.md
+++ b/src/tools/dart-doc.md
@@ -4,7 +4,8 @@ description: API reference generation tool.
 toc: false
 ---
 
-The `dartdoc` command creates API reference documentation
+The `dart doc` command (previously called `dartdoc`)
+creates API reference documentation
 from Dart source code.
 You can add descriptions to the generated documentation
 by using [documentation comments][],
@@ -17,36 +18,29 @@ see the [documentation part of Effective Dart][effective doc].
   without errors.
 {{site.alert.end}}
 
-Run `dartdoc` from the root directory of your package. For example:
+Run `dart doc` from the root directory of your package. For example:
 
 ```terminal
 $ cd my_app
-$ dartdoc
+$ dart doc .
 Documenting my_app...
 ...
 Success! Docs generated into /Users/me/projects/my_app/doc/api
 ```
 
 By default, the documentation files are static HTML files,
-placed in the `doc/api` directory.
-To view the rendered documentation, you need an HTTP server.
+placed in the `doc/api` directory. You can create the
+files in a different directory with the `--output-dir` flag.
 
-Although `dartdoc` is in the Dart SDK,
-it's also available in the [dartdoc package.][]
-You might use the package when you need a programmatic interface
-or when you want to try features that
-aren't yet in the SDK's version of `dartdoc`.
-
-For information on command-line options, use the `--help` flag:
+For information on command-line options, use the `help` command:
 
 ```terminal
-$ dartdoc --help
+$ dart help doc
 ```
 
 [documentation comments]: /guides/language/language-tour#documentation-comments
 [effective doc]: /guides/language/effective-dart/documentation
 [dart analyze]: /tools/dart-analyze
-[dartdoc package.]: {{site.pub-pkg}}/dartdoc
 
 {% comment %}
 [PENDING: Add more help, info on commonly used options, links to examples of use.]

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -96,7 +96,7 @@ The Dart SDK includes the following general-purpose tools:
   testing, compiling, and running Dart code,
   as well as working with the [pub package manager](/guides/packages).
 
-[`dartdoc`](/tools/dartdoc)
+[`dartdoc`](/tools/dart-doc)
 : A documentation generator.
   For examples of dartdoc's output, see the API reference documentation
   published at [api.dart.dev]({{site.dart_api}}) and pub.dev

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -36,7 +36,7 @@ directory that has these command-line tools:
 [`dartaotruntime`](/tools/dartaotruntime)
 : A Dart runtime for AOT-compiled snapshots.
 
-[`dartdoc`](/tools/dartdoc)
+[`dartdoc`](/tools/dart-doc)
 : The API documentation generator.
 
 {{site.alert.note}}


### PR DESCRIPTION
Documentation update related to deprecation of `dartdoc` (see https://github.com/dart-lang/sdk/issues/46100 for context)