### PR TITLE
Add integrity checks for CDN scripts

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -66,9 +66,15 @@
     <link href="{{css}}" rel="stylesheet" type="text/css">
   {% endfor -%}
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+          integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK"
+          crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"
+          integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+          crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js"
+          integrity="sha384-VHvPCCyXqtD5DqJeNxl2dtTyhF78xXNXdkwX1CZeRusQfRKp+tA7hAShOK/B/fQ2"
+          crossorigin="anonymous"></script>
 
   <script src="/assets/js/vendor/code-prettify/prettify.js"></script>
   <script src="/assets/js/vendor/code-prettify/lang-css.js"></script>


### PR DESCRIPTION
Addresses the recently introduced [code scanning alerts](https://github.com/dart-lang/site-www/security/code-scanning/4) for not including integrity checks on our CDN included scripts.