### PR TITLE
Try using Google Sans Mono to improve code font style

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -51,10 +51,10 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Display:wght@400&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Display:wght@400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script 
     src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"

--- a/src/_sass/core/_variables.scss
+++ b/src/_sass/core/_variables.scss
@@ -68,7 +68,7 @@ $site-color-sidebar-active: #1389FD;
 // Typography
 $font-size-base:            1.0rem; // 16px
 $font-family-base:          Roboto, sans-serif;
-$font-family-monospace:     "Roboto Mono", Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+$font-family-monospace:     "Google Sans Mono", "Roboto Mono", Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
 $google-font-family:        "Product Sans", $font-family-base;
 
 // Sidenav, toc, and footer
@@ -95,7 +95,7 @@ $site-font-family-gsans-display: 'Google Sans Display', 'Google Sans', 'Roboto',
 $site-font-family-base: $site-font-family-roboto;
 $site-font-family-alt: $site-font-family-gsans;
 $site-font-family-icon: 'Material Icons';
-$site-font-family-monospace: 'Roboto Mono', monospace;
+$site-font-family-monospace: 'Google Sans Mono', 'Roboto Mono', monospace;
 $site-font-icon: 24px/1 $site-font-family-icon;
 
 // Layout


### PR DESCRIPTION
Roboto Mono hasn't been the most readable looking in a lot of places, so I thought we should give Google Sans Mono a shot instead. So far, it seems like it is an improvement to readability overall, open to other's thoughts though!

We use some of the other Google Sans derivatives elsewhere on the site so it doesn't have any problems fitting in.

I recommend comparing the language tour:

**Staged:** https://dart-dev--pr3871-feature-use-google-s-eykjao42.web.app/guides/language/language-tour
**Live:** https://dart.dev/guides/language/language-tour