### PR TITLE
Add a key binding to focus search input

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -14,7 +14,7 @@ sitemap: false
       <input type="hidden" name="cx" value="011220921317074318178:i4mscbaxtru">
       <input type="hidden" name="ie" value="UTF-8">
       <input type="hidden" name="hl" value="en">
-      <input type="search" name="q" id="q" autocomplete="off" placeholder="Enter keywords">
+      <input class="search-field" type="search" name="q" id="q" autocomplete="off" placeholder="Enter keywords">
     </form>
   </div>
 

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -35,7 +35,7 @@
         <input type="hidden" name="cx" value="011220921317074318178:_yy-tmb5t_i">
         <input type="hidden" name="ie" value="UTF-8">
         <input type="hidden" name="hl" value="en">
-        <input class="site-header__searchfield form-control" type="search" name="q" 
+        <input class="site-header__searchfield form-control search-field" type="search" name="q"
           id="q" autocomplete="off" placeholder="Search" aria-label="Search">
       </form>
     </li>

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -1,6 +1,7 @@
 <div id="sidenav" class="">
   <form action="/search/" class="site-header__search form-inline">
-    <input class="site-header__searchfield form-control" type="search" name="q" id="q" autocomplete="off" placeholder="Search" aria-label="Search">
+    <input class="site-header__searchfield form-control search-field" type="search" name="q"
+           id="q" autocomplete="off" placeholder="Search" aria-label="Search">
   </form>
 
   <div class="site-sidebar">

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -106,37 +106,41 @@ $(function () {
   // Initialize the video on the homepage, if it exists.
   initVideoModal();
 
-  setupSearchShortcut();
+  document.addEventListener('keydown', handleSearchShortcut);
 });
 
-function setupSearchShortcut() {
-  $(document).on('keydown', function (e) {
-    const activeElement = document.activeElement;
-    if (activeElement instanceof HTMLInputElement ||
-        activeElement instanceof HTMLTextAreaElement) {
-      return;
-    }
-    if (e.code === 'Slash') {
-      let parentElement;
-      if (document.body.classList.contains('open_menu')) {
-        parentElement = document.getElementById('sidenav');
-      } else {
-        const bodySearch = document.getElementById('in-content-search');
-        if (bodySearch !== null) {
-          parentElement = bodySearch;
-        } else {
-          parentElement = document.getElementById('cse-search-box');
-        }
-      }
+function handleSearchShortcut(event) {
+  const activeElement = document.activeElement;
+  if (activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement ||
+      event.code !== 'Slash'
+  ) {
+    return;
+  }
 
-      if (parentElement !== null) {
-        parentElement
-            .querySelector('.search-field')
-            .focus();
-        e.preventDefault();
-      }
+  let parentElement;
+  // If the sidebar is open, focus its search field
+  if (document.body.classList.contains('open_menu')) {
+    parentElement = document.getElementById('sidenav');
+  } else {
+    const bodySearch = document.getElementById('in-content-search');
+    // If the page has a search field in the body, focus that
+    if (bodySearch !== null) {
+      parentElement = bodySearch;
+    } else {
+      // Otherwise, fallback to the top navbar search field
+      parentElement = document.getElementById('cse-search-box');
     }
-  });
+  }
+
+  // If we found a search field, focus that
+  if (parentElement !== null) {
+    parentElement
+        .querySelector('.search-field')
+        .focus();
+    // Prevent the initial slash from showing up in the search field
+    event.preventDefault();
+  }
 }
 
 function switchBanner(galleryName) {

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -105,8 +105,39 @@ $(function () {
 
   // Initialize the video on the homepage, if it exists.
   initVideoModal();
+
+  setupSearchShortcut();
 });
 
+function setupSearchShortcut() {
+  $(document).on('keydown', function (e) {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement) {
+      return;
+    }
+    if (e.code === 'Slash') {
+      let parentElement;
+      if (document.body.classList.contains('open_menu')) {
+        parentElement = document.getElementById('sidenav');
+      } else {
+        const bodySearch = document.getElementById('in-content-search');
+        if (bodySearch !== null) {
+          parentElement = bodySearch;
+        } else {
+          parentElement = document.getElementById('cse-search-box');
+        }
+      }
+
+      if (parentElement !== null) {
+        parentElement
+            .querySelector('.search-field')
+            .focus();
+        e.preventDefault();
+      }
+    }
+  });
+}
 
 function switchBanner(galleryName) {
     $('#' + galleryName + ' .selector li').removeClass('highlight');


### PR DESCRIPTION
Adds a key binding ("/") to open and target the appropriate search bar:

- If the side menu is open, always targets its search bar.
- If the 404 page is open and the side menu is closed, targets its inline search bar.
- If the side menu is not open and it's not the 404 page, target the main nav search bar.

Closes https://github.com/dart-lang/site-www/issues/3785