### PR TITLE
Add weak references and finalizers section to library tour

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1047,11 +1047,10 @@ if the target object can't be subclassed.
 
 A [WeakReference][]
 stores a reference to the target object
-without increasing the reference count
-considered by the garbage collector.
+that does not affect how it is 
+collected by the garbage collector.
 Another option is to use an [Expando][]
-to add properties to an object
-without affecting how it's garbage collected.
+to add properties to an object.
 
 A [Finalizer][] can be used to execute a callback function
 after an object is no longer referenced.
@@ -1065,8 +1064,8 @@ after the object is no longer referenced.
 Also, it can be used to close native resources
 such as a database connection or open files.
 
-To ensure that an object won't be finalized
-or garbage collected too early,
+To ensure that an object won't be
+garbage collected and finalized too early,
 classes can implement the [Finalizable][] interface.
 
 ## dart:async - asynchronous programming

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1040,7 +1040,7 @@ For more information, see
 Dart is a [garbage-collected][] language,
 which means that any Dart object
 that isn't referenced by at least one other object
-will eventually be disposed by the garbage collector. 
+can be disposed by the garbage collector. 
 This default behavior might not be desirable in
 some scenarios involving native resources or 
 if the target object can't be subclassed.

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1035,6 +1035,38 @@ For more information, see
 [Exceptions](/guides/language/language-tour#exceptions)
 (in the language tour) and the [Exception API reference.][Exception]
 
+### Weak references and finalizers
+Dart is a [garbage-collected][] language,
+which means that any Dart object
+that isn't referenced by at least one other object
+will eventually be disposed by the garbage collector. 
+This default behavior may not be desireable in
+some scenarios involving native resources or 
+if the target object cannot be sub-classed.
+
+A [WeakReference][]
+stores a reference to the target object
+without increasing the reference count
+considered by the garbage collector.
+Another option is to use an [Expando][]
+to add properties to an object
+without affecting how they are garbage-collected.
+
+A [Finalizer][] can be used to execute a callback function
+after an object is no longer referenced.
+It is not guaranteed to execute this callback, however.
+
+A [NativeFinalizer][]
+provides stronger guarantees
+for interacting with native code using [dart:ffi][].
+Its callback will be called at least once
+after the object is no longer referenced.
+It can be used to close native resources
+such as a database connection or open files.
+
+To ensure that an object won't be finalized
+or garbage collected too early,
+classes can implement the [Finalizable][] interface.
 
 ## dart:async - asynchronous programming
 
@@ -1675,48 +1707,56 @@ sampling of what you can install using pub.
 To learn more about the Dart language, see the
 [language tour][].
 
-[language tour]: /guides/language/language-tour
-[docs.flutter]: {{site.flutter_api}}
-[Assert]: /guides/language/language-tour#assert
 [ArgumentError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/ArgumentError-class.html
+[Assert]: /guides/language/language-tour#assert
 [Comparable]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Comparable-class.html
-[dart:core]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/dart-core-library.html
-[dart:async]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/dart-async-library.html
-[dart:collection]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-collection/dart-collection-library.html
-[dart:convert]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html
-[dart:io tour]: #dartio
-[dart:math]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/dart-math-library.html
-[dart:typed\_data]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-typed_data/dart-typed_data-library.html
 [Dart API]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}
 [DateTime]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/DateTime-class.html
-[double]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
 [Duration]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Duration-class.html
 [Exception]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Exception-class.html
-[Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
+[Expando]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Expando-class.html
+[Finalizable]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-ffi/Finalizable-class.html
+[Finalizer]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Finalizer-class.html
 [Future.wait()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future/wait.html
+[Future]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html
 [IndexedDB]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-indexed_db/dart-indexed_db-library.html
-[int]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/int-class.html
 [Iterable]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
 [Iterator]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterator-class.html
 [JSON]: https://www.json.org/
 [List]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
 [Map]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html
 [Match]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Match-class.html
+[NativeFinalizer]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-ffi/NativeFinalizer-class.html
 [NoSuchMethodError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/NoSuchMethodError-class.html
-[num]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num-class.html
 [Object]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Object-class.html
 [Pattern]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Pattern-class.html
 [Random]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/Random-class.html
-[`Random.secure()`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/Random/Random.secure.html
 [RegExp]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/RegExp-class.html
 [Set]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Set-class.html
 [Stream]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Stream-class.html
-[String]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/String-class.html
 [StringBuffer]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/StringBuffer-class.html
+[String]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/String-class.html
 [Symbol]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Symbol-class.html
+[UTF-8]: https://en.wikipedia.org/wiki/UTF-8
+[Uri]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Uri-class.html
+[WeakReference]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/WeakReference-class.html
+[`Random.secure()`]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/Random/Random.secure.html
+[dart:async]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/dart-async-library.html
+[dart:collection]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-collection/dart-collection-library.html
+[dart:convert]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html
+[dart:core]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/dart-core-library.html
+[dart:ffi]: /guides/libraries/c-interop
+[dart:io tour]: #dartio
+[dart:math]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/dart-math-library.html
+[dart:typed\_data]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-typed_data/dart-typed_data-library.html
+[docs.flutter]: {{site.flutter_api}}
+[double]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/double-class.html
+[garbage-collected]: https://medium.com/flutter/flutter-dont-fear-the-garbage-collector-d69b3ff1ca30
+[int]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/int-class.html
+[language tour]: /guides/language/language-tour
+[num]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num-class.html
 [toStringAsFixed()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num/toStringAsFixed.html
 [toStringAsPrecision()]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/num/toStringAsPrecision.html
-[UTF-8]: https://en.wikipedia.org/wiki/UTF-8
+[weak reference]: https://en.wikipedia.org/wiki/Weak_reference
 [web audio]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-web_audio/dart-web_audio-library.html
-[Uri]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Uri-class.html
 [webdev libraries]: /web/libraries

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1036,13 +1036,14 @@ For more information, see
 (in the language tour) and the [Exception API reference.][Exception]
 
 ### Weak references and finalizers
+
 Dart is a [garbage-collected][] language,
 which means that any Dart object
 that isn't referenced by at least one other object
 will eventually be disposed by the garbage collector. 
-This default behavior may not be desireable in
+This default behavior might not be desirable in
 some scenarios involving native resources or 
-if the target object cannot be sub-classed.
+if the target object can't be subclassed.
 
 A [WeakReference][]
 stores a reference to the target object
@@ -1050,18 +1051,18 @@ without increasing the reference count
 considered by the garbage collector.
 Another option is to use an [Expando][]
 to add properties to an object
-without affecting how they are garbage-collected.
+without affecting how it's garbage collected.
 
 A [Finalizer][] can be used to execute a callback function
 after an object is no longer referenced.
-It is not guaranteed to execute this callback, however.
+However, it is not guaranteed to execute this callback.
 
 A [NativeFinalizer][]
 provides stronger guarantees
-for interacting with native code using [dart:ffi][].
-Its callback will be called at least once
+for interacting with native code using [dart:ffi][];
+its callback is invoked at least once
 after the object is no longer referenced.
-It can be used to close native resources
+Also, it can be used to close native resources
 such as a database connection or open files.
 
 To ensure that an object won't be finalized

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1068,6 +1068,10 @@ To ensure that an object won't be
 garbage collected and finalized too early,
 classes can implement the [Finalizable][] interface.
 
+{{site.alert.version-note}}
+Support for weak references and finalizers was added in Dart 2.17.
+{{site.alert.end}}
+
 ## dart:async - asynchronous programming
 
 Asynchronous programming often uses callback functions, but Dart

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1043,7 +1043,7 @@ that isn't referenced
 can be disposed by the garbage collector. 
 This default behavior might not be desirable in
 some scenarios involving native resources or 
-if the target object can't be subclassed.
+if the target object can't be modified.
 
 A [WeakReference][]
 stores a reference to the target object

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1039,7 +1039,7 @@ For more information, see
 
 Dart is a [garbage-collected][] language,
 which means that any Dart object
-that isn't referenced by at least one other object
+that isn't referenced
 can be disposed by the garbage collector. 
 This default behavior might not be desirable in
 some scenarios involving native resources or 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1072,7 +1072,7 @@ it won't be garbage collected
 until the code block where it is declared has exited.
 
 {{site.alert.version-note}}
-Support for weak references and finalizers was added in Dart 2.17.
+  Support for weak references and finalizers was added in Dart 2.17.
 {{site.alert.end}}
 
 ## dart:async - asynchronous programming

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1067,6 +1067,9 @@ such as a database connection or open files.
 To ensure that an object won't be
 garbage collected and finalized too early,
 classes can implement the [Finalizable][] interface.
+When a local variable is Finalizable, 
+it won't be garbage collected
+until the code block where it is declared has exited.
 
 {{site.alert.version-note}}
 Support for weak references and finalizers was added in Dart 2.17.


### PR DESCRIPTION
This adds a section on weak references and finalizers to the library tour. I added it to the `dart:core` section, but we might want to add a `dart:ffi` section section to this page also.

closes #3903