### PR TITLE
Enable fetching checksums while not in dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eu; \
         DART_SHA256="6c9384814d1d516eec616f40d22df161e219eb15d730105a28bf260f3274b4ed"; \
         SDK_ARCH="arm64";; \
       amd64_dev) \
-        DART_SHA256="5fe7f37d6dc63bf8d3d0cd511a71c5b563d31376bc854e107be577925fd495a1"; \
+        DART_SHA256="1af733e28fb5aa160e3b706a6e52c52c63d3b5a8ad857313ebf996e8341898a5"; \
         SDK_ARCH="x64";; \
       arm64_dev) \
-        DART_SHA256="fa48e48f77c5673e64c160278ed5623d938cb075143203221f8006baa8388966"; \
+        DART_SHA256="43351649429575afa006b9470eb72aea62bceb391c5e0b817a86404479a88934"; \
         SDK_ARCH="arm64";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \

--- a/tool/fetch-dart-sdk-sums.sh
+++ b/tool/fetch-dart-sdk-sums.sh
@@ -3,6 +3,7 @@
 # Prints output similar to cases in Dockerfile for easy composition 
 # when having to update checksum values for updates dart SDK.
 set -eu -o pipefail
+TOOL_DIR="${TOOL_DIR:=$(dirname "$0")}"
 source $TOOL_DIR/utils.sh
 
 VERSION="latest"
@@ -28,12 +29,14 @@ done
 BASEURL="https://storage.googleapis.com/dart-archive/channels"
 CHANNELS="stable beta dev"
 ARCHS="amd64 arm64"
+ENDING='\\\n'
 
 printf "\n$(blue "Copy the following output and replace the existing code in the Dockerfile:")\n\n"
 
+
 for CHANNEL in $CHANNELS; do
   for ARCH in $ARCHS; do
-    echo -e "$(yellow "${ARCH}_${CHANNEL})") \\"
+    printf "$(yellow "${ARCH}_${CHANNEL})") $ENDING"
     _arch=$ARCH
     if [[ "$_arch" == "amd64" ]]; then
       _arch='x64'
@@ -42,11 +45,10 @@ for CHANNEL in $CHANNELS; do
     _url="$BASEURL/$CHANNEL/release/$VERSION/sdk/$_filename"
     curl -fsSLO $_url
     _checksum=$(shasum -a 256 $_filename)
-    IFS=" " # Split checksum output by space delimiter 
-    read -a _fname_arr <<< "$_checksum" # Read in string output as array
-    unset _fname_arr[-1] # Remove filename portion of checksum output
-    echo -e "$(yellow "  DART_SHA256=\"$_fname_arr\";") \\"
-    echo -e "$(yellow "  SDK_ARCH=\"$_arch\";;") \\"
+    read -a _fname_arr <<< "${_checksum}" # Read in string output as array
+    _checkonly="${_fname_arr%:*}" # Remove filename portion of checksum output
+    printf "$(yellow "  DART_SHA256=\"$_fname_arr\";") $ENDING"
+    printf "$(yellow "  SDK_ARCH=\"$_arch\";;") $ENDING"
     rm $_filename
   done
 done

--- a/tool/fetch-dart-sdk-sums.sh
+++ b/tool/fetch-dart-sdk-sums.sh
@@ -31,7 +31,8 @@ CHANNELS="stable beta dev"
 ARCHS="amd64 arm64"
 ENDING='\\\n'
 
-printf "\n$(blue "Copy the following output and replace the existing code in the Dockerfile:")\n\n"
+printf "\n$(blue "Copy the following output and replace the existing code in the Dockerfile")\n"
+printf "$(blue "inside the 'set -eu' run statement:")\n\n"
 
 
 for CHANNEL in $CHANNELS; do

--- a/tool/fetch-node-ppa-sum.sh
+++ b/tool/fetch-node-ppa-sum.sh
@@ -4,5 +4,8 @@ set -eu -o pipefail
 
 NODE_PPA="node_ppa.sh"
 curl -fsSL https://deb.nodesource.com/setup_lts.x -o "$NODE_PPA"
-echo "NODE_SHA256="$(shasum -a 256 $NODE_PPA)"; \\"
+_checksum=$(shasum -a 256 $NODE_PPA)
+read -a _fname_arr <<< "${_checksum}" # Read in string output as array
+_checkonly="${_fname_arr%:*}" # Remove filename portion of checksum output
+echo "NODE_SHA256="$_checkonly"; \\"
 rm $NODE_PPA

--- a/tool/utils.sh
+++ b/tool/utils.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-RED='\e[0;31m'
-YELLOW='\e[0;33m'
-BLUE='\e[0;34m'
-GRAY='\e[0;37m'
-END='\e[0m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+GRAY='\033[0;37m'
+END='\033[0m'
 
 
 function blue() {


### PR DESCRIPTION
Allows running `make fetch-sums` even if not in the dev container and without needing to specify anything else.

- Allow defaulting to `/tool` directory if `TOOL_DIR` is not specified
- Support older versions of bash which do not support negative indices into arrays
- Keep using colors from `utils.sh` so we don't replicate them
- Fix the format of `fetch-node-ppa-sum.sh` to match what is used in Dockerfile

