### PR TITLE
Removed Dart 2.17 from banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,8 +1,6 @@
 {% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
 <div class="banner">
   <p class="banner__text">
-    Dart 2.17 is here, with new language features, improved tooling, and broadened platform integration.
-    <a href="https://medium.com/dartlang/dart-2-17-b216bfc80c5d">Learn more</a><br>
     The Flutter and Dart teams are hiring.
     <a href="https://docs.flutter.dev/jobs">Learn more</a>
   </p>


### PR DESCRIPTION
@mit-mit : Please review the removal of the 2.17 note from the banner.

![Screen Shot 2022-08-17 at 12 44 58 PM](https://user-images.githubusercontent.com/706219/185207051-c7a66825-0420-4c95-b624-210fbb79567c.png)

[Staged](https://dart--staging.web.app/)
No build errors.
No related issue.