### PR TITLE
Effective Dart: update type promotion suggestion for private final

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -354,13 +354,20 @@ then it probably does make sense to have a separate boolean field.
 
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
-to functions expecting a non-nullable type. Unfortunately, promotion is only
-sound for local variables and parameters, so fields and top-level variables
-aren't promoted.
+to functions expecting a non-nullable type. 
 
-One pattern to work around this is to assign the field's value to a local
-variable. Null checks on that variable do promote, so you can safely treat
-it as non-nullable.
+Type promotion is only sound, however, for local variables, parameters, and
+private final fields. Instances that are open to manipulation, whether
+explicitly, like top-level variables, or implicitly, like fields with a concrete
+getter of the same name in the same library, cannot be type promoted.
+
+Declaring members [private] and [final] as we generally recommend would bypass
+these limitations, but that's not always an option. One pattern to work around
+this is to assign the field's value to a local variable. Null checks on that
+variable will promote, so you can safely treat it as non-nullable.
+
+[private]: design#prefer-making-declarations-private
+[final]: design#prefer-making-fields-and-top-level-variables-final
 
 {:.good}
 <?code-excerpt "usage_good.dart (shadow-nullable-field)"?>
@@ -384,7 +391,7 @@ class UploadException {
 {% endprettify %}
 
 Assigning to a local variable can be cleaner and safer than using `!` every
-place the field or top-level variable is used:
+place the instance is used:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>


### PR DESCRIPTION


- Added private final fields to the "promotion is only sound for..." sentence
- Expanded on the "...so fields and top-level variables aren't promoted" clause 
  - To me it's a little more nuanced than just "so fields _that aren't private and final_ and top-level variables aren't promoted", hence the longer explanation of what's not promoted and _why_. 
- Added caveat before the main example that if your field is private and final, which can be concluded as the recommended default from the Effective Dart: Design page, that is also a technically a workaround to nullable fields not being type promoted. 

I don't want to disrupt the purpose of that page, so please let me know if the drawn out explanation there distracts from the recommendation in that section!


------
_Note for future me:_
I admit this is a weird spot to essentially define type promotion, but it's kind of the only/clearest place that already does so in the docs... (maybe I'm wrong). 

There's [Type promotion on null checks](https://dart.dev/null-safety/understanding-null-safety#type-promotion-on-null-checks) and [Working with nullable fields](https://dart.dev/null-safety/understanding-null-safety#working-with-nullable-fields) in Understanding null safety. Based on the page title it seems like that'd be a better spot for a type promotion definition. 

But the actual definition of what is and isn't possible with type promotion, in both those sections, is buried in the narrative style of the examples in each section. I.e. just clicking one of those links and arriving on the page at that section doesn't define type definition clearly for a reader who lands there without context. I will be updating those sections as well, though.