### PR TITLE
user-data in PUB_HOSTED_URL is no longer supported

### DIFF
--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -23,8 +23,10 @@ Environment variables allow you to customize pub to suit your needs.
   use the `PUB_HOSTED_URL` environment variable. For example:
 
 {% prettify sh tag=pre+code %}
-PUB_HOSTED_URL = http://user:password@177.0.0.1:9999
+PUB_HOSTED_URL = http://pub.example.com
 {% endprettify %}
+
+See also [overriding the default package repository](/tools/pub/custom-package-repositories#overriding-the-default-package-repository).
 
 {{site.alert.note}}
   If you are attempting to use `pub get` behind a corporate firewall

--- a/src/tools/pub/environment-variables.md
+++ b/src/tools/pub/environment-variables.md
@@ -22,11 +22,12 @@ Environment variables allow you to customize pub to suit your needs.
   To specify the location of a particular mirror server,
   use the `PUB_HOSTED_URL` environment variable. For example:
 
-{% prettify sh tag=pre+code %}
-PUB_HOSTED_URL = http://pub.example.com
-{% endprettify %}
+```shell
+PUB_HOSTED_URL = https://pub.example.com
+```
 
-See also [overriding the default package repository](/tools/pub/custom-package-repositories#overriding-the-default-package-repository).
+For more information about using a private package repository,
+see [Overriding the default package repository][].
 
 {{site.alert.note}}
   If you are attempting to use `pub get` behind a corporate firewall
@@ -37,3 +38,4 @@ See also [overriding the default package repository](/tools/pub/custom-package-r
 {{site.alert.end}}
 
 [`pub get` fails from behind a corporate firewall]: /tools/pub/troubleshoot#pub-get-fails-from-behind-a-corporate-firewall
+[Overriding the default package repository]: /tools/pub/custom-package-repositories#overriding-the-default-package-repository


### PR DESCRIPTION
Never realized that this was an advertised feature. In any case, we removed user-data support in the URL a while ago.

Having username and password in the URL is unfortunate for many reasons:
 * Using hosted-dependency syntax in `pubspec.yaml` would put secrets in `pubspec.yaml`.
 * The URL and embedded user-data is cached in `PUB_CACHE` (potentially leaking secrets and minimizing cache reuse).
 * The URL and embedded user-data is cached in `pubspec.lock` (I'm guessing, I didn't test it).

In any case, using `dart pub token add` is a much better solution, see:
https://dart.dev/tools/pub/custom-package-repositories