### PR TITLE
Remove some JS mentions from the language tour

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -841,8 +841,10 @@ Perhaps the most common collection in nearly every programming language
 is the *array*, or ordered group of objects. In Dart, arrays are
 [`List`][] objects, so most people just call them *lists*.
 
-Dart list literals look like JavaScript array literals. Here’s a simple
-Dart list:
+Dart list literals are denoted by
+a comma separated list of Dart expressions,
+enclosed in square brackets (`[]`).
+Here's a simple Dart list:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (list-literal)"?>
 ```dart
@@ -871,9 +873,9 @@ var list = [
 ```
 
 Lists use zero-based indexing, where 0 is the index of the first value
-and `list.length - 1` is the index of the last value. You can get a
-list’s length and refer to list values just as you would in
-JavaScript:
+and `list.length - 1` is the index of the last value. 
+You can get a list’s length using the `.length` property
+and access a list's values using the subscript operator (`[]`):
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-indexing)"?>
 ```dart
@@ -1092,8 +1094,8 @@ nobleGases[18] = 'argon';
   For details, see [Using constructors](#using-constructors).
 {{site.alert.end}}
 
-Add a new key-value pair to an existing map just as you would in
-JavaScript:
+Add a new key-value pair to an existing map
+using the subscript assignment operator (`[]=`):
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (map-add-item)"?>
 ```dart
@@ -1101,7 +1103,7 @@ var gifts = {'first': 'partridge'};
 gifts['fourth'] = 'calling birds'; // Add a key-value pair
 ```
 
-Retrieve a value from a map the same way you would in JavaScript:
+Retrieve a value from a map using the subscript operator (`[]`):
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-retrieve-item)"?>
 ```dart
@@ -1109,7 +1111,7 @@ var gifts = {'first': 'partridge'};
 assert(gifts['first'] == 'partridge');
 ```
 
-If you look for a key that isn’t in a map, you get a null in return:
+If you look for a key that isn’t in a map, you get `null` in return:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-missing-key)"?>
 ```dart
@@ -2209,8 +2211,9 @@ if (isRaining()) {
 }
 ```
 
-Unlike JavaScript, conditions must use boolean values, nothing else. See
-[Booleans](#booleans) for more information.
+The statement conditions must be expressions
+that evaluate to boolean values, nothing else.
+See [Booleans](#booleans) for more information.
 
 
 ### For loops


### PR DESCRIPTION
The language tour is not meant just for those that know JavaScript, especially when they can use the [Learning Dart as a JavaScript developer](https://dart.dev/guides/language/coming-from/js-to-dart) article. This PR removes some of those JavaScript mentions to make the documentation more generic for other developers.