### PR TITLE
Effective Dart: Add back guidance about linking to the unnamed constructor

### DIFF
--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -85,7 +85,7 @@ void miscDeclAnalyzedButNotTested() {
     void method1() {}
 
     // #docregion ctor
-    /// To create a point, call [Point.new()] or use [Point.polar()] to ...
+    /// To create a point, call [Point.new] or use [Point.polar()] to ...
     // #enddocregion ctor
     void method2() {}
   };

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -85,7 +85,7 @@ void miscDeclAnalyzedButNotTested() {
     void method1() {}
 
     // #docregion ctor
-    /// To create a point, call [Point.new] or use [Point.polar()] to ...
+    /// To create a point, call [Point.new] or use [Point.polar] to ...
     // #enddocregion ctor
     void method2() {}
   };

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -85,7 +85,7 @@ void miscDeclAnalyzedButNotTested() {
     void method1() {}
 
     // #docregion ctor
-    /// To create a point from polar coordinates, use [Point.polar()].
+    /// To create a point, call [Point.new()] or use [Point.polar()] to ...
     // #enddocregion ctor
     void method2() {}
   };

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -335,7 +335,7 @@ constructor, use `.new` after the class name:
 {:.good}
 <?code-excerpt "docs_good.dart (ctor)"?>
 {% prettify dart tag=pre+code %}
-/// To create a point, call [Point.new()] or use [Point.polar()] to ...
+/// To create a point, call [Point.new] or use [Point.polar()] to ...
 {% endprettify %}
 
 ### DO use prose to explain parameters, return values, and exceptions.

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -335,7 +335,7 @@ constructor, use `.new` after the class name:
 {:.good}
 <?code-excerpt "docs_good.dart (ctor)"?>
 {% prettify dart tag=pre+code %}
-/// To create a point, call [Point.new] or use [Point.polar()] to ...
+/// To create a point, call [Point.new] or use [Point.polar] to ...
 {% endprettify %}
 
 ### DO use prose to explain parameters, return values, and exceptions.

--- a/src/_guides/language/effective-dart/documentation.md
+++ b/src/_guides/language/effective-dart/documentation.md
@@ -329,12 +329,13 @@ separated by a dot:
 /// Similar to [Duration.inDays], but handles fractional days.
 {% endprettify %}
 
-The dot syntax can also be used to refer to named constructors:
+The dot syntax can also be used to refer to named constructors. For the unnamed
+constructor, use `.new` after the class name:
 
 {:.good}
 <?code-excerpt "docs_good.dart (ctor)"?>
 {% prettify dart tag=pre+code %}
-/// To create a point from polar coordinates, use [Point.polar()].
+/// To create a point, call [Point.new()] or use [Point.polar()] to ...
 {% endprettify %}
 
 ### DO use prose to explain parameters, return values, and exceptions.


### PR DESCRIPTION
Effective Dart: Add back guidance about linking to the unnamed constructor

Now that Dart has constructor tear-offs and a consistent way to refer
to unnamed constructors, undo https://github.com/dart-lang/site-www/pull/3006
with the new `.new` syntax.