### PR TITLE
Fix new BODY_MIGHT_COMPLETE_NORMALLY_CATCH_ERROR hint

### DIFF
--- a/examples/futures/bin/mixing_errors_problematic.dart
+++ b/examples/futures/bin/mixing_errors_problematic.dart
@@ -21,6 +21,7 @@ void main() {
   parseAndRead(data).catchError((e) {
     print('Inside catchError');
     print(e);
+    return -1;
   });
 }
 

--- a/examples/futures/bin/mixing_errors_solution.dart
+++ b/examples/futures/bin/mixing_errors_solution.dart
@@ -19,6 +19,7 @@ void main() {
   parseAndRead(data).catchError((e) {
     print('Inside catchError');
     print(e);
+    return -1;
   });
 }
 

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -325,6 +325,7 @@ void main() {
   parseAndRead(data).catchError((e) {
     print('Inside catchError');
     print(e);
+    return -1;
   });
 }
 
@@ -371,6 +372,7 @@ void main() {
   parseAndRead(data).catchError((e) {
     print('Inside catchError');
     print(e);
+    return -1;
   });
 }
 


### PR DESCRIPTION
This is causing failures in the dev branch due to the introduction of the hint in https://github.com/dart-lang/sdk/commit/1739cc6d89727bdc802d63a37b12570bbfdcc93a