### PR TITLE
Document URI http and https factory constructors

### DIFF
--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -552,13 +552,11 @@ void main() {
 
     test('http constructors', () {
       // #docregion Uri-http
-      var httpUri = Uri.http('example.org', '/foo/bar#frag', {'lang': 'dart'});
-      var httpsUri =
-          Uri.https('example.org', '/foo/bar#frag', {'lang': 'dart'});
+      var httpUri = Uri.http('example.org', '/foo/bar', {'lang': 'dart'});
+      var httpsUri = Uri.https('example.org', '/foo/bar', {'lang': 'dart'});
 
-      assert(httpUri.toString() == 'http://example.org/foo/bar#frag?lang=dart');
-      assert(
-          httpsUri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+      assert(httpUri.toString() == 'http://example.org/foo/bar?lang=dart');
+      assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
       // #enddocregion Uri-http
     });
   });

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -546,7 +546,7 @@ void main() {
           path: '/foo/bar',
           fragment: 'frag',
           queryParameters: {'lang': 'dart'});
-      assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+      assert(uri.toString() == 'https://example.org/foo/bar?lang=dart#frag');
       // #enddocregion Uri
     });
 

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -544,9 +544,22 @@ void main() {
           scheme: 'https',
           host: 'example.org',
           path: '/foo/bar',
-          fragment: 'frag');
-      assert(uri.toString() == 'https://example.org/foo/bar#frag');
+          fragment: 'frag',
+          queryParameters: {'lang': 'dart'});
+      assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
       // #enddocregion Uri
+    });
+
+    test('http constructors', () {
+      // #docregion Uri-http
+      var httpUri = Uri.http('example.org', '/foo/bar#frag', {'lang': 'dart'});
+      var httpsUri =
+          Uri.https('example.org', '/foo/bar#frag', {'lang': 'dart'});
+
+      assert(httpUri.toString() == 'http://example.org/foo/bar#frag?lang=dart');
+      assert(
+          httpsUri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+      // #enddocregion Uri-http
     });
   });
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -795,7 +795,7 @@ assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
 
 If you don't need to specify a fragment,
 to create a URI with a http or https scheme,
-you can instead use the `Uri.http` or `Uri.https` factory constructors:
+you can instead use the [`Uri.http`][] or [`Uri.https`][] factory constructors:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri-http)"?>
 ```dart
@@ -805,6 +805,9 @@ var httpsUri = Uri.https('example.org', '/foo/bar', {'lang': 'dart'});
 assert(httpUri.toString() == 'http://example.org/foo/bar?lang=dart');
 assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
 ```
+
+[`Uri.http`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Uri/Uri.http.html
+[`Uri.https`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Uri/Uri.https.html
 
 ### Dates and times
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -801,6 +801,7 @@ you can instead use the `Uri.http` or `Uri.https` factory constructors:
 var httpUri = Uri.http('example.org', '/foo/bar#frag', {'lang': 'dart'});
 var httpsUri =
     Uri.https('example.org', '/foo/bar#frag', {'lang': 'dart'});
+
 assert(httpUri.toString() == 'http://example.org/foo/bar#frag?lang=dart');
 assert(
     httpsUri.toString() == 'https://example.org/foo/bar#frag?lang=dart');

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -792,6 +792,18 @@ var uri = Uri(
 assert(uri.toString() == 'https://example.org/foo/bar#frag');
 ```
 
+To create a URI with a http or https scheme,
+you can instead use the `Uri.http` or `Uri.https` factory constructors:
+
+<?code-excerpt "misc/test/library_tour/core_test.dart (Uri-http)"?>
+```dart
+var httpUri = Uri.http('example.org', '/foo/bar#frag', {'lang': 'dart'});
+var httpsUri =
+    Uri.https('example.org', '/foo/bar#frag', {'lang': 'dart'});
+assert(httpUri.toString() == 'http://example.org/foo/bar#frag?lang=dart');
+assert(
+    httpsUri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+```
 
 ### Dates and times
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -793,7 +793,8 @@ var uri = Uri(
 assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
 ```
 
-To create a URI with a http or https scheme and without a fragment,
+If you don't need to specify a fragment,
+to create a URI with a http or https scheme,
 you can instead use the `Uri.http` or `Uri.https` factory constructors:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri-http)"?>

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -790,7 +790,7 @@ var uri = Uri(
     path: '/foo/bar',
     fragment: 'frag',
     queryParameters: {'lang': 'dart'});
-assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+assert(uri.toString() == 'https://example.org/foo/bar?lang=dart#frag');
 ```
 
 If you don't need to specify a fragment,

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -793,18 +793,16 @@ var uri = Uri(
 assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
 ```
 
-To create a URI with a http or https scheme,
+To create a URI with a http or https scheme and without a fragment,
 you can instead use the `Uri.http` or `Uri.https` factory constructors:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Uri-http)"?>
 ```dart
-var httpUri = Uri.http('example.org', '/foo/bar#frag', {'lang': 'dart'});
-var httpsUri =
-    Uri.https('example.org', '/foo/bar#frag', {'lang': 'dart'});
+var httpUri = Uri.http('example.org', '/foo/bar', {'lang': 'dart'});
+var httpsUri = Uri.https('example.org', '/foo/bar', {'lang': 'dart'});
 
-assert(httpUri.toString() == 'http://example.org/foo/bar#frag?lang=dart');
-assert(
-    httpsUri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
+assert(httpUri.toString() == 'http://example.org/foo/bar?lang=dart');
+assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
 ```
 
 ### Dates and times

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -788,8 +788,9 @@ var uri = Uri(
     scheme: 'https',
     host: 'example.org',
     path: '/foo/bar',
-    fragment: 'frag');
-assert(uri.toString() == 'https://example.org/foo/bar#frag');
+    fragment: 'frag',
+    queryParameters: {'lang': 'dart'});
+assert(uri.toString() == 'https://example.org/foo/bar#frag?lang=dart');
 ```
 
 To create a URI with a http or https scheme,


### PR DESCRIPTION
I've seen these be pretty popular as many use cases of URIs are `https`.

**Staged:** https://dart-dev--pr4325-feature-uri-http-con-4ybvwyf0.web.app/guides/libraries/library-tour#building-uris