### PR TITLE
Add archive support for Windows ARM64 builds

### DIFF
--- a/src/get-dart/archive/out/web/download_archive.dart.js
+++ b/src/get-dart/archive/out/web/download_archive.dart.js
@@ -3823,6 +3823,8 @@ Kh(a,b){var s,r=b.length
 if(r===0)return
 if(a===b)throw A.J(A.a4(a))
 for(s=0;s<r;++s)a.push(b[s])},
+V1(a){if(!!a.fixed$length)A.vh(A.u0("clear"))
+a.length=0},
 aN(a,b){var s,r=a.length
 for(s=0;s<r;++s){b.$1(a[s])
 if(a.length!==r)throw A.J(A.a4(a))}},
@@ -5554,7 +5556,7 @@ s=A.Fl(t.N,t.z)
 r=n.Cf()
 for(q=0;p=r.length,q<p;++q){o=r[q]
 s.Y5(0,o,n.q(0,o))}if(p===0)r.push("")
-else B.Nm.sB(r,0)
+else B.Nm.V1(r)
 n.a=n.b=null
 return n.c=s},
 fb(a){var s
@@ -7000,119 +7002,120 @@ A.TT(new A.wz(n,k)).Rz(0,q)
 n=l.querySelectorAll(o!=="all"?s+('[data-os="'+A.Ej(o)+'"]'):s)
 n.toString
 A.TT(new A.wz(n,k)).Rz(0,q)}},
-PS(b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4="data-version",b5="href"
-for(s=B.zu.gvc(),s=s.gkz(s),r=this.a,q="https://storage.googleapis.com/dart-archive/channels/"+r+"/release/",p=b6.a,o=t.bY,n=p.f,m=t.W,l=this.c,k=t.fD,r=r==="dev",j=b6.b.a,i=b6.c,h=i!=="stable",i=i==="beta";s.G();){g=s.gl()
-f=B.zu.q(0,g)
+PS(b7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5="data-version",b6="href"
+for(s=B.fj.gvc(),s=s.gkz(s),r=this.a,q="https://storage.googleapis.com/dart-archive/channels/"+r+"/release/",p=b7.a,o=t.bY,n=p.f,m=t.W,l=this.c,k=t.fD,j=b7.c,i=j!=="stable",j=j==="beta",r=r==="dev",h=b7.b.a;s.G();){g=s.gl()
+f=B.fj.q(0,g)
 if(f==null)f=B.iH
-for(e=f.length,d=g==="macOS",c=0;c<e;++c){b=f[c]
-if(B.OI.q(0,g)==="linux"){a=b.a
-if(a==="ARMv7")a0=j<A.Gl(r?"2015-10-21":"2015-08-31").a
-else a0=!1
-if(a0)continue
-else if(a==="ARMv8 (ARM64)"&&j<A.Gl("2017-03-09").a)continue
-else if(a==="RISC-V (RV64GC)"){if(p.iM(0,A.jm(2,17,0,"258.0.dev"))<0)continue
-if(!h||i)continue}}else if(d){a=b.a
-if(a==="IA32"){if(p.iM(0,A.jm(2,7,0,null))>0)continue}else if(a==="ARM64"&&p.iM(0,A.jm(2,14,1,null))<0)continue}a=l.tBodies
-a.toString
-a=new A.zO(a,k)
-if(a.gB(a)===0)A.vh(A.Wp())
-a1=m.a(J.oD(a.q(0,0),-1))
-a1.setAttribute(b4,n)
-a=B.OI.q(0,g)
-a1.setAttribute("data-os",a==null?"":a)
-a=a1.insertCell(-1)
-a.toString
-o.a(a)
-a.textContent=n
-a0=document
-a2=a0.createElement("span")
-a2.toString
-a2.textContent=" ("+A.Ej(A.yl(b6))+")"
-a3=a2.classList
-a3.contains("muted").toString
-a3.add("muted")
-a.appendChild(a2).toString
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2).textContent=g
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2)
-a3=a2.classList
-a3.contains("nowrap").toString
-a3.add("nowrap")
-a=b.a
-a2.textContent=a
-a4=["Dart SDK","Debian package"]
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2)
-a3=a2.classList
-a3.contains("archives").toString
-a3.add("archives")
-for(a5=b.b,a6=0;a6<2;++a6){a7=a4[a6]
-if(B.Nm.tg(a5,a7)){if(a7==="Dart Editor")continue
-a8=A.Ej(B.OI.q(0,a7))+"-"+A.Ej(B.OI.q(0,g))+"-"+A.Ej(B.OI.q(0,a))
-a9=a7==="Debian package"
-if(a9)if(p.iM(0,A.jm(2,0,0,null))<0)continue
-else a8="dart_"+A.C5(b6)
-b0=q+A.C5(b6)+"/"+A.Ej(B.d4.q(0,a7))+"/"+a8+A.Ej(B.EL.q(0,a7))
-b1=a0.createElement("a")
-b1.textContent=a7
-b1.setAttribute(b5,b0)
-a2.appendChild(b1).toString
-b2=A.En(b6)
-if(!a9)a9=b2==null||b2>38976
-else a9=!1
-if(a9){a9=a0.createTextNode(" ")
-a9.toString
-a2.appendChild(a9).toString
-b1=a0.createElement("a")
-b1.textContent="(SHA-256)"
-b1.setAttribute(b5,b0+".sha256sum")
-a3=b1.classList
-a3.contains("sha").toString
-a3.add("sha")
-a2.appendChild(b1).toString}a9=a0.createElement("br")
-a9.toString
-a2.appendChild(a9).toString}}}}s=l.tBodies
+for(e=f.length,d=g==="Windows",c=g==="macOS",b=0;b<e;++b){a=f[b]
+if(B.OI.q(0,g)==="linux"){a0=a.a
+if(a0==="ARMv7")a1=h<A.Gl(r?"2015-10-21":"2015-08-31").a
+else a1=!1
+if(a1)continue
+else if(a0==="ARMv8 (ARM64)"&&h<A.Gl("2017-03-09").a)continue
+else if(a0==="RISC-V (RV64GC)"){if(p.iM(0,A.jm(2,17,0,"258.0.dev"))<0)continue
+if(!i||j)continue}}else if(c){a0=a.a
+if(a0==="IA32"){if(p.iM(0,A.jm(2,7,0,null))>0)continue}else if(a0==="ARM64"&&p.iM(0,A.jm(2,14,1,null))<0)continue}else if(d)if(a.a==="ARM64"){if(p.iM(0,A.jm(2,18,0,"41.0.dev"))<0)continue
+if(!i||j)continue}a0=l.tBodies
+a0.toString
+a0=new A.zO(a0,k)
+if(a0.gB(a0)===0)A.vh(A.Wp())
+a2=m.a(J.oD(a0.q(0,0),-1))
+a2.setAttribute(b5,n)
+a0=B.OI.q(0,g)
+a2.setAttribute("data-os",a0==null?"":a0)
+a0=a2.insertCell(-1)
+a0.toString
+o.a(a0)
+a0.textContent=n
+a1=document
+a3=a1.createElement("span")
+a3.toString
+a3.textContent=" ("+A.Ej(A.yl(b7))+")"
+a4=a3.classList
+a4.contains("muted").toString
+a4.add("muted")
+a0.appendChild(a3).toString
+a3=a2.insertCell(-1)
+a3.toString
+o.a(a3).textContent=g
+a3=a2.insertCell(-1)
+a3.toString
+o.a(a3)
+a4=a3.classList
+a4.contains("nowrap").toString
+a4.add("nowrap")
+a0=a.a
+a3.textContent=a0
+a5=["Dart SDK","Debian package"]
+a3=a2.insertCell(-1)
+a3.toString
+o.a(a3)
+a4=a3.classList
+a4.contains("archives").toString
+a4.add("archives")
+for(a6=a.b,a7=0;a7<2;++a7){a8=a5[a7]
+if(B.Nm.tg(a6,a8)){if(a8==="Dart Editor")continue
+a9=A.Ej(B.OI.q(0,a8))+"-"+A.Ej(B.OI.q(0,g))+"-"+A.Ej(B.OI.q(0,a0))
+b0=a8==="Debian package"
+if(b0)if(p.iM(0,A.jm(2,0,0,null))<0)continue
+else a9="dart_"+A.C5(b7)
+b1=q+A.C5(b7)+"/"+A.Ej(B.zu.q(0,a8))+"/"+a9+A.Ej(B.EL.q(0,a8))
+b2=a1.createElement("a")
+b2.textContent=a8
+b2.setAttribute(b6,b1)
+a3.appendChild(b2).toString
+b3=A.En(b7)
+if(!b0)b0=b3==null||b3>38976
+else b0=!1
+if(b0){b0=a1.createTextNode(" ")
+b0.toString
+a3.appendChild(b0).toString
+b2=a1.createElement("a")
+b2.textContent="(SHA-256)"
+b2.setAttribute(b6,b1+".sha256sum")
+a4=b2.classList
+a4.contains("sha").toString
+a4.add("sha")
+a3.appendChild(b2).toString}b0=a1.createElement("br")
+b0.toString
+a3.appendChild(b0).toString}}}}s=l.tBodies
 s.toString
 k=new A.zO(s,k)
-a1=m.a(J.oD(k.gFV(k),-1))
-a1.setAttribute(b4,n)
-a1.setAttribute("data-os","api")
+a2=m.a(J.oD(k.gFV(k),-1))
+a2.setAttribute(b5,n)
+a2.setAttribute("data-os","api")
 k=document.createElement("span")
 k.toString
-k.textContent=" ("+A.Ej(A.yl(b6))+")"
-a3=k.classList
-a3.contains("muted").toString
-a3.add("muted")
-m=a1.insertCell(-1)
+k.textContent=" ("+A.Ej(A.yl(b7))+")"
+a4=k.classList
+a4.contains("muted").toString
+a4.add("muted")
+m=a2.insertCell(-1)
 m.toString
 o.a(m)
 m.textContent=n
 m.appendChild(k).toString
-k=a1.insertCell(-1)
+k=a2.insertCell(-1)
 k.toString
 o.a(k).textContent="---"
-k=a1.insertCell(-1)
+k=a2.insertCell(-1)
 k.toString
 o.a(k).textContent="---"
-k=a1.insertCell(-1)
+k=a2.insertCell(-1)
 k.toString
 o.a(k)
-a3=k.classList
-a3.contains("archives").toString
-a3.add("archives")
+a4=k.classList
+a4.contains("archives").toString
+a4.add("archives")
 p=p["["](0)
 o=A.J6()
 o.textContent="API docs"
-o.setAttribute(b5,q+p+"/api-docs/dartdocs-gen-api.zip")
+o.setAttribute(b6,q+p+"/api-docs/dartdocs-gen-api.zip")
 k.appendChild(o).toString
 l=l.querySelectorAll(".template")
 l.toString
-b3=new A.wz(l,t.Z)
-for(s=new A.a7(b3,b3.gB(b3)),r=A.Lh(s).c;s.G();){q=s.d
+b4=new A.wz(l,t.Z)
+for(s=new A.a7(b4,b4.gB(b4)),r=A.Lh(s).c;s.G();){q=s.d
 if(q==null)q=r.a(q)
 p=q.parentNode
 if(p!=null)p.removeChild(q).toString}}}
@@ -8474,7 +8477,7 @@ B.ea=A.QI(s([0,0,32754,11263,65534,34815,65534,18431]),t.t)
 B.Wd=A.QI(s([0,0,65490,12287,65535,34815,65534,18431]),t.t)
 B.Ux=A.QI(s(["Dart SDK","Debian package"]),t.s)
 B.EL=new A.LP(2,{"Dart SDK":"-release.zip","Debian package":"-1_amd64.deb"},B.Ux,t.w)
-B.d4=new A.LP(2,{"Dart SDK":"sdk","Debian package":"linux_packages"},B.Ux,t.w)
+B.zu=new A.LP(2,{"Dart SDK":"sdk","Debian package":"linux_packages"},B.Ux,t.w)
 B.e8=A.QI(s(["macOS","Linux","Windows"]),t.s)
 B.Vb=A.QI(s(["Dart SDK"]),t.s)
 B.pB=new A.mi("x64",B.Vb)
@@ -8486,8 +8489,8 @@ B.Cj=new A.mi("ARMv8 (ARM64)",B.Vb)
 B.hI=new A.mi("ARMv7",B.Vb)
 B.af=new A.mi("RISC-V (RV64GC)",B.Vb)
 B.La=A.QI(s([B.mb,B.x3,B.Cj,B.hI,B.af]),t.c)
-B.rQ=A.QI(s([B.pB,B.x3]),t.c)
-B.zu=new A.LP(3,{macOS:B.q9,Linux:B.La,Windows:B.rQ},B.e8,A.N0("LP<qU,zM<mi>>"))
+B.PV=A.QI(s([B.pB,B.x3,B.Lv]),t.c)
+B.fj=new A.LP(3,{macOS:B.q9,Linux:B.La,Windows:B.PV},B.e8,A.N0("LP<qU,zM<mi>>"))
 B.CM=new A.LP(0,{},B.xD,t.w)
 B.o6=A.QI(s(["29803","30107","30188","31822","30798","30036","32314","33014","34825","35530","36345","35121","36647","38663","37644","37972","37348","37942","39553","42013","41096","42039","42828","44672","45104","45396","45692","30039","29962","30104","30338","30187","30657","30821","31123","31329","30939","31777","31661","31736","31918","31818","32164","32242","32426","32688","32712","32844","32778","32954","33060","33192","33495","34229","33731","34463","34284","34497","34591","34792","34756","35275","35068","34683","35677","35890","35960","36091","35362","36146","36210","36284","36412","36341","36630","36542","36871","37028","37071","37223","37161","37360","37251","37302","37385","37438","37532","36979","37580","37475","37639","37743","37846","37936","38083","38145","38380","38621","38831","38967","39285","39401","39442","39661","39537","40090","39799","40675","40302","40806","40917","40987","41004","41090","41275","41389","41515","41684","41762","41923","41847","41793","41978","42033","41145","42684","42546","42856","42241","43384","43584","43903","44224","43715","44018","44260","44314","44550","44500","44532","44630","44728","44601","45054","45089","45201","45268","45369","45311","45519"]),t.s)
 B.xy=new A.LP(150,{"29803":"0.8.10-rev.3.29803","30107":"0.8.10-rev.10.30107","30188":"1.0.0-rev.3.30188","31822":"1.1.1","30798":"1.0.0-rev.10.30798","30036":"0.8.10-rev.6.30036","32314":"1.1.3","33014":"1.2.0","34825":"1.3.0","35530":"1.3.6","36345":"1.4.0","35121":"1.3.3","36647":"1.4.2","38663":"1.5.8","37644":"1.5.1","37972":"1.5.3","37348":"1.4.3","37942":"1.5.2","39553":"1.6.0","42013":"1.8.0","41096":"1.7.2","42039":"1.8.3","42828":"1.8.5","44672":"1.9.1","45104":"1.9.3","45396":"1.10.0","45692":"1.10.1","30039":"0.8.10-rev.8.30039","29962":"0.8.10-rev.6.29962","30104":"0.8.10-rev.10.30104","30338":"1.0.0-rev.7.30338","30187":"1.0.0-rev.3.30187","30657":"1.0.1-rev.3.30657","30821":"1.0.2-rev.1.30821","31123":"1.1.0-dev.4.0","31329":"1.1.0-dev.5.0","30939":"1.0.3-rev.0.30939","31777":"1.1.0-dev.5.10","31661":"1.1.0-dev.5.6","31736":"1.1.0-dev.5.9","31918":"1.2.0-dev.1.0","31818":"1.1.0-dev.5.11","32164":"1.2.0-dev.2.4","32242":"1.2.0-dev.3.2","32426":"1.2.0-dev.4.0","32688":"1.2.0-dev.5.7","32712":"1.2.0-dev.5.8","32844":"1.2.0-dev.5.12","32778":"1.2.0-dev.5.11","32954":"1.2.0-dev.5.15","33060":"1.3.0-dev.0.0","33192":"1.3.0-dev.1.1","33495":"1.3.0-dev.3.2","34229":"1.3.0-dev.5.2","33731":"1.3.0-dev.4.1","34463":"1.3.0-dev.7.2","34284":"1.3.0-dev.6.1","34497":"1.3.0-dev.7.5","34591":"1.3.0-dev.7.7","34792":"1.3.0-dev.7.12","34756":"1.3.0-dev.7.11","35275":"1.4.0-dev.3.0","35068":"1.4.0-dev.2.2","34683":"1.3.0-dev.7.10","35677":"1.4.0-dev.5.1","35890":"1.4.0-dev.6.2","35960":"1.4.0-dev.6.3","36091":"1.4.0-dev.6.5","35362":"1.4.0-dev.4.0","36146":"1.4.0-dev.6.6","36210":"1.4.0-dev.6.7","36284":"1.4.0-dev.6.8","36412":"1.5.0-dev.0.0","36341":"1.4.0-dev.6.9","36630":"1.5.0-dev.2.0","36542":"1.5.0-dev.1.1","36871":"1.5.0-dev.3.4","37028":"1.5.0-dev.4.1","37071":"1.5.0-dev.4.2","37223":"1.5.0-dev.4.7","37161":"1.5.0-dev.4.5","37360":"1.5.0-dev.4.13","37251":"1.5.0-dev.4.8","37302":"1.5.0-dev.4.11","37385":"1.5.0-dev.4.14","37438":"1.5.0-dev.4.15","37532":"1.5.0-dev.4.17","36979":"1.5.0-dev.4.0","37580":"1.5.0-dev.4.20","37475":"1.5.0-dev.4.16","37639":"1.5.0-dev.4.23","37743":"1.6.0-dev.0.0","37846":"1.6.0-dev.0.1","37936":"1.6.0-dev.1.2","38083":"1.6.0-dev.2.0","38145":"1.6.0-dev.3.0","38380":"1.6.0-dev.4.0","38621":"1.6.0-dev.6.0","38831":"1.6.0-dev.7.0","38967":"1.6.0-dev.8.0","39285":"1.6.0-dev.9.3","39401":"1.6.0-dev.9.5","39442":"1.6.0-dev.9.6","39661":"1.7.0-dev.0.1","39537":"1.6.0-dev.9.7","40090":"1.7.0-dev.2.0","39799":"1.7.0-dev.1.0","40675":"1.7.0-dev.4.0","40302":"1.7.0-dev.3.0","40806":"1.7.0-dev.4.1","40917":"1.7.0-dev.4.3","40987":"1.7.0-dev.4.4","41004":"1.7.0-dev.4.5","41090":"1.7.0-dev.4.6","41275":"1.8.0-dev.1.1","41389":"1.8.0-dev.2.0","41515":"1.8.0-dev.3.0","41684":"1.8.0-dev.4.0","41762":"1.8.0-dev.4.1","41923":"1.8.0-dev.4.5","41847":"1.8.0-dev.4.4","41793":"1.8.0-dev.4.2","41978":"1.8.0-dev.4.6","42033":"1.9.0-dev.0.0","41145":"1.8.0-dev.0.0","42684":"1.9.0-dev.3.0","42546":"1.9.0-dev.2.2","42856":"1.9.0-dev.4.0","42241":"1.9.0-dev.1.0","43384":"1.9.0-dev.5.1","43584":"1.9.0-dev.7.1","43903":"1.9.0-dev.8.4","44224":"1.9.0-dev.10.0","43715":"1.9.0-dev.8.0","44018":"1.9.0-dev.9.1","44260":"1.9.0-dev.10.2","44314":"1.9.0-dev.10.4","44550":"1.9.0-dev.10.10","44500":"1.9.0-dev.10.7","44532":"1.9.0-dev.10.9","44630":"1.9.0-dev.10.13","44728":"1.10.0-dev.0.1","44601":"1.9.0-dev.10.12","45054":"1.10.0-dev.1.0","45089":"1.10.0-dev.1.1","45201":"1.10.0-dev.1.5","45268":"1.10.0-dev.1.7","45369":"1.10.0-dev.1.10","45311":"1.10.0-dev.1.9","45519":"1.11.0-dev.0.0"},B.o6,t.w)

--- a/src/get-dart/dart_sdk_archive/lib/src/util.dart
+++ b/src/get-dart/dart_sdk_archive/lib/src/util.dart
@@ -72,6 +72,7 @@ const Map<String, List<PlatformVariant>> platforms = {
   'Windows': [
     PlatformVariant('x64', ['Dart SDK']),
     PlatformVariant('IA32', ['Dart SDK']),
+    PlatformVariant('ARM64', ['Dart SDK']),
   ],
 };
 

--- a/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
+++ b/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
@@ -169,6 +169,21 @@ class VersionSelector {
             // (earlier builds did not have trained snapshots).
             continue;
           }
+        } else if (name == 'Windows') {
+          if (platformVariant.architecture == 'ARM64') {
+            // No Windows arm64 SDK builds before 2.18.0-41.0.dev,
+            // and not in stable or beta yet.
+            // TODO: After this ships in stable 2.x, remove the stable check,
+            // and just test for versionInfo.version < Version(2,x,0).
+            if (versionInfo.version < Version(2, 18, 0, pre: '41.0.dev')) {
+              continue;
+            }
+
+            if (versionInfo.channel == 'stable' ||
+                versionInfo.channel == 'beta') {
+              continue;
+            }
+          }
         }
 
         // Build rows for all supported builds.

--- a/src/get-dart/index.md
+++ b/src/get-dart/index.md
@@ -56,7 +56,8 @@ The Dart SDK is supported on Windows, Linux, and macOS.
 ### Windows
 
 * **Supported versions:** Windows 10.
-* **Supported architectures:** x64, IA32.
+* **Supported architectures:** x64, IA32, ARM64.<br>
+  Support for ARM64 is experimental, and is available only in the dev channel.
 
 ### Linux
 


### PR DESCRIPTION
This won't work yet as no dev build has been published yet, only mainline builds.

Waiting on the next dev build to be published and making sure the ARM64 toolchain support remains.