### PR TITLE
Do not run stage workflow on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+    if: ${{ github.ref != 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The checks are duplicated by the `deploy` workflow on the `main` branch.