### PR TITLE
[2.19] Adjust Flutter compute function mention

### DIFF
--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -298,16 +298,6 @@ This section discusses some examples
 that use the `Isolate` API
 to implement isolates.
 
-{{site.alert.flutter-note}}
-  If you're using Flutter on a non-web platform,
-  then instead of using the `Isolate` API directly,
-  consider using the [Flutter `compute()` function][].
-  The `compute()` function is a simple way to
-  move a single function call to a worker isolate.
-{{site.alert.end}}
-
- [Flutter `compute()` function]: {{site.flutter-docs}}/cookbook/networking/background-parsing#4-move-this-work-to-a-separate-isolate
-
 ### Implementing a simple worker isolate
 
 These examples implement a main isolate
@@ -323,6 +313,19 @@ setting up and managing worker isolates:
 6. Checks, captures, and throws exceptions and errors back to the main isolate
 
 [`Isolate.run()`]: {{site.dart-api}}/dev/dart-isolate/Isolate/run.html
+
+{{site.alert.flutter-note}}
+  If you're using Flutter,
+  then instead of using `Isolate.run()`,
+  consider using the [Flutter `compute()` function][].
+  On native platforms, 
+  the `compute()` function is implemented using `Isolate.run()`,
+  while on the web platform, 
+  it falls back to running the passed-in callback
+  on the current event loop.
+{{site.alert.end}}
+
+[Flutter `compute()` function]: {{site.flutter-docs}}/cookbook/networking/background-parsing#4-move-this-work-to-a-separate-isolate
 
 #### Running an existing method in a new isolate
 

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -316,14 +316,14 @@ setting up and managing worker isolates:
 
 {{site.alert.flutter-note}}
   If you're using Flutter,
-  then instead of using `Isolate.run()`,
-  consider using the [Flutter `compute()` function][].
-  On native platforms, 
-  the `compute()` function is implemented using `Isolate.run()`,
-  while on the web platform, 
-  it falls back to running the passed-in callback
-  on the current event loop.
+  consider using the [Flutter `compute()` function][]
+  instead of `Isolate.run()` to allow your code to work
+  on both [native and non-native platforms][].
+  `Isolate.run()` is the better API choice
+  for Flutter on native platforms only. 
 {{site.alert.end}}
+
+[native and non-native platforms]: overview#platform
 
 [Flutter `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute.html
 

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -317,10 +317,12 @@ setting up and managing worker isolates:
 {{site.alert.flutter-note}}
   If you're using Flutter,
   consider using [Flutter's `compute()` function][]
-  instead of `Isolate.run()` to allow your code to work
-  on both [native and non-native platforms][].
-  `Isolate.run()` is the more ergonomic API choice
-  for Flutter apps targeting native platforms only. 
+  instead of `Isolate.run()`.
+  The `compute` function
+  allows your code to work  on both
+  [native and non-native platforms][].
+  Use `Isolate.run()` when targeting native platforms only
+  for a more ergonomic API.
 {{site.alert.end}}
 
 [native and non-native platforms]: /overview#platform

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -316,16 +316,15 @@ setting up and managing worker isolates:
 
 {{site.alert.flutter-note}}
   If you're using Flutter,
-  consider using the [Flutter `compute()` function][]
+  consider using [Flutter's `compute()` function][]
   instead of `Isolate.run()` to allow your code to work
   on both [native and non-native platforms][].
-  `Isolate.run()` is the better API choice
-  for Flutter on native platforms only. 
+  `Isolate.run()` is the more ergonomic API choice
+  for Flutter apps targeting native platforms only. 
 {{site.alert.end}}
 
-[native and non-native platforms]: overview#platform
-
-[Flutter `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute.html
+[native and non-native platforms]: /overview#platform
+[Flutter's `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute.html
 
 #### Running an existing method in a new isolate
 

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -325,7 +325,7 @@ setting up and managing worker isolates:
   on the current event loop.
 {{site.alert.end}}
 
-[Flutter `compute()` function]: {{site.flutter-docs}}/cookbook/networking/background-parsing#4-move-this-work-to-a-separate-isolate
+[Flutter `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute.html
 
 #### Running an existing method in a new isolate
 


### PR DESCRIPTION
Move the mention of Flutter's `compute` function to after introducing `Isolate.run` and adjust the guidance around when to use it in terms of `Isolate.run`.