### PR TITLE
Make explicit downcast section more releastic

### DIFF
--- a/examples/type_system/analyzer-results-beta.txt
+++ b/examples/type_system/analyzer-results-beta.txt
@@ -9,14 +9,14 @@ Analyzing type_system...
            - The member being overridden at lib/common_fixes_analysis.dart:74:8.
   error - lib/common_fixes_analysis.dart:97:9 - The superconstructor call must be last in an initializer list: 'Animal'. - super_invocation_not_last
   error - lib/common_fixes_analysis.dart:117:16 - The argument type 'bool Function(String)' can't be assigned to the parameter type 'bool Function(dynamic)'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:27:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:34:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
-  error - lib/strong_analysis.dart:45:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:61:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:83:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
-  error - lib/strong_analysis.dart:107:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
-  error - lib/strong_analysis.dart:119:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:144:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:29:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
+  error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
+  error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
+  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-beta.txt
+++ b/examples/type_system/analyzer-results-beta.txt
@@ -16,7 +16,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:148:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-beta.txt
+++ b/examples/type_system/analyzer-results-beta.txt
@@ -13,7 +13,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
   error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
   error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
   error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment

--- a/examples/type_system/analyzer-results-dev.txt
+++ b/examples/type_system/analyzer-results-dev.txt
@@ -9,14 +9,14 @@ Analyzing type_system...
            - The member being overridden at lib/common_fixes_analysis.dart:74:8.
   error - lib/common_fixes_analysis.dart:97:9 - The superconstructor call must be last in an initializer list: 'Animal'. - super_invocation_not_last
   error - lib/common_fixes_analysis.dart:117:16 - The argument type 'bool Function(String)' can't be assigned to the parameter type 'bool Function(dynamic)'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:27:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:34:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
-  error - lib/strong_analysis.dart:45:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:61:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:83:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
-  error - lib/strong_analysis.dart:107:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
-  error - lib/strong_analysis.dart:119:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:144:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:29:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
+  error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
+  error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
+  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-dev.txt
+++ b/examples/type_system/analyzer-results-dev.txt
@@ -16,7 +16,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:148:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-dev.txt
+++ b/examples/type_system/analyzer-results-dev.txt
@@ -13,7 +13,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
   error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
   error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
   error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment

--- a/examples/type_system/analyzer-results-stable.txt
+++ b/examples/type_system/analyzer-results-stable.txt
@@ -9,14 +9,14 @@ Analyzing type_system...
            - The member being overridden at lib/common_fixes_analysis.dart:74:8.
   error - lib/common_fixes_analysis.dart:97:9 - The superconstructor call must be last in an initializer list: 'Animal'. - super_invocation_not_last
   error - lib/common_fixes_analysis.dart:117:16 - The argument type 'bool Function(String)' can't be assigned to the parameter type 'bool Function(dynamic)'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:27:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:34:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
-  error - lib/strong_analysis.dart:45:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:61:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:83:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
-  error - lib/strong_analysis.dart:107:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
-  error - lib/strong_analysis.dart:119:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:144:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:29:17 - The argument type 'List<dynamic>' can't be assigned to the parameter type 'List<int>'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
+  error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
+  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
+  error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
+  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-stable.txt
+++ b/examples/type_system/analyzer-results-stable.txt
@@ -16,7 +16,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
-  error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
+  error - lib/strong_analysis.dart:148:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment
   error - test/strong_test.dart:120:26 - A value of type 'dynamic' can't be assigned to a variable of type 'List<String>'. Try changing the type of the variable, or casting the right-hand type to 'List<String>'. - invalid_assignment
 
 16 issues found.

--- a/examples/type_system/analyzer-results-stable.txt
+++ b/examples/type_system/analyzer-results-stable.txt
@@ -13,7 +13,7 @@ Analyzing type_system...
   error - lib/strong_analysis.dart:36:16 - A value of type 'int' can't be assigned to a variable of type 'bool'. Try changing the type of the variable, or casting the right-hand type to 'bool'. - invalid_assignment
   error - lib/strong_analysis.dart:47:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
   error - lib/strong_analysis.dart:63:15 - The argument type 'int' can't be assigned to the parameter type 'String'. - argument_type_not_assignable
-  error - lib/strong_analysis.dart:88:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
+  error - lib/strong_analysis.dart:85:9 - A value of type 'double' can't be assigned to a variable of type 'int'. Try changing the type of the variable, or casting the right-hand type to 'int'. - invalid_assignment
   error - lib/strong_analysis.dart:109:23 - A value of type 'String' can't be assigned to a variable of type 'double'. Try changing the type of the variable, or casting the right-hand type to 'double'. - invalid_assignment
   error - lib/strong_analysis.dart:121:19 - A value of type 'Cat' can't be assigned to a variable of type 'MaineCoon'. Try changing the type of the variable, or casting the right-hand type to 'MaineCoon'. - invalid_assignment
   error - lib/strong_analysis.dart:147:24 - A value of type 'List<Animal>' can't be assigned to a variable of type 'List<Cat>'. Try changing the type of the variable, or casting the right-hand type to 'List<Cat>'. - invalid_assignment

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -136,7 +136,8 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion generic-type-assignment-MaineCoon
-    List<Cat> myCats = <MaineCoon>[];
+    List<MaineCoon> myMaineCoons = ellipsis();
+    List<Cat> myCats = myMaineCoons;
     // #enddocregion generic-type-assignment-MaineCoon
   }
 

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -1,5 +1,7 @@
 // NOTE: Declarations in this file are analyzed but not tested.
-// ignore_for_file: unused_element, unused_local_variable
+// ignore_for_file: unused_element, unused_local_variable, dead_code
+
+import 'package:examples_util/ellipsis.dart';
 
 import 'animal.dart';
 
@@ -140,14 +142,16 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion generic-type-assignment-Animal
+    List<Animal> myAnimals = ellipsis();
     // ignore: stable, beta, dev, invalid_assignment
-    List<Cat> myCats = <Animal>[];
+    List<Cat> myCats = myAnimals;
     // #enddocregion generic-type-assignment-Animal
   }
 
   {
     // #docregion generic-type-assignment-implied-cast
-    List<Cat> myCats = <Animal>[] as List<Cat>;
+    List<Animal> myAnimals = ellipsis();
+    List<Cat> myCats = myAnimals as List<Cat>;
     // #enddocregion generic-type-assignment-implied-cast
   }
 }

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -448,9 +448,10 @@ In the following example, you can assign a `MaineCoon` list to `myCats` because
 `List<MaineCoon>` is a subtype of `List<Cat>`:
 
 {:.passes-sa}
-<?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-MaineCoon)" replace="/MaineCoon/[!$&!]/g"?>
+<?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-MaineCoon)" replace="/<MaineCoon/<[!MaineCoon!]/g"?>
 {% prettify dart tag=pre+code %}
-List<Cat> myCats = <[!MaineCoon!]>[];
+List<[!MaineCoon!]> myMaineCoons = ...
+List<Cat> myCats = myMaineCoons;
 {% endprettify %}
 
 What about going in the other direction? 

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -457,9 +457,9 @@ What about going in the other direction?
 Can you assign an `Animal` list to a `List<Cat>`?
 
 {:.fails-sa}
-<?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-Animal)" replace="/Animal/[!$&!]/g"?>
+<?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-Animal)" replace="/<Animal/<[!Animal!]/g"?>
 {% prettify dart tag=pre+code %}
-List<[!Animal!]> myAnimals = ...;
+List<[!Animal!]> myAnimals = ...
 List<Cat> myCats = myAnimals;
 {% endprettify %}
 
@@ -482,7 +482,7 @@ but it might fail at runtime.
 
 <?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-implied-cast)" replace="/as.*(?=;)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-List<Animal> myAnimals = ...;
+List<Animal> myAnimals = ...
 List<Cat> myCats = myAnimals [!as List<Cat>!];
 {% endprettify %}
 

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -444,8 +444,9 @@ of lists of animals—a `List` of `Cat` is a subtype of a `List` of
 
 <img src="images/type-hierarchy-generics.png" alt="List<Animal> -> List<Cat> -> List<MaineCoon>">
 
-In the following example, you can assign a `MaineCoon` list to `myCats` because
-`List<MaineCoon>` is a subtype of `List<Cat>`:
+In the following example, 
+you can assign a `MaineCoon` list to `myCats`
+because `List<MaineCoon>` is a subtype of `List<Cat>`:
 
 {:.passes-sa}
 <?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-MaineCoon)" replace="/<MaineCoon/<[!MaineCoon!]/g"?>

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -459,7 +459,8 @@ Can you assign an `Animal` list to a `List<Cat>`?
 {:.fails-sa}
 <?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-Animal)" replace="/Animal/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-List<Cat> myCats = <[!Animal!]>[];
+List<[!Animal!]> myAnimals = ...;
+List<Cat> myCats = myAnimals;
 {% endprettify %}
 
 This assignment doesn't pass static analysis 
@@ -475,13 +476,14 @@ which is disallowed from non-`dynamic` types such as `Animal`.
   in the [analysis options file.][analysis]
 {{site.alert.end}}
 
-To make this code pass static analysis, 
-use an explicit cast, 
-which might fail at runtime.
+To make this type of code pass static analysis, 
+you can use an explicit cast, 
+but it might fail at runtime.
 
 <?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-implied-cast)" replace="/as.*(?=;)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
-List<Cat> myCats = <Animal>[] [!as List<Cat>!];
+List<Animal> myAnimals = ...;
+List<Cat> myCats = myAnimals [!as List<Cat>!];
 {% endprettify %}
 
 ### Methods

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -477,14 +477,16 @@ which is disallowed from non-`dynamic` types such as `Animal`.
 {{site.alert.end}}
 
 To make this type of code pass static analysis, 
-you can use an explicit cast, 
-but it might fail at runtime.
+you can use an explicit cast. 
 
 <?code-excerpt "lib/strong_analysis.dart (generic-type-assignment-implied-cast)" replace="/as.*(?=;)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 List<Animal> myAnimals = ...
 List<Cat> myCats = myAnimals [!as List<Cat>!];
 {% endprettify %}
+
+An explicit cast might still fail at runtime, though,
+depending on the actual value of the casted list (`myAnimals`).
 
 ### Methods
 

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -487,7 +487,7 @@ List<Cat> myCats = myAnimals [!as List<Cat>!];
 {% endprettify %}
 
 An explicit cast might still fail at runtime, though,
-depending on the actual value of the casted list (`myAnimals`).
+depending on the actual type of the list being cast (`myAnimals`).
 
 ### Methods
 


### PR DESCRIPTION
Updates the example and wording to more clearly specify this is just an example situation of when a runtime exception may occur, and add ambiguity as to the actual value of the casted list to showcase that it may or may not fail.

Staged: https://dart-dev--pr4289-fix-4288-rx9byyx1.web.app/guides/language/type-system#generic-type-assignment

Fixes https://github.com/dart-lang/site-www/issues/4288