### PR TITLE
Update some old version mentions

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -97,13 +97,6 @@ add static analysis to your tool, see the
 Place the analysis options file, `analysis_options.yaml`,
 at the root of the package, in the same directory as the pubspec file.
 
-{{site.alert.tip}}
-  The older name for the analysis options file was `.analysis_options`;
-  support for that filename was dropped in Dart 2.8.
-  To upgrade an `.analysis_options` file,
-  just change its name to `analysis_options.yaml`.
-{{site.alert.end}}
-
 Here's a sample analysis options file:
 
 <?code-excerpt "analysis_options.yaml" from="include" remove="implicit-dynamic" retain="/^$|\w+:|- cancel/" remove="https:"?>

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -30,7 +30,7 @@ on the [Flutter website]({{site.flutter}}).
   Although you might still find examples of
   using the standalone `pub` command instead of
   `dart pub` or `flutter pub`,
-  the standalone `pub` command is deprecated.
+  the standalone `pub` command has been removed.
 {{site.alert.end}}
 
 If you encounter problems using the pub tool,


### PR DESCRIPTION
- Remove mention of the `.analysis_options` file which has been removed for over 4 years.
- Update mention of standalone `pub` tool to reference removal