### PR TITLE
Don't generate external link icons on fully specified dart.dev links

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -197,7 +197,10 @@ $(function() {
   $(window).smartresize(fixNav());
 
   // Add external link indicators
-  $('a[href^="http"], a[target="_blank"]').not('.no-automatic-external').addClass('external');
+  $('a[href^="http"], a[target="_blank"]')
+      .not('.no-automatic-external')
+      .not('a[href^="https://dart.dev"]')
+      .addClass('external');
 
   // Collapsible inline TOC expand/collapse
   $(".site-toc--inline__toggle").on('click', function () {


### PR DESCRIPTION
Fixes #4076