### PR TITLE
Revert "Update template names for `dart create`"

### DIFF
--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -65,13 +65,13 @@ $ dart create --help
 ```
 
 You'll see a list of templates, including various web and server-side apps.
-One of the templates is named **console**.
+One of the templates is named **console-full**.
 
 Use the `dart create` command to
 generate a command-line app named `vector_victor`:
 
 ```terminal
-$ dart create -t console vector_victor 
+$ dart create -t console-full vector_victor 
 $ cd vector_victor
 ```
 

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -50,10 +50,10 @@ More information:
 ## 3. Create a small app
 
 Use the [`dart create`](/tools/dart-create) command
-and the `console` template to create a command-line app:
+and the `console-full` template to create a command-line app:
 
 ```terminal
-$ dart create -t console cli
+$ dart create -t console-full cli
 ```
 
 This command creates a small Dart app that has the following:

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -76,7 +76,7 @@ see the [migration guide][].
   For example:
 
   ```terminal
-  $ dart create -t console my_cli
+  $ dart create -t console-full my_cli
   $ cd my_cli
   $ dart migrate --apply-changes
   ```

--- a/src/tools/dart-create.md
+++ b/src/tools/dart-create.md
@@ -31,10 +31,11 @@ The following table shows the templates you can use:
 |------------------+------------------------------------------------------|
 | Template         | Description                                          |
 |------------------|------------------------------------------------------|
-| `console`        | A command-line application..                         |
-| `package`        | A package containing shared Dart libraries.         |
+| `console-simple` | A simple command-line app (the default template).    |
+| `console-full`   | A complete command-line app.                         |
+| `package-simple` | A starting point for Dart libraries or apps.         |
 | `server-shelf`   | A server built using [shelf][].                      |
-| `web`            | A web app built using core Dart libraries.           |
+| `web-simple`     | A web app built using core Dart libraries.           |
 {:.table .table-striped .nowrap}
 
 [shelf]: {{site.pub-pkg}}/shelf
@@ -68,16 +69,21 @@ $ dart create --help
 Create a new Dart project.
 
 Usage: dart create [arguments] <directory>
--h, --help                       Print this usage information.
--t, --template                   The project template to use.
+-h, --help        Print this usage information.
+-t, --template    The project template to use.
+                  [console-simple (default), console-full, package-simple, server-shelf, web-simple]
+    --[no-]pub    Whether to run 'pub get' after the project has been created.
+                  (defaults to on)
+    --force       Force project generation, even if the target directory already exists.
 
-          [console] (default)    A command-line application.
-          [package]              A package containing shared Dart libraries.
-          [server-shelf]         A server app using `package:shelf`
-          [web]                  A web app that uses only core Dart libraries.
+Run "dart help" to see global options.
 
-    --[no-]pub                   Whether to run 'pub get' after the project has been created.
-                                 (defaults to on)
-    --force                      Force project generation, even if the target directory already exists.
+Available templates:
+  console-simple: A simple command-line application. (default)
+    console-full: A command-line application sample.
+  package-simple: A starting point for Dart libraries or applications.
+    server-shelf: A server app using `package:shelf`
+      web-simple: A web app that uses only core Dart libraries.
+
 ```
 {% endcomment %}

--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -14,7 +14,7 @@ Here's how you might use the `dart` tool
 to create, analyze, test, and run an app:
 
 ```terminal
-$ dart create -t console my_app
+$ dart create -t console-full my_app
 $ cd my_app
 $ dart analyze
 $ dart test


### PR DESCRIPTION
As far as I can tell, these new names won't be supported until at least Dart 2.17, so I don't think we should merge these changes yet. Users will be confused if the specified templates don't work with their recent version of Dart.

Reverts dart-lang/site-www#3851