### PR TITLE
Fix broken API doc link and add more ignores to linkcheck

### DIFF
--- a/src/_includes/tools/dart-compile-js-options.md
+++ b/src/_includes/tools/dart-compile-js-options.md
@@ -75,7 +75,7 @@ Some other handy options include:
 [`String.fromEnvironment`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/String/String.fromEnvironment.html
 [`int.fromEnvironment`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/int/int.fromEnvironment.html
 [`bool.fromEnvironment`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/bool/bool.fromEnvironment.html
-[`bool.hasEnvironment`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/bool/bool.hasEnvironment.html
+[`bool.hasEnvironment`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/bool/bool.hasEnvironment.html
 
 ###### Display options
 

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -4,6 +4,9 @@
 localhost:(404\d|8080)
 127.0.0.1:(404\d|8080)
 
+# Sites which don't allow robots or break from rate limiting
+https://github.com
+
 # FIXME(Temporary): linkcheck seems to be intermittently failing when accessing main.css
 # https://github.com/dart-lang/site-www/issues/1107
 /assets/css/main.css
@@ -12,3 +15,7 @@ fonts.gstatic.com
 fonts.googleapis.com
 
 github.com/dart-lang/site-www/issues/new
+
+# Redirects from firebase.json
+/jobs
+/go/.*?


### PR DESCRIPTION
- Fixes the broken link to `bool.hasEnvironment`
- Adds some ignores to the link checker tool we use which cause issues when checking external links:
  - GitHub since it rate limits requests
  - /go/ links to match flutter/website since these are redirects to external sites, not part of the site
  - /jobs for a similar reason - the linkcheck tool seems to think it is part of the site
  
In CI we currently don't check external links, so these issues don't pop up, but when I run external links locally the problems arise.