### PR TITLE
Improve cookie notice handling

### DIFF
--- a/src/_includes/cookie-notice.html
+++ b/src/_includes/cookie-notice.html
@@ -1,10 +1,10 @@
-<section class="cookie-notice">
+<section id="cookie-notice">
   <div class="container">
     <p>Google uses cookies to deliver its services, to personalize ads, and to 
       analyze traffic. You can adjust your privacy controls anytime in your 
       <a href="https://myaccount.google.com/data-and-personalization" target="_blank" rel="noopener" class="no-automatic-external">Google settings</a>. 
       <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener" class="no-automatic-external">Learn more</a>.
     </p>
-    <button id="cookie-consent" class="btn btn-primary">Okay</a>
+    <button id="cookie-consent" class="btn btn-primary">Okay</button>
   </div>
 </section>

--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -1,4 +1,4 @@
-.cookie-notice {
+#cookie-notice {
   background-color: white;
   padding: 2.5rem 0 !important;
   position: fixed;
@@ -48,7 +48,7 @@
   }
 }
 
-body.homepage .cookie-notice {
+body.homepage #cookie-notice {
   background-color: $site-color-dark-background;
 
   .container {

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -138,7 +138,6 @@ function setPopovers(root, viewport) {
 
 /**
  * Activate the cookie notice footer
- * @returns null
  */
 function initCookieNotice() {
   const notice = document.getElementById('cookie-notice');

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -141,7 +141,7 @@ function setPopovers(root, viewport) {
  * @returns null
  */
 function initCookieNotice() {
-  const notice = document.querySelector('.cookie-notice');
+  const notice = document.getElementById('cookie-notice');
   const agreeBtn = document.getElementById('cookie-consent');
   const cookieKey = 'dart-site-cookie-consent';
   const cookieConsentValue = 'true'
@@ -155,7 +155,7 @@ function initCookieNotice() {
 
   agreeBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    Cookies.set(cookieKey, cookieConsentValue);
+    Cookies.set(cookieKey, cookieConsentValue, { sameSite: 'strict', expires: 30});
     notice.classList.remove(activeClass);
   });
 }


### PR DESCRIPTION
The previous handling was getting annoying as it was stored in a session local cookie, so every time someone opened the browser again the notice would reappear. This adjusts the cookie to have an expiration date. 

@btobin @RedBrogdon Does the choice need to only last a session? It seems other sites persist this decision. If it is okay: how long can we persist it for? I set 30 days in this PR but longer would be nice :)

Thanks for the help!

_Also switches the element to an ID since there is only one anyway._