### PR TITLE
Extend `dart fix` tool documentation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -137,7 +137,7 @@
       { "source": "/go/analysis-server-protocol", "destination": "https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/doc/api.html", "type": 301 },
       { "source": "/go/cloud", "destination": "/server/google-cloud?utm_source=go-link&utm_medium=referral&utm_campaign=go-cloud", "type": 301 },
       { "source": "/go/core-lints", "destination": "https://github.com/dart-lang/lints", "type": 301 },
-      { "source": "/go/dart-fix", "destination": "https://github.com/dart-lang/sdk/blob/main/pkg/dartdev/doc/dart-fix.md", "type": 301 },
+      { "source": "/go/dart-fix", "destination": "/tools/dart-fix", "type": 301 },
       { "source": "/go/dartdoc-options-file", "destination": "https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml", "type": 301 },
       { "source": "/go/data-driven-fixes", "destination": "https://github.com/flutter/flutter/wiki/Data-driven-Fixes", "type": 301 },
       { "source": "/go/dot-packages-deprecation", "destination": "https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md", "type": 301 },

--- a/src/tools/dart-fix.md
+++ b/src/tools/dart-fix.md
@@ -1,15 +1,22 @@
 ---
 title: dart fix
-description: Help for bringing your code up-to-date.
+description: Command-line tool for applying analysis fixes and migrating API usages.
 toc: false
 ---
 
-The `dart fix` command (added in Dart 2.12)
+The `dart fix` command
 finds and fixes two types of issues:
 
-* Analysis issues that have associated automated fixes
+* Analysis issues identified by [`dart analyze`][]
+  that have associated automated fixes
   (sometimes called _quick-fixes_ or _code actions_)
+
+  To learn more about customizing the analysis issues identified,
+  see [Customizing static analysis](/guides/language/analysis-options).
 * Issues that have associated package API migration information
+
+  For information about how automated package API changes work,
+  see [Data driven fixes][] on the Flutter wiki.
 
 {% include tools/dart-tool-note.md %}
 
@@ -25,9 +32,5 @@ To apply the proposed changes, use the `--apply` flag:
 $ dart fix --apply
 ```
 
-For information about how automated package API changes work,
-see [dart.dev/go/dart-fix](/go/dart-fix).
-
-The `dart fix` command replaces [`dartfix`][].
-
-[`dartfix`]: {{site.pub-pkg}}/dartfix
+[`dart analyze`]: /tools/dart-analyze
+[Data driven fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes


### PR DESCRIPTION
- Adjusts redirect to point to dart.dev article since the content is repeated in both locations
- Expands on documentation of issues the tool fixes
- Remove mention of Dart 2.12 now that it's been more than a year
- Link to Flutter wiki's [Data driven fixes](https://github.com/flutter/flutter/wiki/Data-driven-Fixes) document which covers the migration type of fixes in detail

**Staged:** https://dart-dev--pr3978-misc-dart-fix-extend-ej3oy6to.web.app/tools/dart-fix