### PR TITLE
Add code excerpts to new boolean equality guideline

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -6,7 +6,7 @@
 // ignore_for_file: avoid_function_literals_in_foreach_calls, prefer_function_declarations_over_variables
 // ignore_for_file: prefer_adjacent_string_concatenation, prefer_is_not_empty, prefer_interpolation_to_compose_strings
 // ignore_for_file: unnecessary_this, always_declare_return_types, no_leading_underscores_for_local_identifiers
-// ignore_for_file: deprecated_colon_for_default_value
+// ignore_for_file: deprecated_colon_for_default_value, unchecked_use_of_nullable_value
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
@@ -20,18 +20,22 @@ class EnableableThing {
 
 void miscDeclAnalyzedButNotTested() {
   {
-    dynamic optionalThing;
-    // #docregion convert-null-equals
-    // If you want null to be false:
-    if (optionalThing?.isEnabled == true) {
-      print('Have enabled thing.');
-    }
+    bool nonNullableBool = true;
+    bool? nullableBool = null;
 
-    // If you want null to be true:
-    if (optionalThing?.isEnabled != false) {
-      print('Have enabled thing or nothing.');
-    }
-    // #enddocregion convert-null-equals
+    // #docregion non-null-boolean-expression
+    if (nonNullableBool == true) {/* ... */}
+
+    if (nonNullableBool == false) {/* ... */}
+    // #enddocregion non-null-boolean-expression
+
+    // #docregion nullable-boolean-expression
+    // Static error if null:
+    if (nullableBool) {/* ... */}
+
+    // If you want null to be false:
+    if (nullableBool == true) {/* ... */}
+    // #enddocregion nullable-boolean-expression
   }
 
   {

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable
 // ignore_for_file: prefer_function_declarations_over_variables, strict_raw_type,
 // ignore_for_file: prefer_initializing_formals, prefer_typing_uninitialized_variables
-// ignore_for_file: use_super_parameters, dead_code, avoid_init_to_null
+// ignore_for_file: use_super_parameters, dead_code
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
@@ -13,6 +13,7 @@ Func0<Future<void>> longRunningCalculation = () => Future.value();
 Func0 somethingRisky = () {};
 Func1 raiseAlarm = (_) {}, handle = (_) {};
 Func1<bool, dynamic> canHandle = (_) => false, verifyResult = (_) => false;
+T? somethingNullable<T>() => null;
 
 class Thing {
   bool get isEnabled => true;
@@ -21,7 +22,7 @@ class Thing {
 void miscDeclAnalyzedButNotTested() {
   {
     bool nonNullableBool = true;
-    bool? nullableBool = null;
+    bool? nullableBool = somethingNullable<bool>();
 
     // #docregion non-null-boolean-expression
     if (nonNullableBool) {/* ... */}

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable
 // ignore_for_file: prefer_function_declarations_over_variables, strict_raw_type,
 // ignore_for_file: prefer_initializing_formals, prefer_typing_uninitialized_variables
-// ignore_for_file: use_super_parameters, dead_code
+// ignore_for_file: use_super_parameters, dead_code, avoid_init_to_null
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
@@ -20,18 +20,23 @@ class Thing {
 
 void miscDeclAnalyzedButNotTested() {
   {
-    Thing? optionalThing;
-    // #docregion convert-null-aware
-    // If you want null to be false:
-    if (optionalThing?.isEnabled ?? false) {
-      print('Have enabled thing.');
-    }
+    bool nonNullableBool = true;
+    bool? nullableBool = null;
 
-    // If you want null to be true:
-    if (optionalThing?.isEnabled ?? true) {
-      print('Have enabled thing or nothing.');
-    }
-    // #enddocregion convert-null-aware
+    // #docregion non-null-boolean-expression
+    if (nonNullableBool) {/* ... */}
+
+    if (!nonNullableBool) {/* ... */}
+    // #enddocregion non-null-boolean-expression
+
+    // #docregion nullable-boolean-expression
+    // If you want null to result in false:
+    if (nullableBool ?? false) {/* ... */}
+
+    // If you want null to result in false
+    // and you want the variable to type promote:
+    if (nullableBool != null && nullableBool) {/* ... */}
+    // #enddocregion nullable-boolean-expression
   }
 
   {

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -254,6 +254,7 @@ It's always simpler to eliminate the equality operator,
 and use the unary negation operator `!` if necessary:
 
 {:.good}
+<?code-excerpt "usage_good.dart (non-null-boolean-expression)"?>
 {% prettify dart tag=pre+code %}
 if (nonNullableBool) { ... }
 
@@ -261,14 +262,18 @@ if (!nonNullableBool) { ... }
 {% endprettify %}
 
 {:.bad}
+<?code-excerpt "usage_bad.dart (non-null-boolean-expression)"?>
 {% prettify dart tag=pre+code %}
 if (nonNullableBool == true) { ... }
+
+if (nonNullableBool == false) { ... }
 {% endprettify %}
 
 To evaluate a boolean expression that *is nullable*, you should use `??`
 or an explicit `!= null` check.
 
 {:.good}
+<?code-excerpt "usage_good.dart (nullable-boolean-expression)"?>
 {% prettify dart tag=pre+code %}
 // If you want null to result in false:
 if (nullableBool ?? false) { ... }
@@ -279,8 +284,9 @@ if (nullableBool != null && nullableBool) { ... }
 {% endprettify %}
 
 {:.bad}
+<?code-excerpt "usage_bad.dart (nullable-boolean-expression)"?>
 {% prettify dart tag=pre+code %}
-// Error if null 
+// Static error if null:
 if (nullableBool) { ... }
 
 // If you want null to be false:


### PR DESCRIPTION
This PR is targeting https://github.com/dart-lang/site-www/pull/4423, both adding code excerpts and removing the ones replaced by the new guideline. This also adds the bad example of comparing to `false`.

I'd like to add code excerpts as while they are simple snippets, it guarantees any future updates or additions to the snippets still are correct. It also helps guarantee formatting is correct.