### PR TITLE
Revert "Remove jquery usage from os tabs"

### DIFF
--- a/src/assets/js/os-tabs.js
+++ b/src/assets/js/os-tabs.js
@@ -1,47 +1,35 @@
 function setupOsTabs() {
-  const tabs = document.querySelectorAll('.tabs__top-bar li');
-  const tabContents = document.querySelectorAll('.tabs__content');
+  "use strict";
+
+  var tabs = $('.tabs__top-bar li');
+  var tabContents = $('.tabs__content');
 
   function clearTabsCurrent() {
-    tabs.forEach(function (tab) {
-      tab.classList.remove('current');
-    });
-    tabContents.forEach(function (content) {
-      content.classList.remove('current');
-    });
+    tabs.removeClass('current');
+    tabContents.removeClass('current');
   }
 
-  tabs.forEach(function (tab) {
-    tab.addEventListener('click', function () {
-      clearTabsCurrent();
+  tabs.click(function () {
+    clearTabsCurrent();
 
-      const tabId = tab.getAttribute('data-tab');
-      tab.classList.add('current');
-      document.getElementById(tabId).classList.add('current');
-    });
+    var tab_id = $(this).attr('data-tab');
+
+    $(this).addClass('current');
+    $("#" + tab_id).addClass('current');
   });
 
-  // The following selects the correct default tab in /tutorials/server/get-started
+  // The following selects the correct default tab in /guides/get-started
   function selectOperatingSystemInTabs(osName) {
     clearTabsCurrent();
 
-    document
-        .querySelector("li[data-tab='tab-sdk-install-" + osName + "']")
-        .classList
-        .add('current');
-
-    document
-        .getElementById('tab-sdk-install-' + osName)
-        .classList
-        .add('current');
+    $("li[data-tab='tab-sdk-install-" + osName + "']").addClass('current');
+    $('#tab-sdk-install-' + osName).addClass('current');
   }
 
-  const userAgent = window.navigator.userAgent;
-
-  if (userAgent.indexOf("Mac") !== -1) {
+  if (window.navigator.userAgent.indexOf("Mac") != -1) {
     selectOperatingSystemInTabs('mac');
-  } else if (userAgent.indexOf("Linux") !== -1 &&
-      userAgent.indexOf("Android") === -1) {
+  } else if (window.navigator.userAgent.indexOf("Linux") != -1 &&
+             window.navigator.userAgent.indexOf("Android") == -1) {
     // Doesn't auto-select the Linux tab when on Android.
     selectOperatingSystemInTabs('linux');
   }


### PR DESCRIPTION
This is causing issues preventing some site interactive elements to fail to a NPE.

Reverts dart-lang/site-www#3869