### PR TITLE
Remove now unnecessary dart tool version note

### DIFF
--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -29,19 +29,6 @@ $ dart pub outdated
 $ dart pub upgrade
 ```
 
-{{site.alert.version-note}}
-  Before Dart 2.10, the `dart` tool was used only to run the
-  Dart VM.
-  In 2.10, new `dart` commands such as `analyze` and `test` were added
-  to replace functionality that was
-  previously provided by standalone command-line tools.
-  Those standalone tools—for example,
-  `dartanalyzer` and `pub`—are
-  now being [discontinued gradually][].
-{{site.alert.end}}
-
-[discontinued gradually]: https://github.com/dart-lang/sdk/issues/46100
-
 The following table shows which commands you can use with the `dart` tool.
 If you're developing for Flutter,
 you might use the [`flutter` tool][] instead.


### PR DESCRIPTION
This note is no longer necessary with `dart run` being present for a long time and the other commands now being migrated.

Contributes to https://github.com/dart-lang/site-www/issues/3910