### PR TITLE
Remove jobs/hiring note from banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,8 +1,6 @@
 {% comment %}Drop the div .alert classes to revert to the default banner styling.{% endcomment -%}
 <div class="banner">
   <p class="banner__text">
-    Dart 2.18 is available now with Objective-C & Swift interoperability and improvements to networking, type inference, and async code performance. <a href="https://medium.com/@mit.mit/dart-2-18-f4b3101f146c">Learn more</a><br>
-    The Flutter and Dart teams are hiring.
-    <a href="https://docs.flutter.dev/jobs">Learn more</a>
+    Dart 2.18 is available now with Objective-C & Swift interoperability and improvements to networking, type inference, and async code performance. <a href="https://medium.com/@mit.mit/dart-2-18-f4b3101f146c">Learn more</a>
   </p>
 </div>


### PR DESCRIPTION
The current listing is outdated and mostly empty.