### PR TITLE
Remove Code example headers from TOC in cheatsheet codelab

### DIFF
--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -40,6 +40,7 @@ Here are some examples of using string interpolation:
 | `'$myObject'`               | | The value of `myObject.toString()` |
 
 ### Code example
+{: .no_toc}
 
 The following function takes two integers as parameters.
 Make it return a string containing both integers separated by a space.
@@ -123,6 +124,7 @@ read the [sound null safety guide](/null-safety).
 
 
 ### Code example
+{: .no_toc}
 
 Try to declare two variables below:
 - A nullable `String` named `name` with the value `'Jane'`.
@@ -190,6 +192,7 @@ print(null ?? 12); // <-- Prints 12.
 ```
 
 ### Code example
+{: .no_toc}
 
 Try substituting in the `??=` and `??` operators
 to implement the described behavior in the following snippet.
@@ -285,6 +288,7 @@ null.
 
 
 ### Code example
+{: .no_toc}
 
 Try using conditional property access to finish the code snippet below.
 
@@ -381,6 +385,7 @@ final aListOfBaseType = <BaseType>[SubType(), SubType()];
 ```
 
 ### Code example
+{: .no_toc}
 
 Try setting the following variables to the indicated values. Replace the existing null values.
 
@@ -506,6 +511,7 @@ bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
 ```
 
 ### Code example
+{: .no_toc}
 
 Try finishing the following statements, which use arrow syntax.
 
@@ -661,6 +667,7 @@ querySelector('#confirm')
 ```
 
 ### Code example
+{: .no_toc}
 
 Use cascades to create a single statement that
 sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
@@ -805,6 +812,7 @@ class MyClass {
 ```
 
 ### Code example
+{: .no_toc}
 
 Imagine you have a shopping cart class that keeps a private `List<double>`
 of prices.
@@ -959,6 +967,7 @@ int sumUpToFive(int a, [int b = 2, int c = 3, int d = 4, int e = 5]) {
 ```
 
 ### Code example
+{: .no_toc}
 
 Implement a function called `joinWithCommas()` that accepts one to
 five integers, then returns a string of those numbers separated by commas.
@@ -1091,6 +1100,7 @@ A function can't have both optional positional and named parameters.
 
 
 ### Code example
+{: .no_toc}
 
 Add a `copyWith()` instance method to the `MyDataObject`
 class. It should take three named, nullable parameters:
@@ -1271,6 +1281,7 @@ try {
 ```
 
 ### Code example
+{: .no_toc}
 
 Implement `tryFunction()` below. It should execute an untrustworthy method and
 then do the following:
@@ -1481,6 +1492,7 @@ MyColor({this.red = 0, this.green = 0, this.blue = 0});
 ```
 
 ### Code example
+{: .no_toc}
 
 Add a one-line constructor to `MyClass` that uses
 `this.` syntax to receive and assign values for
@@ -1583,6 +1595,7 @@ NonNegativePoint(this.x, this.y)
 ```
 
 ### Code example
+{: .no_toc}
 
 Complete the `FirstTwoLetters` constructor below.
 Use an initializer list to assign the first two characters in `word` to
@@ -1703,6 +1716,7 @@ final myPoint = Point.origin();
 ```
 
 ### Code example
+{: .no_toc}
 
 Give the `Color` class a constructor named `Color.black`
 that sets all three properties to zero.
@@ -1797,6 +1811,7 @@ class Shape {
 ```
 
 ### Code example
+{: .no_toc}
 
 Fill in the factory constructor named `IntegerHolder.fromList`,
 making it do the following:
@@ -1992,6 +2007,7 @@ class Automobile {
 ```
 
 ### Code example
+{: .no_toc}
 
 Remember the `Color` class from above? Create a named constructor called
 `black`, but rather than manually assigning the properties, redirect it to the
@@ -2078,6 +2094,7 @@ class ImmutablePoint {
 ```
 
 ### Code example
+{: .no_toc}
 
 Modify the `Recipe` class so its instances can be constants,
 and create a constant constructor that does the following:


### PR DESCRIPTION
They are duplicated and don't add anything to the TOC.