### PR TITLE
Expand on catch example on samples page

### DIFF
--- a/examples/misc/test/samples_test.dart
+++ b/examples/misc/test/samples_test.dart
@@ -277,9 +277,9 @@ void main() {
   });
 
   test('try', () {
-    void testTry() async {
-      final flybyObjects = ['Moon'];
-      // #docregion try
+    final flybyObjects = ['Moon'];
+    // #docregion try
+    Future<void> describeFlybyObjects(List<String> flybyObjects) async {
       try {
         for (final object in flybyObjects) {
           var description = await File('$object.txt').readAsString();
@@ -290,9 +290,10 @@ void main() {
       } finally {
         flybyObjects.clear();
       }
-      // #enddocregion try
     }
+    // #enddocregion try
 
-    expect(testTry, prints(startsWith('Could not describe object:')));
+    expect(() => describeFlybyObjects(flybyObjects),
+        prints(startsWith('Could not describe object:')));
   });
 }

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -445,18 +445,20 @@ if (astronauts == 0) {
 To catch an exception, use a `try` statement with `on` or `catch` (or both):
 
 <?code-excerpt "misc/test/samples_test.dart (try)"?>
-```
-try {
-  for (final object in flybyObjects) {
-    var description = await File('$object.txt').readAsString();
-    print(description);
+{% prettify dart tag=pre+code %}
+Future<void> describeFlybyObjects(List<String> flybyObjects) async {
+  try {
+    for (final object in flybyObjects) {
+      var description = await File('$object.txt').readAsString();
+      print(description);
+    }
+  } [!on IOException catch (e)!] {
+    print('Could not describe object: $e');
+  } finally {
+    flybyObjects.clear();
   }
-} on IOException catch (e) {
-  print('Could not describe object: $e');
-} finally {
-  flybyObjects.clear();
 }
-```
+{% endprettify %}
 
 Note that the code above is asynchronous;
 `try` works for both synchronous code and code in an `async` function.

--- a/src/samples/index.md
+++ b/src/samples/index.md
@@ -444,7 +444,7 @@ if (astronauts == 0) {
 
 To catch an exception, use a `try` statement with `on` or `catch` (or both):
 
-<?code-excerpt "misc/test/samples_test.dart (try)"?>
+<?code-excerpt "misc/test/samples_test.dart (try)" replace="/on.*e\)/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 Future<void> describeFlybyObjects(List<String> flybyObjects) async {
   try {


### PR DESCRIPTION
- Add a method declaration to make it more clear the code snippet is async (see https://github.com/dart-lang/site-www/pull/4463 for more context)
- Use Dart syntax highlighting
- Highlight catch part of sample to make it more clear what is being discussed