### PR TITLE
[2.19] Remove pub.dartlang.org

### DIFF
--- a/src/tools/pub/troubleshoot.md
+++ b/src/tools/pub/troubleshoot.md
@@ -190,7 +190,7 @@ that blocks internet access from `dart`.
    still runs in the background.
    This filter causes a failure to connect to `pub.dev`.
    To resolve this issue, 
-   add both `https://pub.dev` and `https://pub.dartlang.org`
+   add both `https://pub.dev`
    to the trusted zone:
 
    1. Open Kaspersky Internet Security.


### PR DESCRIPTION
Based on [this line in the changelog](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#pub:~:text=The%20client%20will%20now%20default%20to%20the%20pub.dev%20repository%20instead%20of%20pub.dartlang.org.%20This%20will%20cause%20a%20change%20in%20pubspec.lock.):

> The client will now default to the `pub.dev` repository instead of `pub.dartlang.org`. This will cause a change in pubspec.lock.

I thought _maybe_ we could remove mentions of `pub.dartlang.org`. I only found [this one](https://dart.dev/tools/pub/troubleshoot#:~:text=Detailed%20instructions%20for%20Kaspersky%20Internet%20Security), and it's not necessarily in relation to `pubspec.lock`, so I'm not sure if it makes sense to remove it in this context. 

@jonasfj (or anyone else) should we remove it or leave it alone? Let me know! 


