### PR TITLE
Remove unnecessary null safety argument on embedded DartPads

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1559,7 +1559,7 @@ list.forEach((item) {
 Click **Run** to execute the code.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anonymous-function-main)"?>
-```dart:run-dartpad:height-400px:ga_id-anonymous_functions:null_safety-true
+```dart:run-dartpad:height-400px:ga_id-anonymous_functions
 void main() {
   const list = ['apples', 'bananas', 'oranges'];
   list.forEach((item) {
@@ -2958,7 +2958,7 @@ In the following example, the constructor for the Employee class calls the named
 constructor for its superclass, Person. Click **Run** to execute the code.
 
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart (super)" plaster="none"?>
-```dart:run-dartpad:height-450px:ga_id-non_default_superclass_constructor:null_safety-true
+```dart:run-dartpad:height-450px:ga_id-non_default_superclass_constructor
 class Person {
   String? firstName;
 
@@ -3042,7 +3042,7 @@ initializes three final fields in an initializer list. Click **Run** to execute
 the code.
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_distance_field.dart"?>
-```dart:run-dartpad:height-340px:ga_id-initializer_list:null_safety-true
+```dart:run-dartpad:height-340px:ga_id-initializer_list
 import 'dart:math';
 
 class Point {
@@ -4374,7 +4374,7 @@ that takes three strings and concatenates them, separating each with a space,
 and appending an exclamation. Click **Run** to execute the code.
 
 <?code-excerpt "misc/lib/language_tour/callable_classes.dart"?>
-```dart:run-dartpad:height-350px:ga_id-callable_classes:null_safety-true
+```dart:run-dartpad:height-350px:ga_id-callable_classes
 class WannabeFunction {
   String call(String a, String b, String c) => '$a $b $c!';
 }

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -63,7 +63,7 @@ generating a simple stream of integers using an `async*` function:
 {{site.alert.end}}
 
 <?code-excerpt "misc/lib/tutorial/sum_stream.dart"?>
-```dart:run-dartpad:null_safety-true
+```dart:run-dartpad
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
   await for (final value in stream) {
@@ -114,7 +114,7 @@ error using **try-catch**.  The following example throws an
 error when the loop iterator equals 4:
 
 <?code-excerpt "misc/lib/tutorial/sum_stream_with_catch.dart"?>
-```dart:run-dartpad:null_safety-true
+```dart:run-dartpad
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
   try {

--- a/src/_tutorials/web/fetch-data.md
+++ b/src/_tutorials/web/fetch-data.md
@@ -178,7 +178,7 @@ void _showJson([Event? _]) {
 {% endcomment %}
 
 <iframe
-src="{{site.dartpad-embed-html}}?id=ddebf4ee5ba6757aafe07f7779d7b0c1&null_safety=true&ga_id=about_json"
+src="{{site.dartpad-embed-html}}?id=ddebf4ee5ba6757aafe07f7779d7b0c1&ga_id=about_json"
     width="100%"
     height="600px"
     style="border: 1px solid #ccc;">
@@ -399,7 +399,7 @@ and loads the file.
 
 {% comment %} https://gist.github.com/parlough/c637fbedc6aa0d2a8ffcd44562648197 {% endcomment %}
 <iframe
-src="{{site.dartpad-embed-html}}?id=c637fbedc6aa0d2a8ffcd44562648197&null_safety=true&ga_id=using_getstring"
+src="{{site.dartpad-embed-html}}?id=c637fbedc6aa0d2a8ffcd44562648197&ga_id=using_getstring"
     width="100%"
     height="500px"
     style="border: 1px solid #ccc;">
@@ -455,7 +455,7 @@ an HttpRequest object.
 
 {% comment %} https://gist.github.com/parlough/2211d1ee6e16a6fc76cee04fc8fb5df2 {% endcomment %}
 <iframe
-src="{{site.dartpad-embed-html}}?id=2211d1ee6e16a6fc76cee04fc8fb5df2&null_safety=true&ga_id=using_http_request"
+src="{{site.dartpad-embed-html}}?id=2211d1ee6e16a6fc76cee04fc8fb5df2&ga_id=using_http_request"
     width="100%"
     height="500px"
     style="border: 1px solid #ccc;">

--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -30,7 +30,7 @@ to the list of pets.
   {% include dartpad-embedded-troubleshooting.md %}
 {{site.alert.end}}
 
-```dart:run-dartpad:mode-html:ga_id-play_with_a_web_app:null_safety-true
+```dart:run-dartpad:mode-html:ga_id-play_with_a_web_app
 {$ begin main.dart $}
 import 'dart:html';
 

--- a/src/codelabs/async-await.md
+++ b/src/codelabs/async-await.md
@@ -49,7 +49,7 @@ Before running this example, try to spot the issue -- what do you think the
 output will be?
 
 <?code-excerpt "async_await/bin/get_order_sync_bad.dart" remove="Fetching"?>
-```dart:run-dartpad:height-380px:ga_id-incorrect_usage:null_safety-true
+```dart:run-dartpad:height-380px:ga_id-incorrect_usage
 // This example shows how *not* to write asynchronous Dart code.
 
 String createOrderMessage() {
@@ -145,7 +145,7 @@ printing to the console. Because it doesn't return a usable value,
 try to predict which will print first: "Large Latte" or "Fetching user order...".
 
 <?code-excerpt "async_await/bin/futures_intro.dart"?>
-```dart:run-dartpad:height-300px:ga_id-introducting_futures:null_safety-true
+```dart:run-dartpad:height-300px:ga_id-introducting_futures
 Future<void> fetchUserOrder() {
   // Imagine that this function is fetching user info from another service or database.
   return Future.delayed(const Duration(seconds: 2), () => print('Large Latte'));
@@ -168,7 +168,7 @@ Run the following example to see how a future completes with an error.
 A bit later you'll learn how to handle the error.
 
 <?code-excerpt "async_await/bin/futures_intro.dart (error)" replace="/Error//g"?>
-```dart:run-dartpad:height-300px:ga_id-completing_with_error:null_safety-true
+```dart:run-dartpad:height-300px:ga_id-completing_with_error
 Future<void> fetchUserOrder() {
 // Imagine that this function is fetching user info but encounters a bug
   return Future.delayed(const Duration(seconds: 2),
@@ -343,7 +343,7 @@ Run the following example to see how execution proceeds within an `async`
 function body. What do you think the output will be?
 
 <?code-excerpt "async_await/bin/async_example.dart" remove="/\/\/ print/"?>
-```dart:run-dartpad:height-530px:ga_id-execution_within_async_function:null_safety-true
+```dart:run-dartpad:height-530px:ga_id-execution_within_async_function
 Future<void> printOrderMessage() async {
   print('Awaiting user order...');
   var order = await fetchUserOrder();
@@ -422,7 +422,7 @@ Implement an `async` function `reportLogins()` so that it does the following:
   * Example return value from `reportLogins()`: `"Total number of logins: 57"`
 * Gets the number of logins by calling the provided function `fetchLoginAmount()`.
 
-```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_using:null_safety-true
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_using
 {$ begin main.dart $}
 // Part 1
 // You can call the provided async function fetchRole()
@@ -588,7 +588,7 @@ Run the following example to see how to handle an error from an
 asynchronous function. What do you think the output will be?
 
 <?code-excerpt "async_await/bin/try_catch.dart"?>
-```dart:run-dartpad:height-530px:ga_id-try_catch:null_safety-true
+```dart:run-dartpad:height-530px:ga_id-try_catch
 Future<void> printOrderMessage() async {
   try {
     print('Awaiting user order...');
@@ -639,7 +639,7 @@ that does the following:
 {% comment %}
 PENDING: Any way to auto-include this code?
 {% endcomment %}
-```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_errors:null_safety-true
+```dart:run-dartpad:theme-dark:height-380px:ga_id-practice_errors
 {$ begin main.dart $}
 // Implement changeUsername here
 changeUsername() {}
@@ -818,7 +818,7 @@ Write the following:
 {% comment %}
 PENDING: Any way to auto-include this code?
 {% endcomment %}
-```dart:run-dartpad:theme-dark:height-380px:ga_id-putting_it_all_together:null_safety-true
+```dart:run-dartpad:theme-dark:height-380px:ga_id-putting_it_all_together
 {$ begin main.dart $}
 // Part 1
 addHello(user){}

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -45,7 +45,7 @@ The following function takes two integers as parameters.
 Make it return a string containing both integers separated by a space.
 For example, `stringify(2, 3)` should return `'2 3'`.
 
-```dart:run-dartpad:ga_id-string_interpolation:null_safety-true
+```dart:run-dartpad:ga_id-string_interpolation
 {$ begin main.dart $}
 String stringify(int x, int y) {
   TODO('Return a formatted string here');
@@ -130,7 +130,7 @@ Try to declare two variables below:
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:ga_id-nullable_variables:null_safety-true
+```dart:run-dartpad:ga_id-nullable_variables
 {$ begin main.dart $}
 // Declare the two variables here
 {$ end main.dart $}
@@ -196,7 +196,7 @@ to implement the described behavior in the following snippet.
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:height-255px:ga_id-null_aware:null_safety-true
+```dart:run-dartpad:height-255px:ga_id-null_aware
 {$ begin main.dart $}
 String? foo = 'a string';
 String? bar; // = null
@@ -288,7 +288,7 @@ null.
 
 Try using conditional property access to finish the code snippet below.
 
-```dart:run-dartpad:ga_id-conditional-property_access:null_safety-true
+```dart:run-dartpad:ga_id-conditional-property_access
 {$ begin main.dart $}
 // This method should return the uppercase version of `str`
 // or null if `str` is null.
@@ -384,7 +384,7 @@ final aListOfBaseType = <BaseType>[SubType(), SubType()];
 
 Try setting the following variables to the indicated values. Replace the existing null values.
 
-```dart:run-dartpad:height-400px:ga_id-collection_literals:null_safety-true
+```dart:run-dartpad:height-400px:ga_id-collection_literals
 {$ begin main.dart $}
 // Assign this a list containing 'a', 'b', and 'c' in that order:
 final aListOfStrings = null;
@@ -509,7 +509,7 @@ bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
 
 Try finishing the following statements, which use arrow syntax.
 
-```dart:run-dartpad:height-345px:ga_id-arrow_syntax:null_safety-true
+```dart:run-dartpad:height-345px:ga_id-arrow_syntax
 {$ begin main.dart $}
 class MyClass {
   int value1 = 2;
@@ -665,7 +665,7 @@ sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
 to `1`, `'String!'`, and `[3.0]` (respectively)
 and then calls `allDone()`.
 
-```dart:run-dartpad:height-345px:ga_id-cascades:null_safety-true
+```dart:run-dartpad:height-345px:ga_id-cascades
 {$ begin main.dart $}
 class BigObject {
   int anInt = 0;
@@ -815,7 +815,7 @@ Add the following:
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:height-240px:ga_id-getters_setters:null_safety-true
+```dart:run-dartpad:height-240px:ga_id-getters_setters
 {$ begin main.dart $}
 class InvalidPriceException {}
 
@@ -970,7 +970,7 @@ Here are some examples of function calls and returned values:
 
 <br>
 
-```dart:run-dartpad:ga_id-optional_positional_parameters:null_safety-true
+```dart:run-dartpad:ga_id-optional_positional_parameters
 {$ begin main.dart $}
 String joinWithCommas(int a, [int? b, int? c, int? d, int? e]) {
   return TODO();
@@ -1101,7 +1101,7 @@ then copy its value into `anInt`.
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:height-310px:ga_id-optional_named_parameters:null_safety-true
+```dart:run-dartpad:height-310px:ga_id-optional_named_parameters
 {$ begin main.dart $}
 class MyDataObject {
   final int anInt;
@@ -1278,7 +1278,7 @@ then do the following:
 * After everything's caught and handled, call `logger.doneLogging`
   (try using `finally`).
 
-```dart:run-dartpad:height-420px:ga_id-exceptions:null_safety-true
+```dart:run-dartpad:height-420px:ga_id-exceptions
 {$ begin main.dart $}
 typedef VoidFunction = void Function();
 
@@ -1481,7 +1481,7 @@ all three properties of the class.
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:ga_id-this_constructor:null_safety-true
+```dart:run-dartpad:ga_id-this_constructor
 {$ begin main.dart $}
 class MyClass {
   final int anInt;
@@ -1598,7 +1598,7 @@ FINALLY: Suggest using https://pub.dev/packages/characters
 if this is a user-entered string.
 {% endcomment %}
 
-```dart:run-dartpad:ga_id-initializer_lists:null_safety-true
+```dart:run-dartpad:ga_id-initializer_lists
 {$ begin main.dart $}
 class FirstTwoLetters {
   final String letterOne;
@@ -1702,7 +1702,7 @@ that sets all three properties to zero.
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:height-240px:ga_id-named_constructors:null_safety-true
+```dart:run-dartpad:height-240px:ga_id-named_constructors
 {$ begin main.dart $}
 class Color {
   int red;
@@ -1802,7 +1802,7 @@ making it do the following:
   create an `IntegerTriple` with the values in order.
 * Otherwise, throw an `Error`.
 
-```dart:run-dartpad:height-415px:ga_id-factory_constructors:null_safety-true
+```dart:run-dartpad:height-415px:ga_id-factory_constructors
 {$ begin main.dart $}
 class IntegerHolder {
   IntegerHolder();
@@ -1992,7 +1992,7 @@ default constructor with zeros as the arguments.
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:height-255px:ga_id-redirecting_constructors:null_safety-true
+```dart:run-dartpad:height-255px:ga_id-redirecting_constructors
 {$ begin main.dart $}
 class Color {
   int red;
@@ -2084,7 +2084,7 @@ and create a constant constructor that does the following:
 
 Ignore all initial errors in the DartPad.
 
-```dart:run-dartpad:ga_id-const_constructors:null_safety-true
+```dart:run-dartpad:ga_id-const_constructors
 {$ begin main.dart $}
 class Recipe {
   List<String> ingredients;

--- a/src/codelabs/iterables.md
+++ b/src/codelabs/iterables.md
@@ -119,7 +119,7 @@ using a `for-in` loop.
 The following example shows you how to read elements using  a `for-in` loop.
 
 <?code-excerpt "iterables/test/iterables_test.dart (for-in)"?>
-```dart:run-dartpad:ga_id-for_in_loop:null_safety-true
+```dart:run-dartpad:ga_id-for_in_loop
 void main() {
   const iterable = ['Salad', 'Popcorn', 'Toast'];
   for (final element in iterable) {
@@ -167,7 +167,7 @@ but you can use the `last` property.
 {{site.alert.end}}
 
 <?code-excerpt "iterables/test/iterables_test.dart (first-last)"?>
-```dart:run-dartpad:ga_id-first_and_last:null_safety-true
+```dart:run-dartpad:ga_id-first_and_last
 void main() {
   Iterable<String> iterable = const ['Salad', 'Popcorn', 'Toast'];
   print('The first element is ${iterable.first}');
@@ -205,7 +205,7 @@ Run the following example to see how `firstWhere()` works.
 Do you think all the functions will give the same result?
 
 <?code-excerpt "iterables/test/iterables_test.dart (first-where-long)"?>
-```dart:run-dartpad:height-565px:ga_id-using_firstwhere:null_safety-true
+```dart:run-dartpad:height-565px:ga_id-using_firstwhere
 bool predicate(String item) {
   return item.length > 5;
 }
@@ -308,7 +308,7 @@ satisfies the following conditions:
 All the elements in the test data are [strings][String class];
 you can check the class documentation for help.
 
-```dart:run-dartpad:theme-dark:ga_id-practice_writing_a_test_predicate:null_safety-true
+```dart:run-dartpad:theme-dark:ga_id-practice_writing_a_test_predicate
 {$ begin main.dart $}
 // Implement the predicate of singleWhere
 // with the following conditions
@@ -410,7 +410,7 @@ you can use to verify conditions:
 Run this exercise to see them in action.
 
 <?code-excerpt "iterables/test/iterables_test.dart (any-every)"?>
-```dart:run-dartpad:height-255px:ga_id-using_any_and_every:null_safety-true
+```dart:run-dartpad:height-255px:ga_id-using_any_and_every
 void main() {
   const items = ['Salad', 'Popcorn', 'Toast'];
 
@@ -459,7 +459,7 @@ Use `any()` and `every()` to implement two functions:
 * Part 2: Implement `everyUserOver13()`.
   * Return `true` if all users are 14 or older.
 
-```dart:run-dartpad:theme-dark:height-395px:ga_id-verify_iterable:null_safety-true
+```dart:run-dartpad:theme-dark:height-395px:ga_id-verify_iterable
 {$ begin main.dart $}
 bool anyUserUnder18(Iterable<User> users) {
   TODO('Implement this method');
@@ -642,7 +642,7 @@ Run this example to see how `where()` can be used together with other
 methods like `any()`.
 
 <?code-excerpt "iterables/test/iterables_test.dart (numbers-where)"?>
-```dart:run-dartpad:height-380px:ga_id-using_where:null_safety-true
+```dart:run-dartpad:height-380px:ga_id-using_where
 void main() {
   var evenNumbers = const [1, -2, 3, 42].where((number) => number.isEven);
 
@@ -685,7 +685,7 @@ Run this example to see how `takeWhile()` and `skipWhile()` can
 split an `Iterable` containing numbers.
 
 <?code-excerpt "iterables/test/iterables_test.dart (take-while-long)"?>
-```dart:run-dartpad:ga_id-using_takewhile:null_safety-true
+```dart:run-dartpad:ga_id-using_takewhile
 void main() {
   const numbers = [1, 3, -2, 0, 4, 5];
 
@@ -729,7 +729,7 @@ Use `where()` to implement two functions:
   * Return an `Iterable` containing all users with
     names of length 3 or less.
 
-```dart:run-dartpad:theme-dark:height-380px:ga_id-filtering_elements_from_a_list:null_safety-true
+```dart:run-dartpad:theme-dark:height-380px:ga_id-filtering_elements_from_a_list
 {$ begin main.dart $}
 Iterable<User> filterOutUnder21(Iterable<User> users) {
   TODO('Implement this method');
@@ -864,7 +864,7 @@ multiply all the elements of an `Iterable` by 2.
 What do you think the output will be?
 
 <?code-excerpt "iterables/test/iterables_test.dart (numbers-by-two)"?>
-```dart:run-dartpad:ga_id-using_map:null_safety-true
+```dart:run-dartpad:ga_id-using_map
 void main() {
   var numbersByTwo = const [1, -2, 3, 42].map((number) => number * 2);
   print('Numbers: $numbersByTwo');
@@ -884,7 +884,7 @@ contains strings containing each user's name and age.
 Each string in the `Iterable` must follow this format:
 `'{name} is {age}'`—for example `'Alice is 21'`.
 
-```dart:run-dartpad:theme-dark:height-310px:ga_id-mapping_to_a_different_type:null_safety-true
+```dart:run-dartpad:theme-dark:height-310px:ga_id-mapping_to_a_different_type
 {$ begin main.dart $}
 Iterable<String> getNameAndAges(Iterable<User> users) {
   TODO('Implement this method');
@@ -1003,7 +1003,7 @@ Part 3: Implement `validEmailAddresses()`.
 - Use the provided function `isValidEmailAddress()` to evaluate whether
   an `EmailAddress` is valid.
 
-```dart:run-dartpad:theme-dark:height-600px:ga_id-putting_it_all_together:null_safety-true
+```dart:run-dartpad:theme-dark:height-600px:ga_id-putting_it_all_together
 {$ begin main.dart $}
 Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {
   TODO('Implement this method');

--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -46,7 +46,7 @@ The variable `a` below is declared as an `int`. Try changing the value in the
 assignment to 3 or 145. Anything but null!
 
 <?code-excerpt "null_safety_codelab/bin/non_nullable_types.dart" replace="/145/null/g"?>
-```dart:run-dartpad:ga_id-nonnullable_type:null_safety-true
+```dart:run-dartpad:ga_id-nonnullable_type
 void main() {
   int a;
   a = null;
@@ -60,7 +60,7 @@ What if you need a variable that *can* hold a null value?  Try changing the
 type of `a` so that `a` can be either null or an int:
 
 <?code-excerpt "null_safety_codelab/bin/nullable_types.dart" replace="/int\?/int/g"?>
-```dart:run-dartpad:ga_id-nullable_type:null_safety-true
+```dart:run-dartpad:ga_id-nullable_type
 void main() {
   int a;
   a = null;
@@ -75,7 +75,7 @@ question marks to correct the type declarations of `aNullableListOfStrings` and
 `aListOfNullableStrings`:
 
 <?code-excerpt "null_safety_codelab/bin/more_nullable_types.dart" replace="/String\?/String/g; /\?\ aNull/ aNull/g"?>
-```dart:run-dartpad:ga_id-nullable_type_generics:null_safety-true
+```dart:run-dartpad:ga_id-nullable_type_generics
 void main() {
   List<String> aListOfStrings = ['one', 'two', 'three'];
   List<String> aNullableListOfStrings;
@@ -107,7 +107,7 @@ In the code below, try adding exclamation points to correct the
 broken assignments:
 
 <?code-excerpt "null_safety_codelab/bin/assertion_operator.dart" replace="/first!/first/g; /!.abs/.abs/g"?>
-```dart:run-dartpad:ga_id-null_assertion:null_safety-true
+```dart:run-dartpad:ga_id-null_assertion
 int? couldReturnNullButDoesnt() => -3;
 
 void main() {
@@ -144,7 +144,7 @@ Try uncommenting the `if`-`else` statement in the code below, and
 watch the analyzer errors disappear:
 
 <?code-excerpt "null_safety_codelab/bin/definite_assignment.dart" replace="/if/\/\/if/g; /\ \ text\ =/\/\/  text =/g; /\ \ \}/  \/\/}/g"?>
-```dart:run-dartpad:ga_id-definite_assignment:null_safety-true
+```dart:run-dartpad:ga_id-definite_assignment
 void main() {
   String text;
 
@@ -165,7 +165,7 @@ In the code below, add an `if` statement to the beginning of `getLength` that
 returns zero if `str` is null:
 
 <?code-excerpt "null_safety_codelab/bin/type_promotion.dart" replace="/.*if\ \(.*\n.*\n.*//g"?>
-```dart:run-dartpad:ga_id-null_checking:null_safety-true
+```dart:run-dartpad:ga_id-null_checking
 int getLength(String? str) {
   // Add null check here
 
@@ -183,7 +183,7 @@ Promotion works with exceptions as well as return statements. Try a null check
 that throws an `Exception` instead of returning zero.
 
 <?code-excerpt "null_safety_codelab/bin/promotion_exceptions.dart" replace="/.*if\ \(.*\n.*\n.*//g"?>
-```dart:run-dartpad:ga_id-promotion_exceptions:null_safety-true
+```dart:run-dartpad:ga_id-promotion_exceptions
 int getLength(String? str) {
   // Try throwing an exception here if `str` is null.
 
@@ -218,7 +218,7 @@ Try using the `late` keyword to correct the following code. For a little extra
 fun afterward, try commenting out the line that sets `description`!
 
 <?code-excerpt "null_safety_codelab/bin/late_keyword.dart" replace="/late\ String\ _description/String _description/g"?>
-```dart:run-dartpad:ga_id-late_keyword:null_safety-true
+```dart:run-dartpad:ga_id-late_keyword
 class Meal {
   String _description;
 
@@ -247,7 +247,7 @@ Note that you don't need to remove `final`. You can create
 you set their values once, and after that they're read-only.
 
 <?code-excerpt "null_safety_codelab/bin/late_circular_references.dart" replace="/late\ final\ Team/final Team/g; /late\ final\ Coach/final Coach/g"?>
-```dart:run-dartpad:ga_id-late_circular:null_safety-true
+```dart:run-dartpad:ga_id-late_circular
 class Team {
   final Coach coach;
 }
@@ -282,7 +282,7 @@ Try this:
 </ol>
 
 <?code-excerpt "null_safety_codelab/bin/late_lazy.dart"?>
-```dart:run-dartpad:ga_id-lazy_late:null_safety-true
+```dart:run-dartpad:ga_id-lazy_late
 int _computeValue() {
   print('In _computeValue...');
   return 3;

--- a/src/overview.md
+++ b/src/overview.md
@@ -62,7 +62,7 @@ To learn more about the language, take the [Dart language
 tour](/guides/language/language-tour).
 
 <?code-excerpt "misc/lib/overview_pi.dart"?>
-```dart:run-dartpad:ga_id-overview:null_safety-true
+```dart:run-dartpad:ga_id-overview
 import 'dart:math' show Random;
 
 void main() async {


### PR DESCRIPTION
DartPad no longer supports pre-null safe code, so the `null_safety` parameter was removed and no longer does anything. This PR removes all unnecessary usages of it.