### PR TITLE
Prevent banner from going above warning on scroll

### DIFF
--- a/src/_sass/core/_variables.scss
+++ b/src/_sass/core/_variables.scss
@@ -20,7 +20,7 @@ $site-color-footer: $site-color-dark-background;
 $site-color-primary: $flutter-color-blue-500;
 
 // Layer stack
-$site-z-header: 1000;
+$site-z-header: 10000;
 $site-z-footer: 99;
 $site-z-snackbar: 150;
 $hero-layer-1-z: 40;


### PR DESCRIPTION
The header where the warning is needs to be placed in front of the banner so the banner disappears on scroll.

Caused by: https://github.com/dart-lang/site-www/commit/e188064ca0e8a377606141ee3f68a027532404d0

Before:
<img width="739" alt="Banner wrongly in front of warning " src="https://user-images.githubusercontent.com/18372958/196532259-af47eee1-2527-4a4e-81f3-3cb7f4ddf2b9.png">

After:
<img width="879" alt="Banner properly behind warning" src="https://user-images.githubusercontent.com/18372958/196532224-28d9c620-f870-45d8-af0b-61c4eee285f0.png">
