### PR TITLE
Simplify async main return types to not return a Future

### DIFF
--- a/examples/async_await/bin/async_example.dart
+++ b/examples/async_await/bin/async_example.dart
@@ -12,7 +12,7 @@ Future<String> fetchUserOrder() {
   return Future.delayed(const Duration(seconds: 4), () => 'Large Latte');
 }
 
-Future<void> main() async {
+void main() async {
   countSeconds(4);
   await printOrderMessage();
 }

--- a/examples/async_await/bin/get_order.dart
+++ b/examples/async_await/bin/get_order.dart
@@ -11,7 +11,7 @@ Future<String> fetchUserOrder() =>
     );
 
 // #docregion main-sig
-Future<void> main() async {
+void main() async {
   // #enddocregion main-sig
   print('Fetching user order...');
   // #docregion print-order

--- a/examples/async_await/bin/try_catch.dart
+++ b/examples/async_await/bin/try_catch.dart
@@ -19,6 +19,6 @@ Future<String> fetchUserOrder() {
   return str;
 }
 
-Future<void> main() async {
+void main() async {
   await printOrderMessage();
 }

--- a/examples/html/test/html_test.dart
+++ b/examples/html/test/html_test.dart
@@ -62,7 +62,7 @@ void main() {
   test('getString', () async {
     final url = 'https://httpbin.org';
     // #docregion getString
-    Future<void> main() async {
+    void main() async {
       String pageHtml = await HttpRequest.getString(url);
       // Do something with pageHtml...
       // #enddocregion getString
@@ -80,7 +80,7 @@ void main() {
   test('request', () async {
     final url = 'https://httpbin.org/headers';
     // #docregion request
-    Future<void> main() async {
+    void main() async {
       HttpRequest req = await HttpRequest.request(
         url,
         method: 'HEAD',
@@ -105,7 +105,7 @@ void main() {
             '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
         .join('&');
 
-    Future<void> main() async {
+    void main() async {
       const data = {'dart': 'fun', 'angular': 'productive'};
 
       var request = HttpRequest();

--- a/examples/misc/bin/cat_no_hash.dart
+++ b/examples/misc/bin/cat_no_hash.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main(List<String> args) async {
+void main(List<String> args) async {
   var file = File(args[0]);
   var lines = utf8.decoder
       .bind(file.openRead()) //!<br>

--- a/examples/misc/lib/articles/io/io_file_system_test.dart
+++ b/examples/misc/lib/articles/io/io_file_system_test.dart
@@ -2,7 +2,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   var file = File(Platform.script.toFilePath());
   print(await (file.readAsString(encoding: ascii)));
 }

--- a/examples/misc/lib/articles/io/io_http_server_file_test.dart
+++ b/examples/misc/lib/articles/io/io_http_server_file_test.dart
@@ -35,7 +35,7 @@ Future<void> sendNotFound(HttpResponse response) async {
   await response.close();
 }
 
-Future<void> main() async {
+void main() async {
   // Compute base path for the request based on the location of the
   // script, and then start the server.
   final script = File(Platform.script.toFilePath());

--- a/examples/misc/lib/articles/io/io_http_server_test.dart
+++ b/examples/misc/lib/articles/io/io_http_server_test.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final server = await HttpServer.bind('127.0.0.1', 8082);
   await for (final request in server) {
     request.response.write('Hello, world');

--- a/examples/misc/lib/articles/io/io_process_stdio_test.dart
+++ b/examples/misc/lib/articles/io/io_process_stdio_test.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final output = File('output.txt').openWrite();
   Process process = await Process.start('ls', ['-l']);
 

--- a/examples/misc/lib/articles/io/io_process_test.dart
+++ b/examples/misc/lib/articles/io/io_process_test.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   // List all files in the current directory,
   // in UNIX-like operating systems.
   ProcessResult results = await Process.run('ls', ['-l']);

--- a/examples/misc/lib/articles/io/io_process_transform_test.dart
+++ b/examples/misc/lib/articles/io/io_process_transform_test.dart
@@ -2,7 +2,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final process = await Process.start('ls', ['-l']);
   final lineStream = process.stdout
       .transform(const Utf8Decoder())

--- a/examples/misc/lib/articles/io/io_random_access_test.dart
+++ b/examples/misc/lib/articles/io/io_random_access_test.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final semicolon = ';'.codeUnitAt(0);
   final result = <int>[];
 

--- a/examples/misc/lib/articles/io/io_stream_test.dart
+++ b/examples/misc/lib/articles/io/io_stream_test.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final result = <int>[];
 
   Stream<List<int>> stream = File(Platform.script.toFilePath()).openRead();

--- a/examples/misc/lib/language_tour/async.dart
+++ b/examples/misc/lib/language_tour/async.dart
@@ -52,7 +52,7 @@ Future<void> miscDeclAnalyzedButNotTested() async {
   {
     Future<void> checkVersion() async {}
     // #docregion main
-    Future<void> main() async {
+    void main() async {
       checkVersion();
       print('In main: version is ${await lookUpVersion()}');
     }
@@ -63,7 +63,7 @@ Future<void> miscDeclAnalyzedButNotTested() async {
     Stream<dynamic> requestServer = Stream.empty();
     Future<dynamic> handleRequest(_) async => Never;
     // #docregion number_thinker
-    Future<void> main() async {
+    void main() async {
       // ...
       await for (final request in requestServer) {
         handleRequest(request);

--- a/examples/misc/lib/library_tour/async/stream.dart
+++ b/examples/misc/lib/library_tour/async/stream.dart
@@ -30,7 +30,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion await-for
-    Future<void> main(List<String> arguments) async {
+    void main(List<String> arguments) async {
       // ...
       if (await FileSystemEntity.isDirectory(searchPath)) {
         final startingDir = Directory(searchPath);

--- a/examples/misc/lib/library_tour/io/http_server.dart
+++ b/examples/misc/lib/library_tour/io/http_server.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 int stopAfter = 10;
 // #docregion
-Future<void> main() async {
+void main() async {
   final requests = await HttpServer.bind('localhost', 8888);
   // #enddocregion
   final _requests = requests.take(stopAfter);

--- a/examples/misc/lib/pi/pi_monte_carlo.dart
+++ b/examples/misc/lib/pi/pi_monte_carlo.dart
@@ -23,7 +23,7 @@ int numIterations = 500; //!web-only
 //!web-only
 //!tip("main()")
 // #docregion try-dart
-Future<void> main() async {
+void main() async {
   print('Compute π using the Monte Carlo method.'); //!tip("π")
   var output = querySelector('#value-of-pi')!; //!web-only
   //!tip("await")

--- a/examples/misc/lib/tutorial/misc.dart
+++ b/examples/misc/lib/tutorial/misc.dart
@@ -8,7 +8,7 @@ void futuresTutorial() {
   void doSomethingWith(_) {}
   // #docregion multiple-await
   // Sequential processing using async and await.
-  Future<void> main() async {
+  void main() async {
     await expensiveA();
     await expensiveB();
     doSomethingWith(await expensiveC());

--- a/examples/misc/lib/tutorial/sum_stream.dart
+++ b/examples/misc/lib/tutorial/sum_stream.dart
@@ -15,7 +15,7 @@ Stream<int> countStream(int to) async* {
   }
 }
 
-Future<void> main() async {
+void main() async {
   var stream = countStream(10);
   var sum = await sumStream(stream);
   print(sum); // 55

--- a/examples/misc/lib/tutorial/sum_stream_with_catch.dart
+++ b/examples/misc/lib/tutorial/sum_stream_with_catch.dart
@@ -21,7 +21,7 @@ Stream<int> countStream(int to) async* {
   }
 }
 
-Future<void> main() async {
+void main() async {
   var stream = countStream(10);
   var sum = await sumStream(stream);
   print(sum); // -1

--- a/examples/misc/test/library_tour/io_test.dart
+++ b/examples/misc/test/library_tour/io_test.dart
@@ -13,7 +13,7 @@ import 'package:examples_util/print_matcher.dart' as m;
 void main() {
   test('readAsString, readAsLines', () async {
     // #docregion readAsString
-    Future<void> main() async {
+    void main() async {
       var config = File('test_data/config.txt');
 
       // Put the whole file in a single string.
@@ -34,7 +34,7 @@ void main() {
 
   test('readAsBytes', () {
     // #docregion readAsBytes
-    Future<void> main() async {
+    void main() async {
       var config = File('test_data/config.txt');
 
       var contents = await config.readAsBytes();
@@ -47,7 +47,7 @@ void main() {
 
   test('try-catch', () {
     // #docregion try-catch
-    Future<void> main() async {
+    void main() async {
       var config = File('does-not-exist.txt');
       try {
         var contents = await config.readAsString();
@@ -88,7 +88,7 @@ void main() {
 
   test('list-dir', () {
     // #docregion list-dir
-    Future<void> main() async {
+    void main() async {
       var dir = Directory('test_data');
 
       try {
@@ -111,7 +111,7 @@ void main() {
 
   test('client-server', () async {
     // #docregion client
-    Future<void> main() async {
+    void main() async {
       var url = Uri.parse('http://localhost:8888/dart');
       var httpClient = HttpClient();
       var request = await httpClient.getUrl(url);
@@ -141,7 +141,7 @@ void main() {
 // included in the excerpt.
 
 // #docregion read-from-stream
-Future<void> main_test_read_from_stream() async {
+void main_test_read_from_stream() async {
   var config = File('test_data/config.txt');
   Stream<List<int>> inputStream = config.openRead();
 

--- a/src/_articles/libraries/dart-io.md
+++ b/src/_articles/libraries/dart-io.md
@@ -99,7 +99,7 @@ class.
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   var file = File(Platform.script.toFilePath());
   print(await (file.readAsString(encoding: ascii)));
 }
@@ -129,7 +129,7 @@ until it encounters the char code for `;`.
 ```dart
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final semicolon = ';'.codeUnitAt(0);
   final result = <int>[];
 
@@ -166,7 +166,7 @@ this stream (using `await for`) and the data is given in chunks.
 ```dart
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final result = <int>[];
 
   Stream<List<int>> stream = File(Platform.script.toFilePath()).openRead();
@@ -206,7 +206,7 @@ need interactive control over the process.
 ```dart
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   // List all files in the current directory,
   // in UNIX-like operating systems.
   ProcessResult results = await Process.run('ls', ['-l']);
@@ -240,7 +240,7 @@ we use a
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final process = await Process.start('ls', ['-l']);
   final lineStream = process.stdout
       .transform(const Utf8Decoder())
@@ -270,7 +270,7 @@ to pipe the output of the process to a file.
 ```dart
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final output = File('output.txt').openWrite();
   Process process = await Process.start('ls', ['-l']);
 
@@ -301,7 +301,7 @@ that just answers 'Hello, world' to any request.
 ```dart
 import 'dart:io';
 
-Future<void> main() async {
+void main() async {
   final server = await HttpServer.bind('127.0.0.1', 8082);
   await for (final request in server) {
     request.response.write('Hello, world');
@@ -361,7 +361,7 @@ Future<void> sendNotFound(HttpResponse response) async {
   await response.close();
 }
 
-Future<void> main() async {
+void main() async {
   // Compute base path for the request based on the location of the
   // script, and then start the server.
   final script = File(Platform.script.toFilePath());

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4197,7 +4197,7 @@ the body of `main()` must be marked as `async`:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (main)" replace="/async|await/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-Future<void> main() [!async!] {
+void main() [!async!] {
   checkVersion();
   print('In main: version is ${[!await!] lookUpVersion()}');
 }
@@ -4301,7 +4301,7 @@ the body of `main()` must be marked as `async`:
 
 <?code-excerpt "misc/lib/language_tour/async.dart (number_thinker)" replace="/async|await for/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-Future<void> main() [!async!] {
+void main() [!async!] {
   // ...
   [!await for!] (final request in requestServer) {
     handleRequest(request);

--- a/src/_guides/libraries/_dart-html-tour.md
+++ b/src/_guides/libraries/_dart-html-tour.md
@@ -337,7 +337,7 @@ to ensure that you have the data before continuing execution.
 
 <?code-excerpt "html/test/html_test.dart (getString)" plaster="none" replace="/await.*;/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-Future<void> main() async {
+void main() async {
   String pageHtml = [!await HttpRequest.getString(url);!]
   // Do something with pageHtml...
 }
@@ -361,7 +361,7 @@ retrieves, you can use the `request()` static method instead of
 
 <?code-excerpt "html/test/html_test.dart (request)" replace="/await.*;/[!$&!]/g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   HttpRequest req = await HttpRequest.request(
     url,
     method: 'HEAD',
@@ -418,7 +418,7 @@ String encodeMap(Map<String, String> data) => data.entries
         '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
     .join('&');
 
-Future<void> main() async {
+void main() async {
   const data = {'dart': 'fun', 'angular': 'productive'};
 
   var request = HttpRequest();

--- a/src/_guides/libraries/_dart-io-tour.md
+++ b/src/_guides/libraries/_dart-io-tour.md
@@ -45,7 +45,7 @@ strings.
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (readAsString)" replace="/\btest_data\///g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   var config = File('config.txt');
 
   // Put the whole file in a single string.
@@ -68,7 +68,7 @@ when it’s available.
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (readAsBytes)" replace="/\btest_data\///g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   var config = File('config.txt');
 
   var contents = await config.readAsBytes();
@@ -84,7 +84,7 @@ or (in an `async` function) use try-catch:
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (try-catch)" replace="/does-not-exist/config/g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   var config = File('config.txt');
   try {
     var contents = await config.readAsString();
@@ -107,7 +107,7 @@ or `await for`, part of Dart's
 import 'dart:io';
 import 'dart:convert';
 
-Future<void> main() async {
+void main() async {
   var config = File('config.txt');
   Stream<List<int>> inputStream = config.openRead();
 
@@ -160,7 +160,7 @@ when a file or directory is encountered.
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (list-dir)" replace="/\btest_data\b/tmp/g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   var dir = Directory('tmp');
 
   try {
@@ -211,7 +211,7 @@ the response is status code 404 (page not found).
 
 <?code-excerpt "misc/lib/library_tour/io/http_server.dart" replace="/\b_//g"?>
 ```dart
-Future<void> main() async {
+void main() async {
   final requests = await HttpServer.bind('localhost', 8888);
   await for (final request in requests) {
     processRequest(request);
@@ -247,7 +247,7 @@ Here’s an example of using HttpClient:
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (client)"?>
 ```dart
-Future<void> main() async {
+void main() async {
   var url = Uri.parse('http://localhost:8888/dart');
   var httpClient = HttpClient();
   var request = await httpClient.getUrl(url);

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1290,7 +1290,7 @@ looks more like synchronous code:
 
 <?code-excerpt "misc/lib/library_tour/async/stream.dart (await-for)" replace="/await for/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-Future<void> main(List<String> arguments) async {
+void main(List<String> arguments) async {
   // ...
   if (await FileSystemEntity.isDirectory(searchPath)) {
     final startingDir = Directory(searchPath);

--- a/src/_main-example.html
+++ b/src/_main-example.html
@@ -6,9 +6,9 @@ from sources in the example folder.
 <pre class="prettyprint lang-dart">
 <code><a tabindex="0" role="button" data-toggle="popover" data-content="Dart has one canonical way to import libraries, and one canonical (and easy) way to install library packages.">import</a> '<a tabindex="0" role="button" data-toggle="popover" data-content="The whole standard library is meticulously maintained. It has been called “well-crafted” by none other than Erik Meijer.">dart:math</a>' show Random;
 
-Future&lt;void&gt; <a tabindex="0" role="button" data-toggle="popover" data-content="The <code>main()</code> function is the single point of entry.">main()</a> async {
+void <a tabindex="0" role="button" data-toggle="popover" data-content="The <code>main()</code> function is the single point of entry.">main()</a> async {
   print('Compute <a tabindex="0" role="button" data-toggle="popover" data-content="Unicode support is baked in.">π</a> using the Monte Carlo method.');
-  <a tabindex="0" role="button" data-toggle="popover" data-content="Language-level asynchrony support makes you more productive when dealing with deeply asynchronous code (like most UI code, for example).">await</a> for (var estimate in computePi().take(500)) {
+  <a tabindex="0" role="button" data-toggle="popover" data-content="Language-level asynchrony support makes you more productive when dealing with deeply asynchronous code (like most UI code, for example).">await</a> for (final estimate in computePi().take(500)) {
     print('π ≅ <a tabindex="0" role="button" data-toggle="popover" data-content="String interpolation is easy. Just put <code>${expression}</code> or <code>$variable</code> in your string literal.">$estimate</a>');
   }
 }

--- a/src/_try-dart-examples.md
+++ b/src/_try-dart-examples.md
@@ -184,7 +184,7 @@ void main() {
 ```dart
 import 'dart:math' show Random;
 
-Future<void> main() async {
+void main() async {
   print('Compute π using the Monte Carlo method.');
   await for (final estimate in computePi().take(100)) {
     print('π ≅ $estimate');

--- a/src/_tutorials/language/streams.md
+++ b/src/_tutorials/language/streams.md
@@ -78,7 +78,7 @@ Stream<int> countStream(int to) async* {
   }
 }
 
-Future<void> main() async {
+void main() async {
   var stream = countStream(10);
   var sum = await sumStream(stream);
   print(sum); // 55
@@ -137,7 +137,7 @@ Stream<int> countStream(int to) async* {
   }
 }
 
-Future<void> main() async {
+void main() async {
   var stream = countStream(10);
   var sum = await sumStream(stream);
   print(sum); // -1
@@ -346,7 +346,7 @@ All lines are printed, except any that begin with a hashtag, `#`.
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main(List<String> args) async {
+void main(List<String> args) async {
   var file = File(args[0]);
   var lines = utf8.decoder
       .bind(file.openRead())

--- a/src/codelabs/async-await.md
+++ b/src/codelabs/async-await.md
@@ -355,7 +355,7 @@ Future<String> fetchUserOrder() {
   return Future.delayed(const Duration(seconds: 4), () => 'Large Latte');
 }
 
-Future<void> main() async {
+void main() async {
   countSeconds(4);
   await printOrderMessage();
 }
@@ -607,7 +607,7 @@ Future<String> fetchUserOrder() {
   return str;
 }
 
-Future<void> main() async {
+void main() async {
   await printOrderMessage();
 }
 ```

--- a/src/get-dart/sdk_builds.dart/example/print_latest_versions.dart
+++ b/src/get-dart/sdk_builds.dart/example/print_latest_versions.dart
@@ -9,7 +9,7 @@ import 'package:sdk_builds/sdk_builds.dart';
 
 final _dd = DartDownloads();
 
-Future<void> main() async {
+void main() async {
   try {
     await latest('stable');
     await latest('dev');

--- a/tool/effective-dart-rules/bin/main.dart
+++ b/tool/effective-dart-rules/bin/main.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as path;
 final _unescape = HtmlUnescape();
 final _anchorPattern = RegExp(r'(.+)\{#([^#]+)\}');
 
-Future<void> main(List<String> arguments) async {
+void main(List<String> arguments) async {
   const dirPath = 'src/_guides/language/effective-dart';
   const filenames = ['style.md', 'documentation.md', 'usage.md', 'design.md'];
 


### PR DESCRIPTION
@mit-mit I'm not sure what you discussed at the language team meeting, but it seems the desire is to not suggest using `Future<void>` for the main method. How do these changes look?