### PR TITLE
Add dart.dev/go/content-hashes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -138,6 +138,7 @@
 
       { "source": "/go/analysis-server-protocol", "destination": "https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/doc/api.html", "type": 301 },
       { "source": "/go/cloud", "destination": "/server/google-cloud?utm_source=go-link&utm_medium=referral&utm_campaign=go-cloud", "type": 301 },
+      { "source": "/go/content-hashes", "destination": "https://github.com/dart-lang/site-www/issues/4361", "type": 301 },
       { "source": "/go/core-lints", "destination": "https://github.com/dart-lang/lints", "type": 301 },
       { "source": "/go/dart-fix", "destination": "/tools/dart-fix", "type": 301 },
       { "source": "/go/dartdoc-options-file", "destination": "https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml", "type": 301 },


### PR DESCRIPTION
Ensuring that the link doesn't go to 404, instead it'll go to the bug that we should write the page.

See https://github.com/dart-lang/site-www/issues/4361

Hopefully, this helps us not forget to write the page, and helps users highlight it if we do.
It's certainly better than having a 404.