### PR TITLE
Pin ruby dockerfile to a hash, also pin versions of firebase-tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: npm install -g firebase-tools
+      - run: npm install -g firebase-tools@11.0.1
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: stable
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: npm install -g firebase-tools
+      - run: npm install -g firebase-tools@11.0.1
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3-slim-bullseye as base
+FROM ruby:3-slim-bullseye@sha256:fd04845e99c1370b5bd56e0c703cdd4f8d20e7f896ec122a1b5b51d4da66c7aa as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=US/Pacific
@@ -106,7 +106,7 @@ RUN BUNDLE_WITHOUT="test production" bundle install --jobs=4 --retry=2
 
 ENV NODE_ENV=development
 COPY package.json package-lock.json ./
-RUN npm install -g firebase-tools
+RUN npm install -g firebase-tools@11.0.1
 RUN npm install
 
 COPY ./ ./
@@ -169,7 +169,7 @@ RUN bundle exec jekyll build --config $BUILD_CONFIGS
 
 # ============== DEPLOY to FIREBASE ==============
 FROM build as deploy
-RUN npm install -g firebase-tools
+RUN npm install -g firebase-tools@11.0.1
 ARG FIREBASE_TOKEN
 ENV FIREBASE_TOKEN=$FIREBASE_TOKEN
 ARG FIREBASE_PROJECT=default


### PR DESCRIPTION
This PR pins the dockerfile ruby image hash, along with explicitly declaring the version of firebase-tools in order to ensure consistent builds and increase security.
This PR resolves a couple of security vulnerabilities:
* https://github.com/dart-lang/site-www/security/code-scanning/16
* https://github.com/dart-lang/site-www/security/code-scanning/46
* https://github.com/dart-lang/site-www/security/code-scanning/45