### PR TITLE
Some minor updates to JetBrains IDE page

### DIFF
--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -3,18 +3,22 @@ title: IntelliJ & Android Studio
 description: Use Dart with a variety of IDEs and editors from JetBrains.
 ---
 
-The [Dart plugin][] adds Dart support to JetBrains IDEs such as
-IntelliJ IDEA, WebStorm, and Android Studio.
-IntelliJ IDEA is an intelligent Java IDE
-with support for many other languages and frameworks.
-WebStorm is an IDE based on IntelliJ IDEA
-that's focused on web development and debugging.
-Android Studio is an IDE based on IntelliJ IDEA
-that's used for Android and Flutter development.
+The [Dart plugin][] adds Dart support
+to IntelliJ Platform-based IDEs developed by JetBrains.
+These IDEs provide features unique to specific development technologies.
+The IDEs recommended for Dart and Flutter development include:
+
+- [IntelliJ IDEA][] which specializes in JVM-based language development.
+- [WebStorm][] which specializes in web app development.
+- [Android Studio][] which specializes in Android and Flutter development.
 
 Whichever JetBrains IDE you choose for Dart development,
 this page has resources to help you get started quickly
 and find more information when you need it.
+
+[IntelliJ IDEA]: https://www.jetbrains.com/idea/
+[WebStorm]: https://www.jetbrains.com/webstorm/
+[Android Studio]: https://developer.android.com/studio
 
 ## Getting started
 
@@ -26,17 +30,17 @@ Then install the Dart plugin and tell it where to find the Dart SDK.
 
 Install a JetBrains IDE if you don't already have one. Choose one:
 
-* [IntelliJ IDEA][IDEA]{:target="_blank" rel="noopener"}
-* [IntelliJ IDEA EAP][IDEA EAP]{:target="_blank" rel="noopener"}
+* [IntelliJ IDEA][IDEA-Install]{:target="_blank" rel="noopener"}
+* [IntelliJ IDEA EAP][IDEA-EAP-Install]{:target="_blank" rel="noopener"}
   (for early access to the latest Dart language features and IntelliJ functionality)
-* [WebStorm][]{:target="_blank" rel="noopener"}
-* [Android Studio][]{:target="_blank" rel="noopener"}
+* [WebStorm][WS-Install]{:target="_blank" rel="noopener"}
+* [Android Studio][AS-Install]{:target="_blank" rel="noopener"}
 * [Another JetBrains product][Other]{:target="_blank" rel="noopener"}
 
-[IDEA]: https://www.jetbrains.com/idea/download/
-[IDEA EAP]: https://www.jetbrains.com/idea/nextversion/
-[WebStorm]: https://www.jetbrains.com/webstorm/download/
-[Android Studio]: https://developer.android.com/studio/install
+[IDEA-Install]: https://www.jetbrains.com/idea/download/
+[IDEA-EAP-Install]: https://www.jetbrains.com/idea/nextversion/
+[WS-Install]: https://www.jetbrains.com/webstorm/download/
+[AS-Install]: https://developer.android.com/studio/install
 [Other]: https://www.jetbrains.com/products.html
 
 {{site.alert.note}}

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -4,21 +4,17 @@ description: Use Dart with a variety of IDEs and editors from JetBrains.
 ---
 
 The [Dart plugin][] adds Dart support to JetBrains IDEs such as
-IntelliJ IDEA and Android Studio.
+IntelliJ IDEA, WebStorm, and Android Studio.
 IntelliJ IDEA is an intelligent Java IDE
 with support for many other languages and frameworks.
+WebStorm is an IDE based on IntelliJ IDEA
+that's focused on web development and debugging.
 Android Studio is an IDE based on IntelliJ IDEA
 that's used for Android and Flutter development.
 
 Whichever JetBrains IDE you choose for Dart development,
 this page has resources to help you get started quickly
 and find more information when you need it.
-
-{{site.alert.note}}
-  [WebStorm,](https://www.jetbrains.com/webstorm/)
-  a JetBrains IDE for client-side development,
-  comes with the Dart plugin pre-installed.
-{{site.alert.end}}
 
 ## Getting started
 
@@ -33,10 +29,14 @@ Install a JetBrains IDE if you don't already have one. Choose one:
 * [IntelliJ IDEA][IDEA]{:target="_blank" rel="noopener"}
 * [IntelliJ IDEA EAP][IDEA EAP]{:target="_blank" rel="noopener"}
   (for early access to the latest Dart language features and IntelliJ functionality)
+* [WebStorm][]{:target="_blank" rel="noopener"}
+* [Android Studio][]{:target="_blank" rel="noopener"}
 * [Another JetBrains product][Other]{:target="_blank" rel="noopener"}
 
 [IDEA]: https://www.jetbrains.com/idea/download/
 [IDEA EAP]: https://www.jetbrains.com/idea/nextversion/
+[WebStorm]: https://www.jetbrains.com/webstorm/download/
+[Android Studio]: https://developer.android.com/studio/install
 [Other]: https://www.jetbrains.com/products.html
 
 {{site.alert.note}}
@@ -92,7 +92,7 @@ Here's one way to configure Dart support:
 <li>
   <p>
     If you don't see a value for the <b>Dart SDK</b> path,
-    enter it.
+    enter or select it.
   </p>
 
   <p>
@@ -152,6 +152,5 @@ See the JetBrains website for more information.
   * [Features](https://www.jetbrains.com/idea/features/)
   * [Quick start](https://www.jetbrains.com/help/idea/getting-started.html)
 * [Dart Plugin by JetBrains][Dart plugin]
-* [Eclipse to IntelliJ migration guide](https://www.jetbrains.com/help/idea/migrating-from-eclipse-to-intellij-idea.html)
 
 [Dart plugin]: https://plugins.jetbrains.com/plugin/6351-dart/


### PR DESCRIPTION
- WebStorm no longer bundles the Dart plugin by default but we should still mention it, as it is more lightweight than IntelliJ Ultimate while supporting web functionality.
- Link to Android Studio install
- Remove Eclipse migration link. We're long past the days of Eclipse and Dart Editor support.