### PR TITLE
Add support for Linux riscv64 in beta archive list

### DIFF
--- a/src/get-dart/archive/out/web/download_archive.dart.js
+++ b/src/get-dart/archive/out/web/download_archive.dart.js
@@ -3823,6 +3823,8 @@ Kh(a,b){var s,r=b.length
 if(r===0)return
 if(a===b)throw A.J(A.a4(a))
 for(s=0;s<r;++s)a.push(b[s])},
+V1(a){if(!!a.fixed$length)A.vh(A.u0("clear"))
+a.length=0},
 aN(a,b){var s,r=a.length
 for(s=0;s<r;++s){b.$1(a[s])
 if(a.length!==r)throw A.J(A.a4(a))}},
@@ -5554,7 +5556,7 @@ s=A.Fl(t.N,t.z)
 r=n.Cf()
 for(q=0;p=r.length,q<p;++q){o=r[q]
 s.Y5(0,o,n.q(0,o))}if(p===0)r.push("")
-else B.Nm.sB(r,0)
+else B.Nm.V1(r)
 n.a=n.b=null
 return n.c=s},
 fb(a){var s
@@ -7000,119 +7002,119 @@ A.TT(new A.wz(n,k)).Rz(0,q)
 n=l.querySelectorAll(o!=="all"?s+('[data-os="'+A.Ej(o)+'"]'):s)
 n.toString
 A.TT(new A.wz(n,k)).Rz(0,q)}},
-PS(b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4="data-version",b5="href"
-for(s=B.zu.gvc(),s=s.gkz(s),r=this.a,q="https://storage.googleapis.com/dart-archive/channels/"+r+"/release/",p=b6.a,o=t.bY,n=p.f,m=t.W,l=this.c,k=t.fD,r=r==="dev",j=b6.b.a,i=b6.c,h=i!=="stable",i=i==="beta";s.G();){g=s.gl()
-f=B.zu.q(0,g)
-if(f==null)f=B.iH
-for(e=f.length,d=g==="macOS",c=0;c<e;++c){b=f[c]
-if(B.OI.q(0,g)==="linux"){a=b.a
-if(a==="ARMv7")a0=j<A.Gl(r?"2015-10-21":"2015-08-31").a
-else a0=!1
-if(a0)continue
-else if(a==="ARMv8 (ARM64)"&&j<A.Gl("2017-03-09").a)continue
-else if(a==="RISC-V (RV64GC)"){if(p.iM(0,A.jm(2,17,0,"258.0.dev"))<0)continue
-if(!h||i)continue}}else if(d){a=b.a
-if(a==="IA32"){if(p.iM(0,A.jm(2,7,0,null))>0)continue}else if(a==="ARM64"&&p.iM(0,A.jm(2,14,1,null))<0)continue}a=l.tBodies
-a.toString
-a=new A.zO(a,k)
-if(a.gB(a)===0)A.vh(A.Wp())
-a1=m.a(J.oD(a.q(0,0),-1))
-a1.setAttribute(b4,n)
-a=B.OI.q(0,g)
-a1.setAttribute("data-os",a==null?"":a)
-a=a1.insertCell(-1)
-a.toString
-o.a(a)
-a.textContent=n
-a0=document
-a2=a0.createElement("span")
-a2.toString
-a2.textContent=" ("+A.Ej(A.yl(b6))+")"
-a3=a2.classList
-a3.contains("muted").toString
-a3.add("muted")
-a.appendChild(a2).toString
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2).textContent=g
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2)
-a3=a2.classList
-a3.contains("nowrap").toString
-a3.add("nowrap")
-a=b.a
-a2.textContent=a
-a4=["Dart SDK","Debian package"]
-a2=a1.insertCell(-1)
-a2.toString
-o.a(a2)
-a3=a2.classList
-a3.contains("archives").toString
-a3.add("archives")
-for(a5=b.b,a6=0;a6<2;++a6){a7=a4[a6]
-if(B.Nm.tg(a5,a7)){if(a7==="Dart Editor")continue
-a8=A.Ej(B.OI.q(0,a7))+"-"+A.Ej(B.OI.q(0,g))+"-"+A.Ej(B.OI.q(0,a))
-a9=a7==="Debian package"
-if(a9)if(p.iM(0,A.jm(2,0,0,null))<0)continue
-else a8="dart_"+A.C5(b6)
-b0=q+A.C5(b6)+"/"+A.Ej(B.d4.q(0,a7))+"/"+a8+A.Ej(B.EL.q(0,a7))
-b1=a0.createElement("a")
-b1.textContent=a7
-b1.setAttribute(b5,b0)
-a2.appendChild(b1).toString
-b2=A.En(b6)
-if(!a9)a9=b2==null||b2>38976
-else a9=!1
-if(a9){a9=a0.createTextNode(" ")
-a9.toString
-a2.appendChild(a9).toString
-b1=a0.createElement("a")
-b1.textContent="(SHA-256)"
-b1.setAttribute(b5,b0+".sha256sum")
-a3=b1.classList
-a3.contains("sha").toString
-a3.add("sha")
-a2.appendChild(b1).toString}a9=a0.createElement("br")
-a9.toString
-a2.appendChild(a9).toString}}}}s=l.tBodies
+PS(b5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3="data-version",b4="href"
+for(s=B.zu.gvc(),s=s.gkz(s),r=this.a,q="https://storage.googleapis.com/dart-archive/channels/"+r+"/release/",p=b5.a,o=t.bY,n=p.f,m=t.W,l=this.c,k=t.fD,r=r==="dev",j=b5.b.a,i=b5.c==="stable";s.G();){h=s.gl()
+g=B.zu.q(0,h)
+if(g==null)g=B.iH
+for(f=g.length,e=h==="macOS",d=0;d<f;++d){c=g[d]
+if(B.OI.q(0,h)==="linux"){b=c.a
+if(b==="ARMv7")a=j<A.Gl(r?"2015-10-21":"2015-08-31").a
+else a=!1
+if(a)continue
+else if(b==="ARMv8 (ARM64)"&&j<A.Gl("2017-03-09").a)continue
+else if(b==="RISC-V (RV64GC)"){if(p.iM(0,A.jm(2,17,0,"258.0.dev"))<0)continue
+if(i)continue}}else if(e){b=c.a
+if(b==="IA32"){if(p.iM(0,A.jm(2,7,0,null))>0)continue}else if(b==="ARM64"&&p.iM(0,A.jm(2,14,1,null))<0)continue}b=l.tBodies
+b.toString
+b=new A.zO(b,k)
+if(b.gB(b)===0)A.vh(A.Wp())
+a0=m.a(J.oD(b.q(0,0),-1))
+a0.setAttribute(b3,n)
+b=B.OI.q(0,h)
+a0.setAttribute("data-os",b==null?"":b)
+b=a0.insertCell(-1)
+b.toString
+o.a(b)
+b.textContent=n
+a=document
+a1=a.createElement("span")
+a1.toString
+a1.textContent=" ("+A.Ej(A.yl(b5))+")"
+a2=a1.classList
+a2.contains("muted").toString
+a2.add("muted")
+b.appendChild(a1).toString
+a1=a0.insertCell(-1)
+a1.toString
+o.a(a1).textContent=h
+a1=a0.insertCell(-1)
+a1.toString
+o.a(a1)
+a2=a1.classList
+a2.contains("nowrap").toString
+a2.add("nowrap")
+b=c.a
+a1.textContent=b
+a3=["Dart SDK","Debian package"]
+a1=a0.insertCell(-1)
+a1.toString
+o.a(a1)
+a2=a1.classList
+a2.contains("archives").toString
+a2.add("archives")
+for(a4=c.b,a5=0;a5<2;++a5){a6=a3[a5]
+if(B.Nm.tg(a4,a6)){if(a6==="Dart Editor")continue
+a7=A.Ej(B.OI.q(0,a6))+"-"+A.Ej(B.OI.q(0,h))+"-"+A.Ej(B.OI.q(0,b))
+a8=a6==="Debian package"
+if(a8)if(p.iM(0,A.jm(2,0,0,null))<0)continue
+else a7="dart_"+A.C5(b5)
+a9=q+A.C5(b5)+"/"+A.Ej(B.d4.q(0,a6))+"/"+a7+A.Ej(B.EL.q(0,a6))
+b0=a.createElement("a")
+b0.textContent=a6
+b0.setAttribute(b4,a9)
+a1.appendChild(b0).toString
+b1=A.En(b5)
+if(!a8)a8=b1==null||b1>38976
+else a8=!1
+if(a8){a8=a.createTextNode(" ")
+a8.toString
+a1.appendChild(a8).toString
+b0=a.createElement("a")
+b0.textContent="(SHA-256)"
+b0.setAttribute(b4,a9+".sha256sum")
+a2=b0.classList
+a2.contains("sha").toString
+a2.add("sha")
+a1.appendChild(b0).toString}a8=a.createElement("br")
+a8.toString
+a1.appendChild(a8).toString}}}}s=l.tBodies
 s.toString
 k=new A.zO(s,k)
-a1=m.a(J.oD(k.gFV(k),-1))
-a1.setAttribute(b4,n)
-a1.setAttribute("data-os","api")
+a0=m.a(J.oD(k.gFV(k),-1))
+a0.setAttribute(b3,n)
+a0.setAttribute("data-os","api")
 k=document.createElement("span")
 k.toString
-k.textContent=" ("+A.Ej(A.yl(b6))+")"
-a3=k.classList
-a3.contains("muted").toString
-a3.add("muted")
-m=a1.insertCell(-1)
+k.textContent=" ("+A.Ej(A.yl(b5))+")"
+a2=k.classList
+a2.contains("muted").toString
+a2.add("muted")
+m=a0.insertCell(-1)
 m.toString
 o.a(m)
 m.textContent=n
 m.appendChild(k).toString
-k=a1.insertCell(-1)
+k=a0.insertCell(-1)
 k.toString
 o.a(k).textContent="---"
-k=a1.insertCell(-1)
+k=a0.insertCell(-1)
 k.toString
 o.a(k).textContent="---"
-k=a1.insertCell(-1)
+k=a0.insertCell(-1)
 k.toString
 o.a(k)
-a3=k.classList
-a3.contains("archives").toString
-a3.add("archives")
+a2=k.classList
+a2.contains("archives").toString
+a2.add("archives")
 p=p["["](0)
 o=A.J6()
 o.textContent="API docs"
-o.setAttribute(b5,q+p+"/api-docs/dartdocs-gen-api.zip")
+o.setAttribute(b4,q+p+"/api-docs/dartdocs-gen-api.zip")
 k.appendChild(o).toString
 l=l.querySelectorAll(".template")
 l.toString
-b3=new A.wz(l,t.Z)
-for(s=new A.a7(b3,b3.gB(b3)),r=A.Lh(s).c;s.G();){q=s.d
+b2=new A.wz(l,t.Z)
+for(s=new A.a7(b2,b2.gB(b2)),r=A.Lh(s).c;s.G();){q=s.d
 if(q==null)q=r.a(q)
 p=q.parentNode
 if(p!=null)p.removeChild(q).toString}}}

--- a/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
+++ b/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
@@ -145,7 +145,7 @@ class VersionSelector {
             continue;
           } else if (platformVariant.architecture == 'RISC-V (RV64GC)') {
             // No Linux risc64 SDK builds before 2.17.0-258.0.dev,
-            // and not in stable or beta yet.
+            // and none in stable yet.
             // TODO: After this ships in stable 2.x, remove the stable check,
             // and just test for versionInfo.version < Version(2,x,0).
             if (versionInfo.version < Version(2, 17, 0, pre: '258.0.dev')) {

--- a/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
+++ b/src/get-dart/dart_sdk_archive/lib/src/version_selector.dart
@@ -152,8 +152,7 @@ class VersionSelector {
               continue;
             }
 
-            if (versionInfo.channel == 'stable' ||
-                versionInfo.channel == 'beta') {
+            if (versionInfo.channel == 'stable') {
               continue;
             }
           }

--- a/src/get-dart/index.md
+++ b/src/get-dart/index.md
@@ -62,7 +62,8 @@ The Dart SDK is supported on Windows, Linux, and macOS.
 
 * **Supported versions:** [Debian stable][] and [Ubuntu LTS][] under standard support.
 * **Supported architectures:** x64, IA32, ARM64, ARM, RISC-V (RV64GC).<br>
-  Support for RISC-V is experimental, and is available only in the dev channel.
+  Support for RISC-V is experimental, 
+  and is available only in the beta and dev channels.
 
 {{site.alert.note}}
   The arm support requires glibc 2.23 or newer due to a


### PR DESCRIPTION
Contributes to https://github.com/dart-lang/site-www/issues/3906 now that RV64GC builds are available in the beta channel.