### PR TITLE
Fix installation method for Debian

### DIFF
--- a/src/get-dart/_linux.md
+++ b/src/get-dart/_linux.md
@@ -12,8 +12,8 @@ Perform the following **one-time setup**:
 ```terminal
 $ sudo apt-get update
 $ sudo apt-get install apt-transport-https
-$ sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-$ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+$ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+$ echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 ```
 Then install the Dart SDK:
 
@@ -25,7 +25,7 @@ $ sudo apt-get install dart
 #### Install a Debian package
 
 Alternatively, download Dart SDK [as a Debian package](#){:.debian-link-stable}
-in the `.deb` package format. 
+in the `.deb` package format.
 
 #### Modify PATH for access to all Dart binaries
 


### PR DESCRIPTION
Since Ubuntu 20.10, setting up APT repo key with `apt-key` is deprecated. It is recommended to specify separate key for 3rd-party repo. This PR is to update the guide to follow newer method.

This updated guide also avoid running shell with `sudo` to reduce security concern.