### PR TITLE
Update remaining DartPad links to be up to date

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,9 +35,6 @@ pub: https://pub.dev
 pub-api: https://pub.dev/documentation
 pub-pkg: https://pub.dev/packages
 dartpad: https://dartpad.dev
-dartpad-embed: https://dartpad.dev/embed-dart.html
-dartpad-embed-html: https://dartpad.dev/embed-html.html
-dartpad-embed-inline: https://dartpad.dev/embed-inline.html
 news: https://news.dartlang.org
 group: https://groups.google.com/a/dartlang.org
 

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -20,7 +20,7 @@ void _miscDeclAnalyzedButNotTested() {
     void printInts(List<int> a) => print(a);
 
     void main() {
-      var list = [];
+      final list = [];
       list.add(1);
       list.add('2');
       // ignore: stable, beta, dev, argument_type_not_assignable

--- a/examples/type_system/test/strong_test.dart
+++ b/examples/type_system/test/strong_test.dart
@@ -18,7 +18,7 @@ void main() {
     void printInts(List<int> a) => print(a);
 
     void main() {
-      var list = <int>[];
+      final list = <int>[];
       list.add(1);
       list.add(2);
       printInts(list);

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2661,11 +2661,6 @@ double distance = p.distanceTo(Point(4, 4));
 Use `?.` instead of `.` to avoid an exception
 when the leftmost operand is null:
 
-{% comment %}
-{{site.dartpad}}/0cb25997742ed5382e4a
-https://gist.github.com/0cb25997742ed5382e4a
-{% endcomment %}
-
 <?code-excerpt "misc/test/language_tour/classes_test.dart (safe-member-access)"?>
 ```dart
 // If p is non-null, set a variable equal to its y value.

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -73,7 +73,7 @@ void main() {
 }
 {% endprettify %}
 
-[Try it in DartPad]({{site.dartpad}}/f64e963cb5f894e2146c2b28d5efa4ed).
+[Try it in DartPad]({{site.dartpad}}/25074a51a00c71b4b000f33b688dedd0).
 
 ## What is soundness?
 
@@ -452,13 +452,6 @@ In the following example, you can assign a `MaineCoon` list to `myCats` because
 {% prettify dart tag=pre+code %}
 List<Cat> myCats = <[!MaineCoon!]>[];
 {% endprettify %}
-
-{% comment %}
-Gist:  https://gist.github.com/4a2a9bc2242042ba5338533d091213c0
-DartPad: {{site.dartpad}}/4a2a9bc2242042ba5338533d091213c0
-
-[Try it in DartPad]({{site.dartpad}}/4a2a9bc2242042ba5338533d091213c0).
-{% endcomment %}
 
 What about going in the other direction? 
 Can you assign an `Animal` list to a `List<Cat>`?

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -31,7 +31,7 @@ and `main()` creates a list and passes it to `printInts()`.
 void printInts(List<int> a) => print(a);
 
 void main() {
-  var list = [];
+  final list = [];
   list.add(1);
   list.add('2');
   printInts([!list!]);
@@ -66,7 +66,7 @@ that passes static analysis and runs with no errors or warnings.
 void printInts(List<int> a) => print(a);
 
 void main() {
-  var list = [!<int>!][];
+  final list = [!<int>!][];
   list.add(1);
   list.add([!2!]);
   printInts(list);

--- a/src/overview.md
+++ b/src/overview.md
@@ -113,8 +113,8 @@ class Point {
 {{site.alert.info}}
   This example is running in an embedded [DartPad](/tools/dartpad).
   You can also
-  <a href="{{site.dartpad}}/4d688b6e468fb4c53d312250f557ec5c"
-  target="_blank">open this example in its own window</a>.
+  <a href="{{site.dartpad}}/bc63d212c3252e44058ff76f34ef5730"
+  target="_blank" rel="noopener">open this example in its own window</a>.
 {{site.alert.end}}
 
 


### PR DESCRIPTION
Updates some snippets to match most up to date code and have more meaningful titles.

Also removes some old stale gists/DartPads that have not been used and are outdated. Can be found in git history if ever needed for reference.

Closes https://github.com/dart-lang/site-www/issues/3728