### PR TITLE
Adjust documentation away from dart2js as a tool

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2457,7 +2457,7 @@ That depends on the tools and framework you're using:
 * Flutter enables assertions in [debug mode.][Flutter debug mode]
 * Development-only tools such as [dartdevc][]
   typically enable assertions by default.
-* Some tools, such as [`dart run`][] and [`dart2js`][]
+* Some tools, such as [`dart run`][] and [dart2js][]
   support assertions through a command-line flag: `--enable-asserts`.
 
 In production code, assertions are ignored, and
@@ -4623,7 +4623,7 @@ To learn more about Dart's core libraries, see
 [characters API]: {{site.pub-api}}/characters
 [characters example]: {{site.pub-pkg}}/characters/example
 [characters package]: {{site.pub-pkg}}/characters
-[`dart2js`]: /tools/dart2js
+[dart2js]: /tools/dart2js
 [`dart run`]: /tools/dart-run
 [dart:html]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-html
 [dart:isolate]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-isolate

--- a/src/overview.md
+++ b/src/overview.md
@@ -234,13 +234,14 @@ turn runs in a browser — for example, [V8](https://v8.dev/) inside
 [Chrome](https://www.google.com/chrome/).
 
 Dart web contains both an incremental dev compiler enabling a fast developer
-cycle, and an optimizing production compiler, `dart2js`, which compiles Dart
+cycle, and an optimizing production compiler, dart2js, which compiles Dart
 code to fast, compact, deployable JavaScript using techniques such as dead-code
 elimination.
 
 More information:
 * [Get started: Web apps](/tutorials/web/get-started)
-* [`dartdevc` compiler](/tools/dartdevc)
+* [dart2js compiler](/tools/dart2js)
+* [dartdevc compiler](/tools/dartdevc)
 * [`webdev` tool](/tools/webdev)
 * [Web deployment tips](/web/deployment)
 

--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -250,20 +250,32 @@ they can have much slower startup than architecture-specific AOT output formats.
 ### JavaScript (js) {#js}
 
 The `js` subcommand compiles Dart code to deployable JavaScript.
-For running and debugging during development,
-see the [`webdev serve`][] command.
 
-You usually use the [`webdev` tool][webdev] instead of
-directly using a Dart-to-JavaScript compiler.
-The [`webdev build`][] command, by default,
-produces deployable JavaScript.
-The [`webdev serve`][] command uses `dartdevc` by default, but you can switch
-to producing deployable JavaScript by using the `--release` flag.
+Here's an example of compiling a Dart application to JavaScript
+with many optimizations enabled:
 
-For more information on building and deploying JavaScript applications,
-see [Web deployment](/web/deployment).
+```terminal
+$ dart compile js -02 -o out/main.js web/main.dart
+```
+
+For more information on configuring the compiler, 
+see the [dart2js compiler options](/tools/dart2js#options).
+
+{{site.alert.note}}
+  You usually use the [`webdev` tool][webdev] instead of
+  directly using a Dart-to-JavaScript compiler.
+  The [`webdev build`][] command, by default,
+  also produces deployable JavaScript.
+  The [`webdev serve`][] command, by default,
+  uses the [dartdevc compiler][]
+  for running and debugging during development.
+{{site.alert.end}}
+
+To learn more about building and deploying JavaScript applications,
+check out [Web deployment](/web/deployment).
 
 [webdev]: /tools/webdev
 [`webdev build`]: /tools/webdev#build
 [`webdev serve`]: /tools/webdev#serve
 [Dart runtime]: /overview#runtime
+[dartdevc compiler]: /tools/dartdevc/faq

--- a/src/tools/dart2js.md
+++ b/src/tools/dart2js.md
@@ -1,42 +1,53 @@
 ---
 title: "dart2js: Dart-to-JavaScript compiler"
 short-title: dart2js
-description: The dart2js tool compiles Dart code to deployable JavaScript.
+description: The dart2js compiler compiles Dart code to deployable JavaScript.
 ---
 
-Use the _dart2js_ tool to compile Dart code to deployable JavaScript.
+{{site.alert.version-note}}
+  The `dart2js` command-line tool is deprecated as of Dart 2.17
+  and will be removed in a future release.
+  
+  Use [`dart compile js`](/tools/dart-compile#js) 
+  or the [`webdev`][] tool
+  to compile Dart code to deployable JavaScript.
+{{site.alert.end}}
+
+Use the _dart2js_ compiler to compile Dart code to deployable JavaScript.
 Another Dart-to-JavaScript compiler, [dartdevc][], is for development use only.
-The [webdev build][] command uses dart2js by default.
-The [webdev serve][] command uses dartdevc by default, but you can switch
+The [`webdev build`][] command uses dart2js by default.
+The [`webdev serve`][] command uses dartdevc by default, but you can switch
 to dart2js using the `--release` flag.
 
-The dart2js tool provides hints for improving your Dart code and removing
-unused code.
+The dart2js compiler provides hints and warnings
+for improving your Dart code.
 Also see [`dart analyze`](/tools/dart-analyze),
-which performs a similar analysis but has a different implementation.
+which performs further analysis.
 
-This page tells you how to use dart2js on the command line. It also give tips
-on debugging the JavaScript that dart2js generates.
+This page tells you how to use the dart2js compiler.
+It also give tips on debugging the JavaScript that dart2js generates.
 
 ## Basic usage
 
 Here’s an example of compiling a Dart file to JavaScript:
 
 ```terminal
-$ dart2js -O2 -o test.js test.dart
+$ dart compile js -O2 -o test.js test.dart
 ```
 
-This command produces a file that contains the JavaScript equivalent of your
-Dart code. It also produces a source map, which can help you debug the
+This command produces a file that contains
+the JavaScript equivalent of your Dart code. 
+It also produces a source map, 
+which can help you debug the
 JavaScript version of the app more easily.
 
 {{site.alert.note}}
   The <code>-O<em>n</em></code> argument specifies the optimization level.
-  We recommend starting at `-O1` (the default) and then increasing to `-O2` or
-  higher when you're ready to deploy.
+  We recommend starting at `-O1` (the default) 
+  and then increasing to `-O2` or higher when you're ready to deploy.
   The `-O3` and `-O4` optimization levels are suitable only for
-  **well tested code** ([see the <code>-O<em>n</em></code> descriptions,
-  below](#basic-options)).
+  **well tested code** 
+  ([see the <code>-O<em>n</em></code> descriptions, below](#basic-options)).
 {{site.alert.end}}
 
 
@@ -55,11 +66,11 @@ see the [build_web_compilers package.][build_web_compilers]
 
 #### Basic options
 
-Common command-line options for dart2js include:
+Common options for the dart2js compiler include:
 
-`-o <file>` or `--out=<file>`
-: Generates the output into `<file>`. If not specified,
-  the output goes in a file named `out.js`.
+`-o <file>` or `--output=<file>`
+: Generates the output into `<file>`. 
+  If not specified, the output goes in a file named `out.js`.
 
 `--enable-asserts`
 : Enables assertion checking.
@@ -67,7 +78,8 @@ Common command-line options for dart2js include:
 `-O{0|1|2|3|4}`
 : Controls optimizations that can help reduce code size and
   improve performance of the generated code.
-  For more details on these optimizations, run `dart2js -hv`.
+  For more details on these optimizations, 
+  run `dart compile js -hv`.
 
   * `-O0`: Disables many optimizations.
   * `-O1`: Enables default optimizations.
@@ -76,7 +88,7 @@ Common command-line options for dart2js include:
     are safe for all programs.
     {{site.alert.note}}
       With `-O2`, string representations of types are no longer the same as
-      those in the Dart VM and [dartdevc][].
+      those in the Dart VM and with [the dartdevc compiler][dartdevc].
     {{site.alert.end}}
   * `-O3`: Enables `-O2` optimizations, plus omits implicit type checks.
     {{site.alert.warning}}
@@ -91,6 +103,9 @@ Common command-line options for dart2js include:
       Before relying on `-O4`, **test for edge cases in user input**.
     {{site.alert.end}}
 
+`--no-source-maps`
+: Do not generate a source map file.
+
 `-h` or `--help`
 : Displays help. To get information about all options, use `-hv`.
 
@@ -102,7 +117,7 @@ Some other handy options include:
 `--packages=<path>`
 : Specifies the path to the package resolution configuration file.
   For more information, see
-  [Package Resolution Configuration File.](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md)
+  [Dart Package Configuration File.][]
 
 `-D<flag>=<value>`
 : Defines an environment variable.
@@ -122,7 +137,8 @@ The following options help you control the output of dart2js:
 : Doesn't display hints.
 
 `--terse`
-: Emits diagnostics, without suggesting how to get rid of the diagnosed problems.
+: Emits diagnostics, 
+  without suggesting how to get rid of the diagnosed problems.
 
 `-v` or `--verbose`
 : Displays lots of information.
@@ -131,6 +147,9 @@ The following options help you control the output of dart2js:
 #### Analysis options
 
 The following options control the analysis that dart2js performs on Dart code:
+
+`--fatal-warnings`
+: Treat warnings as compilation errors.
 
 `--enable-diagnostic-colors`
 : Adds colors to diagnostic messages.
@@ -152,26 +171,29 @@ The following options control the analysis that dart2js performs on Dart code:
 
 ## Helping dart2js generate better code {#helping-dart2js-generate-efficient-code}
 
-Follow these practices to help dart2js do better type inference, so it can generate smaller and faster JavaScript code:
+Follow these practices to help dart2js do better type inference, 
+so it can generate smaller and faster JavaScript code:
 
 * Don't use `Function.apply()`.
 * Don't override `noSuchMethod()`.
-* Avoid setting variables to null.
-* Be consistent with the types of arguments you pass into each function or
-  method.
+* Avoid setting variables to `null`.
+* Be consistent with the types of arguments
+  you pass into each function or method.
 
 {{site.alert.tip}}
-  Don’t worry about the size of your app’s included libraries. The dart2js tool
-  performs tree shaking to omit unused classes, functions, methods, and so on.
-  Just import the libraries you need, and let dart2js get rid of what you don’t
-  need.
+  Don’t worry about the size of your app’s included libraries. 
+  The dart2js compiler performs tree shaking to omit
+  unused classes, functions, methods, and so on.
+  Just import the libraries you need, 
+  and let dart2js get rid of what you don’t need.
 {{site.alert.end}}
 
 
 ## Debugging {#debugging}
 
-This section gives tips for debugging dart2js-produced code in Chrome, Firefox,
-and Safari. Debugging the JavaScript produced by dart2js is easiest in
+This section gives tips for debugging dart2js-produced code
+in Chrome, Firefox, and Safari. 
+Debugging the JavaScript produced by dart2js is easiest in
 browsers such as Chrome that support source maps.
 
 {{site.alert.tip}}
@@ -180,9 +202,9 @@ browsers such as Chrome that support source maps.
 {{site.alert.end}}
 
 Whichever browser you use, you should enable pausing on at least
-uncaught exceptions, and perhaps on all exceptions. For frameworks such
-as dart:async that wrap user code in try-catch, we
-recommend pausing on all exceptions.
+uncaught exceptions, and perhaps on all exceptions. 
+For frameworks such as `dart:async` that wrap user code in try-catch, 
+we recommend pausing on all exceptions.
 
 [debugging web apps]: /web/debugging
 
@@ -206,7 +228,7 @@ To debug in Edge:
 
 1. Update to the latest version of Edge. 
 2. Load **Developer Tools** (**F12**). For more information, see
-   [Using the F12 developer tools.](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide)
+   [Using the F12 developer tools.](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/landing/)
 3. Reload the app. The **debugger** tab shows source-mapped files.
 4. Exception behavior can be controlled through **Ctrl+Shift+E**;
    the default is **Break on unhandled exceptions**.
@@ -215,8 +237,8 @@ To debug in Edge:
 
 To debug in Firefox:
 
-1. Open the Web Developer Tools window, as described in the
-   [Firefox developer tools documentation](https://developer.mozilla.org/en-US/docs/Tools).
+1. Open the **Web Developer Tools** window, as described in the
+   [Firefox developer tools documentation](https://firefox-source-docs.mozilla.org/devtools-user/index.html).
 2. Enable **Pause on exceptions**, as shown in the following figure:
    
    <img width="640px" src="/assets/img/ff-debug.png" alt="Enable Pause on exceptions in Firefox debugger">
@@ -227,7 +249,8 @@ To debug in Firefox:
 
 To debug in Safari:
 
-1. Turn on the Develop menu, as described in the [Safari Web Inspector Tutorial.](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/Web_Inspector_Tutorial/EnableWebInspector/EnableWebInspector.html)
+1. Turn on the **Develop** menu, 
+   as described in the [Safari Web Inspector Tutorial.](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/Web_Inspector_Tutorial/EnableWebInspector/EnableWebInspector.html)
 2. Enable breaks, either on all exceptions or only on uncaught exceptions.
    See [Add a JavaScript breakpoint](https://support.apple.com/en-ca/guide/safari-developer/add-a-javascript-breakpoint-dev5e4caf347/mac) under [Safari Developer Help.](https://support.apple.com/en-ca/guide/safari-developer/welcome/mac)
 3. Reload your app.
@@ -236,6 +259,8 @@ To debug in Safari:
 [build_web_compilers]: {{site.pub-pkg}}/build_web_compilers
 [config]: /tools/build_runner#config
 [dartdevc]: /tools/dartdevc
-[webdev]: /tools/webdev
-[webdev build]: /tools/webdev#build
-[webdev serve]: /tools/webdev#serve
+[`webdev`]: /tools/webdev
+[`webdev build`]: /tools/webdev#build
+[`webdev serve`]: /tools/webdev#serve
+
+[Dart Package Configuration File.]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.mdx

--- a/src/tools/dart2js.md
+++ b/src/tools/dart2js.md
@@ -53,7 +53,8 @@ JavaScript version of the app more easily.
 
 ## Build config usage
 
-You can also configure dart2js options in a build config file.
+You can also configure dart2js options in a build config file
+when using the [`webdev`][] tool or [build_runner][].
 For more information,
 see the [build_web_compilers package.][build_web_compilers]
 

--- a/src/tools/dartdevc/index.md
+++ b/src/tools/dartdevc/index.md
@@ -11,6 +11,7 @@ lets you run and debug your Dart web app in the Chrome browser.
 {{site.alert.note}}
   The dartdevc compiler is for _development_ only.
   Continue to use [dart2js](/tools/dart2js)
+  through [`dart compile js`](/tools/dart-compile#js) or the [`webdev`][] tool
   to compile for deployment.
 {{site.alert.end}}
 
@@ -31,7 +32,7 @@ refresh times with dartdevc are much faster than with dart2js.
 ## More information
 
 * [dartdevc: FAQ](/tools/dartdevc/faq)
-* [webdev][], which uses dartdevc by default when serving and testing web apps
+* [`webdev`][], which uses dartdevc by default when serving and testing web apps
 
 [serve]: /tools/webdev#serve
-[webdev]: /tools/webdev
+[`webdev`]: /tools/webdev

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -111,13 +111,14 @@ The following tools support developing web apps:
 : A CLI for Dart web app development,
   including building and serving web apps.
 
-[`dart2js`](/tools/dart2js)
+[dart2js](/tools/dart2js)
 : The original Dart-to-JavaScript compiler, with tree shaking.
-  IDEs and the `webdev` CLI use `dart2js` when building web apps for deployment.
+  IDEs, `dart compile js`, and the `webdev` CLI 
+  use dart2js when building web apps for deployment.
 
-[`dartdevc`](/tools/dartdevc)
+[dartdevc](/tools/dartdevc)
 : The Dart dev compiler, a modular Dart-to-JavaScript compiler.
-  IDEs and the `webdev` CLI use `dartdevc` when running a development server.
+  IDEs and the `webdev` CLI use dartdevc when running a development server.
 
 
 ## Tools for developing command-line apps and servers {#server}


### PR DESCRIPTION
Points developers to `dart compile js` and `webdev build` where appropriate and adjusts wording and formatting of dart2js as a tool to it being a compiler. Also fixes some formatting and links on the dart2js page.

This can land before the release of 2.17 as `webdev build` and `dart compile js` support everything needed already.

Fixes https://github.com/dart-lang/site-www/issues/3842