### PR TITLE
Update homebrew switch version method to not recommend downgrading

### DIFF
--- a/src/get-dart/_mac.md
+++ b/src/get-dart/_mac.md
@@ -5,11 +5,13 @@ and then run the following commands:
 $ brew tap dart-lang/dart
 $ brew install dart
 ```
+
 {{site.alert.important}}
-  Make sure the **Homebrew `bin` directory is in your `PATH`**. Setting up the
-  path correctly makes it easier to use Dart SDK commands such as `dart` and
-  `dart format`. For help setting up your path, consult the [Homebrew
-  FAQ.](https://docs.brew.sh/FAQ)
+  Make sure the **Homebrew `bin` directory is in your `PATH`**. 
+  Setting up the  path correctly makes it easier to use Dart SDK commands
+  such as `dart run` and `dart format`. 
+  For help setting up your path, 
+  consult the [Homebrew FAQ.](https://docs.brew.sh/FAQ)
 {{site.alert.end}}
 
 To upgrade when a new release of Dart is available:
@@ -18,22 +20,20 @@ To upgrade when a new release of Dart is available:
 $ brew upgrade dart
 ```
 
-To switch between locally installed Dart releases, use
-`brew switch dart <version>`. Example:
+To switch between locally installed Dart releases, 
+first install the version you want to switch to if you haven't.
+For example, to install Dart 2.12:
 
 ```terminal
-$ brew switch dart 2.12.4
+$ brew install dart@2.12
 ```
 
-{{site.alert.version-note}}
-  The `brew switch` command was removed
-  after the 2.6 release of Homebrew.
-  To continue using `brew switch`,
-  downgrade Homebrew to a 2.6 version:
-  ```terminal
-  $ cd /usr/local/Homebrew && git checkout 2.6.2
-  ```
-{{site.alert.end}}
+Then to switch between versions, 
+unlink the current version and link the desired version.
+
+```terminal
+$ brew unlink dart@<old> && brew unlink dart@<new> && brew link dart@<new>
+```
 
 To see which versions of Dart you've installed:
 

--- a/src/get-dart/_mac.md
+++ b/src/get-dart/_mac.md
@@ -8,9 +8,9 @@ $ brew install dart
 
 {{site.alert.important}}
   Make sure the **Homebrew `bin` directory is in your `PATH`**. 
-  Setting up the  path correctly makes it easier to use Dart SDK commands
+  Setting up the path correctly makes it easier to use Dart SDK commands
   such as `dart run` and `dart format`. 
-  For help setting up your path, 
+  For help configuring your path, 
   consult the [Homebrew FAQ.](https://docs.brew.sh/FAQ)
 {{site.alert.end}}
 


### PR DESCRIPTION
Recommending downgrading homebrew just to switch versions doesn't seem like a great long-term solution, potentially leaving users with security vulnerabilities in the future. 

I haven't had a chance to test this on a Mac yet. I should be able to soon but if anyone has one, that would be helpful! Thanks!

Staged (macOS tab): https://dart-dev--pr3840-fix-do-not-recommend-ist8uhzo.web.app/get-dart