### PR TITLE
Add back Google Sans Display and cleanup font usage

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -49,12 +49,15 @@
     <meta property="og:type" content="{{og_type}}" />
   {% endif -%}
 
-  <link href="https://fonts.googleapis.com/css?family=Google+Sans:400,500,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Material+Icons" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Display:wght@400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script 
-    src="https://use.fontawesome.com/releases/v5.15.1/js/all.js" 
+    src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
     data-auto-replace-svg="nest">
   </script>
 


### PR DESCRIPTION
- Adds back Google Sans Display which is used for headers
- Adds `preconnect` headers which allow some browsers to begin the connection to the fonts resources earlier
- Use the new css2 API 
- Update Font Awesome