### PR TITLE
Simplify linter rule links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,6 @@ flutter_api: https://api.flutter.dev
 pub: https://pub.dev
 pub-api: https://pub.dev/documentation
 pub-pkg: https://pub.dev/packages
-lints: https://dart.dev/tools/linter-rules
 dartpad: https://dartpad.dev
 dartpad-embed: https://dartpad.dev/embed-dart.html
 dartpad-embed-html: https://dartpad.dev/embed-html.html

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -559,7 +559,7 @@ Use the following resources to learn more about static analysis in Dart:
 [diagnostics]: /tools/diagnostic-messages
 [invalid_assignment]: /tools/diagnostic-messages#invalid_assignment
 [language version]: /guides/language/evolution#language-versioning
-[linter rules]: {{site.lints}}
+[linter rules]: /tools/linter-rules
 [type-system]: /guides/language/type-system
 [dead_code]: /tools/diagnostic-messages#dead_code
 [disable individual rules]: #disabling-individual-rules

--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -331,7 +331,7 @@ To keep the preamble of your file tidy, we have a prescribed order that
 directives should appear in. Each "section" should be separated by a blank line.
 
 A single linter rule handles all the ordering guidelines:
-[directives_ordering.]({{site.lints}}#directives_ordering)
+[directives_ordering.](/tools/linter-rules#directives_ordering)
 
 
 ### DO place "dart:" imports before other imports.


### PR DESCRIPTION
The site shortcut no longer leads to a separate site, so the shortcut doesn't make sense and results in an external icon despite being unnecessary. 