### PR TITLE
Fixes and improvements to dart doc documentation

### DIFF
--- a/src/tools/dart-doc.md
+++ b/src/tools/dart-doc.md
@@ -9,30 +9,37 @@ creates API reference documentation
 from Dart source code.
 You can add descriptions to the generated documentation
 by using [documentation comments][],
-which can contain markdown formatting.
+which can contain [Markdown][] formatting.
 For guidance on writing doc comments,
 see the [documentation part of Effective Dart][effective doc].
 
 {{site.alert.note}}
-  To generate documentation, your package must pass [dart analyze][]
+  To generate documentation, 
+  you must first run [`dart pub get`](/tools/pub/cmd/pub-get)
+  and your package must pass [`dart analyze`](/tools/dart-analyze)
   without errors.
 {{site.alert.end}}
 
-Run `dart doc` from the root directory of your package. For example:
+Run `dart doc` from the root directory of your package. 
+For example:
 
 ```terminal
 $ cd my_app
+$ dart pub get
 $ dart doc .
 Documenting my_app...
 ...
 Success! Docs generated into /Users/me/projects/my_app/doc/api
 ```
 
-By default, the documentation files are static HTML files,
-placed in the `doc/api` directory. You can create the
-files in a different directory with the `--output-dir` flag.
+By default, 
+the documentation files are static HTML files,
+placed in the `doc/api` directory. 
+You can create the files in a different directory
+with the `--output` flag.
 
-For information on command-line options, use the `help` command:
+For information on command-line options, 
+use the `help` command:
 
 ```terminal
 $ dart help doc
@@ -40,7 +47,7 @@ $ dart help doc
 
 [documentation comments]: /guides/language/language-tour#documentation-comments
 [effective doc]: /guides/language/effective-dart/documentation
-[dart analyze]: /tools/dart-analyze
+[Markdown]: {{site.pub-pkg}}/markdown
 
 {% comment %}
 [PENDING: Add more help, info on commonly used options, links to examples of use.]


### PR DESCRIPTION
- Adds a mention that `dart pub get` is required: https://github.com/dart-lang/dartdoc/issues/2992
- Adds a link to the markdown package for more information
- Fixes mention to `--output` flag
- Improves some formatting and semantic line breaks