### PR TITLE
Include quick fix status in linter rule documentation

### DIFF
--- a/src/_includes/linter-rules-section.md
+++ b/src/_includes/linter-rules-section.md
@@ -36,6 +36,10 @@ _This rule is currently **{{lint.maturity}}**._
 
 {% endif %}
 
+{% if lint.fixStatus == "hasFix" %}
+<em>This rule has a [quick fix](#quick-fixes) available.</em>
+{% endif %}
+
 {% if lint.incompatible != empty %}
 
 {% assign incompatible_rules = "" %}

--- a/src/tools/linter-rules.md
+++ b/src/tools/linter-rules.md
@@ -102,6 +102,10 @@ Deprecated
 : These rules are no longer suggested for use
   and might be removed in a future linter release.
 
+## Quick fixes
+
+TODO: Quick fixes documentation
+
 ## Error rules
 
 These rules identify possible errors and other mistakes in your code.

--- a/src/tools/linter-rules.md
+++ b/src/tools/linter-rules.md
@@ -104,7 +104,17 @@ Deprecated
 
 ## Quick fixes
 
-TODO: Quick fixes documentation
+Some rules can be fixed automatically using quick fixes.
+A quick fix is an automated edit 
+targeted at fixing the issue
+reported by the linter rule.
+
+If the rule has a quick fix,
+it can be applied using [`dart fix`](/tools/dart-fix)
+or using your [editor with Dart support](/tools#ides-and-editors).
+To learn more, see [Quick fixes for analysis issues][].
+
+[Quick fixes for analysis issues]: https://medium.com/dartlang/quick-fixes-for-analysis-issues-c10df084971a
 
 ## Error rules
 


### PR DESCRIPTION
Reuses the explanation of a quick fix from elsewhere. I would like to introduce a fleshed out document covering quick fixes eventually, but this is nice location to link to in the mean time.

**Staged:** https://dart-dev--pr4149-misc-update-linter-r-gpy8zbl6.web.app/tools/linter-rules#quick-fixes

Fixes https://github.com/dart-lang/site-www/issues/4143