### PR TITLE
Add 2.18 type inference workaround from change log to sound-problems.md

### DIFF
--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -134,14 +134,18 @@ void funcCast() {
 
 //-----------------------------------------------
 
-// #docregion type-inf-null
+void infNull() {
+  // #docregion type-inf-null
   List<int> ints = [1, 2, 3];
-  var maximumOrNull = ints.fold(null,
-      (a, b) => a == null || a < b ? b : a);
-// #enddocregion type-inf-null
+  // ignore: non_bool_operand, undefined_operator
+  var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
+  // #enddocregion type-inf-null    
+} 
 
-// #docregion type-inf-fix
+void infFix() {
+  // #docregion type-inf-fix
   List<int> ints = [1, 2, 3];
-  var maximumOrNull = ints.fold<int?>(null,
-      (a, b) => a == null || a < b ? b : a);
-// #enddocregion type-inf-fix
+  var maximumOrNull =
+      ints.fold<int?>(null, (a, b) => a == null || a < b ? b : a);
+  // #enddocregion type-inf-fix
+}

--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -131,3 +131,17 @@ void funcCast() {
   filterValues((x) => (x as String).contains('Hello'));
   // #enddocregion func-cast
 }
+
+//-----------------------------------------------
+
+// #docregion type-inf-null
+  List<int> ints = [1, 2, 3];
+  var maximumOrNull = ints.fold(null,
+      (a, b) => a == null || a < b ? b : a);
+// #enddocregion type-inf-null
+
+// #docregion type-inf-fix
+  List<int> ints = [1, 2, 3];
+  var maximumOrNull = ints.fold<int?>(null,
+      (a, b) => a == null || a < b ? b : a);
+// #enddocregion type-inf-fix

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -268,6 +268,8 @@ To learn more about named parameters and arguments, see the
 [Named parameters]: /guides/language/language-tour#named-parameters
 
 
+### Dart 2.18
+
 ## Language versioning
 
 A single Dart SDK can simultaneously support

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -37,7 +37,8 @@ List<String> [!string = numbers!];
 Since neither `List<int>` nor `List<String>` is a subtype of the other,
 Dart rules this out statically. 
 
-You can see other examples of static analysis errors, as well as other error types, in the sections below.
+You can see other examples of static analysis errors,
+as well as other error types, in the following sections.
 
 
 ## No type errors {#no-type-errors}
@@ -489,24 +490,24 @@ filterValues((x) => (x [!as String!]).contains('Hello'));
 ### Incorrect type inference
 
 ```nocode
-error - ...
+error - The return type '...' isn't a '...', as required by the closure's context - return_of_invalid_type_from_closure
 ```
 
-On rare occasions, Dart's enhaced type inference may infer the wrong type for function literal arguments in a generic constructor invocation.
+On rare occasions, Dart's enhanced type inference might infer
+the wrong type for function literal arguments in a generic constructor invocation.
 This primarily affects `Iterable.fold`
 
 #### Example
 
-In this code, type inference will infer that `a` has a type of `Null`:
+In the following code,
+type inference will infer that `a` has a type of `Null`:
 
 {:.fails-sa}
 <?code-excerpt "lib/... ()" replace=""?>
 {% prettify dart tag=pre+code %}
-void main() {
   List<int> ints = [1, 2, 3];
   var maximumOrNull = ints.fold(null,
       (a, b) => a == null || a < b ? b : a);
-}
 {% endprettify %}
 
 #### Fix: Supply appropriate type as explicit type argument
@@ -514,11 +515,9 @@ void main() {
 {:.passes-sa}
 <?code-excerpt "lib/... ()" replace=""?>
 {% prettify dart tag=pre+code %}
-void main() {
   List<int> ints = [1, 2, 3];
   var maximumOrNull = ints.fold<int?>(null,
       (a, b) => a == null || a < b ? b : a);
-}
 {% endprettify %}
 
 <hr>

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -495,7 +495,7 @@ error - The return type '...' isn't a '...', as required by the closure's contex
 
 On rare occasions, Dart's enhanced type inference might infer
 the wrong type for function literal arguments in a generic constructor invocation.
-This primarily affects `Iterable.fold`
+This primarily affects `Iterable.fold`.
 
 #### Example
 
@@ -503,7 +503,7 @@ In the following code,
 type inference will infer that `a` has a type of `Null`:
 
 {:.fails-sa}
-<?code-excerpt "lib/... ()" replace=""?>
+<?code-excerpt "lib/common_fixes_analysis.dart (type-inf-null)"?>
 {% prettify dart tag=pre+code %}
   List<int> ints = [1, 2, 3];
   var maximumOrNull = ints.fold(null,
@@ -513,7 +513,7 @@ type inference will infer that `a` has a type of `Null`:
 #### Fix: Supply appropriate type as explicit type argument
 
 {:.passes-sa}
-<?code-excerpt "lib/... ()" replace=""?>
+<?code-excerpt "lib/common_fixes_analysis.dart  (type-inf-fix)"?>
 {% prettify dart tag=pre+code %}
   List<int> ints = [1, 2, 3];
   var maximumOrNull = ints.fold<int?>(null,

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -508,8 +508,7 @@ type inference will infer that `a` has a type of `Null`:
 <?code-excerpt "lib/common_fixes_analysis.dart (type-inf-null)"?>
 {% prettify dart tag=pre+code %}
   List<int> ints = [1, 2, 3];
-  var maximumOrNull = ints.fold(null,
-      (a, b) => a == null || a < b ? b : a);
+  var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
 {% endprettify %}
 
 #### Fix: Supply appropriate type as explicit type argument
@@ -518,8 +517,8 @@ type inference will infer that `a` has a type of `Null`:
 <?code-excerpt "lib/common_fixes_analysis.dart  (type-inf-fix)"?>
 {% prettify dart tag=pre+code %}
   List<int> ints = [1, 2, 3];
-  var maximumOrNull = ints.fold<int?>(null,
-      (a, b) => a == null || a < b ? b : a);
+  var maximumOrNull =
+      ints.fold<int?>(null, (a, b) => a == null || a < b ? b : a);
 {% endprettify %}
 
 <hr>

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -20,9 +20,10 @@ and see [these other resources](/guides/language/type-system#other-resources).
 
 ## Troubleshooting
 
-Dart enforces a sound type system. This means you can't write code where a
+Dart enforces a sound type system. 
+This means you can't write code where a
 variable's value differs from its static type.
-An `int` type can't store a number with a decimal place.
+A variable with an `int` type can't store a number with a decimal place.
 Dart checks variable values against their types at
 [compile-time](#static-errors-and-warnings) and [runtime](#runtime-errors).
 

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -20,7 +20,27 @@ and see [these other resources](/guides/language/type-system#other-resources).
 
 ## Troubleshooting
 
-### No type errors {#no-type-errors}
+Dart enforces a sound type system. Roughly, this means
+you can't get into a situation where the value stored in a variable is
+different from the variable's static type. Like most modern statically
+typed languages, Dart accomplishes this with a combination of
+[static (compile-time)](#static-errors-and-warnings) and [dynamic (runtime)](#runtime-errors) checking.
+
+For example, the following type error is detected at compile-time:
+
+{:.fails-sa}
+{% prettify dart tag=pre+code %}
+List<int> numbers = [1, 2, 3];
+List<String> [!string = numbers!];
+{% endprettify %}
+
+Since neither `List<int>` nor `List<String>` is a subtype of the other,
+Dart rules this out statically. 
+
+You can see other examples of static analysis errors, as well as other error types, in the sections below.
+
+
+## No type errors {#no-type-errors}
 
 If you're not seeing expected errors or warnings,
 make sure that you're using the latest version of Dart
@@ -466,29 +486,48 @@ filterValues((x) => (x [!as String!]).contains('Hello'));
 
 <hr>
 
-<a id="common-errors-and-warnings"></a>
-## Runtime errors
+### Incorrect type inference
 
-Dart enforces a sound type system. Roughly, this means
-you can't get into a situation where the value stored in a variable is
-different from the variable's static type. Like most modern statically
-typed languages, Dart accomplishes this with a combination of static
-(compile-time) and dynamic (runtime) checking.
+```nocode
+error - ...
+```
 
-For example, the following type error is detected at compile-time:
+On rare occasions, Dart's enhaced type inference may infer the wrong type for function literal arguments in a generic constructor invocation.
+This primarily affects `Iterable.fold`
+
+#### Example
+
+In this code, type inference will infer that `a` has a type of `Null`:
 
 {:.fails-sa}
+<?code-excerpt "lib/... ()" replace=""?>
 {% prettify dart tag=pre+code %}
-List<int> numbers = [1, 2, 3];
-List<String> [!string = numbers!];
+void main() {
+  List<int> ints = [1, 2, 3];
+  var maximumOrNull = ints.fold(null,
+      (a, b) => a == null || a < b ? b : a);
+}
 {% endprettify %}
 
-Since neither `List<int>` nor `List<String>` is a subtype of the other,
-Dart rules this out statically. You can see other examples of these
-static analysis errors in 
-[Unexpected collection element type](#unexpected-collection-element-type).
+#### Fix: Supply appropriate type as explicit type argument
 
-The errors discussed in the remainder of this section are reported at
+{:.passes-sa}
+<?code-excerpt "lib/... ()" replace=""?>
+{% prettify dart tag=pre+code %}
+void main() {
+  List<int> ints = [1, 2, 3];
+  var maximumOrNull = ints.fold<int?>(null,
+      (a, b) => a == null || a < b ? b : a);
+}
+{% endprettify %}
+
+<hr>
+
+<a id="common-errors-and-warnings"></a>
+
+## Runtime errors
+
+The errors discussed in this section are reported at
 [runtime](type-system#runtime-checks).
 
 ### Invalid casts

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -20,7 +20,12 @@ and see [these other resources](/guides/language/type-system#other-resources).
 
 ## Troubleshooting
 
-Dart enforces a sound type system. Roughly, this means
+Dart enforces a sound type system. This means you can't write code where a
+variable's value differs from its static type.
+An `int` type can't store a number with a decimal place.
+Dart checks variable values against their types at
+[compile-time](#static-errors-and-warnings) and [runtime](#runtime-errors).
+
 you can't get into a situation where the value stored in a variable is
 different from the variable's static type. Like most modern statically
 typed languages, Dart accomplishes this with a combination of

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -494,10 +494,6 @@ filterValues((x) => (x [!as String!]).contains('Hello'));
 
 ### Incorrect type inference
 
-```nocode
-error - The return type '...' isn't a '...', as required by the closure's context - return_of_invalid_type_from_closure
-```
-
 On rare occasions, Dart's enhanced type inference might infer
 the wrong type for function literal arguments in a generic constructor invocation.
 This primarily affects `Iterable.fold`.

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -17,6 +17,17 @@ and follow the [Dart blog][].
 [dart-announce]: https://groups.google.com/a/dartlang.org/d/forum/announce
 [Dart blog]: https://medium.com/dartlang
 
+## August 30, 2022: 2.18 release
+
+This section lists notable changes made from May 12, 2022,
+through August 30, 2022.
+For details about the 2.18 release,
+see [Dart 2.18: ][], and the [change log][https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2180].
+
+In addition to bug fixes and incremental improvements,
+we made the following changes to this site:
+
+
 ## May 11, 2022: 2.17 release
 
 This section lists notable changes made from February 4, 2022,


### PR DESCRIPTION
Thought it might be a good idea to add the ["workaround"](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#language-1) from the type inference enhancement included in 2.18 _somewhere_ in the docs, and this seemed like a good spot.

I'm not sure how the code excerpts work yet though, so, still a draft.

TODO
- [x]  Error message
- [ ]  Complete example code excerpts

I also moved a summary paragraph from the bottom of the page under the **Runtime errors** section. To me, it seems like a summary of the entire page and read strange at the bottom. So it's at the top now.