### PR TITLE
Mention super parameters with initializing formals

### DIFF
--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -8,6 +8,13 @@ import 'package:examples_util/ellipsis.dart';
 
 import 'design_good.dart';
 
+class Key {}
+
+class StatelessWidget {
+  final Key? key;
+  StatelessWidget({this.key});
+}
+
 void miscDeclAnalyzedButNotTested() {
   (errors, monsters, subscription) {
     // #docregion code-like-prose
@@ -160,6 +167,10 @@ class MyIterable<T> {
 class Point1 {
   double x, y;
   Point1(double this.x, double this.y);
+}
+
+class MyWidget extends StatelessWidget {
+  MyWidget({Key? super.key});
 }
 // #enddocregion dont-type-init-formals
 

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -35,6 +35,13 @@ class Padding extends Widget {
   Padding({required double padding, required Widget child});
 }
 
+class Key {}
+
+class StatelessWidget {
+  final Key? key;
+  StatelessWidget({this.key});
+}
+
 void miscDeclAnalyzedButNotTested() {
   (Iterable errors, Iterable<Monster> monsters) {
     // #docregion code-like-prose
@@ -348,6 +355,10 @@ void miscDeclAnalyzedButNotTested() {
 class Point1 {
   double x, y;
   Point1(this.x, this.y);
+}
+
+class MyWidget extends StatelessWidget {
+  MyWidget({super.key});
 }
 // #enddocregion dont-type-init-formals
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1354,7 +1354,8 @@ function's parameters. In those cases, you may need to annotate.
 If a constructor parameter is using `this.` to initialize a field, 
 or `super.` to forward a super parameter, 
 then the type of the parameter
-is inferred to have the same type as the field.
+is inferred to have the same type as 
+the field or super-constructor parameter respectively.
 
 {:.good}
 <?code-excerpt "design_good.dart (dont-type-init-formals)"?>

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1351,8 +1351,9 @@ function's parameters. In those cases, you may need to annotate.
 
 {% include linter-rule-mention.md rule="type_init_formals" %}
 
-If a constructor parameter is using `this.` to initialize a field, then the type
-of the parameter is inferred to have the same type as the field.
+If a constructor parameter is using `this.` to initialize a field, or `super.`
+to forward a super parameter, then the type of the parameter is inferred to have
+the same type as the field.
 
 {:.good}
 <?code-excerpt "design_good.dart (dont-type-init-formals)"?>
@@ -1360,6 +1361,9 @@ of the parameter is inferred to have the same type as the field.
 class Point {
   double x, y;
   Point(this.x, this.y);
+}
+class MyWidget extends StatelessWidget {
+  MyWidget({super.key});
 }
 {% endprettify %}
 
@@ -1369,6 +1373,9 @@ class Point {
 class Point {
   double x, y;
   Point(double this.x, double this.y);
+}
+class MyWidget extends StatelessWidget {
+  MyWidget({Key? super.key});
 }
 {% endprettify %}
 

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1351,9 +1351,10 @@ function's parameters. In those cases, you may need to annotate.
 
 {% include linter-rule-mention.md rule="type_init_formals" %}
 
-If a constructor parameter is using `this.` to initialize a field, or `super.`
-to forward a super parameter, then the type of the parameter is inferred to have
-the same type as the field.
+If a constructor parameter is using `this.` to initialize a field, 
+or `super.` to forward a super parameter, 
+then the type of the parameter
+is inferred to have the same type as the field.
 
 {:.good}
 <?code-excerpt "design_good.dart (dont-type-init-formals)"?>

--- a/src/_guides/language/effective-dart/design.md
+++ b/src/_guides/language/effective-dart/design.md
@@ -1362,6 +1362,7 @@ class Point {
   double x, y;
   Point(this.x, this.y);
 }
+
 class MyWidget extends StatelessWidget {
   MyWidget({super.key});
 }
@@ -1374,6 +1375,7 @@ class Point {
   double x, y;
   Point(double this.x, double this.y);
 }
+
 class MyWidget extends StatelessWidget {
   MyWidget({Key? super.key});
 }


### PR DESCRIPTION
Fixes #4262

Dart 2.17.0 introduced a syntax for implicitly forwarding constructor arguments to the super constructor. The type is inferred in the same way as initializing formals, so expand the section to include mention of `super.` syntax, and an example.