### PR TITLE
Cleanup DevTools opening

### DIFF
--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -6,7 +6,7 @@ description: A suite of debugging and performance tools.
 Dart DevTools is a suite of debugging and performance tools
 for Dart and Flutter.
 These tools are distributed as part of the `dart` tool
-and interact with tools like IDEs, `dart run`, and `webdev`.
+and interact with tools such as IDEs, `dart run`, and `webdev`.
 
 The following table shows which tools
 you can use with common Dart app types.

--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -4,8 +4,9 @@ description: A suite of debugging and performance tools.
 ---
 
 Dart DevTools is a suite of debugging and performance tools
-for Dart and Flutter 
-that is distributed as part of the `dart` tool.
+for Dart and Flutter.
+These tools are distributed as part of the `dart` tool
+and interact with tools like IDEs, `dart run`, and `webdev`.
 
 The following table shows which tools
 you can use with common Dart app types.

--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -4,9 +4,8 @@ description: A suite of debugging and performance tools.
 ---
 
 Dart DevTools is a suite of debugging and performance tools
-for Dart and Flutter.
-These tools are distributed in IDEs, the `flutter` tool, the `webdev` tool,
-and the [devtools package.][devtools package]
+for Dart and Flutter 
+that is distributed as part of the `dart` tool.
 
 The following table shows which tools
 you can use with common Dart app types.
@@ -182,7 +181,6 @@ Click **Debugger** to start debugging the app.
 [CPU profiler]: {{site.flutter_docs}}/development/tools/devtools/cpu-profiler
 [Debugger]: {{site.flutter_docs}}/development/tools/devtools/debugger
 [Debugging Dart web apps]: /web/debugging
-[devtools package]: {{site.pub-pkg}}/devtools
 [Flutter inspector]: {{site.flutter_docs}}/development/tools/devtools/inspector
 [Flutter mobile or desktop]: {{site.flutter_docs}}/development/tools/devtools/overview
 [Flutter web]: {{site.flutter_docs}}/development/tools/devtools/overview

--- a/src/web/debugging.md
+++ b/src/web/debugging.md
@@ -201,7 +201,6 @@ For more information, see the following:
 
 * Documentation for [your IDE][IDE]
 * [Dart DevTools documentation][Dart DevTools]
-* [devtools package documentation][devtools-pkg]
 * [dartdevc FAQ][]
 * [webdev tool documentation][webdev]
 * [webdev package documentation][webdev-pkg]
@@ -216,7 +215,6 @@ For more information, see the following:
 [dart2js-debug]: /tools/dart2js#debugging
 [dartdevc]: /tools/dartdevc
 [dartdevc FAQ]: /tools/dartdevc/faq
-[devtools-pkg]: {{site.pub-pkg}}/devtools
 [Google Chrome]: https://www.google.com/chrome
 [issue 1925]: https://github.com/flutter/devtools/issues/1925
 [JavaScript debugging reference]: https://developers.google.com/web/tools/chrome-devtools/javascript/reference


### PR DESCRIPTION
- Drops links to package as it is now discontinued
- Clarify it is actually distributed as part of the `dart` tool