### PR TITLE
Drop reference to (long deprecated) dump info visualizer

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -141,6 +141,7 @@
       { "source": "/go/dartdoc-options-file", "destination": "https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml", "type": 301 },
       { "source": "/go/data-driven-fixes", "destination": "https://github.com/flutter/flutter/wiki/Data-driven-Fixes", "type": 301 },
       { "source": "/go/dot-packages-deprecation", "destination": "https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md", "type": 301 },
+      { "source": "/go/dart2js-info", "destination": "https://github.com/dart-lang/sdk/tree/main/pkg/dart2js_info", "type": 301 },
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
       { "source": "/go/ffi", "destination": "/guides/libraries/c-interop", "type": 301 },

--- a/src/tools/dart2js.md
+++ b/src/tools/dart2js.md
@@ -166,9 +166,8 @@ The following options control the analysis that dart2js performs on Dart code:
 `--dump-info`
 : Generates a file (with the suffix `.info.json`)
   that contains information about the generated code.
-  You can inspect the generated file with the
-  [Dump Info Visualizer.](https://github.com/dart-lang/dump-info-visualizer)
-
+  You can inspect the generated file with tools in
+  [dart2js_info](https://github.com/dart-lang/sdk/tree/main/pkg/dart2js_info).
 
 ## Helping dart2js generate better code {#helping-dart2js-generate-efficient-code}
 

--- a/src/tools/dart2js.md
+++ b/src/tools/dart2js.md
@@ -167,7 +167,7 @@ The following options control the analysis that dart2js performs on Dart code:
 : Generates a file (with the suffix `.info.json`)
   that contains information about the generated code.
   You can inspect the generated file with tools in
-  [dart2js_info](https://github.com/dart-lang/sdk/tree/main/pkg/dart2js_info).
+  [dart2js_info](/go/dart2js-info).
 
 ## Helping dart2js generate better code {#helping-dart2js-generate-efficient-code}
 


### PR DESCRIPTION
Replace with link to tools in the SDK
