### PR TITLE
Update mention of dartdevc supporting deferred library checks

### DIFF
--- a/src/tools/dartdevc/faq.md
+++ b/src/tools/dartdevc/faq.md
@@ -104,7 +104,7 @@ For more information, see
 
 [Lazily loading libraries][] is a production use case,
 and dartdevc isn't intended for production code.
-However, dartdevc does validate that
+However, dartdevc validates that
 when code uses a deferred library,
 that code first calls `loadLibrary()`.
 

--- a/src/tools/dartdevc/faq.md
+++ b/src/tools/dartdevc/faq.md
@@ -104,13 +104,11 @@ For more information, see
 
 [Lazily loading libraries][] is a production use case,
 and dartdevc isn't intended for production code.
-However, dartdevc could validate that
+However, dartdevc does validate that
 when code uses a deferred library,
 that code first calls `loadLibrary()`.
-For more information, see [SDK issue #27776.][27776]
 
 [Lazily loading libraries]: /guides/language/language-tour#lazily-loading-a-library
-[27776]: https://github.com/dart-lang/sdk/issues/27776
 
 
 ### Where can I see known problems with dartdevc?


### PR DESCRIPTION
The relevant issue(https://github.com/dart-lang/sdk/issues/27776) is now fixed and DDC now implements the mentioned checks.