### PR TITLE
Introduce a new initializing parameters section to the language tour

### DIFF
--- a/examples/misc/lib/language_tour/classes/point.dart
+++ b/examples/misc/lib/language_tour/classes/point.dart
@@ -8,11 +8,11 @@ const double yOrigin = 0;
 
 // #docregion class-with-distanceTo, constructor-initializer
 class Point {
-  double x = 0;
-  double y = 0;
+  final double x;
+  final double y;
 
   // #enddocregion class-with-distanceTo, named-constructor
-  // Syntactic sugar for setting x and y
+  // Sets the x and y instance variables
   // before the constructor body runs.
   // #docregion class-with-distanceTo, named-constructor
   Point(this.x, this.y);

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -10,7 +10,8 @@ class Point {
   double y = 0;
 
   Point(double x, double y) {
-    // There's a better way to do this, stay tuned.
+    // See initializing parameters for a better way
+    // to initialize instance variables.
     this.x = x;
     this.y = y;
   }

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -6,8 +6,8 @@
 ///
 // #docregion constructor-long-way
 class Point {
-  final double? x;
-  final double? y;
+  double x = 0;
+  double y = 0;
 
   Point(double x, double y) {
     // There's a better way to do this, stay tuned.

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -6,8 +6,8 @@
 ///
 // #docregion constructor-long-way
 class Point {
-  double x = 0;
-  double y = 0;
+  final double? x;
+  final double? y;
 
   Point(double x, double y) {
     // There's a better way to do this, stay tuned.

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2850,7 +2850,8 @@ class Point {
   double y = 0;
 
   Point(double x, double y) {
-    // See initializing parameters for a better way to do this
+    // See initializing parameters for a better way
+    // to initialize instance variables.
     this.x = x;
     this.y = y;
   }

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2860,24 +2860,33 @@ class Point {
 The `this` keyword refers to the current instance.
 
 {{site.alert.note}}
-  Use `this` only when there is a name conflict. Otherwise, Dart style
-  omits the `this`.
+  Use `this` only when there is a name conflict. 
+  Otherwise, Dart style omits the `this`.
 {{site.alert.end}}
 
+
+#### Initializing parameters
+
 The pattern of assigning a constructor argument to an instance variable
-is so common, Dart has syntactic sugar to make it easy:
+is so common, 
+Dart has initializing parameters to make it easy.
+
+Initializing parameters can also be used to initialize
+non-nullable or `final` instance variables,
+which both must be initialized or provided a default value.
 
 <?code-excerpt "misc/lib/language_tour/classes/point.dart (constructor-initializer)" plaster="none"?>
 ```dart
 class Point {
-  double x = 0;
-  double y = 0;
+  final double x;
+  final double y;
 
-  // Syntactic sugar for setting x and y
+  // Sets the x and y instance variables
   // before the constructor body runs.
   Point(this.x, this.y);
 }
 ```
+
 
 #### Default constructors
 
@@ -3166,8 +3175,8 @@ instance method:
 import 'dart:math';
 
 class Point {
-  double x = 0;
-  double y = 0;
+  final double x;
+  final double y;
 
   Point(this.x, this.y);
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2850,7 +2850,7 @@ class Point {
   double y = 0;
 
   Point(double x, double y) {
-    // There's a better way to do this, stay tuned.
+    // See initializing parameters for a better way to do this
     this.x = x;
     this.y = y;
   }
@@ -2997,6 +2997,7 @@ class Employee extends Person {
   example, arguments can call static methods but not instance methods.
 {{site.alert.end}}
 
+
 #### Initializer list
 
 Besides invoking a superclass constructor, you can also initialize
@@ -3078,6 +3079,7 @@ class Point {
   Point.alongXAxis(double x) : this(x, 0);
 }
 ```
+
 
 #### Constant constructors
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2894,11 +2894,13 @@ If you don’t declare a constructor, a default constructor is provided
 for you. The default constructor has no arguments and invokes the
 no-argument constructor in the superclass.
 
+
 #### Constructors aren’t inherited
 
 Subclasses don’t inherit constructors from their superclass. A subclass
 that declares no constructors has only the default (no argument, no
 name) constructor.
+
 
 #### Named constructors
 
@@ -2911,8 +2913,8 @@ const double xOrigin = 0;
 const double yOrigin = 0;
 
 class Point {
-  double x = 0;
-  double y = 0;
+  final double x;
+  final double y;
 
   Point(this.x, this.y);
 
@@ -2927,6 +2929,7 @@ Remember that constructors are not inherited, which means that a
 superclass’s named constructor is not inherited by a subclass. If you
 want a subclass to be created with a named constructor defined in the
 superclass, you must implement that constructor in the subclass.
+
 
 #### Invoking a non-default superclass constructor
 


### PR DESCRIPTION
Introduces a new dedicated section to discuss initializing parameters as they are a now more important concept for constructors since non-nullable fields must initialized in the constructor definition or initializer list. This will allow the section to be linked to.

Also prepares for future additions related to super initializer parameters.

**Staged:** https://dart-dev--pr3960-feature-initializing-i5431kt1.web.app/guides/language/language-tour#initializing-parameters

_Makes progress towards https://github.com/dart-lang/site-www/issues/3753_