### PR TITLE
Remove link to unmaintained and outdated translated site

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -72,7 +72,7 @@ Learn how to
 
 ## Additional community resources
 
-Our wonderful community has provided these resources.
+Our wonderful community has provided these resources:
 
 * [Chinese version of this site (此网站的中文版)](https://dart.cn)
 

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -75,7 +75,6 @@ Learn how to
 Our wonderful community has provided these resources.
 
 * [Chinese version of this site (此网站的中文版)](https://dart.cn)
-* [Russian version of this site](https://dart-docs-ru.web.app/)
 
 Also see the [Flutter community page.]({{site.flutter}}/community)
 


### PR DESCRIPTION
The site is unmaintained, outdated, and doesn't have much translated currently.

We can always add it back in the future if the site or another equivalent is maintained again.