### PR TITLE
Remove outdated `dart compile js` note

### DIFF
--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -267,12 +267,6 @@ produces deployable JavaScript.
 The [`webdev serve`][] command uses `dartdevc` by default, but you can switch
 to producing deployable JavaScript by using the `--release` flag.
 
-{{site.alert.version-note}}
-  Although we expect the `js` subcommand to replace the `dart2js` command,
-  as of Dart 2.12 `js` is missing
-  some of the more advanced flags available in `dart2js`.
-{{site.alert.end}}
-
 For more information, see the [`dart2js` documentation](/tools/dart2js).
 
 [`dartdevc`]: /tools/dartdevc


### PR DESCRIPTION
Since https://github.com/dart-lang/sdk/commit/10819f6e213ea21fdce9828311a6274aa8c36c22 (released with Dart 2.14), the `dart compile js` command forwards extra parameters and flags to `dart2js`. 

It's been 6 months since the release of 2.14 and most users would be using `dart2js` instead before then, but if anyone thinks a version note would be particularly helpful, let me know and I can add one. Thanks!