### PR TITLE
Remove non-null-safe video playlist

### DIFF
--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -2,7 +2,6 @@
 title: Videos
 description: Learn by watching! Here's a collection of videos about Dart.
 dart-playlist-id: PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J
-smartherd-playlist-id: PLlxmoA0rQ-LyHW9voBdNo4gEEIh0SjG-q
 ---
 
 Here are some videos about the Dart language and core libraries.

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -14,7 +14,6 @@ If you'd like other videos to be listed on this page,
 TODO: If the list of videos grows, consider automating this like book.md.
 {% endcomment %}
 
-<!-- Flutter DevRel playlist -->
 ## Dart videos from Google
 
 A playlist of Google-produced videos,
@@ -24,13 +23,3 @@ to the Dart session from Google I/O 2019.
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{page.dart-playlist-id}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 [Playlist: Dart videos](https://www.youtube.com/playlist?list={{page.dart-playlist-id}})
-
-
-<!-- Smartherd playlist -->
-## Dart tutorial for beginners (by Smartherd)
-
-A community-provided series of tutorial videos about the Dart language.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list={{page.smartherd-playlist-id}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-[Playlist: Dart tutorial for beginners](https://www.youtube.com/playlist?list={{page.smartherd-playlist-id}})


### PR DESCRIPTION
Many of these videos predate Dart 2 and all predate null safety. 

It would be nice to include an alternate, but better not to link to an outdated resource.