### PR TITLE
Incorrect lint link

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1115,7 +1115,7 @@ class Box {
 
 ### PREFER using a `final` field to make a read-only property.
 
-{% include linter-rule-mention.md rule="unnecessary_getters_setters" %}
+{% include linter-rule-mention.md rule="unnecessary_getters" %}
 
 If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1115,8 +1115,6 @@ class Box {
 
 ### PREFER using a `final` field to make a read-only property.
 
-{% include linter-rule-mention.md rule="unnecessary_getters" %}
-
 If you have a field that outside code should be able to see but not assign to, a
 simple solution that works in many cases is to simply mark it `final`.
 


### PR DESCRIPTION
[PREFER using a final field to make a read-only property](https://dart.dev/guides/language/effective-dart/usage#prefer-using-a-final-field-to-make-a-read-only-property) points to [`unnecessary_getters_setters`](https://dart.dev/tools/linter-rules#unnecessary_getters_setters), but the actual corresponding lint is [`unnecessary_getters`](https://github.com/dart-lang/linter/blob/main/lib/src/rules/unnecessary_getters.dart).

However, `unnecessary_getters` doesn't seem to have an entry on the [Linter rules](https://dart.dev/tools/linter-rules) page? This will stay a draft until there's something to link to.