### PR TITLE
Link directly to more useful macOS code signing instructions

### DIFF
--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -76,12 +76,13 @@ Hello World
 ```
 
 {{site.alert.info}}
-  **On macOS,** the Dart VM (`dart`) can load only **signed libraries.**
-  For details and workarounds,
-  see [SDK issue #38314.][38314]
+  **On macOS,** executables, including the Dart VM (`dart`),
+  can load only **signed libraries.**
+  For more information on signing libraries, 
+  see Apple's [Code Signing Guide.][codesign]
 {{site.alert.end}}
 
-[38314]: https://github.com/dart-lang/sdk/issues/38314
+[codesign]: https://developer.apple.com/library/content/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html
   
 
 ### Using dart:ffi


### PR DESCRIPTION
Also makes it seems less of a `dart` restriction, as it applies to all executables on macOS.

We could drop the mention but it seems relevant for developers as they may not be aware of the platform's requirements/limitations and it is different from other OSes.

Fixes #4055