### PR TITLE
Minor fixes to recent concurrency doc changes

### DIFF
--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -484,7 +484,8 @@ Starting a web worker is similar to using `Isolate.spawnUri` to start an isolate
 You can also start an isolate with `Isolate.spawn`,
 which requires fewer resources because it
 [reuses some of the same code and data](#performance-and-isolate-groups)
-as the spawning isolate. Web workers don't have an equivalent API.
+as the spawning isolate. 
+Web workers don't have an equivalent API.
 
 [Dart web platform]: /overview#platform
-[web workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
+[web workers]: https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Using_web_workers

--- a/src/faq.md
+++ b/src/faq.md
@@ -288,14 +288,10 @@ since web apps cannot use isolates.
 To run code concurrently, web apps use [web workers][] instead.
 Web workers lack the ease and efficiency of isolates,
 and have different capabilities and restrictions.
-To learn more, see the
-[Concurrency in Dart](/guides/language/concurrency#concurrency-on-the-web) page.
+To learn more, see
+[Concurrency on the web](/guides/language/concurrency#concurrency-on-the-web).
 
-{% comment %}
-TODO: Change "Concurrency in Dart" link to the section on web apps that I'll be adding in another PR.
-{% endcomment %}
-
-[web workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
+[web workers]: https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Using_web_workers
 
 ---
 


### PR DESCRIPTION
Sorry, I didn't have a chance to take a final look before merging. Some minor fixes:

- Since the link is directly to the "Concurrency on the web" section, specify that
- Use the MDN links which don't specify a locale (https://developers.google.com/style/links-external)
- Remove the TODO which looks to have been fixed (can revert if you mean a different section)