### PR TITLE
Run most of stage steps in non-local branches and for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -96,7 +95,11 @@ jobs:
         with:
           sdk: stable
       - run: tool/check-links.sh
-      - uses: FirebaseExtended/action-hosting-deploy@3a02c012c6a9b183828eeb456247327a894fc698
+      - name: Stage site on Firebase
+        if: ${{ 
+          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.user.login != 'dependabot[bot]' }}
+        uses: FirebaseExtended/action-hosting-deploy@3a02c012c6a9b183828eeb456247327a894fc698
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_DEV }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - run: tool/check-links.sh
       - name: Stage site on Firebase
         if: ${{ 
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: FirebaseExtended/action-hosting-deploy@3a02c012c6a9b183828eeb456247327a894fc698
         with:


### PR DESCRIPTION
This allows the build and link check to run on PRs which do not originate from a dart-lang/site-www branch, allowing increased testing/coverage of external contributor PRs. This will also prevent dependabot from trying to stage the website on Firebase as it doesn't have access to secrets and will fail. 

Fixes https://github.com/dart-lang/site-www/issues/3954