### PR TITLE
Expand enum documentation in language tour

### DIFF
--- a/examples/misc/lib/language_tour/classes/enum.dart
+++ b/examples/misc/lib/language_tour/classes/enum.dart
@@ -3,6 +3,13 @@ enum Color { red, green, blue }
 // #enddocregion enum
 
 void main() {
+  // #docregion access
+  final favoriteColor = Color.blue;
+  if (favoriteColor == Color.blue) {
+    print('Your favorite color is blue!');
+  }
+  // #enddocregion access
+
   // #docregion index
   assert(Color.red.index == 0);
   assert(Color.green.index == 1);
@@ -29,4 +36,8 @@ void main() {
       print(aColor); // 'Color.blue'
   }
   // #enddocregion switch
+
+  // #docregion name
+  print(EnumName(Color.blue).name); // 'blue'
+  // #enddocregion name
 }

--- a/examples/misc/test/language_tour/classes_test.dart
+++ b/examples/misc/test/language_tour/classes_test.dart
@@ -138,7 +138,8 @@ void main() {
   });
 
   test('enum_with_main', () {
-    expect(enum_with_main.main, m.prints('Color.blue'));
+    expect(enum_with_main.main,
+        m.prints(['Your favorite color is blue!', 'Color.blue', 'blue']));
   });
 
   test('orchestra', () {

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3546,10 +3546,10 @@ enum Color { red, green, blue }
   You can also use [trailing commas][] when declaring an enumerated type
   to help prevent copy-paste errors:
 
-  <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)" replace="/blue/$[!,!]/g"?>
-  ```dart
-    enum Color { red, green, blue[!,!] }
-  ```
+  <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)" replace="/(blue)/$1[!,!]/g"?>
+  {% prettify dart tag=pre+code %}
+  enum Color { red, green, blue[!,!] }
+  {% endprettify %}
 {{site.alert.end}}
 
 Access the enumerated values like

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -4664,7 +4664,7 @@ To learn more about Dart's core libraries, see
 [`Enum`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Enum-class.html
 [`EnumName`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/EnumName-class.html
 [`Error`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
-[`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/EnumName.html
+[`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
 [extension methods page]: /guides/language/extension-methods
 [Flutter]: {{site.flutter}}
 [Flutter debug mode]: {{site.flutter-docs}}/testing/debugging#debug-mode-assertions

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3544,12 +3544,7 @@ enum Color { red, green, blue }
 
 {{site.alert.tip}}
   You can also use [trailing commas][] when declaring an enumerated type
-  to help prevent copy-paste errors:
-
-  <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)" replace="/(blue)/$1[!,!]/g"?>
-  {% prettify dart tag=pre+code %}
-  enum Color { red, green, blue[!,!] }
-  {% endprettify %}
+  to help prevent copy-paste errors.
 {{site.alert.end}}
 
 Access the enumerated values like

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -554,6 +554,7 @@ use the `Map()` constructor to create a map.
 Some other types also have special roles in the Dart language:
 
 * `Object`: The superclass of all Dart classes except `Null`.
+* `Enum`: The superclass of all enums.
 * `Future` and `Stream`: Used in [asynchrony support](#asynchrony-support).
 * `Iterable`: Used in [for-in loops][iteration] and
   in synchronous [generator functions](#generator).
@@ -3526,17 +3527,41 @@ Enumerated types, often called _enumerations_ or _enums_,
 are a special kind of class used to represent
 a fixed number of constant values.
 
+{{site.alert.note}}
+  All enums automatically extend the [`Enum`][] class.
+{{site.alert.end}}
 
 #### Using enums
 
-Declare an enumerated type using the `enum` keyword:
+To declare a simple enumerated type,
+use the `enum` keyword and
+list the values you want to be enumerated:
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)"?>
 ```dart
 enum Color { red, green, blue }
 ```
 
-You can use [trailing commas][] when declaring an enumerated type.
+{{site.alert.tip}}
+  You can also use [trailing commas][] when declaring an enumerated type
+  to help prevent copy-paste errors:
+
+  <?code-excerpt "misc/lib/language_tour/classes/enum.dart (enum)" replace="/blue/$[!,!]/g"?>
+  ```dart
+    enum Color { red, green, blue[!,!] }
+  ```
+{{site.alert.end}}
+
+Access the enumerated values like
+any other [static variable](#static-variables):
+
+<?code-excerpt "misc/lib/language_tour/classes/enum.dart (access)"?>
+```dart
+final favoriteColor = Color.blue;
+if (favoriteColor == Color.blue) {
+  print('Your favorite color is blue!');
+}
+```
 
 Each value in an enum has an `index` getter,
 which returns the zero-based position of the value in the enum declaration.
@@ -3550,7 +3575,7 @@ assert(Color.green.index == 1);
 assert(Color.blue.index == 2);
 ```
 
-To get a list of all of the values in the enum,
+To get a list of all the enumerated values,
 use the enum's `values` constant.
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (values)"?>
@@ -3576,6 +3601,15 @@ switch (aColor) {
   default: // Without this, you see a WARNING.
     print(aColor); // 'Color.blue'
 }
+```
+
+If you need to access the enumerated value of an enum,
+such as `'blue'` from `Color.blue`, 
+use the [`EnumName`] extension:
+
+<?code-excerpt "misc/lib/language_tour/classes/enum.dart (name)"?>
+```dart
+print(EnumName(Color.blue).name); // 'blue'
 ```
 
 Enumerated types have the following limits:

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3598,7 +3598,7 @@ switch (aColor) {
 }
 ```
 
-If you need to access the enumerated value of an enum,
+If you need to access the name of an enumerated value,
 such as `'blue'` from `Color.blue`, 
 use the [`EnumName`][] extension:
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3600,7 +3600,7 @@ switch (aColor) {
 
 If you need to access the enumerated value of an enum,
 such as `'blue'` from `Color.blue`, 
-use the [`EnumName`] extension:
+use the [`EnumName`][] extension:
 
 <?code-excerpt "misc/lib/language_tour/classes/enum.dart (name)"?>
 ```dart
@@ -4661,8 +4661,10 @@ To learn more about Dart's core libraries, see
 [dartdevc]: /tools/dartdevc
 [DON’T use const redundantly]: /guides/language/effective-dart/usage#dont-use-const-redundantly
 [`double`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
+[`Enum`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Enum-class.html
+[`EnumName`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/EnumName-class.html
 [`Error`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Error-class.html
-[`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
+[`Exception`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/EnumName.html
 [extension methods page]: /guides/language/extension-methods
 [Flutter]: {{site.flutter}}
 [Flutter debug mode]: {{site.flutter-docs}}/testing/debugging#debug-mode-assertions


### PR DESCRIPTION
Introduces some improvements and extensions to enum documentation to make future changes for enhanced enums easier.

**Staged:** https://dart-dev--pr4019-feature-expand-enum-j5sop42u.web.app/guides/language/language-tour#enumerated-types