### PR TITLE
[2.19] Remove `.packages` workaround

### DIFF
--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -145,13 +145,6 @@ By default, pub precompiles executables
 in immediate dependencies (`--precompile`).
 To prevent precompilation, use `--no-precompile`.
 
-### `--legacy-packages-file`
-
-If you're using Dart 2.18 and use any third-party tools
-that rely on the discontinued `.packages` file,
-use `--legacy-packages-file` to generate a `.packages` file.
-Support for this flag will be removed in Dart 2.19.
-
 
 {{site.alert.info}}
   *Problems?*


### PR DESCRIPTION
`--legacy-packages-file` completely de-supported in 2.19