### PR TITLE
Regenerate SDK checksums and update surrounding generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eu; \
         DART_SHA256="95312f8e1253b9f67e800f4949972de39ed4870681c4544a799899a75bc1bdbd"; \
         SDK_ARCH="arm64";; \
       amd64_dev) \
-        DART_SHA256="5350fa5bc1476113123c9c791fbaf56080b214c214bcee5e768538ddccefd04a"; \
+        DART_SHA256="b33662233081d04b4f5cec82d92dd5ed4316fe87abff5d3708cd8a4c76665925"; \
         SDK_ARCH="x64";; \
       arm64_dev) \
-        DART_SHA256="d873b691a748df2dc68057f02947ec03ace56481bd1150a3a4baf84b1167c2d6"; \
+        DART_SHA256="97d13e4f0faca7768a593119d06292322594fc5610a336455e9d745d0de1a229"; \
         SDK_ARCH="arm64";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,16 +39,16 @@ RUN set -eu; \
         DART_SHA256="8836c294234352cc53e8aea4a1ce0442ebbb769a536ce7f309579da5020a2395"; \
         SDK_ARCH="arm64";; \
       amd64_beta) \
-        DART_SHA256="b758aefce016c0dfdc8b4e2941c88e0a5c0d29339c4432abd58fab4ef076d2dc"; \
+        DART_SHA256="315767a7242ad49d9003a5d4d43ebd7bbe8556c7a7ac1dbfc160d71216b732c6"; \
         SDK_ARCH="x64";; \
       arm64_beta) \
-        DART_SHA256="1427731141075364bc2f6b2c89c3db28e781048b05149ab8d336ab213382aea6"; \
+        DART_SHA256="95312f8e1253b9f67e800f4949972de39ed4870681c4544a799899a75bc1bdbd"; \
         SDK_ARCH="arm64";; \
       amd64_dev) \
-        DART_SHA256="12f1f7bc8b7d47fdaab5db420ff5640f1f2f0ad37eae7586e291d4b410aef528"; \
+        DART_SHA256="5350fa5bc1476113123c9c791fbaf56080b214c214bcee5e768538ddccefd04a"; \
         SDK_ARCH="x64";; \
       arm64_dev) \
-        DART_SHA256="90fdcadbd1065c26a198aabebde53460ab83cf900c8363d51ccc263cddd51ab8"; \
+        DART_SHA256="d873b691a748df2dc68057f02947ec03ace56481bd1150a3a4baf84b1167c2d6"; \
         SDK_ARCH="arm64";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN set -eu; \
     URL="$BASEURL/$DART_CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
     curl -fsSLO "$URL"; \
     echo "$DART_SHA256 *$SDK" | sha256sum --check --status --strict - || (\
-        echo -e "\n\nDART CHECKSUM FAILED! Run tool/fetch-dart-sdk-sums.sh for updated values.\n\n" && \
+        echo -e "\n\nDART CHECKSUM FAILED! Run 'make fetch-sums' for updated values.\n\n" && \
         rm "$SDK" && \
         exit 1 \
     ); \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 all: clean up down debug shell serve test-build test-run setup \
 	serve emulate stage test build-image build deploy deploy-ci \
-	fetch-sdk-sums test-builds test-run
+	fetch-sums test-builds test-run
 
 .PHONY: all
 .DEFAULT_GOAL := up
@@ -142,7 +142,7 @@ fetch-sums:
 	tool/fetch-dart-sdk-sums.sh \
 		--version ${DART_VERSION} \
 		--channel ${DART_CHANNEL}
-	tool/fetch-node-ppa/sum.sh
+	tool/fetch-node-ppa-sum.sh
 
 # Test the dev container with pure docker
 test-builds:

--- a/README.md
+++ b/README.md
@@ -218,14 +218,27 @@ $ tool/compile.sh
 ## Dockerfile Maintenance
 
 ### Dart SDK and Node PPA Checksum values
-Since both the Dart SDK and Node PPA `curl` remote files, it's important to verify checksum values. Both installs use `latest` and `lts` respectively, so these files may be periodically updated. When this happens, local checksums may fail and **This will break the Docker/Compose setup/build**. You will see the relevant output in your shell e.g. `DART CHECKSUM FAILED!...`. When this happens, run the following command:
+
+Since both the Dart SDK and Node PPA `curl` remote files, 
+it's important to verify checksum values. 
+Both installs use `latest` and `lts` respectively, 
+so these files may be periodically updated. 
+When this happens, 
+local checksums may fail and **This will break the Docker/Compose setup/build**.
+You will see the relevant output in your shell e.g. `DART CHECKSUM FAILED!...`. 
+When this happens, run the following command:
 
 ```bash
+make run
+
 make fetch-sums
 ```
 
-This command will output the updated checksum values for both Node and Dart, and that output will be formatted similar or the same as what is currently in the Dockerfile. Copy this output and replace the relevant install code in the Dockerfile, then rerun your setup/build again. 
-
+This command will output the updated checksum values for both Node and Dart, 
+and that output will be formatted similar 
+or the same as what is currently in the Dockerfile. 
+Copy this output and replace the relevant install code in the Dockerfile, 
+then rerun your setup/build again. 
 
 
 

--- a/tool/fetch-dart-sdk-sums.sh
+++ b/tool/fetch-dart-sdk-sums.sh
@@ -33,7 +33,7 @@ printf "\n$(blue "Copy the following output and replace the existing code in the
 
 for CHANNEL in $CHANNELS; do
   for ARCH in $ARCHS; do
-    echo -e "$(yellow "${ARCH}_${CHANNEL}) \\")"
+    echo -e "$(yellow "${ARCH}_${CHANNEL})") \\"
     _arch=$ARCH
     if [[ "$_arch" == "amd64" ]]; then
       _arch='x64'
@@ -45,8 +45,8 @@ for CHANNEL in $CHANNELS; do
     IFS=" " # Split checksum output by space delimiter 
     read -a _fname_arr <<< "$_checksum" # Read in string output as array
     unset _fname_arr[-1] # Remove filename portion of checksum output
-    echo -e "$(yellow "  DART_SHA256=\"$_fname_arr\"; \\")"
-    echo -e "$(yellow "  SDK_ARCH=\"$_arch\";; \\")"
+    echo -e "$(yellow "  DART_SHA256=\"$_fname_arr\";") \\"
+    echo -e "$(yellow "  SDK_ARCH=\"$_arch\";;") \\"
     rm $_filename
   done
 done


### PR DESCRIPTION
Testing and updating the surrounding tooling so it's ready for the next release.

Had to move `\` out of color as they were being lost.

\cc @btobin