### PR TITLE
Fix os-tabs error breaking interactive elements and CSS

### DIFF
--- a/src/assets/js/os-tabs.js
+++ b/src/assets/js/os-tabs.js
@@ -25,15 +25,19 @@ function setupOsTabs() {
   function selectOperatingSystemInTabs(osName) {
     clearTabsCurrent();
 
-    document
-        .querySelector("li[data-tab='tab-sdk-install-" + osName + "']")
-        .classList
-        .add('current');
+    const tabListItem = document
+        .querySelector("li[data-tab='tab-sdk-install-" + osName + "']");
 
-    document
-        .getElementById('tab-sdk-install-' + osName)
-        .classList
-        .add('current');
+    if (tabListItem) {
+      tabListItem.classList.add('current');
+    }
+
+    const installItem = document
+        .getElementById('tab-sdk-install-' + osName);
+
+    if (installItem) {
+      installItem.classList.add('current');
+    }
   }
 
   const userAgent = window.navigator.userAgent;


### PR DESCRIPTION
I accidentally introduced this bug when converting from jquery to vanilla JS, as jquery gracefully handled not finding the elements. These elements don't exist on every page, causing a NPE and breaking the loading of some interactive elements (menu button).

Supersedes https://github.com/dart-lang/site-www/pull/3875