### PR TITLE
Clarify what can be accessed with the cascade operator

### DIFF
--- a/examples/misc/bin/cheatsheet/cascades.dart
+++ b/examples/misc/bin/cheatsheet/cascades.dart
@@ -18,13 +18,15 @@ void main() {
   button?.text = 'Confirm';
   button?.classes.add('important');
   button?.onClick.listen((e) => window.alert('Confirmed!'));
+  button?.scrollIntoView();
   // #enddocregion query-without-cascades
 
   // #docregion query-with-cascades
   querySelector('#confirm')
     ?..text = 'Confirm'
     ..classes.add('important')
-    ..onClick.listen((e) => window.alert('Confirmed!'));
+    ..onClick.listen((e) => window.alert('Confirmed!'))
+    ..scrollIntoView();
   // #enddocregion query-with-cascades
 }
 

--- a/examples/misc/test/language_tour/browser_test.dart
+++ b/examples/misc/test/language_tour/browser_test.dart
@@ -16,7 +16,8 @@ void main() {
     querySelector('#confirm') // Get an object.
       ?..text = 'Confirm' // Use its members.
       ..classes.add('important')
-      ..onClick.listen((e) => window.alert('Confirmed!'));
+      ..onClick.listen((e) => window.alert('Confirmed!'))
+      ..scrollIntoView();
     // #enddocregion cascade-operator
 
     expect(document.querySelector('#confirm')?.text, 'Confirm');
@@ -31,6 +32,7 @@ void main() {
     button?.text = 'Confirm';
     button?.classes.add('important');
     button?.onClick.listen((e) => window.alert('Confirmed!'));
+    button?.scrollIntoView();
     // #enddocregion cascade-operator-example-expanded
 
     expect(document.querySelector('#confirm')?.text, 'Confirm');

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2081,8 +2081,8 @@ String playerName(String? name) {
 ### Cascade notation
 
 Cascades (`..`, `?..`) allow you to make a sequence of operations
-on the same object. In addition to function calls,
-you can also access fields on that same object.
+on the same object. In addition to accessing instance members,
+you can also call instance methods on that same object.
 This often saves you the step of creating a temporary variable and
 allows you to write more fluid code.
 
@@ -2112,10 +2112,6 @@ paint.strokeCap = StrokeCap.round;
 paint.strokeWidth = 5.0;
 ```
 
-{% comment %}
-[TODO #2950: make sure `?..` is covered in /null-safety]
-{% endcomment %}
-
 If the object that the cascade operates on can be null,
 then use a _null-shorting_ cascade (`?..`) for the first operation.
 Starting with `?..` guarantees that none of the cascade operations
@@ -2127,6 +2123,7 @@ querySelector('#confirm') // Get an object.
   ?..text = 'Confirm' // Use its members.
   ..classes.add('important')
   ..onClick.listen((e) => window.alert('Confirmed!'));
+  ..scrollIntoView();
 ```
 
 {{site.alert.version-note}}
@@ -2141,6 +2138,7 @@ var button = querySelector('#confirm');
 button?.text = 'Confirm';
 button?.classes.add('important');
 button?.onClick.listen((e) => window.alert('Confirmed!'));
+button?.scrollIntoView();
 ```
 
 You can also nest cascades. For example:

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2122,7 +2122,7 @@ are attempted on that null object.
 querySelector('#confirm') // Get an object.
   ?..text = 'Confirm' // Use its members.
   ..classes.add('important')
-  ..onClick.listen((e) => window.alert('Confirmed!'));
+  ..onClick.listen((e) => window.alert('Confirmed!'))
   ..scrollIntoView();
 ```
 

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -641,6 +641,7 @@ var button = querySelector('#confirm');
 button?.text = 'Confirm';
 button?.classes.add('important');
 button?.onClick.listen((e) => window.alert('Confirmed!'));
+button?.scrollIntoView();
 ```
 
 To instead use cascades, 
@@ -655,7 +656,8 @@ and makes the `button` variable unnecessary:
 querySelector('#confirm')
   ?..text = 'Confirm'
   ..classes.add('important')
-  ..onClick.listen((e) => window.alert('Confirmed!'));
+  ..onClick.listen((e) => window.alert('Confirmed!'))
+  ..scrollIntoView();
 ```
 
 ### Code example


### PR DESCRIPTION
Also adds an example of using an instance method directly as part of the cascade.

Fixes #4064