### PR TITLE
Update SDK constraint for 2.19 examples and remove related ignores

### DIFF
--- a/examples/concurrency/lib/simple_isolate_closure.dart
+++ b/examples/concurrency/lib/simple_isolate_closure.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: undefined_method
-
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';

--- a/examples/concurrency/lib/simple_worker_isolate.dart
+++ b/examples/concurrency/lib/simple_worker_isolate.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: undefined_method
-
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';

--- a/examples/concurrency/pubspec.yaml
+++ b/examples/concurrency/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0-0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, unused_element, strict_raw_type, undefined_annotation, experiment_not_enabled, missing_identifier
+// ignore_for_file: type_annotate_public_apis, unused_element, strict_raw_type
 // ignore_for_file: no_leading_underscores_for_local_identifiers, use_function_type_syntax_for_parameters
 
 // #docregion library-doc
@@ -8,6 +8,10 @@ library;
 // #enddocregion library-doc
 
 import 'package:examples_util/ellipsis.dart';
+
+class TestOn {
+  const TestOn(String platform);
+}
 
 void miscDeclAnalyzedButNotTested() {
   (Iterable _chunks) {

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -7,7 +7,6 @@
 // ignore_for_file: prefer_adjacent_string_concatenation, prefer_is_not_empty, prefer_interpolation_to_compose_strings
 // ignore_for_file: unnecessary_this, always_declare_return_types, no_leading_underscores_for_local_identifiers
 // ignore_for_file: deprecated_colon_for_default_value
-// ignore_for_file: experiment_not_enabled, missing_identifier
 
 // #docregion library-dir
 

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0-0 <3.0.0"
 
 dependencies:
   args: ^2.3.0

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, prefer_collection_literals, avoid_function_literals_in_foreach_calls, undefined_method
+// ignore_for_file: type_annotate_public_apis, prefer_collection_literals, avoid_function_literals_in_foreach_calls
 import 'package:test/test.dart';
 
 import 'package:examples/library_tour/core/comparable.dart' as comparable;

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -35,7 +35,7 @@ when determining which library a part belongs to.
 
 [discouraged]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
 
-The preferred syntax syntax is to use a URI string that points
+The preferred syntax is to use a URI string that points
 directly to the library file. 
 If you have some library, `my_library.dart`, that contains:
 


### PR DESCRIPTION
This PR does the following:
- Updates lower SDK constraint for examples which use 2.19 features
- Removes ignores related to those elements missing
- Remove the `undefined_annotation` ignore in `docs_good.dart` by adding a stub of the used annotation to the file
- Removes a duplicate "syntax"

Fixes #4394 