### PR TITLE
Remove specific version mention when highlighting Flutter includes Dart

### DIFF
--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -3,7 +3,7 @@ you need an SDK.
 You can either download the Dart SDK directly
 (as described below)
 or [download the Flutter SDK,][]
-which (as of Flutter 1.21) includes the full Dart SDK.
+which includes the full Dart SDK.
 
 [download the Flutter SDK,]: {{site.flutter-docs}}/get-started/install
 

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -51,7 +51,7 @@ Install a JetBrains IDE if you don't already have one. Choose one:
 If you don't already have the Dart SDK,
 install it.
 You can get it either by itself or by downloading the Flutter SDK,
-which (as of Flutter 1.21) includes the full Dart SDK.
+which includes the full Dart SDK.
 
 Choose one:
 


### PR DESCRIPTION
It's been over 2 years since the release of Flutter 1.21, it doesn't seem like this mention is necessary anymore.