### PR TITLE
[2.17] Update template names for `dart create`

### DIFF
--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -65,13 +65,13 @@ $ dart create --help
 ```
 
 You'll see a list of templates, including various web and server-side apps.
-One of the templates is named **console-full**.
+One of the templates is named **console**.
 
 Use the `dart create` command to
 generate a command-line app named `vector_victor`:
 
 ```terminal
-$ dart create -t console-full vector_victor 
+$ dart create -t console vector_victor 
 $ cd vector_victor
 ```
 

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -50,10 +50,10 @@ More information:
 ## 3. Create a small app
 
 Use the [`dart create`](/tools/dart-create) command
-and the `console-full` template to create a command-line app:
+and the `console` template to create a command-line app:
 
 ```terminal
-$ dart create -t console-full cli
+$ dart create -t console cli
 ```
 
 This command creates a small Dart app that has the following:

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -76,7 +76,7 @@ see the [migration guide][].
   For example:
 
   ```terminal
-  $ dart create -t console-full my_cli
+  $ dart create -t console my_cli
   $ cd my_cli
   $ dart migrate --apply-changes
   ```

--- a/src/tools/dart-create.md
+++ b/src/tools/dart-create.md
@@ -31,11 +31,10 @@ The following table shows the templates you can use:
 |------------------+------------------------------------------------------|
 | Template         | Description                                          |
 |------------------|------------------------------------------------------|
-| `console-simple` | A simple command-line app (the default template).    |
-| `console-full`   | A complete command-line app.                         |
-| `package-simple` | A starting point for Dart libraries or apps.         |
+| `console`        | A command-line application..                         |
+| `package`        | A package containing shared Dart libraries.         |
 | `server-shelf`   | A server built using [shelf][].                      |
-| `web-simple`     | A web app built using core Dart libraries.           |
+| `web`            | A web app built using core Dart libraries.           |
 {:.table .table-striped .nowrap}
 
 [shelf]: {{site.pub-pkg}}/shelf
@@ -69,21 +68,16 @@ $ dart create --help
 Create a new Dart project.
 
 Usage: dart create [arguments] <directory>
--h, --help        Print this usage information.
--t, --template    The project template to use.
-                  [console-simple (default), console-full, package-simple, server-shelf, web-simple]
-    --[no-]pub    Whether to run 'pub get' after the project has been created.
-                  (defaults to on)
-    --force       Force project generation, even if the target directory already exists.
+-h, --help                       Print this usage information.
+-t, --template                   The project template to use.
 
-Run "dart help" to see global options.
+          [console] (default)    A command-line application.
+          [package]              A package containing shared Dart libraries.
+          [server-shelf]         A server app using `package:shelf`
+          [web]                  A web app that uses only core Dart libraries.
 
-Available templates:
-  console-simple: A simple command-line application. (default)
-    console-full: A command-line application sample.
-  package-simple: A starting point for Dart libraries or applications.
-    server-shelf: A server app using `package:shelf`
-      web-simple: A web app that uses only core Dart libraries.
-
+    --[no-]pub                   Whether to run 'pub get' after the project has been created.
+                                 (defaults to on)
+    --force                      Force project generation, even if the target directory already exists.
 ```
 {% endcomment %}

--- a/src/tools/dart-create.md
+++ b/src/tools/dart-create.md
@@ -31,7 +31,7 @@ The following table shows the templates you can use:
 |------------------+------------------------------------------------------|
 | Template         | Description                                          |
 |------------------|------------------------------------------------------|
-| `console`        | A command-line application..                         |
+| `console`        | A command-line application.                          |
 | `package`        | A package containing shared Dart libraries.         |
 | `server-shelf`   | A server built using [shelf][].                      |
 | `web`            | A web app built using core Dart libraries.           |

--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -14,7 +14,7 @@ Here's how you might use the `dart` tool
 to create, analyze, test, and run an app:
 
 ```terminal
-$ dart create -t console-full my_app
+$ dart create -t console my_app
 $ cd my_app
 $ dart analyze
 $ dart test


### PR DESCRIPTION
Related to: https://dart-review.googlesource.com/c/sdk/+/232800

Should not be merged until next stable release.

Fixes https://github.com/dart-lang/site-www/issues/3922