### PR TITLE
Switch to material icon for inline TOC expand button

### DIFF
--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -21,8 +21,8 @@
     Contents
     <button type="button" class="btn site-toc--button__page-top" aria-label="Page top"></button>
     {% if collapsible %}
-      <span class="{{include.id}}__toggle toc-toggle-down"><i class="fas fa-chevron-down"></i></span>
-      <span class="{{include.id}}__toggle toc-toggle-up"><i class="fas fa-chevron-up"></i></span>
+      <span class="{{include.id}}__toggle toc-toggle-down"><i class="material-icons">keyboard_arrow_down</i></span>
+      <span class="{{include.id}}__toggle toc-toggle-up"><i class="material-icons">keyboard_arrow_up</i></span>
     {% endif %}
   </header>
   {{toc}}

--- a/src/_sass/components/_toc.scss
+++ b/src/_sass/components/_toc.scss
@@ -120,6 +120,10 @@
       display: none;
     }
 
+    .toc-toggle-up, .toc-toggle-down {
+      user-select: none;
+    }
+
     &.toc-collapsed {
       .section-nav {
         max-height: 72px;


### PR DESCRIPTION
This allows it to match the sidebar where we already use the material icon version of this icon.

<img width="480" alt="New expand icon in inline TOC" src="https://user-images.githubusercontent.com/18372958/159718698-9b4cb3a5-01d8-4b8d-99bd-abd89784e27b.png">
