### PR TITLE
Cleanup sitewide shorthand usages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Dart
-description: Dart is a platform for building structured apps. It includes a language, a VM, libraries, tools, and compilers to many targets, including JavaScript.
+description: Dart is a client-optimized language for developing fast apps on any platform.
 url: https://dart.dev
 dev-url: https://dartlang-org-dev.firebaseapp.com
 repo:
@@ -25,10 +25,9 @@ toc:
   no_toc_section_class: no_toc_section # ignore if in no_toc_section element
 
 
-dart-site: '' 
-dart_vm: /server
+dart-site: ''
 flutter: https://flutter.dev
-flutter_docs: https://docs.flutter.dev
+flutter-docs: https://docs.flutter.dev
 dart_api: https://api.dart.dev
 flutter_api: https://api.flutter.dev
 pub: https://pub.dev
@@ -36,7 +35,6 @@ pub-api: https://pub.dev/documentation
 pub-pkg: https://pub.dev/packages
 dartpad: https://dartpad.dev
 news: https://news.dartlang.org
-group: https://groups.google.com/a/dartlang.org
 
 show_banner: true
 
@@ -96,11 +94,6 @@ og_image_vers: "?2"
 
 
 ## Site-wide shorthands
-
-os-list:
-  - Windows
-  - macOS
-  - Linux
 
 alert:
   important: >-

--- a/src/_articles/libraries/dart-io.md
+++ b/src/_articles/libraries/dart-io.md
@@ -19,7 +19,7 @@ by going through a couple of examples.
   When writing a Flutter app, use
   [Flutter-specific APIs]({{site.flutter_api}})
   instead of dart:io whenever possible. For example, use the
-  [Flutter asset support]({{site.flutter_docs}}/development/ui/assets-and-images) to load
+  [Flutter asset support]({{site.flutter-docs}}/development/ui/assets-and-images) to load
   images and other assets into your app.
 {{site.alert.end}}
 

--- a/src/_guides/json.md
+++ b/src/_guides/json.md
@@ -29,7 +29,7 @@ The following libraries and packages are useful across Dart platforms:
 
 ## Flutter resources
 
-[JSON and serialization]({{site.flutter_docs}}/development/data-and-backend/json)
+[JSON and serialization]({{site.flutter-docs}}/development/data-and-backend/json)
 : Shows how Flutter apps can serialize and deserialize both
   with dart:convert and with json_serializable.
 

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -77,7 +77,7 @@ and other suggested guidelines in
 [Effective Dart][]. Dart tools such as the
 [Dart compiler (`dart compile`)](/tools/dart-compile),
 [`dart analyze`](/tools/dart-analyze),
-[`flutter analyze`]({{site.flutter_docs}}/testing/debugging#the-dart-analyzer),
+[`flutter analyze`]({{site.flutter-docs}}/testing/debugging#the-dart-analyzer),
 and [JetBrains IDEs](/tools/jetbrains-plugin)
 use the analyzer package to evaluate your code.
 

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -238,7 +238,7 @@ In client apps, the result of a too-lengthy synchronous operation is often
 [janky (non-smooth) UI animation][jank].
 Worse, the UI might become completely unresponsive.
 
-[jank]: {{site.flutter_docs}}/perf/rendering
+[jank]: {{site.flutter-docs}}/perf/rendering-performance
 
 
 ### Background workers
@@ -252,7 +252,7 @@ is spawning a simple worker isolate that
 performs a computation and then exits.
 The worker isolate returns its result in a message when the worker exits.
 
-[json]: {{site.flutter_docs}}/cookbook/networking/background-parsing
+[json]: {{site.flutter-docs}}/cookbook/networking/background-parsing
 
 ![A figure showing a main isolate and a simple worker isolate](/guides/language/concurrency/images/isolate-bg-worker.png)
 
@@ -292,7 +292,7 @@ to implement isolates.
   move a single function call to a worker isolate.
 {{site.alert.end}}
 
- [Flutter `compute()` function]: {{site.flutter_docs}}/cookbook/networking/background-parsing#4-move-this-work-to-a-separate-isolate
+ [Flutter `compute()` function]: {{site.flutter-docs}}/cookbook/networking/background-parsing#4-move-this-work-to-a-separate-isolate
 
 
 ### Implementing a simple worker isolate

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -342,7 +342,7 @@ For more information about how language versioning works, see the
 [Dart FFI]: /guides/libraries/c-interop
 [dart-tool]: /tools/dart-tool
 [extension methods]: /guides/language/extension-methods
-[`flutter` tool]: {{site.flutter_docs}}/reference/flutter-cli
+[`flutter` tool]: {{site.flutter-docs}}/reference/flutter-cli
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language specification]: /guides/language/spec
 [language tour]: /guides/language/language-tour

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4401,7 +4401,7 @@ For more information, see the following:
 
 [Isolate.spawn()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-isolate/Isolate/spawn.html
 [TransferableTypedData]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-isolate/TransferableTypedData-class.html
-[background json]: {{site.flutter_docs}}/cookbook/networking/background-parsing
+[background json]: {{site.flutter-docs}}/cookbook/networking/background-parsing
 [Isolate sample app]: https://github.com/flutter/samples/tree/master/isolate_example
 
 
@@ -4636,7 +4636,7 @@ To learn more about Dart's core libraries, see
 [`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
 [extension methods page]: /guides/language/extension-methods
 [Flutter]: {{site.flutter}}
-[Flutter debug mode]: {{site.flutter_docs}}/testing/debugging#debug-mode-assertions
+[Flutter debug mode]: {{site.flutter-docs}}/testing/debugging#debug-mode-assertions
 [forEach()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/forEach.html
 [Function API reference]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 [`Future`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -231,7 +231,7 @@ to automatically create FFI wrappers from C header files.
 
 
 [Abi]: {{site.dart_api}}/stable/dart-ffi/Abi-class.html
-[binding]: {{site.flutter_docs}}/development/platform-integration/c-interop
+[binding]: {{site.flutter-docs}}/development/platform-integration/c-interop
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 [hello_world]: {{page.hw}}
 [primitives]: {{page.samples}}/primitives

--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -56,7 +56,7 @@ such as packages for mobile (Flutter) and web development.
 
 ### Flutter packages
 
-See [Using packages]({{site.flutter_docs}}/development/packages-and-plugins/using-packages)
+See [Using packages]({{site.flutter-docs}}/development/packages-and-plugins/using-packages)
 on the Flutter site.
 Or use the pub.dev site to [search for Flutter packages.]({{site.pub}}/flutter)
 

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -34,7 +34,7 @@ follow these links:
 
 1. [Package layout ](https://dart.dev/tools/pub/package-layout)
 2. [Flutter Favorite](https://flutter.dev/docs/development/packages-and-plugins/favorites)
-3. [Package scoring](https://pub.dev/help/scoring)
+3. [Package scoring]({{site.pub}}/help/scoring)
 4. [Verified publishers](https://dart.dev/tools/pub/verified-publishers)
 5. [Pubspec file](https://dart.dev/tools/pub/pubspec)
 
@@ -418,4 +418,4 @@ You’re the only person who can provide the information that the reader needs.
 [Make a README]: https://www.makeareadme.com
 [README Checklist]: https://github.com/ddbeck/readme-checklist/blob/main/checklist.md
 [style-guide]: https://developers.google.com/style/highlights
-[`yaml`]: https://pub.dev/packages/yaml 
+[`yaml`]: {{site.pub-pkg}}/yaml 

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -15,7 +15,7 @@ using the [`dart test`][] command
 (or, for Flutter apps, [`flutter test`][]).
 
 [`dart test`]: /tools/dart-test
-[`flutter test`]: {{site.flutter_docs}}/reference/flutter-cli
+[`flutter test`]: {{site.flutter-docs}}/reference/flutter-cli
 
 ## Kinds of testing
 
@@ -82,7 +82,7 @@ following packages are useful across Dart platforms:
 
 Use the following resources to learn more about testing Flutter apps:
 
-* [Testing Flutter Apps]({{site.flutter_docs}}/testing)<br>
+* [Testing Flutter Apps]({{site.flutter-docs}}/testing)<br>
   How to perform unit, widget, or integration tests on a Flutter app.
 * [flutter_test]({{site.flutter_api}}/flutter/flutter_test/flutter_test-library.html)<br>
   A testing library for Flutter built on top of package:test.

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -13,7 +13,7 @@ To stay on top of announcements, including breaking changes,
 join the [Dart announcements Google group][dart-announce]
 and follow the [Dart blog][].
 
-[flutter-whats-new]: {{site.flutter_docs}}/whats-new
+[flutter-whats-new]: {{site.flutter-docs}}/whats-new
 [dart-announce]: https://groups.google.com/a/dartlang.org/d/forum/announce
 [Dart blog]: https://medium.com/dartlang
 
@@ -31,7 +31,7 @@ see [Dart 2.16: Improved tooling and platform handling][].
 
 We [updated the website infrastructure][] to a Docker-based setup
 to enable [easier contributions][] and more closely align with
-the setup for [docs.flutter.dev]({{site.flutter_docs}}).
+the setup for [docs.flutter.dev]({{site.flutter-docs}}).
 
 In addition to other bug fixes and incremental improvements,
 we made the following changes to this site:

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -5,7 +5,7 @@ You can either download the Dart SDK directly
 or [download the Flutter SDK,][]
 which (as of Flutter 1.21) includes the full Dart SDK.
 
-[download the Flutter SDK,]: {{site.flutter_docs}}/get-started/install
+[download the Flutter SDK,]: {{site.flutter-docs}}/get-started/install
 
 <ul class="tabs__top-bar">
   <li class="tab-link current" data-tab="tab-sdk-install-windows">Windows</li>

--- a/src/_includes/web-tutorials.md
+++ b/src/_includes/web-tutorials.md
@@ -18,7 +18,7 @@ These tutorials cover topics relevant to Dart web apps.
     <p> Delete elements from the web page. </p>
   </div>
   <div class="card">
-    <h3><a href="{{site.flutter_docs}}/get-started/codelab-web">Use Flutter Web</a></h3>
+    <h3><a href="{{site.flutter-docs}}/get-started/codelab-web">Use Flutter Web</a></h3>
     <p>Write your first Flutter app on the web.</p>
   </div>
 </div>

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -40,7 +40,7 @@ in a well-built package.
   concepts are the same, and you can share packages between
   your Flutter and web or server-side apps.
   For more information, see the
-  [Flutter package documentation.]({{site.flutter_docs}}/development/packages-and-plugins/using-packages)
+  [Flutter package documentation.]({{site.flutter-docs}}/development/packages-and-plugins/using-packages)
 {{site.alert.end}}
 
 
@@ -285,7 +285,7 @@ use the `package:` prefix.
    so that it imports the vector_math library and uses some of its API.
    For inspiration, look at the
    [vector_math API
-   docs]({{site.pub}}/documentation/vector_math/latest),
+   docs]({{site.pub-api}}/vector_math/latest),
    which you can find from the pub.dev site entry.
 
    {{site.alert.note}}

--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -39,4 +39,4 @@ which was introduced in Dart 2.12.
 ## Flutter
 
 To learn about Flutter, try one of the
-[Flutter codelabs.]({{site.flutter_docs}}/codelabs)
+[Flutter codelabs.]({{site.flutter-docs}}/codelabs)

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -2,6 +2,7 @@
 permalink: /community
 title: Community and support
 description: Communities, mailing lists, and bug databases for the Dart project.
+group: https://groups.google.com/a/dartlang.org
 ---
 
 Track the Dart project, get help, and talk with other Dart developers.
@@ -12,7 +13,7 @@ For details, see our [code of conduct](/code-of-conduct).
 
 ## Stay informed
 
-[Dart announce]({{site.group}}/d/forum/announce)
+[Dart announce]({{page.group}}/d/forum/announce)
 : Low traffic announcements of new releases, breaking changes,
   and other important news. Recommended!
 
@@ -42,10 +43,10 @@ Get answers and connect with Dart developers.
 
 #### Google Groups
 
-[General discussions]({{site.group}}/d/forum/misc)
+[General discussions]({{page.group}}/d/forum/misc)
 : Discuss miscellaneous Dart topics.
 
-[Dart analyzer]({{site.group}}/d/forum/analyzer-discuss)
+[Dart analyzer]({{page.group}}/d/forum/analyzer-discuss)
 : Get help understanding the [Dart analyzer](/tools/dart-analyze).
 
 ## Contribute
@@ -63,7 +64,7 @@ Learn how to
   * [This site](https://github.com/dart-lang/site-www/)
     ([issue tracker](https://github.com/dart-lang/site-www/issues/))
 
-[Dart reviews]({{site.group}}/d/forum/reviews)
+[Dart reviews]({{page.group}}/d/forum/reviews)
 : High-traffic list of all core SDK code reviews.
 
 ## Additional community resources

--- a/src/dart-2.md
+++ b/src/dart-2.md
@@ -167,9 +167,9 @@ environment:
 [dartdevc]: /tools/dartdevc
 [build system]: https://github.com/dart-lang/build/tree/master/docs
 [automated tests]: /guides/testing
-[Flutter analyzer]: {{site.flutter_docs}}/testing/debugging#the-dart-analyzer
+[Flutter analyzer]: {{site.flutter-docs}}/testing/debugging#the-dart-analyzer
 [dart analyze]: /tools/dart-analyze
-[flutter pub upgrade]: {{site.flutter_docs}}/development/packages-and-plugins/using-packages#updating-package-dependencies
+[flutter pub upgrade]: {{site.flutter-docs}}/development/packages-and-plugins/using-packages#updating-package-dependencies
 [dart pub upgrade]: /guides/packages#upgrading-a-dependency
 [dart2_fix]: https://github.com/dart-archive/dart2_fix
 [apiref]: {{site.dart_api}}/dev
@@ -180,7 +180,7 @@ environment:
 [Dart Language Specification]: /guides/language/spec
 [dart-lang/sdk CHANGELOG]: https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#200---2018-08-07
 [Fixing Common Type Problems]: /guides/language/sound-problems
-[Flutter SDK upgrade]: {{site.flutter_docs}}/development/tools/sdk/upgrading
+[Flutter SDK upgrade]: {{site.flutter-docs}}/development/tools/sdk/upgrading
 [Dart SDK install]: /get-dart
 [Leaf's email]: https://groups.google.com/d/msg/flutter-dev/H8dDhWg_c8I/_Ql78q_6AgAJ
 [prerelease]: /get-dart#release-channels

--- a/src/faq.md
+++ b/src/faq.md
@@ -197,7 +197,7 @@ Inside or outside of Google, [every Flutter app][FlutterShowcase] uses Dart.
 [DDC]: https://github.com/dart-lang/sdk/tree/main/pkg/dev_compiler#dev_compiler
 [strong mode]: /guides/language/type-system
 [Dart's type system]: /guides/language/type-system
-[Flutter no mirrors]: {{site.flutter_docs}}/resources/faq#does-flutter-come-with-a-reflection--mirrors-system
+[Flutter no mirrors]: {{site.flutter-docs}}/resources/faq#does-flutter-come-with-a-reflection--mirrors-system
 [FlutterShowcase]: {{site.flutter}}/showcase
 
 ---

--- a/src/multiplatform-apps.md
+++ b/src/multiplatform-apps.md
@@ -22,7 +22,7 @@ and a [Dart-to-JavaScript compiler](/overview#web-platform) for web code —
 create fast production code for any platform.
 
 <p class="text-center"> 
-  <a href="{{site.flutter_docs}}/get-started" class="btn btn-primary btn-lg no-automatic-external">
+  <a href="{{site.flutter-docs}}/get-started" class="btn btn-primary btn-lg no-automatic-external">
     <img src="/assets/img/shared/flutter/icon/64.png" width="32px" alt="Flutter">
     Get started
   </a>

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -6,7 +6,7 @@ smartherd-playlist-id: PLlxmoA0rQ-LyHW9voBdNo4gEEIh0SjG-q
 ---
 
 Here are some videos about the Dart language and core libraries.
-For more videos, see the [Flutter video page.]({{site.flutter_docs}}/resources/videos)
+For more videos, see the [Flutter video page.]({{site.flutter-docs}}/resources/videos)
 If you'd like other videos to be listed on this page,
 [let us know.](https://github.com/dart-lang/site-www/issues)
 

--- a/src/tools/dart-devtools.md
+++ b/src/tools/dart-devtools.md
@@ -168,17 +168,17 @@ displaying information about the target app.
 Click **Debugger** to start debugging the app.
 
 
-[App size tool]: {{site.flutter_docs}}/development/tools/devtools/app-size
+[App size tool]: {{site.flutter-docs}}/development/tools/devtools/app-size
 [Chrome DevTools.]: https://developer.chrome.com/docs/devtools/
 [Command-line]: #using-devtools-with-a-command-line-app
-[CPU profiler]: {{site.flutter_docs}}/development/tools/devtools/cpu-profiler
-[Debugger]: {{site.flutter_docs}}/development/tools/devtools/debugger
+[CPU profiler]: {{site.flutter-docs}}/development/tools/devtools/cpu-profiler
+[Debugger]: {{site.flutter-docs}}/development/tools/devtools/debugger
 [Debugging Dart web apps]: /web/debugging
-[Flutter inspector]: {{site.flutter_docs}}/development/tools/devtools/inspector
-[Flutter devtools]: {{site.flutter_docs}}/development/tools/devtools/overview
-[Logging view]: {{site.flutter_docs}}/development/tools/devtools/logging
-[Memory view]: {{site.flutter_docs}}/development/tools/devtools/memory
-[Network view]: {{site.flutter_docs}}/development/tools/devtools/network
+[Flutter inspector]: {{site.flutter-docs}}/development/tools/devtools/inspector
+[Flutter devtools]: {{site.flutter-docs}}/development/tools/devtools/overview
+[Logging view]: {{site.flutter-docs}}/development/tools/devtools/logging
+[Memory view]: {{site.flutter-docs}}/development/tools/devtools/memory
+[Network view]: {{site.flutter-docs}}/development/tools/devtools/network
 [Other web]: #using-devtools-with-a-non-flutter-web-app
-[Performance view]: {{site.flutter_docs}}/development/tools/devtools/performance
-[Timeline view]: {{site.flutter_docs}}/development/tools/devtools/timeline
+[Performance view]: {{site.flutter-docs}}/development/tools/devtools/performance
+[Timeline view]: {{site.flutter-docs}}/development/tools/devtools/timeline

--- a/src/tools/dart-test.md
+++ b/src/tools/dart-test.md
@@ -14,7 +14,7 @@ as described in [Testing Flutter apps][].
 
 [testing documentation]: /guides/testing
 [`test` package]: {{site.pub-pkg}}/test
-[Testing Flutter apps]: {{site.flutter_docs}}/testing
+[Testing Flutter apps]: {{site.flutter-docs}}/testing
 
 {% include tools/dart-tool-note.md %}
 

--- a/src/tools/dart-tool.md
+++ b/src/tools/dart-tool.md
@@ -33,7 +33,7 @@ The following table shows which commands you can use with the `dart` tool.
 If you're developing for Flutter,
 you might use the [`flutter` tool][] instead.
 
-[`flutter` tool]: {{site.flutter_docs}}/reference/flutter-cli
+[`flutter` tool]: {{site.flutter-docs}}/reference/flutter-cli
 
 |-----------+-----------------------------------------+-----------------------------------|
 | Command   | Example of use                          | More information                  |

--- a/src/tools/dartpad/troubleshoot.md
+++ b/src/tools/dartpad/troubleshoot.md
@@ -28,7 +28,7 @@ then try the following:
   **allow cookies for dartpad.dev**.
   If you're using embedded DartPads,
   such as in the [Dart cheatsheet codelab](/codelabs/dart-cheatsheet) or the
-  [implicit animations codelab]({{site.flutter_docs}}/codelabs/implicit-animations),
+  [implicit animations codelab]({{site.flutter-docs}}/codelabs/implicit-animations),
   you might need to allow cookies for the embedding site domain, as well
   (in these cases, **dart.dev** and **flutter.dev**, respectively).
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -11,7 +11,7 @@ If you aren't sure which tools you need, **get the Flutter SDK.**
 |------------+-----------------------------------+--------------------------|
 | App type   | Get started instructions          | Tool information         |
 |------------|-----------------------------------|--------------------------|
-| Flutter (mobile and more) | [Install Flutter]({{site.flutter_docs}}/get-started/install) | [Flutter tools]({{site.flutter_docs}}/using-ide) |
+| Flutter (mobile and more) | [Install Flutter]({{site.flutter-docs}}/get-started/install) | [Flutter tools]({{site.flutter-docs}}/using-ide) |
 | Web app (non-Flutter) | [Install the Dart SDK](/tools/sdk) | [General-purpose tools][] and [web tools](#web) |
 | Server or command line | [Install the Dart SDK](/tools/sdk) | [General-purpose tools][] and [specialized tools](#server) |
 {:.table .table-striped}

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -56,7 +56,7 @@ which (as of Flutter 1.21) includes the full Dart SDK.
 Choose one:
 
 * [Download the Dart SDK](/get-dart)
-* [Download the Flutter SDK]({{site.flutter_docs}}/get-started/install)
+* [Download the Flutter SDK]({{site.flutter-docs}}/get-started/install)
 
 
 ### Configuring Dart support

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -19,10 +19,10 @@ but if your current directory holds a Flutter app
 or other Flutter-specific code,
 use `flutter pub <subcommand>` instead.
 For more information, see
-[Using packages]({{site.flutter_docs}}/development/packages-and-plugins/using-packages)
+[Using packages]({{site.flutter-docs}}/development/packages-and-plugins/using-packages)
 on the [Flutter website]({{site.flutter}}).
 
-[flutter-cli]: {{site.flutter_docs}}/reference/flutter-cli
+[flutter-cli]: {{site.flutter-docs}}/reference/flutter-cli
 [dart-cli]: /tools/dart-tool
 
 {{site.alert.version-note}}

--- a/src/tools/pub/package-layout.md
+++ b/src/tools/pub/package-layout.md
@@ -14,7 +14,7 @@ package, and how to name things.
   **Note:**
   Flutter apps can use custom directories for their assets.
   For details, see
-  [Adding assets and images]({{site.flutter_docs}}/development/ui/assets-and-images)
+  [Adding assets and images]({{site.flutter-docs}}/development/ui/assets-and-images)
   on the [Flutter website.]({{site.flutter}})
   </div>
 </div></aside>

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -414,7 +414,7 @@ where you can mark the package as discontinued.
 If you change your mind, you can remove the discontinued mark at any time.
 
 
-[Create a verified publisher]: https://pub.dev/create-publisher
+[Create a verified publisher]: {{site.pub}}/create-publisher
 [BSD 3-clause license]: https://opensource.org/licenses/BSD-3-Clause
 [Google Account]: https://support.google.com/accounts/answer/27441
 [Markdown]: {{site.pub-pkg}}/markdown

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -85,7 +85,7 @@ Pub ignores all other fields,
 
 {{site.alert.info}}
   **Flutter note:** Pubspecs for [Flutter apps]({{site.flutter}}) can have
-  [additional fields]({{site.flutter_docs}}/development/tools/pubspec)
+  [additional fields]({{site.flutter-docs}}/development/tools/pubspec)
   for configuring the environment and managing assets.
 {{site.alert.end}}
 
@@ -318,7 +318,7 @@ platforms:
 {{site.alert.end}}
 
 [publish a package]: /tools/pub/publishing
-[plugin declarations]: {{site.flutter_docs}}/development/packages-and-plugins/developing-packages#plugin-platforms
+[plugin declarations]: {{site.flutter-docs}}/development/packages-and-plugins/developing-packages#plugin-platforms
 
 
 ### Publish_to

--- a/src/tools/vs-code.md
+++ b/src/tools/vs-code.md
@@ -17,6 +17,6 @@ other kinds of Dart apps:
 * [Visual Studio Code][vscode-flutter] on the Flutter site has
   details on using VS Code to develop Flutter apps.
 
-[setup]: {{site.flutter_docs}}/get-started/editor?tab=vscode
+[setup]: {{site.flutter-docs}}/get-started/editor?tab=vscode
 [vs-code]: https://code.visualstudio.com/
-[vscode-flutter]: {{site.flutter_docs}}/development/tools/vs-code
+[vscode-flutter]: {{site.flutter-docs}}/development/tools/vs-code


### PR DESCRIPTION
- Removes some unused shorthand options
- Standardizes `flutter_docs` to `flutter-docs` to match others
- Switches some links to use their shorthand equivalent
- Fixes link to https://docs.flutter.dev/perf/rendering-performance