### PR TITLE
Remove empty TOC on pub environment variables page

### DIFF
--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -2,6 +2,7 @@
 title: Configuring pub environment variables
 short-title: Pub environment variables
 description: How to configure your environment for Dart's package management tool, pub.
+toc: false
 ---
 
 Environment variables allow you to customize pub to suit your needs.


### PR DESCRIPTION
**Staged:** https://dart-dev--pr3898-fix-remove-empty-toc-qp9vg28t.web.app/tools/pub/environment-variables#optional-environment-variables