### PR TITLE
Add ignore to fix warning around import examples

### DIFF
--- a/examples/misc/lib/effective_dart/style_lib_bad.dart
+++ b/examples/misc/lib/effective_dart/style_lib_bad.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_import
+// ignore_for_file: unused_import, duplicate_import
 // #docregion export
 import 'src/error.dart';
 export 'src/error.dart';

--- a/examples/misc/lib/effective_dart/style_lib_good.dart
+++ b/examples/misc/lib/effective_dart/style_lib_good.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_import
+// ignore_for_file: unused_import, duplicate_import
 // #docregion
 library peg_parser.source_scanner;
 


### PR DESCRIPTION
These newly introduced diagnostics are causing the build to fail.

These files are showcasing import styles so these duplicates are okay.