### PR TITLE
Mark os tabs event listener as passive

### DIFF
--- a/src/assets/js/os-tabs.js
+++ b/src/assets/js/os-tabs.js
@@ -18,7 +18,7 @@ function setupOsTabs() {
       const tabId = tab.getAttribute('data-tab');
       tab.classList.add('current');
       document.getElementById(tabId).classList.add('current');
-    });
+    }, {passive: true});
   });
 
   // The following selects the correct default tab in /tutorials/server/get-started


### PR DESCRIPTION
Indicates to the browser we won't cancel the default behavior of the click: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners