### PR TITLE
Add temporary link fix for FFI link in diagnostic documentation

### DIFF
--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -19764,3 +19764,5 @@ Iterable<String> get zero sync* {
   yield '0';
 }
 {% endprettify %}
+
+[C interop using dart:ffi]: /guides/libraries/c-interop


### PR DESCRIPTION
This link is linked to many times throughout the page but has no link target, causing the links to fail. This is a temporary fix until the generator adds the link itself.