### PR TITLE
Remove "also contains" from SDK page

### DIFF
--- a/src/tools/sdk.md
+++ b/src/tools/sdk.md
@@ -39,18 +39,8 @@ directory that has these command-line tools:
 [`dartdoc`](/tools/dartdoc)
 : The API documentation generator.
 
-{{site.alert.note}}
-  The Dart SDK also contains `dart2js`, `dart2native`, `dartanalyzer`,
-  `dartdevc`, `dartfmt`, and `pub` commands.
-  However, as of 2.10 the `dart` tool provides a unified interface
-  to their functionality.
-  We recommend that you transition to using
-  [the `dart` tool](/tools/dart-tool).
-{{site.alert.end}}
-
 For more information about the SDK, see its
 [README file.](https://github.com/dart-lang/sdk/blob/main/README.dart-sdk)
-
 
 ## Filing bugs and feature requests
 


### PR DESCRIPTION
We've progressed far enough on https://github.com/dart-lang/sdk/issues/46100 that this can now be considered history, and no longer needs mentioning.