### PR TITLE
Add a light background style for alert code blocks

### DIFF
--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -577,9 +577,14 @@ h3.popover-header {
   margin-top: 32px;
   padding: 30px 30px;
 
-  pre, code {
+  code {
     background-color: transparent;
   }
+
+  pre {
+    background-color: #00000010;
+  }
+
   p:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
Previously code blocks had no background, making them indistinguishable from the rest of the alerts. This PR adds a slight background color that maintains the contrast but allows the code to be more identifiable. 

<img width="931" alt="image" src="https://user-images.githubusercontent.com/18372958/161639237-95f2c945-c5dd-41b6-bf96-f03a41b5b130.png">

Fixes #3935