### PR TITLE
Fix: dart installing reference

### DIFF
--- a/src/get-dart/_mac.md
+++ b/src/get-dart/_mac.md
@@ -3,7 +3,7 @@ and then run the following commands:
 
 ```terminal
 $ brew tap dart-lang/dart
-$ brew install dart
+$ brew install dart-sdk
 ```
 
 {{site.alert.important}}


### PR DESCRIPTION
When trying to install dart from the latest Homebrew version with the command "brew install dart" it gives a warning:

"
Warning: No available formula with the name "dart". Did you mean dar or dirt?
==> Searching for similarly named formulae...
These similarly named formulae were found:
dart-sdk            dartsim             dar                 dirt
"

Update dart reference to one that works, dart-sdk