### PR TITLE
Make the reason of commit .lock file clearer

### DIFF
--- a/src/_guides/libraries/private-files.md
+++ b/src/_guides/libraries/private-files.md
@@ -103,7 +103,10 @@ similar to Ruby's `Gemfile.lock`.
 Regenerating the `pubspec.lock` file lets you test your package
 against the latest compatible versions of its dependencies.
 
-**For application packages**, we recommend that you commit
-the `pubspec.lock` file.
-Saving `pubspec.lock` will track the dependencies in production or
-development, it can help you locate problems due to dependency changes.
+**For application packages**, 
+we recommend that you commit the `pubspec.lock` file.
+Versioning the `pubspeck.lock` file
+ensures changes to transitive dependencies are explicit.
+Each time the dependencies change due to `dart pub upgrade`
+or a change in `pubspec.yaml` 
+the difference will be apparent in the lock file.

--- a/src/_guides/libraries/private-files.md
+++ b/src/_guides/libraries/private-files.md
@@ -103,7 +103,7 @@ similar to Ruby's `Gemfile.lock`.
 Regenerating the `pubspec.lock` file lets you test your package
 against the latest compatible versions of its dependencies.
 
-**For application packages**, we recommend that you
-**commit** the `pubspec.lock` file.
-Saving `pubspec.lock` ensures that everyone working on the app
-uses the exact same versions.
+**For application packages**, we recommend that you commit
+the `pubspec.lock` file.
+Saving `pubspec.lock` will track the dependencies in production or
+development, it can help you locate problems due to dependency changes.


### PR DESCRIPTION
It can't `ensures that everyone working on the app uses the exact same versions` because the member of the team are working in different branches, and when they add some new libs or run `flutter clean && flutter pub get` , `pubspec.lock` file will update.

I recommend that you commit the`pubspec.lock` file just because it will help you locate problems in production or development due to dependency changes.

And some old discussions:
https://github.com/dart-archive/one-hour-codelab/pull/41
https://github.com/dart-lang/site-www/pull/2332
https://github.com/dart-lang/site-www/issues/292