### PR TITLE
Adjust pub uploaders documentation for newer methods

### DIFF
--- a/src/_includes/pub-subcommands.md
+++ b/src/_includes/pub-subcommands.md
@@ -9,4 +9,3 @@
 * [`remove`](/tools/pub/cmd/pub-remove)
 * [`token`](/tools/pub/cmd/pub-token)
 * [`upgrade`](/tools/pub/cmd/pub-upgrade)
-* [`uploader`](/tools/pub/cmd/pub-uploader)

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -125,9 +125,11 @@ With pub you can publish packages and command-line apps.
 
 To share your Dart packages with the world, you can
 use the [`publish`](/tools/pub/cmd/pub-lish) subcommand to upload the
-package to the [pub.dev site]({{site.pub}}). The
-[`uploader`](/tools/pub/cmd/pub-uploader) subcommand enables specific
-users to modify and upload new versions of your package.
+package to the [pub.dev site]({{site.pub}}).
+For information on allowing other users 
+to modify and upload new versions of your package,
+see [Uploaders](/tools/pub/publishing#uploaders).
+
 
 #### Command-line apps
 

--- a/src/tools/pub/cmd/pub-uploader.md
+++ b/src/tools/pub/cmd/pub-uploader.md
@@ -4,10 +4,12 @@ description: Use dart pub uploader to add or remove uploaders for your Dart pack
 ---
 
 {{site.alert.warning}}
-  The `dart pub uploader` command is _deprecated_ and will be
-   removed in Dart 2.17. It won't work for earlier versions, either.
-  Package owners can manage uploaders using the admin page on pub.dev:
-  `https://pub.dev/packages/<package>/admin`.
+  The `dart pub uploader` command is _deprecated_ 
+  and will be removed in Dart 2.17. 
+  It won't work for earlier versions either.
+  For information on allowing other users
+  to modify and upload new versions of your package,
+  see [Uploaders](/tools/pub/publishing#uploaders).
 {{site.alert.end}}
 
 _Uploader_ is one of the commands of the [pub tool](/tools/pub/cmd).

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -168,8 +168,9 @@ and C are transitive ones.
 ## Uploader
 
 Someone who has administrative permissions for a package.
-A package uploader can upload new versions of the package,
-and they can also [add and remove other uploaders](/tools/pub/cmd/pub-uploader)
+A package uploader can upload new versions of the package, 
+and they can also 
+[add and remove other uploaders](/tools/pub/publishing#uploaders)
 for that package. 
 
 If a package has a verified publisher,

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -254,8 +254,9 @@ To change the automatically generated list of supported platforms,
 Whoever publishes the first version of a package automatically becomes
 the first and only person authorized to upload additional versions of that package.
 To allow or disallow other people to upload versions,
-use the [`dart pub uploader`][] command
-or transfer the package to a [verified publisher][].
+transfer the package to a [verified publisher][] or
+manage authorized uploaders on the admin page for the package:
+`https://pub.dev/packages/<package>/admin`.
 
 If a package has a verified publisher,
 then the pub.dev page for that package displays the publisher domain.
@@ -417,7 +418,6 @@ If you change your mind, you can remove the discontinued mark at any time.
 For more information, see the reference pages for the following `pub` commands:
 
 * [`dart pub publish`][]
-* [`dart pub uploader`][]
 
 [BSD 3-clause license]: https://opensource.org/licenses/BSD-3-Clause
 [Google Account]: https://support.google.com/accounts/answer/27441
@@ -426,7 +426,6 @@ For more information, see the reference pages for the following `pub` commands:
 [policy]: {{site.pub}}/policy
 [pub]: /guides/packages
 [`dart pub publish`]: /tools/pub/cmd/pub-lish
-[`dart pub uploader`]: /tools/pub/cmd/pub-uploader
 [pubspec]: /tools/pub/pubspec
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html
 [verified publisher]: /tools/pub/verified-publishers

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -413,12 +413,8 @@ Then go to the package's **Admin** tab,
 where you can mark the package as discontinued.
 If you change your mind, you can remove the discontinued mark at any time.
 
-## Resources
 
-For more information, see the reference pages for the following `pub` commands:
-
-* [`dart pub publish`][]
-
+[Create a verified publisher]: https://pub.dev/create-publisher
 [BSD 3-clause license]: https://opensource.org/licenses/BSD-3-Clause
 [Google Account]: https://support.google.com/accounts/answer/27441
 [Markdown]: {{site.pub-pkg}}/markdown


### PR DESCRIPTION
The goal is to begin to point people more directly to the website already instead of considering the command as a possibility when it will be removed very soon.

Fixes #3970

I created https://github.com/dart-lang/site-www/issues/3971 as a followup for when 2.17 is actually released.