### PR TITLE
Mark actions workflows read only to address code scanning alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
 
   stage:
     permissions:
-      contents: read
+      checks: write
+      contents: write
       pull-requests: write
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ jobs:
           DART_CHANNEL: ${{ matrix.sdk }}
 
   deploy:
+    permissions:
+      checks: write
+      pull-requests: write
     if: ${{ github.event_name == 'push' && 
             github.ref == 'refs/heads/main' && 
             github.repository == 'dart-lang/site-www' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,6 @@ jobs:
   stage:
     permissions:
       checks: write
-      contents: write
       pull-requests: write
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   # Keep for Dart SDK reporting
   PUB_ENVIRONMENT: bot.github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,12 @@ jobs:
           channelId: live
 
   stage:
+    permissions:
+      contents: read
+      pull-requests: write
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
As suggested by this security alert: https://github.com/dart-lang/site-www/security/code-scanning/32

\cc @sealesj