### PR TITLE
Add Unofficial Dart Community Discord to community page

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -12,13 +12,15 @@ For details, see our [code of conduct](/code-of-conduct).
 
 ## Stay informed
 
-* [Dart announce]({{site.group}}/d/forum/announce) -
-  Low traffic announcements of new releases, breaking changes,
+[Dart announce]({{site.group}}/d/forum/announce)
+: Low traffic announcements of new releases, breaking changes,
   and other important news. Recommended!
-* [@dart_lang](https://twitter.com/dart_lang) -
-  The official Twitter account.
-* [Dart blog](https://medium.com/dartlang) - 
-  The latest news and insights from a diverse group of Dart users.
+
+[@dart_lang](https://twitter.com/dart_lang)
+: The official Twitter account.
+
+[Dart blog](https://medium.com/dartlang)
+: The latest news and insights from a diverse group of Dart users.
 
 ## Join the conversation
 
@@ -26,29 +28,44 @@ Get answers and connect with Dart developers.
 
 #### Communities
 
-* [StackOverflow](https://stackoverflow.com/tags/dart) -
-  The best place for how-to questions.
-* [Gitter](https://gitter.im/dart-lang/home) -
-  Chat with Dart team and community members.
-* [Dart on Reddit](https://www.reddit.com/r/dartlang)
+[StackOverflow](https://stackoverflow.com/tags/dart)
+: The best place for how-to questions.
+
+[Gitter](https://gitter.im/dart-lang/home)
+: Chat with Dart team and community members.
+
+[Dart on Reddit](https://www.reddit.com/r/dartlang)
+: The subreddit for all things related to Dart.
+
+[The Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx)
+: Chat with other Dart developers and contributors.
+  Come get help, help others, work together, and discuss contributions.
 
 #### Google Groups
 
-* [General discussions]({{site.group}}/d/forum/misc)
-* [Dart analyzer]({{site.group}}/d/forum/analyzer-discuss)
+[General discussions]({{site.group}}/d/forum/misc)
+: Discuss miscellaneous Dart topics.
+
+[Dart analyzer]({{site.group}}/d/forum/analyzer-discuss)
+: Get help understanding the [Dart analyzer](/tools/dart-analyze).
 
 ## Contribute
 
-Dart is open source. Learn how to
+Dart is open source.
+Learn how to
 [contribute to the core SDK.](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md)
 
-* [Dart GitHub repositories](https://github.com/dart-lang/)
+[Dart GitHub repositories](https://github.com/dart-lang/)
+: Track new changes and contribute to various Dart projects.
   * [Core SDK](https://github.com/dart-lang/sdk/)
     ([issue tracker](https://github.com/dart-lang/sdk/issues/))
+  * [The Dart Language](https://github.com/dart-lang/language)
+    ([issue tracker](https://github.com/dart-lang/language/issues))
   * [This site](https://github.com/dart-lang/site-www/)
     ([issue tracker](https://github.com/dart-lang/site-www/issues/))
-* [Dart reviews]({{site.group}}/d/forum/reviews) -
-  High-traffic list of all core SDK code reviews.
+
+[Dart reviews]({{site.group}}/d/forum/reviews)
+: High-traffic list of all core SDK code reviews.
 
 ## Additional community resources
 

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -38,8 +38,7 @@ Get answers and connect with Dart developers.
 : The subreddit for all things related to Dart.
 
 [The Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx)
-: Chat with other Dart developers and contributors.
-  Come get help, help others, work together, and discuss contributions.
+: Chat with and get help from other Dart developers.
 
 #### Google Groups
 


### PR DESCRIPTION
Adds the [Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx) to the community page as it has over 100 members now and has proved to be a great place for discussion around Dart and for getting help.

Had a pre-existing PR before the infrastructure updates, this supersedes that.

Also adds a link to the language repository and formats the rest of the community page. 

**Staged:** https://dart-dev--pr3915-misc-add-dart-commun-4ec2aeow.web.app/community#join-the-conversation