### PR TITLE
Allow manually opened sidenav to be in front

### DIFF
--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -116,6 +116,10 @@
   overflow-y: auto;
   z-index: 1;
 
+  .open_menu & {
+    z-index: 10000;
+  }
+
   .site-sidebar {
     // override shared/_sidebar.scss
     padding: $top-content-padding 30px $content-padding;


### PR DESCRIPTION
The banner was going above the sidenav when opened by the open menu button (when the page is shrunk to not be wide).