### PR TITLE
Update docs to use dart doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -222,7 +222,7 @@
       { "source": "/tools/dart2native", "destination": "/tools/dart-compile", "type": 301 },
       { "source": "/tools/dartanalyzer", "destination": "/tools/dart-analyze", "type": 301 },
       { "source": "/tools/dartdoc", "destination": "/tools/dart-doc", "type": 301 },
-      { "source": "/tools/dartdocgen{,/**}", "destination": "https://github.com/dart-lang/dartdoc#dartdoc", "type": 301 },
+      { "source": "/tools/dartdocgen{,/**}", "destination": "/tools/dart-doc", "type": 301 },
       { "source": "/tools/dartfmt", "destination": "/tools/dart-format", "type": 301 },
       { "source": "/tools/dartium?(.html)", "destination": "/web/dart-2#tools", "type": 301 },
       { "source": "/tools/debian?(.html)", "destination": "/get-dart", "type": 301 },

--- a/firebase.json
+++ b/firebase.json
@@ -221,6 +221,7 @@
       { "source": "/tools/dart2aot", "destination": "/tools/dart-compile", "type": 301 },
       { "source": "/tools/dart2native", "destination": "/tools/dart-compile", "type": 301 },
       { "source": "/tools/dartanalyzer", "destination": "/tools/dart-analyze", "type": 301 },
+      { "source": "/tools/dartdoc", "destination": "/tools/dart-doc", "type": 301 },
       { "source": "/tools/dartdocgen{,/**}", "destination": "https://github.com/dart-lang/dartdoc#dartdoc", "type": 301 },
       { "source": "/tools/dartfmt", "destination": "/tools/dart-format", "type": 301 },
       { "source": "/tools/dartium?(.html)", "destination": "/web/dart-2#tools", "type": 301 },

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -218,6 +218,8 @@
           permalink: /tools/dart-compile
         - title: dart create
           permalink: /tools/dart-create
+        - title: dart doc
+          permalink: /tools/dart-doc
         - title: dart fix 
           permalink: /tools/dart-fix
         - title: dart format 
@@ -230,8 +232,6 @@
           permalink: /tools/dart-test
         - title: dartaotruntime
           permalink: /tools/dartaotruntime
-        - title: dartdoc
-          permalink: /tools/dartdoc
         - title: Experiment flags
           permalink: /tools/experiment-flags
     - title: Other command-line tools

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -65,18 +65,20 @@ of code, but all other comments should use `//`.
 
 ## Doc comments
 
-Doc comments are especially handy because [dartdoc][] parses them and generates
-[beautiful doc pages][docs] from them. A doc comment is any comment that appears
-before a declaration and uses the special `///` syntax that dartdoc looks for.
+Doc comments are especially handy because [`dart doc`][] parses them 
+and generates [beautiful doc pages][docs] from them. 
+A doc comment is any comment that appears before a declaration 
+and uses the special `///` syntax that `dart doc` looks for.
 
-[dartdoc]: https://github.com/dart-lang/dartdoc
+[`dart doc`]: /tools/dart-doc
 [docs]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}
 
 ### DO use `///` doc comments to document members and types.
 
 {% include linter-rule-mention.md rule="slash_for_doc_comments" %}
 
-Using a doc comment instead of a regular comment enables [dartdoc][] to find it
+Using a doc comment instead of a regular comment enables 
+[`dart doc`][] to find it
 and generate documentation for it.
 
 {:.good}
@@ -93,7 +95,7 @@ int get length => ...
 int get length => ...
 {% endprettify %}
 
-For historical reasons, dartdoc supports two syntaxes of doc comments: `///`
+For historical reasons, `dart doc` supports two syntaxes of doc comments: `///`
 ("C# style") and `/** ... */` ("JavaDoc style"). We prefer `///` because it's
 more compact. `/**` and `*/` add two content-free lines to a multiline doc
 comment. The `///` syntax is also easier to read in some situations, such as
@@ -168,7 +170,7 @@ paragraph. If more than a single sentence of explanation is useful, put the
 rest in later paragraphs.
 
 This helps you write a tight first sentence that summarizes the documentation.
-Also, tools like dartdoc use the first paragraph as a short summary in places
+Also, tools like `dart doc` use the first paragraph as a short summary in places
 like lists of classes and members.
 
 {:.good}
@@ -266,9 +268,9 @@ int get checkedCount => ...
 {% endprettify %}
 
 If a property has both a getter and a setter, then create a doc comment for
-only one of them. Dartdoc treats the getter and setter like a single field,
+only one of them. `dart doc` treats the getter and setter like a single field,
 and if both the getter and the setter have doc comments, then
-dartdoc discards the setter's doc comment.
+`dart doc` discards the setter's doc comment.
 
 ### PREFER starting library or type comments with noun phrases.
 
@@ -307,9 +309,9 @@ makes an API easier to learn.
 {% include linter-rule-mention.md rule="comment_references" %}
 
 If you surround things like variable, method, or type names in square brackets,
-then dartdoc looks up the name and links to the relevant API docs. Parentheses
-are optional, but can make it clearer when you're referring to a method or
-constructor.
+then `dart doc` looks up the name and links to the relevant API docs.
+Parentheses are optional, 
+but can make it clearer when you're referring to a method or constructor.
 
 {:.good}
 <?code-excerpt "docs_good.dart (identifiers)"?>
@@ -388,7 +390,7 @@ class ToggleComponent {}
 ## Markdown
 
 You are allowed to use most [markdown][] formatting in your doc comments and
-dartdoc will process it accordingly using the [markdown package.][]
+`dart doc` will process it accordingly using the [markdown package.][]
 
 [markdown]: https://daringfireball.net/projects/markdown/
 [markdown package.]: {{site.pub-pkg}}/markdown

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4606,7 +4606,7 @@ to the docs for the `feed` method,
 and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
-[documentation generation tool, dartdoc.](/tools/dart-doc)
+documentation generation tool, [`dart doc`](/tools/dart-doc).
 For an example of generated documentation, see the [Dart API
 documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
 your comments, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4606,7 +4606,7 @@ to the docs for the `feed` method,
 and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
-[documentation generation tool, dartdoc.](/tools/dartdoc)
+[documentation generation tool, dartdoc.](/tools/dart-doc)
 For an example of generated documentation, see the [Dart API
 documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
 your comments, see

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4607,10 +4607,10 @@ and `[Food]` becomes a link to the docs for the `Food` class.
 
 To parse Dart code and generate HTML documentation, you can use Dart's
 documentation generation tool, [`dart doc`](/tools/dart-doc).
-For an example of generated documentation, see the [Dart API
-documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice on how to structure
-your comments, see
-[Guidelines for Dart Doc Comments.](/guides/language/effective-dart/documentation)
+For an example of generated documentation, see the 
+[Dart API documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) 
+For advice on how to structure your comments, see
+[Effective Dart: Documentation.](/guides/language/effective-dart/documentation)
 
 
 ## Summary

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -245,8 +245,8 @@ see the [pub package layout conventions](/tools/pub/package-layout).
 ## Documenting a library
 
 You can generate API docs for your library using
-the [dartdoc][] tool.
-Dartdoc parses the source looking for
+the [`dart doc`][] tool.
+`dart doc` parses the source looking for
 [documentation comments](/guides/language/effective-dart/documentation#doc-comments),
 which use the `///` syntax:
 
@@ -288,12 +288,12 @@ Links to previous versions' docs are in the
 To ensure that your package's API docs look good on the pub.dev site,
 follow these steps:
 
-* Before publishing your package, run the [dartdoc][] tool
+* Before publishing your package, run the [`dart doc`][] tool
   to make sure that your docs generate successfully and look as expected.
 * After publishing your package, check the **Versions** tab
   to make sure that the docs generated successfully.
 * If the docs didn't generate at all,
-  click **failed** in the **Versions** tab to see the dartdoc output.
+  click **failed** in the **Versions** tab to see the `dart doc` output.
 
 ## Resources
 
@@ -315,4 +315,4 @@ Use the following resources to learn more about library packages:
   [source_gen,](https://github.com/dart-lang/source_gen) and
   [test.](https://github.com/dart-lang/test)
 
-[dartdoc]: https://github.com/dart-lang/dartdoc#dartdoc
+[`dart doc`]: /tools/dart-doc

--- a/src/_guides/libraries/private-files.md
+++ b/src/_guides/libraries/private-files.md
@@ -27,7 +27,8 @@ build/
 pubspec.lock  # Except for application packages
 {% endprettify %}
 
-**Don't commit** the API documentation directory created by dartdoc:
+**Don't commit** the API documentation directory
+created by [`dart doc`](/tools/dart-doc):
 
 {% prettify none tag=pre+code %}
 doc/api/

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -411,7 +411,7 @@ You’re the only person who can provide the information that the reader needs.
 
 [Awesome README]: https://github.com/matiassingers/awesome-readme
 [Badges]: https://github.com/badges/shields#readme
-[dartdoc]: /tools/dartdoc
+[dartdoc]: /tools/dart-doc
 [How to write a great README for your GitHub project]: https://dbader.org/blog/write-a-great-readme-for-your-github-project
 [`in_app_purchase`]: {{site.pub-pkg}}/in_app_purchase
 [in its repo]: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase/doc

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -49,7 +49,7 @@ shows that your package is worth trying.
 {{site.alert.note}}
   The package README is used in multiple ways.
   For example, its content appears not only in the package page on pub.dev,
-  but also in [dartdoc][]-produced API reference documentation.
+  but also in [`dart doc`][]-produced API reference documentation.
 {{site.alert.end}}
 
 Although this page features the [`in_app_purchase`][] package README,
@@ -411,7 +411,7 @@ You’re the only person who can provide the information that the reader needs.
 
 [Awesome README]: https://github.com/matiassingers/awesome-readme
 [Badges]: https://github.com/badges/shields#readme
-[dartdoc]: /tools/dart-doc
+[`dart doc`]: /tools/dart-doc
 [How to write a great README for your GitHub project]: https://dbader.org/blog/write-a-great-readme-for-your-github-project
 [`in_app_purchase`]: {{site.pub-pkg}}/in_app_purchase
 [in its repo]: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase/doc

--- a/src/tools/dart-doc.md
+++ b/src/tools/dart-doc.md
@@ -1,5 +1,5 @@
 ---
-title: dartdoc
+title: dart doc
 description: API reference generation tool.
 toc: false
 ---

--- a/src/tools/dart-doc.md
+++ b/src/tools/dart-doc.md
@@ -4,7 +4,8 @@ description: API reference generation tool.
 toc: false
 ---
 
-The `dartdoc` command creates API reference documentation
+The `dart doc` command (previously called `dartdoc`)
+creates API reference documentation
 from Dart source code.
 You can add descriptions to the generated documentation
 by using [documentation comments][],
@@ -17,36 +18,29 @@ see the [documentation part of Effective Dart][effective doc].
   without errors.
 {{site.alert.end}}
 
-Run `dartdoc` from the root directory of your package. For example:
+Run `dart doc` from the root directory of your package. For example:
 
 ```terminal
 $ cd my_app
-$ dartdoc
+$ dart doc .
 Documenting my_app...
 ...
 Success! Docs generated into /Users/me/projects/my_app/doc/api
 ```
 
 By default, the documentation files are static HTML files,
-placed in the `doc/api` directory.
-To view the rendered documentation, you need an HTTP server.
+placed in the `doc/api` directory. You can create the
+files in a different directory with the `--output-dir` flag.
 
-Although `dartdoc` is in the Dart SDK,
-it's also available in the [dartdoc package.][]
-You might use the package when you need a programmatic interface
-or when you want to try features that
-aren't yet in the SDK's version of `dartdoc`.
-
-For information on command-line options, use the `--help` flag:
+For information on command-line options, use the `help` command:
 
 ```terminal
-$ dartdoc --help
+$ dart help doc
 ```
 
 [documentation comments]: /guides/language/language-tour#documentation-comments
 [effective doc]: /guides/language/effective-dart/documentation
 [dart analyze]: /tools/dart-analyze
-[dartdoc package.]: {{site.pub-pkg}}/dartdoc
 
 {% comment %}
 [PENDING: Add more help, info on commonly used options, links to examples of use.]

--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -54,6 +54,7 @@ you might use the [`flutter` tool][] instead.
 | `analyze` | `dart analyze [<DIRECTORY|DART_FILE>]`  | Analyzes the project's Dart source code.<br>Use instead of `dartanalyzer`.<br>[Learn more.][analyze] |
 | `compile` | `dart compile exe <DART_FILE>`          | Compiles Dart to various formats.<br>Use instead of `dart2js` and `dart2native`.<br>[Learn more.][compile] | 
 | `create`  | `dart create <DIRECTORY>`               | Creates a new project.<br>Use instead of [`stagehand`.][].<br>[Learn more.][create] | 
+| `doc`     | `dart doc <DIRECTORY>`                  | Generates API reference documentation.<br>Use instead of [`dartdoc`][].<br>[Learn more.][doc] |
 | `fix`     | `dart fix <DIRECTORY|DART_FILE>`        | Applies automated fixes to Dart source code.<br>Use instead of [`dartfix`][].<br>[Learn more.][fix] | 
 | `format`  | `dart format <DIRECTORY|DART_FILE>`     | Formats Dart source code.<br>Use instead of `dartfmt`.<br>[Learn more.][format] |
 | `migrate` | `dart migrate`                          | Supports migration to [null safety][].<br>[Learn more.][migrate] |
@@ -66,6 +67,7 @@ you might use the [`flutter` tool][] instead.
 [analyze]: /tools/dart-analyze
 [compile]: /tools/dart-compile
 [create]: /tools/dart-create
+[doc]: /tools/dart-doc
 [fix]: /tools/dart-fix
 [format]: /tools/dart-format
 [pub]: /tools/pub/cmd
@@ -79,7 +81,7 @@ You can also get details on `pub` commands — for example,
 `dart help pub outdated`.
 
 [`dartaotruntime`]: /tools/dartaotruntime
-[`dartdoc`]: https://github.com/dart-lang/dartdoc#dartdoc
+[`dartdoc`]: {{site.pub-pkg}}/dartdoc
 [`dartfix`]: {{site.pub-pkg}}/dartfix
 [null safety]: /null-safety
 [`stagehand`.]: {{site.pub-pkg}}/stagehand

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -96,7 +96,7 @@ The Dart SDK includes the following general-purpose tools:
   testing, compiling, and running Dart code,
   as well as working with the [pub package manager](/guides/packages).
 
-[`dartdoc`](/tools/dartdoc)
+[`dartdoc`](/tools/dart-doc)
 : A documentation generator.
   For examples of dartdoc's output, see the API reference documentation
   published at [api.dart.dev]({{site.dart_api}}) and pub.dev

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -89,18 +89,12 @@ A [Language Server Protocol implementation][LSP] is also available for
 
 ### Command-line tools {#cli}
 
-The Dart SDK includes the following general-purpose tools:
+The Dart SDK includes the following general-purpose `dart` tool:
 
 [`dart`](/tools/dart-tool)
 : A command-line interface (CLI) for creating, formatting, analyzing,
-  testing, compiling, and running Dart code,
+  testing, documenting, compiling, and running Dart code,
   as well as working with the [pub package manager](/guides/packages).
-
-[`dartdoc`](/tools/dart-doc)
-: A documentation generator.
-  For examples of dartdoc's output, see the API reference documentation
-  published at [api.dart.dev]({{site.dart_api}}) and pub.dev
-  (for example, the [`path` API reference]({{site.pub-api}}/path)).
 
 
 ### Debugging

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -103,7 +103,7 @@ Here's one way to configure Dart support:
   {{site.alert.note}}
     The **Dart SDK** specifies the directory that
     contains the SDK's `bin` and `lib` directories;
-    the `bin` directory contains tools such as `dart` and `dartdoc`.
+    the `bin` directory contains tools such as `dart` and `dartaotruntime`.
     The IDE ensures that the path is valid.
   {{site.alert.end}}
 </li>

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -67,7 +67,7 @@ enchilada/
     [application package](/tools/pub/glossary#application-package).
 
 \*** The `doc/api` directory exists locally after you've run
-      [dartdoc.](https://github.com/dart-lang/dartdoc#dartdoc)
+      [`dart doc`](/tools/dart-doc).
       Don't check the `api` directory into source control.
 
 {% include packages-dir.html %}
@@ -413,7 +413,7 @@ enchilada/
 If you've got code and tests, the next piece you might want
 is good documentation. That goes inside a directory named `doc`.
 
-When you run the [dartdoc](https://github.com/dart-lang/dartdoc#dartdoc)
+When you run the [`dart doc`](/tools/dart-doc)
 tool, it places the API documentation, by default, under `doc/api`.
 Since the API documentation is generated from the source code,
 you should not place it under source control.

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -36,7 +36,7 @@ directory that has these command-line tools:
 [`dartaotruntime`](/tools/dartaotruntime)
 : A Dart runtime for AOT-compiled snapshots.
 
-[`dartdoc`](/tools/dartdoc)
+[`dartdoc`](/tools/dart-doc)
 : The API documentation generator.
 
 {{site.alert.note}}

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -31,7 +31,7 @@ directory that has these command-line tools:
 
 [`dart`](/tools/dart-tool)
 : The command-line interface for creating, formatting, analyzing, testing,
-  compiling, and running Dart code.
+  documenting, compiling, and running Dart code.
   
 [`dartaotruntime`](/tools/dartaotruntime)
 : A Dart runtime for AOT-compiled snapshots.

--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -36,12 +36,9 @@ directory that has these command-line tools:
 [`dartaotruntime`](/tools/dartaotruntime)
 : A Dart runtime for AOT-compiled snapshots.
 
-[`dartdoc`](/tools/dart-doc)
-: The API documentation generator.
-
 {{site.alert.note}}
   The Dart SDK also contains `dart2js`, `dart2native`, `dartanalyzer`,
-  `dartdevc`, `dartfmt`, and `pub` commands.
+  `dartdevc`, `dartdoc`, `dartfmt`, and `pub` commands.
   However, as of 2.10 the `dart` tool provides a unified interface
   to their functionality.
   We recommend that you transition to using


### PR DESCRIPTION
Documentation update related to deprecation of `dartdoc` (see https://github.com/dart-lang/sdk/issues/46100 for context)

Closes https://github.com/dart-lang/site-www/issues/3760