### PR TITLE
Update mentioned SDK version to 2.16.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: site_www
 homepage: https://dart.dev
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.0

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "1.24.3",
-    "vers": "2.16.0"
+    "vers": "2.16.1"
   }
 }

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: site_scripts
 description: Utility scripts
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   crypto: ^3.0.1


### PR DESCRIPTION
The site is now tested and built with 2.16.1, so our mention and API links should reflect that.