### PR TITLE
Adjust homepage Try Dart styles to avoid distracting white bar

### DIFF
--- a/src/_sass/_dash.scss
+++ b/src/_sass/_dash.scss
@@ -298,6 +298,10 @@ $dash-dartpad-border: #293542;
   }
 }
 
+.dash-dartpad-row {
+  background-color: $dash-callout;
+}
+
 .dash-dartpad {
   flex: 1;
 
@@ -308,7 +312,7 @@ $dash-dartpad-border: #293542;
   width: 100vw;
   height: 100vh;
   padding: 32px;
-  margin-block-end: 50px;
+  margin-block-end: 48px;
 
   background-color: $dash-callout;
 

--- a/src/index.html
+++ b/src/index.html
@@ -408,7 +408,7 @@ js:
             <img class="galleryThree dash-align-left" src="assets/dash/svg/3-1 - aot compile.svg"/>
         </div>
     </section>
-    <section class="row">
+    <section class="row dash-dartpad-row">
         <div class="dash-dartpad">
             <a id="try-dart" class="frontanchor"></a>
             <h2>Try Dart in your browser</h2>


### PR DESCRIPTION
The "Try Dart" navigation element is meant to navigate to a portion of the page which fills the viewport and looks dedicated to trying Dart in the embedded DartPad. Currently though there is a distracting white bar on the bottom due to the margin added to enable this sizing (https://github.com/dart-lang/site-www/pull/2232). 

This adjusts the row it is in to have a matching background color. I tried switching the margin to padding instead but due to the desire to fill the viewport, this reduces the space available to DartPad. 

The images make the change hard to visualize, I recommend viewing the staged #try-dart on a browser window wide enough to show the navbar items.

**Previously:**

<img width="745" alt="Previous Try Dart portion with white bar" src="https://user-images.githubusercontent.com/18372958/169287794-61181bf9-1751-4724-8fac-b4a28ec12e48.png">

**After:**

<img width="748" alt="New Try Dart portion without white bar" src="https://user-images.githubusercontent.com/18372958/169287890-f4caa800-65e3-4ebc-86ec-664f7df01306.png">
