### PR TITLE
Adjust anonymous function examples to not trigger lint

### DIFF
--- a/examples/misc/test/language_tour/control_flow_test.dart
+++ b/examples/misc/test/language_tour/control_flow_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_function_literals_in_foreach_calls
-
 import 'package:test/test.dart';
 import 'package:examples_util/print_matcher.dart' as m;
 
@@ -21,7 +19,10 @@ void main() {
       for (var i = 0; i < 2; i++) {
         callbacks.add(() => print(i));
       }
-      callbacks.forEach((c) => c());
+
+      for (final c in callbacks) {
+        c();
+      }
       // #enddocregion for-and-closures
     }
 

--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -1,5 +1,5 @@
 // ignore_for_file: unused_element, type_annotate_public_apis, prefer_function_declarations_over_variables
-// ignore_for_file: avoid_function_literals_in_foreach_calls, always_declare_return_types
+// ignore_for_file: always_declare_return_types
 import 'package:examples/language_tour/function_equality.dart'
     as function_equality;
 import 'package:test/test.dart';
@@ -60,9 +60,9 @@ void main() {
     // #enddocregion function-as-var
   });
 
-  const indexedFruit = '''0: apples
-1: bananas
-2: oranges
+  const indexedFruit = '''APPLES: 6
+BANANAS: 7
+ORANGES: 7
 ''';
 
   test('anonymous-function', () {
@@ -71,8 +71,10 @@ void main() {
       void main() {
         // #docregion anonymous-function
         const list = ['apples', 'bananas', 'oranges'];
-        list.forEach((item) {
-          print('${list.indexOf(item)}: $item');
+        list.map((item) {
+          return item.toUpperCase();
+        }).forEach((item) {
+          print('$item: ${item.length}');
         });
         // #enddocregion anonymous-function
       }
@@ -86,9 +88,11 @@ void main() {
 
   test('anon-func', () {
     void testAnonymousFunction() {
-      var list = ['apples', 'bananas', 'oranges'];
+      const list = ['apples', 'bananas', 'oranges'];
       // #docregion anon-func
-      list.forEach((item) => print('${list.indexOf(item)}: $item'));
+      list
+          .map((item) => item.toUpperCase())
+          .forEach((item) => print('$item: ${item.length}'));
       // #enddocregion anon-func
     }
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1568,7 +1568,7 @@ const list = ['apples', 'bananas', 'oranges'];
 list.map((item) {
   return item.toUpperCase();
 }).forEach((item) {
-  print('$item : ${item.length}');
+  print('$item: ${item.length}');
 });
 ```
 
@@ -1581,7 +1581,7 @@ void main() {
   list.map((item) {
     return item.toUpperCase();
   }).forEach((item) {
-    print('$item : ${item.length}');
+    print('$item: ${item.length}');
   });
 }
 ```
@@ -1595,7 +1595,7 @@ to verify that it is functionally equivalent.
 ```dart
 list
     .map((item) => item.toUpperCase())
-    .forEach((item) => print('$item : ${item.length}'));
+    .forEach((item) => print('$item: ${item.length}'));
 ```
 
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1554,15 +1554,21 @@ The code block that follows contains the function's body:
 }; <br>
 </code>
 
-The following example defines an anonymous function with an untyped parameter, `item`.
+The following example defines an anonymous function
+with an untyped parameter, `item`,
+and passes it to the `map` function.
 The function, invoked for each item in the list,
-prints a string that includes the value at the specified index.
+converts each string to uppercase.
+Then in the anonymous function passed to `forEach`,
+each converted string is printed out alongside its length.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anonymous-function)"?>
 ```dart
 const list = ['apples', 'bananas', 'oranges'];
-list.forEach((item) {
-  print('${list.indexOf(item)}: $item');
+list.map((item) {
+  return item.toUpperCase();
+}).forEach((item) {
+  print('$item : ${item.length}');
 });
 ```
 
@@ -1572,20 +1578,24 @@ Click **Run** to execute the code.
 ```dart:run-dartpad:height-400px:ga_id-anonymous_functions
 void main() {
   const list = ['apples', 'bananas', 'oranges'];
-  list.forEach((item) {
-    print('${list.indexOf(item)}: $item');
+  list.map((item) {
+    return item.toUpperCase();
+  }).forEach((item) {
+    print('$item : ${item.length}');
   });
 }
 ```
 
 If the function contains only a single expression or return statement,
-you can shorten it using arrow
-notation. Paste the following line into DartPad and click **Run** to verify that
-it is functionally equivalent.
+you can shorten it using arrow notation. 
+Paste the following line into DartPad and click **Run**
+to verify that it is functionally equivalent.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anon-func)"?>
 ```dart
-list.forEach((item) => print('${list.indexOf(item)}: $item'));
+list
+    .map((item) => item.toUpperCase())
+    .forEach((item) => print('$item : ${item.length}'));
 ```
 
 
@@ -2254,7 +2264,10 @@ var callbacks = [];
 for (var i = 0; i < 2; i++) {
   callbacks.add(() => print(i));
 }
-callbacks.forEach((c) => c());
+
+for (final c in callbacks) {
+  c();
+}
 ```
 
 The output is `0` and then `1`, as expected. In contrast, the example


### PR DESCRIPTION
This is especially important as we show the example in DartPad which warns about the triggered lint.

Also expands on the example by offering a second use case beyond forEach.

**Staged:** https://dart-dev--pr4302-fix-3667-pe6ip9wh.web.app/guides/language/language-tour#anonymous-functions

Fixes #3667