### PR TITLE
Use code block tags instead of plain text to identify language in Coming from article

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -139,8 +139,7 @@ For example, the equals operator `==` and the `identical()`
 method are guaranteed to return true for the
 same values of these types, as shown in the following code:
 
-<!--skip-->
-_Dart_
+{:.include-lang}
 ```dart
 var a = 1;
 var b = 1;
@@ -179,13 +178,12 @@ they have the convenience of exposing their own
 utility functions. Because of this, a `double` can,
 for example, be rounded up as follows:
 
-_Dart_
+{:.include-lang}
 ```dart
 var rounded = 2.5.round();
 ```
 
-
-_JavaScript_
+{:.include-lang}
 ```js
 let rounded = Math.round(2.5);
 ```
@@ -198,7 +196,7 @@ but can also be defined using double quotation marks
 to enable use of single quotation marks within the string
 without escaping. However, single quotes are preferred.
 
-_Dart_
+{:.include-lang}
 ```dart
 var a = 'This is a string.';
 ```
@@ -212,7 +210,7 @@ using the backslash character.
 
 The following code shows some examples. 
 
-_Dart_
+{:.include-lang}
 ```dart
 final singleQuotes = 'I\'m learning Dart'; // I'm learning Dart
 final doubleQuotes = "Escaping the \" character"; // Escaping the " character
@@ -248,7 +246,7 @@ using the `${<expression>}` syntax.
 Dart expands on this by allowing the curly braces
 to be omitted when the expression is a single identifier:
 
-_Dart_
+{:.include-lang}
 ```dart
 var food = 'bread';
 var str = 'I eat $food'; // I eat bread
@@ -266,7 +264,7 @@ Dart has two ways to define multiline strings:
     Any neighboring string literals are automatically
     concatenated, even when they are spread over multiple lines:
 
-_Dart_
+{:.include-lang}
 ```dart
 final s1 = 'String '
     'concatenation'
@@ -279,7 +277,7 @@ When using three quotation marks (either single or double)
 on either side of the string,
 the literal is allowed to span multiple lines:
 
-_Dart_
+{:.include-lang}
 ```dart
 final s2 = '''You can create
 multiline strings like this one.''';
@@ -297,7 +295,7 @@ to determine if two strings are equal.
 Two strings are equal if they contain the same
 sequence of code units.
 
-_Dart_
+{:.include-lang}
 ```dart
 final s1 = 'String '
     'concatenation'
@@ -305,7 +303,7 @@ final s1 = 'String '
 assert(s1 ==
     'String concatenation works even over '
         'line breaks.');
-````
+```
 
 ### Booleans
 
@@ -314,12 +312,12 @@ a binary value. Each language has two objects
 that hold this type: the boolean literals `true` and `false`,
 which are compile-time constants in both languages.
 
-_Dart_
+{:.include-lang}
 ```dart
 var a = true;
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 let a = true;
 ```
@@ -340,7 +338,7 @@ with the following caveats:
 Declaring and initializing variables in Dart works
 almost identically to JavaScript:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Declare a variable
 var name; 
@@ -350,7 +348,7 @@ name = 'bob';
 var name = 'bob';
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 // Declare a variable
 let name; 
@@ -365,7 +363,7 @@ an explicit type. However, by convention,
 var is recommended when the analyzer can
 implicitly infer the type. 
 
-_Dart_
+{:.include-lang}
 ```dart
 String name = 'bob'; // This is the same as 'var', 
                      // since Dart infers the type to be String.
@@ -380,7 +378,7 @@ it defaults back to the `dynamic` type.
 Unlike JavaScript, a Dart variable's type can't be changed
 after initialization:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Variable initialized later, `name` has type `dynamic`.
 var name; 
@@ -430,7 +428,7 @@ In Dart, **constant variables must contain constant values**.
 However, non-constant variables can still contain
 constant values, and values themselves can also be marked `const`.
 
-_Dart_
+{:.include-lang}
 ```dart
 var foo = const []; // foo is not constant, but the value it points to is.
   // You can reassign foo to a different list value,
@@ -456,7 +454,7 @@ so they are unlikely to occur at runtime.
 For example, all the variables in the following code
 are non-nullable:
 
-_Dart_
+{:.include-lang}
 ```dart
 // In null-safe Dart, none of these can ever be null.
 var i = 42; // Inferred to be an int.
@@ -467,7 +465,7 @@ final b = Foo();
 To indicate that a variable might have the value `null`,
 just add `?` to its type declaration:
 
-_Dart_
+{:.include-lang}
 ```dart
 int? aNullableInt = null;
 ```
@@ -475,7 +473,7 @@ int? aNullableInt = null;
 The same goes for any other type declaration,
 such as a function declaration:
 
-_Dart_
+{:.include-lang}
 ```dart
 String? returnsNullable() {
   return random.nextDouble() < 0.5
@@ -507,7 +505,7 @@ by placing it as a suffix to the expression.
 which uses the same symbol but is always prefixed
 to the expression.)
 
-_Dart_
+{:.include-lang}
 ```dart
 int? a = 5;
 
@@ -522,7 +520,7 @@ Like the `?.` operator,
 use the `!` operator when accessing properties
 or methods on an object:
 
-_Dart_
+{:.include-lang}
 ```dart
 myObject!.someProperty;
 myObject!.someMethod();
@@ -542,7 +540,7 @@ you can declare functions pretty much anywhere,
 whether at the top level,
 as a class field, or in the local scope.
 
-_Dart_
+{:.include-lang}
 ```dart
 // On the top level
 multiply(a, b) {
@@ -566,7 +564,7 @@ main() {
 }
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 // On the top level
 function multiply(a, b) {
@@ -599,14 +597,14 @@ contains a single expression or return statement.
 
 For example, the following `isNoble` functions are equivalent:
 
-_Dart_
+{:.include-lang}
 ```dart
 bool isNoble(int atomicNumber) {
   return _nobleGases[atomicNumber] != null;
 }
 ```
 
-_Dart_
+{:.include-lang}
 ```dart
 bool isNoble(int atomicNumber) => _nobleGases[atomicNumber] != null;
 ```
@@ -619,7 +617,7 @@ In Dart, this is not the case.
 By default, all standard parameters are _required_
 positional parameters and must be provided when calling a function.
 
-_Dart_
+{:.include-lang}
 ```dart
 multiply(int a, int b) {
   return a * b;
@@ -648,7 +646,7 @@ Learn more in the preceding section about [null safety](#null-safety).
 The following code has one valid and two invalid examples
 of functions that define optional positional parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Valid: `b` has a default value of 5. `c` is marked as nullable.
 multiply(int a, [int b = 5, int? c]) {
@@ -666,7 +664,7 @@ multiply(int a, [int b, int c]) {
 
 Here are some examples of calling a function that has optional parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 multiply(int a, [int b = 5, int? c]) {
   ...
@@ -700,7 +698,7 @@ either need to have a default value or be flagged as nullable.
 
 The following code defines a function with named parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Valid: 
 // - `a` has been flagged as required
@@ -714,7 +712,7 @@ multiply(bool x, { required int a, int b = 5, int? c}) {
 
 The following examples call a function with named parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 // All are valid function calls. 
 // Beyond providing the required positional parameter:
@@ -731,7 +729,7 @@ which means that they're treated as any other object.
 For example, the following code shows how to
 pass a function as a parameter to another function:
 
-_Dart_
+{:.include-lang}
 ```dart
 void printElement(int element) {
   print(element);
@@ -761,7 +759,7 @@ JavaScript has two ways to declare an anonymous function:
 
 For example:
 
-_JavaScript_
+{:.include-lang}
 ```js
 // A regular function expression, assigned to a variable
 let funcExpr = function(a, b) { return a * b; }
@@ -782,7 +780,7 @@ aren't supported in Dart's anonymous functions.
 (For more information,
 check out the [Classes](#classes) section). 
 
-_Dart_
+{:.include-lang}
 ```dart
 // Assigning an anonymous function to a variable.
 var blockFunc = (int a, int b) {
@@ -801,7 +799,7 @@ This is commonly used (in both languages)
 when using the `map` function
 for arrays and lists:
 
-_JavaScript_
+{:.include-lang}
 ```js
 [1, 2, 3].map(e => e + 3); // [4, 5, 6]
 [1, 2, 3].map(e => { 
@@ -810,7 +808,7 @@ _JavaScript_
 }); // [5, 7, 9]
 ```
 
-_Dart_
+{:.include-lang}
 ```dart
 [1, 2, 3].map((e) => e + 3).toList(); // [4, 5, 6]
 [1, 2, 3].map((e) {
@@ -842,7 +840,7 @@ Add items to the final iterable using the
 The following example shows how to write a
 basic generator function:
 
-_Dart_
+{:.include-lang}
 ```dart
 Iterable<int> naturalsTo(int n) sync* {
   int k = 0;
@@ -896,14 +894,14 @@ Dart's `for-in` loop does this natively.
 The following example shows iterating
 over a collection and printing out each element:
 
-_Dart_
+{:.include-lang}
 ```dart
 for (final element in list) {
   print(element)
 }
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 for (const element of list) {
   console.log(element);
@@ -924,7 +922,7 @@ for (const element of list) {
 When using `continue` in a `switch` statement,
 you can combine it with a label that is put on a case:
 
-_Dart_
+{:.include-lang}
 ```dart
 switch (testEnum) {
   case TestEnum.A:
@@ -944,7 +942,7 @@ Adding new operators is not supported in either language,
 but Dart allows you to overload existing operators
 with the `operator` keyword. For example:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Box {
  Box({
@@ -990,7 +988,7 @@ are almost identical, as shown in the following table:
 
 For example:
 
-_Dart_
+{:.include-lang}
 ```dart
 assert(2 + 3 == 5);
 assert(2 - 3 == -1);
@@ -1020,7 +1018,7 @@ You've probably noticed that Dart also contains
 a `~/ `operator (called a _truncating division operator_),
 that divides a double and outputs a floored integer:
 
-_Dart_
+{:.include-lang}
 ```dart
 assert(25 == 50.4 ~/ 2);
 assert(25 == 50.6 ~/ 2);
@@ -1050,7 +1048,7 @@ so the `==` and `!=` JavaScript operators have no equivalent.
 
 For example:
 
-_Dart_
+{:.include-lang}
 ```dart
 assert(2 == 2);
 assert(2 != 3);
@@ -1085,7 +1083,7 @@ are sure that the object is of that type.
 
 For example:
 
-_Dart_
+{:.include-lang}
 ```dart
 (person as Employee).employeeNumber = 4204583;
 ```
@@ -1097,7 +1095,7 @@ In Dart, the types of local variables update within
 the scope of the if statement.
 This is not the case for instance variables. 
 
-_Dart_
+{:.include-lang}
 ```dart
 if (person is Employee) {
    person.employeeNumber = 4204583;
@@ -1126,7 +1124,6 @@ operators do in JavaScript.
 
 For example:
 
-_Dart/JS_
 ```dart
 if (!done && (col == 0 || col == 3)) {
   // ...Do something...
@@ -1154,7 +1151,7 @@ as shown in the following table:
 
 For example: 
 
-_Dart_
+{:.include-lang}
 ```dart
 final value = 0x22;
 final bitmask = 0x0f;
@@ -1176,12 +1173,12 @@ Both Dart and JavaScript contain a (`?:`)
 ternary operator for evaluating expressions
 that might otherwise require [if-else][] statements:
 
-_Dart_
+{:.include-lang}
 ```dart
 final visibility = isPublic ? 'public' : 'private';
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 let visibility = isPublic ? "public" : "private";
 ```
@@ -1193,7 +1190,6 @@ let visibility = isPublic ? "public" : "private";
 As mentioned previously,
 you can assign values using the (`=`) operator: 
 
-_Dart_
 ```dart
 // Assign value to a
 a = value;
@@ -1212,7 +1208,7 @@ back to that same variable:
 | `-=` | `~/=` | `>>=` |        |      |
 {:.table} 
 
-_Dart_
+{:.include-lang}
 ```dart
 var a = 5;
 a *= 2; // Multiply `a` by 2 and assign the value back to a.
@@ -1231,7 +1227,7 @@ of multiple properties, then calling multiple methods
 on a newly constructed object, all within a single chain
 using the cascade operator:
 
-_Dart_
+{:.include-lang}
 ```dart
 var animal = Animal()
   ..name = "Bob"
@@ -1255,7 +1251,7 @@ List literals are defined the same way in Dart as
 arrays are defined in JavaScript,
 using square brackets and separated by commas: 
 
-_Dart_
+{:.include-lang}
 ```dart
 // Initialize list and specify full type
 final List<String> list1 = <String>['one', 'two', 'three'];
@@ -1272,7 +1268,7 @@ basic actions that you can perform on a Dart `List`.
 The first example shows how to retrieve a value
 from a `List` using the index operator:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 final fruit = fruits[1];
@@ -1281,7 +1277,7 @@ final fruit = fruits[1];
 Add a value to the end of the `List` using the `add` method.
 Add another `List` using the `addAll` method:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits.add('peach');
@@ -1292,7 +1288,7 @@ Insert a value at a specific position using the
 `insert` method. Insert another `List` at a
 specific position using the `insertAll` method:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits.insert(0, 'peach');
@@ -1302,7 +1298,7 @@ fruits.insertAll(0, ['kiwi', 'mango']);
 Update a value in the `List` combining the
 index and assignment operators:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits[2] = 'peach';
@@ -1310,7 +1306,7 @@ fruits[2] = 'peach';
 
 Remove items from a `List` using one of the following methods:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 // Remove the value 'pear' from the list.
@@ -1328,7 +1324,7 @@ fruits.removeWhere((fruit) => fruit.contains('p'));
 
 Use `length` to obtain the number of values in the `List`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 assert(fruits.length == 3);
@@ -1336,7 +1332,7 @@ assert(fruits.length == 3);
 
 Use `isEmpty` to check if the `List` is empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 var fruits = [];
 assert(fruits.isEmpty);
@@ -1344,7 +1340,7 @@ assert(fruits.isEmpty);
 
 Use `isNotEmpty` to check if the `List` is not empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 assert(fruits.isNotEmpty);
@@ -1357,7 +1353,7 @@ One handy feature of Dart's `List` class is the
 create a list of size `n` with the specified default value.
 The following example create a list of 3 items:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Creates: [ 'a', 'a', 'a' ]
 final list1 = List.filled(3, 'a');
@@ -1371,7 +1367,7 @@ size `n` with a default value builder
 that creates elements.
 The value builder takes the index as a parameter.
 
-_Dart_
+{:.include-lang}
 ```dart
 // Creates: [ 'a0', 'a1', 'a2' ]
 final list1 = List.generate(3, (index) => 'a$index');
@@ -1399,7 +1395,7 @@ need hash values to be stored in a `Set`.
 
 The following code snippet shows how to initialize a `Set`: 
 
-_Dart_
+{:.include-lang}
 ```dart
 final abc = {'a', 'b', 'c'};
 ```
@@ -1410,7 +1406,7 @@ curly braces (`{}`) results in creating an empty `Map`.
 To create an empty `Set`, precede the `{}` declaration
 with a type argument or assign `{}` to a variable of type `Set`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final names = <String>{};
 // Set<String> names = {}; // This works, too.
@@ -1423,7 +1419,7 @@ basic actions that you can perform on a Dart `Set`.
 Add a value to the `Set` using the `add` method. 
 Use the `addAll` method to add multiple values:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 fruits.add('peach');
@@ -1433,7 +1429,7 @@ fruits.addAll(['kiwi', 'mango']);
 Use one of the following methods in `Set`
 to remove content from the set:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 // Remove the value 'pear' from the set.
@@ -1446,7 +1442,7 @@ fruits.removeWhere((fruit) => fruit.contains('p'));
 
 Use `length` to get the number of values in the `Set`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 assert(fruits.length == 3);
@@ -1454,7 +1450,7 @@ assert(fruits.length == 3);
 
 Use `isEmpty` to check if the `Set` is empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 var fruits = <String>{};
 assert(fruits.isEmpty);
@@ -1462,7 +1458,7 @@ assert(fruits.isEmpty);
 
 Use `isNotEmpty` to check if the `Set` is not empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 assert(fruits.isNotEmpty);
@@ -1491,7 +1487,7 @@ every object contains a unique hash.
 Here are a couple of simple `Map` examples,
 created using literals:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {
  'first': 'partridge',
@@ -1511,7 +1507,7 @@ basic actions that you can perform on a Dart `Map`.
 The first example shows how to retrieve a value from
 a `Map` using the index operator:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 final gift = gifts['first'];
@@ -1524,7 +1520,7 @@ final gift = gifts['first'];
 Use the `containsKey` method to check if a key
 is already present in the `Map`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 assert(gifts.containsKey('fifth'));
@@ -1536,7 +1532,7 @@ If the `Map` doesn't yet contain the key,
 the entry is added; if the key is already present,
 its value is updated.
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['second'] = 'turtle'; // Gets added
@@ -1546,7 +1542,7 @@ gifts['second'] = 'turtle doves'; // Gets updated
 Use the `addAll` method to add another `Map`;
 use the `addEntries` method to add other entries to the `Map`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['second'] = 'turtle doves';
@@ -1564,7 +1560,7 @@ Use the `remove` method to remove an entry from the `Map`;
 remove all entries that satisfy a given test using the
 `removeWhere` method:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts.remove('first');
@@ -1574,7 +1570,7 @@ gifts.removeWhere((key, value) => value == 'partridge');
 Use `length` to obtain the number of key-value
 pairs in the `Map`:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['fourth'] = 'calling birds';
@@ -1583,7 +1579,7 @@ assert(gifts.length == 2);
 
 Use `isEmpty` to check if the `Map` is empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {};
 assert(gifts.isEmpty);
@@ -1591,7 +1587,7 @@ assert(gifts.isEmpty);
 
 Use `isNotEmpty` to check if the `Map` is not empty:
 
-_Dart_
+{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 assert(gifts.isNotEmpty);
@@ -1617,7 +1613,7 @@ collections like arrays, sets, or dictionaries immutable:
   (as shown in the following example).
   This creates a collection that cannot change its size or content: 
 
-_Dart_
+{:.include-lang}
 ```dart
 final _set = Set<String>.unmodifiable(['a', 'b', 'c']);
 final _list = List<String>.unmodifiable(['a', 'b', 'c']);
@@ -1630,7 +1626,7 @@ As in JavaScript, Dart supports embedding a list
 into another list using the spread operator (`...`)
 and the null-aware spread operator (`...?`).
 
-_Dart_
+{:.include-lang}
 ```dart
 var list1 = [1, 2, 3];
 var list2 = [0, ...list1];　// [0, 1, 2, 3]
@@ -1641,7 +1637,7 @@ var list2 = [0, ...?list1]; // [0]
 
 This also works for sets and maps:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Spread operator with maps
 var map1 = {'foo': 'bar', 'key': 'value'};
@@ -1659,7 +1655,7 @@ functionality when it comes to collections.
 A collection `if` statement includes items from a
 list literal only when the specified condition is met:
 
-_Dart_
+{:.include-lang}
 ```dart
 var nav = [
   'Home',
@@ -1674,7 +1670,7 @@ It works similarly for maps and sets.
 A collection `for` statement allows
 multiple items to be mapped into another list:
 
-_Dart_
+{:.include-lang}
 ```dart
 var listOfInts = [1, 2, 3];
 var listOfStrings = [
@@ -1708,7 +1704,7 @@ directly, as the value might not be available until later.
 The following example shows that handling a future works
 in the same way in Dart as a promise works in JavaScript:
 
-_Dart_
+{:.include-lang}
 ```dart
 Future<String> httpResponseBody = func();
 
@@ -1717,7 +1713,7 @@ httpResponseBody.then((String value) {
 });
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 const httpResponseBody = func();
 
@@ -1729,7 +1725,7 @@ httpResponseBody.then(value => {
 Similarly, futures can fail like promises.
 Catching errors works the same as well:
 
-_Dart_
+{:.include-lang}
 ```dart
 httpResponseBody
   .then(...)
@@ -1738,7 +1734,7 @@ httpResponseBody
   });
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 httpResponseBody
   .then(...)
@@ -1754,7 +1750,7 @@ which is discussed below. However,
 when you have a value that needs to be a `Future`,
 you can convert it as follows: 
 
-_Dart_
+{:.include-lang}
 ```dart
 String str = 'String Value';
 Future<String> strFuture = Future<String>.value(str);
@@ -1773,7 +1769,7 @@ it returns `Future<void>`.
 
 The following example shows how to write an `async` function:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Returns a future of a string, as the method is async
 Future<String> fetchString() async {
@@ -1782,7 +1778,7 @@ Future<String> fetchString() async {
 }
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 // Returns a Promise of a string, as the method is async
 async fetchString() {
@@ -1793,7 +1789,7 @@ async fetchString() {
 
 Call this `async` function as follows:
 
-_Dart_
+{:.include-lang}
 ```dart
 Future<String> stringFuture = fetchString();
 stringFuture.then((String str) {
@@ -1811,7 +1807,7 @@ within an `async` context (such as another `async` function).
 
 The following example shows how to await a future for its value:
 
-_Dart_
+{:.include-lang}
 ```dart
 // We can only await futures within an async context.
 asyncFunction() async {
@@ -1847,7 +1843,7 @@ To listen to a stream, call its `listen` method
 and provide a callback method. This method is
 called whenever the stream emits a value:
 
-_Dart_
+{:.include-lang}
 ```dart
 Stream<int> stream = ...
 stream.listen((int value) {
@@ -1858,7 +1854,7 @@ stream.listen((int value) {
 The `listen` method also has some optional callbacks
 for handling errors or for when the stream completes:
 
-_Dart_
+{:.include-lang}
 ```dart
 stream.listen(
   (int value) { ... },
@@ -1875,7 +1871,7 @@ The `listen` method returns an instance of a
 `StreamSubscription`, which you can use to stop
 listening to the stream:
 
-_Dart_
+{:.include-lang}
 ```dart
 StreamSubscription subscription = stream.listen(...);
 subscription.cancel();
@@ -1888,7 +1884,7 @@ you can combine a stream with a `for-in` loop in an
 callback method for each item emitted,
 and it ends when the stream completes or errors out:
 
-_Dart_
+{:.include-lang}
 ```dart
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
@@ -1904,7 +1900,7 @@ in this way, the error is rethrown at the line
 containing the `await` keyword,
 which you can handle with a `try-catch` statement:
 
-_Dart_
+{:.include-lang}
 ```dart
 try {
   await for (final value in stream) { ... }
@@ -1936,7 +1932,7 @@ such as emitting new items using the `add` method,
 or completing the stream using the `close` method.
 The following example shows basic usage of a stream controller:
 
-_Dart_
+{:.include-lang}
 ```dart
 var listeners = 0;
 StreamController<int>? controller;
@@ -1973,7 +1969,7 @@ This allows events from other streams to be emitted to this stream.
 In the following example,
 the function continues once the newly yielded stream has completed.
 
-_Dart_
+{:.include-lang}
 ```dart
 Stream<int> asynchronousNaturalsTo(int n) async* {
   var k = 0;
@@ -2024,7 +2020,7 @@ and all parameters must be explicitly typed. In Dart,
 the `new` keyword was once required for creating class instances,
 but is now optional and its use is no longer recommended. 
 
-_Dart_
+{:.include-lang}
 ```dart
 class Point {
   double x = 0;
@@ -2048,7 +2044,7 @@ can feel like creating boilerplate code,
 so Dart has some syntactic sugar, called
 [initializing parameters][] to make this easier:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Point {
   double x = 0;
@@ -2068,7 +2064,7 @@ Point p = Point(3, 5);
 Similar to functions, constructors have the
 option to take positioned or named parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Point {
   ...
@@ -2091,7 +2087,7 @@ which run after any fields that aren't set
 using initializing parameters,
 but run before the constructor body:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Point {
   ...
@@ -2111,7 +2107,7 @@ multiple constructors, by allowing you to name them.
 You can optionally have one single unnamed constructor,
 any additional constructors must be named:
 
-_Dart_
+{:.include-lang}
 ```dart
 const double xOrigin = 0;
 const double yOrigin = 0;
@@ -2136,7 +2132,7 @@ you can enforce this by using a `const` constructor.
 Defining your constructor as `const` requires all
 non-static fields in your class to be flagged as `final`: 
 
-_Dart_
+{:.include-lang}
 ```dart
 class ImmutablePoint {
   final double x, y;
@@ -2151,7 +2147,7 @@ You can call constructors from other constructors,
 for example to prevent code duplication or
 to add additional defaults for parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Point {
   double x, y;
@@ -2170,7 +2166,7 @@ You can use a factory constructor when you
 don't need to create a new class instance.
 One example would be when returning a cached instance: 
 
-_Dart_
+{:.include-lang}
 ```dart
 class Logger {
   static final Map<String, Logger> _cache =
@@ -2195,7 +2191,7 @@ class Logger {
 In both Dart and JavaScript, methods are
 functions that provide behavior for an object.
 
-_Dart_
+{:.include-lang}
 ```dart
 void doSomething() { // This is a function
  // Implementation..
@@ -2208,7 +2204,7 @@ class Example {
 }
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 doSomething() { // This is a function
   // Implementation..
@@ -2226,7 +2222,7 @@ class Example {
 Dart allows classes to extend another class,
 in the same way that JavaScript does. 
 
-_Dart_
+{:.include-lang}
 ```dart
 class Animal {
   int eyes;
@@ -2261,7 +2257,7 @@ is not actually overriding a superclass method.
 The parent method that is being overridden can
 still be called using the `super` keyword:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Cat extends Animal {
   ...
@@ -2293,7 +2289,7 @@ While a class can only extend a single class,
 you can implement multiple interfaces at a time,
 even when the implementing class already extends another.
 
-_Dart_
+{:.include-lang}
 ```dart
 class Consumer {
   consume() {
@@ -2313,7 +2309,7 @@ When implementing an interface,
 the `super` method can't be called
 as the method bodies are not inherited:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Cat implements Consumer {
   @override
@@ -2336,7 +2332,7 @@ which do not require a body and are instead required
 to be implemented when the class is either extended
 or its interface is implemented:
 
-_Dart_
+{:.include-lang}
 ```dart
 abstract class Consumer {
   consume();
@@ -2382,7 +2378,7 @@ an existing object, after instantiating.
 The following example shows how similar behavior
 is replicated in JavaScript and how it's achieved in Dart:
 
-_Dart_
+{:.include-lang}
 ```dart
 abstract class Animal {}
 
@@ -2408,7 +2404,7 @@ Bat().walk(); // Not using the Walker mixin
 Dog().fly(); // Not using the Flyer mixin
 ```
 
-_JavaScript_
+{:.include-lang}
 ```js
 class Animal {}
 
@@ -2443,7 +2439,7 @@ Alternatively, you can replace the `class` keyword
 with `mixin` to prevent the mixin from being used
 as a regular class:
 
-_Dart_
+{:.include-lang}
 ```dart
 mixin Walker {
   walk() => print('Walks legs');
@@ -2461,6 +2457,7 @@ The order in which they are added to a class matters.
 
 To give an example:
 
+{:.include-lang}
 ```dart
 class Bird extends Animal with Consumer, Flyer {
 ```
@@ -2486,7 +2483,7 @@ for existing classes.
 As an example, the following extension on the `String` class
 from the Dart SDK allows parsing of integers:
 
-_Dart_
+{:.include-lang}
 ```dart
 extension NumberParsing on String {
   int parseInt() {
@@ -2501,7 +2498,7 @@ or its file must be imported.
 
 Use it as follows:
 
-_Dart_
+{:.include-lang}
 ```dart
 import 'string_apis.dart'; // Import the file the extension is in
 var age = '42'.parseInt(); // Use the extension method.
@@ -2512,7 +2509,7 @@ var age = '42'.parseInt(); // Use the extension method.
 Getters and setters in Dart work exactly like
 their JavaScript counterparts:
 
-_JavaScript_
+{:.include-lang}
 ```js
 class Person {
   _age = 0;
@@ -2534,7 +2531,7 @@ person.age = 10;
 console.log(person.age);
 ```
 
-_Dart_
+{:.include-lang}
 ```dart
 class Person {
   int _age = 0;
@@ -2574,7 +2571,7 @@ various browsers and runtimes for a while already.
 In JavaScript, you can indicate that a class member is private
 by adding a pound symbol (`#`) as a prefix to its name:
 
-_JavaScript_
+{:.include-lang}
 ```js
 class Animal {
   eyes; // Public field 
@@ -2594,7 +2591,7 @@ Similarly, Dart allows developers to make a
 class member private by prefixing its name
 with an underscore (`_`):
 
-_Dart_
+{:.include-lang}
 ```dart
 class Animal {
   int eyes; // Public field 
@@ -2642,7 +2639,7 @@ This has several advantages over just labeling the field as nullable:
 * (Non-nullable) late fields throw a runtime error when
   accessed before they are initialized.
 
-_Dart_
+{:.include-lang}
 ```dart
 // Using null safety:
 class Coffee {
@@ -2664,7 +2661,7 @@ The `_temperature` field can never be assigned `null`.
 You can use the `late` keyword to make initialization _lazy_,
 when combined with an initializer:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Weather {
   late int _temperature = _readThermometer();
@@ -2681,7 +2678,7 @@ initialize the final variable when marking it as `late`,
 it still allows the variable to be initialized only once.
 A second assignment results in a runtime error.
 
-_Dart_
+{:.include-lang}
 ```dart
 late final int a;
 a = 1;
@@ -2702,7 +2699,7 @@ symbols after the method name.
 This type can then be used within the method
 (as the return type), or within the method’s parameters:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Defining a method that uses generics.
 T transform<T>(T param) {
@@ -2719,7 +2716,7 @@ if an `int` is provided, the return value is an `int`.
 
 Define multiple generic types by separating them with a comma:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Defining a method with multiple generics.
 T transform<T, Q>(T param1, Q param2) {
@@ -2740,7 +2737,7 @@ which allows you to tailor reusable classes to specific types.
 In the following example, the `Cache` class is for
 caching specific types:
 
-_Dart_
+{:.include-lang}
 ```dart
 class Cache<T> {
   T getByKey(String key) {}
@@ -2763,7 +2760,7 @@ a family of types using `extends`. This ensures
 that your class is instantiated with a generic type
 that extends a specific type:
 
-_Dart_
+{:.include-lang}
 ```dart
 class NumberManager<T extends num> {
    ...
@@ -2789,7 +2786,7 @@ which is used in some `List` class’s member types.
 When defining a `List` literal,
 you can explicitly define the generic type as follows:
 
-_Dart_
+{:.include-lang}
 ```dart
 // Automatic type inference
 var objList = [5, 2.0]; // Type: List<num>
@@ -2803,7 +2800,7 @@ This is also true for `Map`s,
 which also define their key and value types
 using generics (`class Map<K, V>`):
 
-_Dart_
+{:.include-lang}
 ```dart
 // Automatic type inference
 var map = {
@@ -2832,7 +2829,7 @@ above all declarations for public members.
 Define a doc comment by using three forward slashes
 instead of two (`///`):
 
-_Dart_
+{:.include-lang}
 ```dart
 /// The number of characters in this chunk when unsplit.
 int get length => ...

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -53,7 +53,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Display:wght@400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
   <script 

--- a/src/_sass/core/_mixins.scss
+++ b/src/_sass/core/_mixins.scss
@@ -55,7 +55,7 @@
     position: relative;
     &:after {
       font-family: $font-family-monospace;
-      font-size: 0.75rem;
+      font-size: 0.8125rem;
       font-weight: 500;
       content: $msg;
       position: absolute;

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -489,7 +489,7 @@ li.card {
 @include dart-style-for(runtime-success, $alert-success-bg, $alert-success-fg, '\2714  runtime: success');
 @include dart-style-for(runtime-fail, $alert-danger-bg, $alert-danger-fg, '\2717  runtime: error');
 @include dart-style-for('include-lang.language-dart', $pre-bg, $brand-primary, 'Dart');
-@include dart-style-for(language-js, $pre-bg, #f1c65a, 'JavaScript');
+@include dart-style-for(language-js, $pre-bg, #f1a85a, 'JavaScript');
 
 .muted {
   color: $gray;

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -488,6 +488,8 @@ li.card {
 @include dart-style-for(fails-sa, $alert-danger-bg, $alert-danger-fg, '\2717  static analysis: error/warning');
 @include dart-style-for(runtime-success, $alert-success-bg, $alert-success-fg, '\2714  runtime: success');
 @include dart-style-for(runtime-fail, $alert-danger-bg, $alert-danger-fg, '\2717  runtime: error');
+@include dart-style-for('include-lang.language-dart', $pre-bg, $brand-primary, 'Dart');
+@include dart-style-for(language-js, $pre-bg, #f1c65a, 'JavaScript');
 
 .muted {
   color: $gray;


### PR DESCRIPTION
- Adds a class which allows the Dart/Js language to show up in the codeblock
- Replaces manual Dart/JS tags with the class
- Uses the primary brand color for Dart and a darker yellow than GitHub uses (to preserve contrast) for JS
- Adds font-weight 500 for Google Sans Mono as it is what this codeblock extra text is intended to use

**Before:**
<img width="315" alt="image" src="https://user-images.githubusercontent.com/18372958/199367629-52c3ad23-44f3-47fe-9d8c-185a27d3d8a0.png">

**After:**
<img width="360" alt="image" src="https://user-images.githubusercontent.com/18372958/199367598-39a14776-8631-4579-a845-4146635aa40c.png">

**Staged:** https://dart-dev--pr4336-feature-language-tag-418hoc9h.web.app/guides/language/coming-from/js-to-dart