### PR TITLE
Move default value for optional parameters discussion to each individual section

### DIFF
--- a/examples/misc/lib/language_tour/functions.dart
+++ b/examples/misc/lib/language_tour/functions.dart
@@ -56,21 +56,6 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion list-map-default-function-param
-    void doStuff(
-        {List<int> list = const [1, 2, 3],
-        Map<String, String> gifts = const {
-          'first': 'paper',
-          'second': 'cotton',
-          'third': 'leather'
-        }}) {
-      print('list:  $list');
-      print('gifts: $gifts');
-    }
-    // #enddocregion list-map-default-function-param
-  }
-
-  {
     // #docregion function-as-param
     void printElement(int element) {
       print(element);

--- a/examples/misc/lib/language_tour/functions.dart
+++ b/examples/misc/lib/language_tour/functions.dart
@@ -95,3 +95,9 @@ class Scrollbar extends Widget {
   const Scrollbar({super.key, required Widget child});
   // #enddocregion required-named-parameters
 }
+
+class ScrollbarTwo extends Widget {
+  // #docregion required-named-parameters-nullable
+  const ScrollbarTwo({super.key, required Widget? child});
+  // #enddocregion required-named-parameters-nullable
+}

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1316,7 +1316,7 @@ unless they're explicitly marked as `required`.
 When defining a function, use
 <code>{<em>param1</em>, <em>param2</em>, …}</code>
 to specify named parameters.
-If you don't provide a [default value](#default-parameter-values)
+If you don't provide a default value
 or mark a named parameter as `required`,
 their types must be nullable
 as their default value will be `null`:
@@ -1334,12 +1334,13 @@ For example:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (use-named-parameters)"?>
 ```dart
-enableFlags(bold: true);
+enableFlags(bold: true, hidden: false);
 ```
 
-To provide a default value to a named parameter besides `null`,
+<a id="default-parameters"></a>
+To define a default value for a named parameter besides `null`,
 use `=` to specify a default value.
-The specified default value must be a compile-time constant.
+The specified value must be a compile-time constant.
 For example:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (named-parameter-default-values)"?>
@@ -1368,7 +1369,9 @@ then the analyzer reports an issue.
   A parameter marked as `required`
   can still be nullable:
 
+  <?code-excerpt "misc/lib/language_tour/functions.dart (required-named-parameters)" replace="/required/[!$&!]/g; /ScrollbarTwo/Scrollbar/g;"?>
   ```dart
+  const Scrollbar({super.key, required Widget? child});
   ```
 {{site.alert.end}}
 
@@ -1385,8 +1388,11 @@ repeat(times: 2, () {
 
 #### Optional positional parameters
 
-Wrapping a set of function parameters in `[]` marks them as optional
-positional parameters:
+Wrapping a set of function parameters in `[]`
+marks them as optional positional parameters.
+If you don't provide a default value,
+their types must be nullable
+as their default value will be `null`:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-parameters)"?>
 ```dart
@@ -1399,8 +1405,8 @@ String say(String from, String msg, [String? device]) {
 }
 ```
 
-Here’s an example of calling this function without the optional
-parameter:
+Here’s an example of calling this function
+without the optional parameter:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (call-without-optional-param)"?>
 ```dart
@@ -1415,45 +1421,10 @@ assert(say('Bob', 'Howdy', 'smoke signal') ==
     'Bob says Howdy with a smoke signal');
 ```
 
-<a id="default-parameters"></a>
-#### Default parameter values
-
-Your function can use `=` to define default values for optional parameters,
-both named and positional. The default values must be compile-time constants.
-If no default value is provided, the default value is `null`.
-
-Here's an example of setting default values for named parameters:
-
-<?code-excerpt "misc/lib/language_tour/functions.dart (named-parameter-default-values)"?>
-```dart
-/// Sets the [bold] and [hidden] flags ...
-void enableFlags({bool bold = false, bool hidden = false}) {...}
-
-// bold will be true; hidden will be false.
-enableFlags(bold: true);
-```
-
-{{site.alert.secondary}}
-  **Deprecation note:** Old code might use a colon (`:`) instead of `=`
-  to specify default values of named parameters. 
-  The reason is that originally, only `:` was supported for named parameters. 
-  That support is deprecated and will be removed, 
-  so we recommend that you **[use `=` to specify default values.][use =]**
-
-  If you have the [`prefer_equal_for_default_values`][] linter rule enabled,
-  you can use [`dart fix`][] to migrate to the suggested `=` syntax.
-
-  [use =]: /guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value
-  [`prefer_equal_for_default_values`]: /tools/linter-rules#prefer_equal_for_default_values
-  [`dart fix`]: /tools/dart-fix
-{{site.alert.end}}
-
-{% comment %}
-TODO #2950: Update if/when we drop support for `:`.
-See `defaultNamedParameter` in the language spec.
-{% endcomment %}
-
-The next example shows how to set default values for positional parameters:
+To define a default value for an optional positional parameter besides `null`,
+use `=` to specify a default value.
+The specified value must be a compile-time constant.
+For example:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (optional-positional-param-default)"?>
 ```dart
@@ -1465,28 +1436,6 @@ String say(String from, String msg, [String device = 'carrier pigeon']) {
 assert(say('Bob', 'Howdy') == 'Bob says Howdy with a carrier pigeon');
 ```
 
-You can also pass lists or maps as default values.
-The following example defines a function, `doStuff()`,
-that specifies a default list for the `list`
-parameter and a default map for the `gifts` parameter.
-{% comment %}
-The function is called three times with different values. Click **Run** to see
-list and map default values in action.
-{% endcomment %}
-
-<?code-excerpt "misc/lib/language_tour/functions.dart (list-map-default-function-param)"?>
-```dart
-void doStuff(
-    {List<int> list = const [1, 2, 3],
-    Map<String, String> gifts = const {
-      'first': 'paper',
-      'second': 'cotton',
-      'third': 'leather'
-    }}) {
-  print('list:  $list');
-  print('gifts: $gifts');
-}
-```
 
 ### The main() function
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1375,9 +1375,10 @@ then the analyzer reports an issue.
   ```
 {{site.alert.end}}
 
-Although it often makes sense to place positional arguments first,
-named arguments can be placed anywhere in the argument list
-when it suits your API:
+You might want to place positional arguments first,
+but Dart doesn't require it.
+Dart allows named arguments to be placed anywhere in the
+argument list when it suits your API:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (named-arguments-anywhere)"?>
 ```dart

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1369,9 +1369,9 @@ then the analyzer reports an issue.
   A parameter marked as `required`
   can still be nullable:
 
-  <?code-excerpt "misc/lib/language_tour/functions.dart (required-named-parameters)" replace="/required/[!$&!]/g; /ScrollbarTwo/Scrollbar/g;"?>
+  <?code-excerpt "misc/lib/language_tour/functions.dart (required-named-parameters-nullable)" replace="/Widget\?/[!$&!]/g; /ScrollbarTwo/Scrollbar/g;"?>
   ```dart
-  const Scrollbar({super.key, required Widget? child});
+  const Scrollbar({super.key, required [!Widget?!] child});
   ```
 {{site.alert.end}}
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1315,7 +1315,11 @@ unless they're explicitly marked as `required`.
 
 When defining a function, use
 <code>{<em>param1</em>, <em>param2</em>, …}</code>
-to specify named parameters:
+to specify named parameters.
+If you don't provide a [default value](#default-parameter-values)
+or mark a named parameter as `required`,
+their types must be nullable
+as their default value will be `null`:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (specify-named-parameters)"?>
 ```dart
@@ -1330,8 +1334,43 @@ For example:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (use-named-parameters)"?>
 ```dart
-enableFlags(bold: true, hidden: false);
+enableFlags(bold: true);
 ```
+
+To provide a default value to a named parameter besides `null`,
+use `=` to specify a default value.
+The specified default value must be a compile-time constant.
+For example:
+
+<?code-excerpt "misc/lib/language_tour/functions.dart (named-parameter-default-values)"?>
+```dart
+/// Sets the [bold] and [hidden] flags ...
+void enableFlags({bool bold = false, bool hidden = false}) {...}
+
+// bold will be true; hidden will be false.
+enableFlags(bold: true);
+```
+
+If you instead want a named parameter to be mandatory,
+requiring callers to provide a value for the parameter,
+annotate them with `required`:
+
+<?code-excerpt "misc/lib/language_tour/functions.dart (required-named-parameters)" replace="/required/[!$&!]/g"?>
+```dart
+const Scrollbar({super.key, [!required!] Widget child});
+```
+
+If someone tries to create a `Scrollbar`
+without specifying the `child` argument,
+then the analyzer reports an issue.
+
+{{site.alert.note}}
+  A parameter marked as `required`
+  can still be nullable:
+
+  ```dart
+  ```
+{{site.alert.end}}
 
 Although it often makes sense to place positional arguments first,
 named arguments can be placed anywhere in the argument list
@@ -1343,30 +1382,6 @@ repeat(times: 2, () {
   ...
 });
 ```
-
-{{site.alert.tip}}
-  If a parameter is optional but can't be `null`,
-  provide a [default value](#default-parameter-values).
-{{site.alert.end}}
-
-Although named parameters are a kind of optional parameter,
-you can annotate them with `required` to indicate
-that the parameter is mandatory—that users
-must provide a value for the parameter.
-For example:
-
-<?code-excerpt "misc/lib/language_tour/functions.dart (required-named-parameters)" replace="/required/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
-const Scrollbar({super.key, [!required!] Widget child});
-{% endprettify %}
-
-If someone tries to create a `Scrollbar`
-without specifying the `child` argument,
-then the analyzer reports an issue.
-
-{% comment %}
-NULLSAFE: Rewrite this section.
-{% endcomment %}
 
 #### Optional positional parameters
 


### PR DESCRIPTION
Currently setting default values for optional named and positional parameters was separated, but it is pretty core to each topic, so this PR moves the discussion of default values to each of the parameter sections. This helps the examples make a bit more sense as they are contextualized.

I've also removed the mention of migrating from `=` to `:` because it was added over 6 years ago, most code already uses `:`, the extra mention is large and potentially confusing (and don't want to duplicate it in this new layout), and in Dart 2.19 the old syntax will become a warning anyway.

Also removes the mention of how list and maps can be passed. It doesn't talk about sets or other constant objects which can be passed as well and isn't super relevant to the goals of these sections. We should instead expand on our documentation of const (https://github.com/dart-lang/site-www/issues/4350) elsewhere and link to that.

Overall:
- Moves default value discussion to named and optional positional sections instead of isolated
- Better clarifies the nullable types and when they are needed, as well as how `null` is the default default value
- Moves discussion of named parameters anywhere to end
- Removes mention of old `=` syntax
- Removes mention of how list and maps can be passed as don't want to duplicate it and it is better documented by const documentation elsewhere

Fixes https://github.com/dart-lang/site-www/issues/3737