### PR TITLE
Switch to opt-out system for code block language tags

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -1,6 +1,7 @@
 ---
 title: Learning Dart as a JavaScript developer
 description: Leverage your JavaScript knowledge when learning Dart.
+body_class: highlight-languages
 ---
 
 This guide aims to leverage your JavaScript programming knowledge
@@ -130,7 +131,6 @@ The equals operator `==` and the `identical()` method return `true`
 for the same values of number types. Review the example shown in the
 following code:
 
-{:.include-lang}
 ```dart
 var a = 2;
 var b = 1 + 1;
@@ -168,12 +168,10 @@ You don't need to use an additional object to apply a function to a number.
 
 For example, to round a `double` to an integer:
 
-{:.include-lang}
 ```js
 let rounded = Math.round(2.5);
 ```
 
-{:.include-lang}
 ```dart
 var rounded = 2.5.round();
 ```
@@ -188,7 +186,6 @@ but the language enforces no standard.
 Use double quotation marks if you don't want to escape
 single quotes within the string.
 
-{:.include-lang}
 ```dart
 var a = 'This is a string.';
 ```
@@ -204,7 +201,6 @@ precede that character with the backslash character (`\`).
 
 The following code shows some examples.
 
-{:.include-lang}
 ```dart
 final singleQuotes = 'I\'m learning Dart'; // I'm learning Dart
 final doubleQuotes = "Escaping the \" character"; // Escaping the " character
@@ -243,7 +239,6 @@ a string literal.
 Dart uses this syntax and allows you to omit the curly braces
 when the expression uses a single identifier.
 
-{:.include-lang}
 ```dart
 var food = 'bread';
 var str = 'I eat $food'; // I eat bread
@@ -261,7 +256,6 @@ Dart has two ways to define multiline strings.
     Dart concantenates any neighboring string literals,
     even when spread over multiple lines:
 
-{:.include-lang}
 ```dart
 final s1 = 'String '
     'concatenation'
@@ -274,7 +268,6 @@ When using three quotation marks (either single or double)
 on either side of the string, the literal can span multiple lines.
 
 
-{:.include-lang}
 ```dart
 final s2 = '''
 You can create
@@ -294,7 +287,6 @@ Dart considers two strings equal when they contain the same sequence
 of code units. To determine if two strings have the same sequences,
 use the equal-to operator (`==`).
 
-{:.include-lang}
 ```dart
 final s1 = 'String '
     'concatenation'
@@ -312,13 +304,11 @@ These two values represent whether a value or expression is
 You can return the values using the literals `true` and `false`,
 or produced them using expressions like `x < 5` or `y == null`.
 
-{:.include-lang}
 ```js
 let isBananaPeeled = false;
 ```
 
 
-{:.include-lang}
 ```dart
 var isBananaPeeled = false;
 ```
@@ -338,13 +328,11 @@ A Dart variable gets its type in one of two ways:
 1. Inferred: An expression used to initialize the variable
    By convention, use `var` or `final` when the analyzer can infer the type.
 
-{:.include-lang}
 ```js
 // Declare and initialize a variable at once
 let name = "bob";
 ```
 
-{:.include-lang}
 ```dart
 // Declare a variable with a specific type
 // when you don't provide an initial value
@@ -357,7 +345,6 @@ var name = 'bob';
 
 Variables can only accept values of their type.
 
-{:.include-lang}
 ```dart
 var name = 'bob';
 name = 5; // Forbidden, as `name` has type `String`.
@@ -369,7 +356,6 @@ Dart infers the variable's type to be the catch-all type `dynamic`.
 Like JavaScript variables, you can assign any value to Dart variables
 that use the `dynamic` type.
 
-{:.include-lang}
 ```js
 // Declare a variable
 let name;
@@ -377,7 +363,7 @@ let name;
 name = "bob";
 ```
 
-{:.include-lang}
+
 ```dart
 // Declare a variable without a type or assigned value
 // and Dart infers the 'dynamic' type
@@ -404,7 +390,6 @@ These expressions _cannot_ have side effects.
 Under these conditions, the compiler can then predict the precise value
 of a constant variable or expression, not just its static type.
 
-{:.include-lang}
 ```dart
 final String name;
 // Cannot read name here, not initialized.
@@ -428,7 +413,6 @@ In Dart, _constant variables must contain constant values_.
 Non-constant variables can contain constant values that
 you can also mark as `const`.
 
-{:.include-lang}
 ```dart
 var foo = const [];
   // foo is not constant, but the value it points to is.
@@ -458,7 +442,6 @@ exceptions when writing code, rather than at runtime.
 
 None of the variables in the following code example can be `null`.
 
-{:.include-lang}
 ```dart
 // In null-safe Dart, none of these can ever be null.
 var i = 42; // Inferred to be an int.
@@ -469,7 +452,6 @@ final b = Foo(); // Foo() invokes a constructor
 To indicate that a variable might have the value `null`,
 add `?` to its type declaration:
 
-{:.include-lang}
 ```dart
 int? aNullableInt = null;
 ```
@@ -477,7 +459,6 @@ int? aNullableInt = null;
 The same goes for any other type declaration,
 such as a function declaration:
 
-{:.include-lang}
 ```dart
 String? returnsNullable() {
   return random.nextDouble() < 0.5
@@ -506,7 +487,6 @@ using the (`!`) operator. Place this operator after the expression.
 Don't confuse this with Dart's not (`!`) operator,
 which uses the same symbol but place before the expression.
 
-{:.include-lang}
 ```dart
 int? a = 5;
 
@@ -521,7 +501,6 @@ Like the `?.` operator,
 use the `!` operator when accessing properties
 or methods on an object:
 
-{:.include-lang}
 ```dart
 myObject!.someProperty;
 myObject!.someMethod();
@@ -541,7 +520,6 @@ you can declare functions pretty much anywhere,
 whether at the top level,
 as a class field, or in the local scope.
 
-{:.include-lang}
 ```js
 // On the top level
 function multiply(a, b) {
@@ -565,7 +543,6 @@ function main() {
 }
 ```
 
-{:.include-lang}
 ```dart
 // On the top level
 int multiply(a, b) {
@@ -598,14 +575,12 @@ contains a single expression or return statement.
 
 For example, the following `isNoble` functions are equivalent:
 
-{:.include-lang}
 ```dart
 bool isNoble(int atomicNumber) {
   return _nobleGases[atomicNumber] != null;
 }
 ```
 
-{:.include-lang}
 ```dart
 bool isNoble(int atomicNumber) => _nobleGases[atomicNumber] != null;
 ```
@@ -616,7 +591,6 @@ In JavaScript, all parameters _can_ be positional parameters.
 By default, Dart _requires_ you to pass all parameters as arguments
 to functions.
 
-{:.include-lang}
 ```dart
 int multiply(int a, int b) {
   return a * b;
@@ -644,7 +618,6 @@ To learn more, see the preceding section about [null safety](#null-safety).
 The following code has one valid and two invalid examples
 of functions that define optional positional parameters.
 
-{:.include-lang}
 ```dart
 // Valid: `b` has a default value of 5. `c` is marked as nullable.
 multiply(int a, [int b = 5, int? c]) {
@@ -663,7 +636,6 @@ multiply(int a, [int b, int c]) {
 
 The following example shows how to call a function with optional parameters:
 
-{:.include-lang}
 ```dart
 multiply(int a, [int b = 5, int? c]) {
   ...
@@ -696,7 +668,6 @@ required either need to have a default value or be flagged as nullable.
 
 The following code defines a function with named parameters:
 
-{:.include-lang}
 ```dart
 // Valid:
 // - `a` has been flagged as required
@@ -710,7 +681,6 @@ multiply(bool x, {required int a, int b = 5, int? c}) {
 
 The following examples call a function with named parameters:
 
-{:.include-lang}
 ```dart
 // All are valid function calls.
 // Beyond providing the required positional parameter:
@@ -726,7 +696,6 @@ This means that Dart treats functions as any other object.
 For example, the following code shows how to
 pass a function as a parameter to another function:
 
-{:.include-lang}
 ```dart
 void printElement(int element) {
   print(element);
@@ -763,7 +732,6 @@ like a constructor, or creating a custom binding to this.
 
 To learn more, see the [Classes](#classes) section.
 
-{:.include-lang}
 ```js
 // A regular function expression
 // assigned to a variable
@@ -783,7 +751,7 @@ let arrowFuncExpr = (a, b) => {
 let arrowFuncExpr2 = (a, b) => a * b;
 ```
 
-{:.include-lang}
+
 ```dart
 // Assign an anonymous function
 // to a variable.
@@ -801,7 +769,6 @@ As with JavaScript, you can pass anonymous functions to other functions.
 Developers often pass anonymous functions when using the `map` function
 for arrays and lists:
 
-{:.include-lang}
 ```js
 // returns [4, 5, 6]
 [1, 2, 3].map(e => e + 3);
@@ -813,7 +780,6 @@ for arrays and lists:
 });
 ```
 
-{:.include-lang}
 ```dart
 // returns [4, 5, 6]
 [1, 2, 3].map((e) => e + 3).toList();
@@ -833,7 +799,6 @@ var list2 = [1, 2, 3].map((e) {
 
   A list literal could achieve the same goal.
 
-  {:.include-lang}
   ```dart
   // These two statements are equivalent:
   print([for (var e in [1, 2, 3]) e + 3]);
@@ -859,7 +824,6 @@ The following example shows how to write a
 basic generator function:
 
 
-{:.include-lang}
 ```js
 function* naturalsTo(n) {
   let k = 0;
@@ -876,7 +840,6 @@ for (let value of naturalsTo(5)) {
 ```
 
 
-{:.include-lang}
 ```dart
 Iterable<int> naturalsTo(int n) sync* {
   int k = 0;
@@ -889,7 +852,7 @@ Iterable<int> naturalsTo(int n) sync* {
 print(naturalsTo(5).toList());
 ```
 
-{:.include-lang}
+
 ```js
 function* doubleNaturalsTo(n) {
   let k = 0;
@@ -905,7 +868,6 @@ for (let value of doubleNaturalsTo(3)) {
 }
 ```
 
-{:.include-lang}
 ```dart
 Iterable<int> doubleNaturalsTo(int n) sync* {
   int k = 0;
@@ -946,15 +908,12 @@ Dart's `for-in` loop works like JavaScripts `for-of`.
 The following example shows iterating
 over a collection and printing out each element:
 
-
-{:.include-lang}
 ```js
 for (const element of list) {
   console.log(element);
 }
 ```
 
-{:.include-lang}
 ```dart
 for (final element in list) {
   print(element)
@@ -975,7 +934,6 @@ for (final element in list) {
 When using `continue` in a `switch` statement,
 you can combine it with a label that is put on a case:
 
-{:.include-lang}
 ```dart
 switch (testEnum) {
   case TestEnum.A:
@@ -995,7 +953,6 @@ Neither language supports adding new operators.
 Dart supports overloading some existing operators
 with the `operator` keyword. For example:
 
-{:.include-lang}
 ```dart
 class Vector {
   final double x;
@@ -1037,7 +994,6 @@ are almost identical, as shown in the following table:
 
 For example:
 
-{:.include-lang}
 ```dart
 assert(2 + 3 == 5);
 assert(2 - 3 == -1);
@@ -1067,7 +1023,6 @@ You've probably noticed that Dart also contains
 a `~/` operator (called a _truncating division operator_),
 that divides a double and outputs a floored integer:
 
-{:.include-lang}
 ```dart
 assert(25 == 50.4 ~/ 2);
 assert(25 == 50.6 ~/ 2);
@@ -1095,7 +1050,6 @@ The `==` and `!=` JavaScript operators have no equivalent.
 
 For example:
 
-{:.include-lang}
 ```dart
 assert(2 == 2);
 assert(2 != 3);
@@ -1127,7 +1081,6 @@ if you _know_ that the object will have that type.
 
 For example:
 
-{:.include-lang}
 ```dart
 (person as Employee).employeeNumber = 4204583;
 ```
@@ -1139,7 +1092,6 @@ In Dart, the types of local variables update within
 the scope of the if statement.
 This is not the case for instance variables.
 
-{:.include-lang}
 ```dart
 if (person is Employee) {
    person.employeeNumber = 4204583;
@@ -1167,7 +1119,6 @@ Dart allows `bool` values in conditions and as operands of logical operators.
 
 For example:
 
-{:.include-lang}
 ```dart
 if (!done && (col == 0 || col == 3)) {
   // ...Do something...
@@ -1195,7 +1146,6 @@ as shown in the following table:
 
 For example:
 
-{:.include-lang}
 ```dart
 final value = 0x22;
 final bitmask = 0x0f;
@@ -1221,12 +1171,10 @@ As Dart has another operator (`[]=`) that takes three operands,
 call this operator (`?:`) the conditional operator.
 This operator works for expressions like [if-else][] does for statements.
 
-{:.include-lang}
 ```js
 let visibility = isPublic ? "public" : "private";
 ```
 
-{:.include-lang}
 ```dart
 final visibility = isPublic ? 'public' : 'private';
 ```
@@ -1237,7 +1185,6 @@ final visibility = isPublic ? 'public' : 'private';
 
 Use the (`=`) operator to assign values.
 
-{:.include-lang}
 ```dart
 // Assign value to a
 a = value;
@@ -1274,7 +1221,6 @@ The following table lists these assignment operators:
 
 JavaScript does not support the `~/=` assignment operator.
 
-{:.include-lang}
 ```dart
 var a = 5;
 a *= 2; // Multiply `a` by 2 and assign the result back to a.
@@ -1292,7 +1238,6 @@ JavaScript lacks this syntax.
 The following example shows chaining multiple methods
 on a newly constructed object using the cascade syntax:
 
-{:.include-lang}
 ```dart
 var animal = Animal() // Sets multiple properties and methods
   ..name = "Bob"
@@ -1306,7 +1251,6 @@ print(animal.age); // 5
 
 To make the first cascade syntax null-aware, write it as `?..`.
 
-{:.include-lang}
 ```dart
 var result = maybePerson
     ?..employment = employer
@@ -1325,7 +1269,6 @@ to similar types in JavaScript.
 Dart writes list literals in the same ways as JavaScript arrays.
 Dart encloses lists in square brackets and separate values with commas.
 
-{:.include-lang}
 ```dart
 // Initialize list and specify full type
 final List<String> list1 = <String>['one', 'two', 'three'];
@@ -1342,7 +1285,6 @@ you can perform on a Dart `List`.
 The following example shows how to retrieve a value from a `List`
 using the index operator.
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 final fruit = fruits[1];
@@ -1351,7 +1293,6 @@ final fruit = fruits[1];
 Add a value to the end of the `List` using the `add` method.
 Add another `List` using the `addAll` method:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits.add('peach');
@@ -1362,7 +1303,6 @@ Insert a value at a specific position using the
 `insert` method. Insert another `List` at a
 specific position using the `insertAll` method:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits.insert(0, 'peach');
@@ -1372,7 +1312,6 @@ fruits.insertAll(0, ['kiwi', 'mango']);
 Update a value in the `List` combining the
 index and assignment operators:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 fruits[2] = 'peach';
@@ -1380,7 +1319,6 @@ fruits[2] = 'peach';
 
 Remove items from a `List` using one of the following methods:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 // Remove the value 'pear' from the list.
@@ -1398,7 +1336,6 @@ fruits.removeWhere((fruit) => fruit.contains('p'));
 
 Use `length` to obtain the number of values in the `List`:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 assert(fruits.length == 3);
@@ -1406,7 +1343,6 @@ assert(fruits.length == 3);
 
 Use `isEmpty` to check if the `List` is empty:
 
-{:.include-lang}
 ```dart
 var fruits = [];
 assert(fruits.isEmpty);
@@ -1414,7 +1350,6 @@ assert(fruits.isEmpty);
 
 Use `isNotEmpty` to check if the `List` is not empty:
 
-{:.include-lang}
 ```dart
 final fruits = <String>['apple', 'orange', 'pear'];
 assert(fruits.isNotEmpty);
@@ -1428,7 +1363,6 @@ This `filled` constructor creates a fixed-length list of size `n` with
 one default value.
 The following example create a list of 3 items:
 
-{:.include-lang}
 ```dart
 final list1 = List.filled(3, 'a'); // Creates: [ 'a', 'a', 'a' ]
 ```
@@ -1445,7 +1379,6 @@ This `generate` constructor creates a fixed-length list of size `n`
 with a template to build element values.
 This template takes the index as a parameter.
 
-{:.include-lang}
 ```dart
 // Creates: [ 'a0', 'a1', 'a2' ]
 final list1 = List.generate(3, (index) => 'a$index');
@@ -1470,7 +1403,6 @@ meaning that objects need hash values to be stored in a `Set`.
 
 The following code snippet shows how to initialize a `Set`:
 
-{:.include-lang}
 ```dart
 final abc = {'a', 'b', 'c'};
 ```
@@ -1481,7 +1413,6 @@ curly braces (`{}`) results in creating an empty `Map`.
 To create an empty `Set`, precede the `{}` declaration
 with a type argument or assign `{}` to a variable of type `Set`:
 
-{:.include-lang}
 ```dart
 final names = <String>{};
 // Set<String> names = {}; // This works, too.
@@ -1494,7 +1425,6 @@ basic actions that you can perform on a Dart `Set`.
 Add a value to the `Set` using the `add` method.
 Use the `addAll` method to add multiple values:
 
-{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 fruits.add('peach');
@@ -1504,7 +1434,6 @@ fruits.addAll(['kiwi', 'mango']);
 Use one of the following methods in `Set`
 to remove content from the set:
 
-{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 // Remove the value 'pear' from the set.
@@ -1517,7 +1446,6 @@ fruits.removeWhere((fruit) => fruit.contains('p'));
 
 Use `length` to get the number of values in the `Set`:
 
-{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 assert(fruits.length == 3);
@@ -1525,7 +1453,6 @@ assert(fruits.length == 3);
 
 Use `isEmpty` to check if the `Set` is empty:
 
-{:.include-lang}
 ```dart
 var fruits = <String>{};
 assert(fruits.isEmpty);
@@ -1533,7 +1460,6 @@ assert(fruits.isEmpty);
 
 Use `isNotEmpty` to check if the `Set` is not empty:
 
-{:.include-lang}
 ```dart
 final fruits = {'apple', 'orange', 'pear'};
 assert(fruits.isNotEmpty);
@@ -1560,7 +1486,6 @@ _contents_ of the object, override `hashCode` and `operator==`.
 
 Consider these simple `Map` examples, created using literals:
 
-{:.include-lang}
 ```dart
 final gifts = {
   'first': 'partridge',
@@ -1580,7 +1505,6 @@ you can perform on a Dart `Map`.
 The following example shows how to retrieve a value from a `Map` using
 the index operator.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 final gift = gifts['first'];
@@ -1592,7 +1516,6 @@ If the map does not include the lookup key, the index operator returns `null`.
 
 Use the `containsKey` method to check if the `Map` includes a key.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 assert(gifts.containsKey('fifth'));
@@ -1603,7 +1526,6 @@ in the `Map`.
 If the `Map` doesn't yet contain the key, Dart adds the entry.
 If the key exists, Dart updates its value.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['second'] = 'turtle'; // Gets added
@@ -1613,7 +1535,6 @@ gifts['second'] = 'turtle doves'; // Gets updated
 Use the `addAll` method to add another `Map`.
 Use the `addEntries` method to add other entries to the `Map`.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['second'] = 'turtle doves';
@@ -1630,7 +1551,6 @@ gifts.addEntries([
 Use the `remove` method to remove an entry from the `Map`.
 Use the `removeWhere` method to remove all entries that satisfy a given test.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts.remove('first');
@@ -1639,7 +1559,6 @@ gifts.removeWhere((key, value) => value == 'partridge');
 
 Use `length` to obtain the number of key-value pairs in the `Map`.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['fourth'] = 'calling birds';
@@ -1648,7 +1567,6 @@ assert(gifts.length == 2);
 
 Use `isEmpty` to check if the `Map` is empty.
 
-{:.include-lang}
 ```dart
 final gifts = {};
 assert(gifts.isEmpty);
@@ -1656,7 +1574,6 @@ assert(gifts.isEmpty);
 
 Use `isNotEmpty` to check if the `Map` is not empty.
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 assert(gifts.isNotEmpty);
@@ -1682,7 +1599,6 @@ dictionaries immutable.
   (as shown in the following example).
   This creates a collection that cannot change its size or content:
 
-{:.include-lang}
 ```dart
 final _set = Set<String>.unmodifiable(['a', 'b', 'c']);
 final _list = List<String>.unmodifiable(['a', 'b', 'c']);
@@ -1695,7 +1611,6 @@ As in JavaScript, Dart supports embedding a list
 into another list using the spread operator (`...`)
 and the null-aware spread operator (`...?`).
 
-{:.include-lang}
 ```dart
 var list1 = [1, 2, 3];
 var list2 = [0, ...list1];　// [0, 1, 2, 3]
@@ -1706,7 +1621,6 @@ var list2 = [0, ...?list1]; // [0]
 
 This also works for sets and maps:
 
-{:.include-lang}
 ```dart
 // Spread operator with maps
 var map1 = {'foo': 'bar', 'key': 'value'};
@@ -1724,7 +1638,6 @@ functionality when it comes to collections.
 A collection `if` statement includes items from a
 list literal only when the specified condition is met:
 
-{:.include-lang}
 ```dart
 var nav = [
   'Home',
@@ -1739,7 +1652,6 @@ It works similarly for maps and sets.
 A collection `for` statement allows
 multiple items to be mapped into another list:
 
-{:.include-lang}
 ```dart
 var listOfInts = [1, 2, 3];
 var listOfStrings = [
@@ -1774,7 +1686,6 @@ available until later.
 The following example shows that handling a future works
 in the same way in Dart as a promise works in JavaScript.
 
-{:.include-lang}
 ```js
 const httpResponseBody = func();
 
@@ -1786,7 +1697,6 @@ httpResponseBody.then(value => {
 ```
 
 
-{:.include-lang}
 ```dart
 Future<String> httpResponseBody = func();
 
@@ -1798,7 +1708,6 @@ httpResponseBody.then((String value) {
 Similarly, futures can fail like promises.
 Catching errors works the same as well:
 
-{:.include-lang}
 ```js
 httpResponseBody
   .then(...)
@@ -1809,7 +1718,7 @@ httpResponseBody
   });
 ```
 
-{:.include-lang}
+
 ```dart
 httpResponseBody
   .then(...)
@@ -1825,7 +1734,6 @@ To create a `Future`, define and call an `async` function.
 When you have a value that needs to be a `Future`,
 convert the function as in the following example.
 
-{:.include-lang}
 ```dart
 String str = 'String Value';
 Future<String> strFuture = Future<String>.value(str);
@@ -1844,8 +1752,6 @@ it returns `Future<void>`.
 
 The following example shows how to write an `async` function:
 
-
-{:.include-lang}
 ```js
 // Returns a Promise of a string,
 // as the method is async
@@ -1857,7 +1763,6 @@ async fetchString() {
 ```
 
 
-{:.include-lang}
 ```dart
 // Returns a future of a string,
 // as the method is async
@@ -1868,11 +1773,8 @@ Future<String> fetchString() async {
 }
 ```
 
-
-
 Call this `async` function as follows:
 
-{:.include-lang}
 ```dart
 Future<String> stringFuture = fetchString();
 stringFuture.then((String str) {
@@ -1890,7 +1792,6 @@ within an `async` context (such as another `async` function).
 
 The following example shows how to await a future for its value:
 
-{:.include-lang}
 ```dart
 // We can only await futures within an async context.
 Future<void> asyncFunction() async {
@@ -1926,7 +1827,6 @@ To listen to a stream, call its `listen` method
 and provide a callback method. Whenever the stream emits a value,
 Dart calls this method:
 
-{:.include-lang}
 ```dart
 Stream<int> stream = ...
 stream.listen((int value) {
@@ -1937,7 +1837,6 @@ stream.listen((int value) {
 The `listen` method includes optional callbacks
 for handling errors or for when the stream completes:
 
-{:.include-lang}
 ```dart
 stream.listen(
   (int value) { ... },
@@ -1954,7 +1853,6 @@ The `listen` method returns an instance of a
 `StreamSubscription`, which you can use to stop
 listening to the stream:
 
-{:.include-lang}
 ```dart
 StreamSubscription subscription = stream.listen(...);
 subscription.cancel();
@@ -1967,7 +1865,6 @@ you can combine a stream with a `for-in` loop in an
 callback method for each item emitted,
 and it ends when the stream completes or errors out:
 
-{:.include-lang}
 ```dart
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
@@ -1983,7 +1880,6 @@ in this way, the error is rethrown at the line
 containing the `await` keyword.
 You can handle this error with a `try-catch` statement:
 
-{:.include-lang}
 ```dart
 try {
   await for (final value in stream) { ... }
@@ -2014,7 +1910,6 @@ completes the stream.
 
 The following example shows basic usage of a stream controller:
 
-{:.include-lang}
 ```dart
 var listeners = 0;
 StreamController<int>? controller;
@@ -2049,7 +1944,6 @@ This allows events from other streams to be emitted to this stream.
 In the following example,
 the function continues once the newly yielded stream has completed.
 
-{:.include-lang}
 ```dart
 Stream<int> asynchronousNaturalsTo(int n) async* {
   var k = 0;
@@ -2100,7 +1994,6 @@ and all parameters must be explicitly typed. In Dart,
 the `new` keyword was once required for creating class instances,
 but is now optional and its use is no longer recommended.
 
-{:.include-lang}
 ```dart
 class Point {
   final double x;
@@ -2119,7 +2012,6 @@ Use initializer lists to write your constructor.
 Insert the initializer list between the constructor's parameters
 and body.
 
-{:.include-lang}
 ```dart
 class Point {
   ...
@@ -2139,7 +2031,6 @@ can feel like creating boilerplate code,
 so Dart has some syntactic sugar, called
 [initializing parameters][] to make this easier:
 
-{:.include-lang}
 ```dart
 class Point {
   double x;
@@ -2159,7 +2050,6 @@ Point p = Point(3, 5);
 Similar to functions, constructors have the
 option to take positioned or named parameters:
 
-{:.include-lang}
 ```dart
 class Point {
   ...
@@ -2182,7 +2072,6 @@ multiple constructors, by allowing you to name them.
 You can optionally have one single unnamed constructor,
 any additional constructors must be named:
 
-{:.include-lang}
 ```dart
 const double xOrigin = 0;
 const double yOrigin = 0;
@@ -2205,7 +2094,6 @@ class Point {
 To enable immutable class instances, use a `const` constructor.
 A class with a `const` constructor can have `final` instance variables only.
 
-{:.include-lang}
 ```dart
 class ImmutablePoint {
   final double x, y;
@@ -2219,7 +2107,6 @@ class ImmutablePoint {
 You can call constructors from other constructors to prevent code
 duplication or to add additional defaults for parameters:
 
-{:.include-lang}
 ```dart
 class Point {
   double x, y;
@@ -2238,7 +2125,6 @@ You can use a factory constructor when you
 don't need to create a new class instance.
 One example would be when returning a cached instance:
 
-{:.include-lang}
 ```dart
 class Logger {
   static final Map<String, Logger> _cache =
@@ -2263,7 +2149,6 @@ class Logger {
 In both Dart and JavaScript, methods serve as functions that provide
 behavior for an object.
 
-{:.include-lang}
 ```js
 function doSomething() { // This is a function
   // Implementation..
@@ -2276,8 +2161,6 @@ class Example {
 }
 ```
 
-
-{:.include-lang}
 ```dart
 void doSomething() { // This is a function
  // Implementation..
@@ -2297,7 +2180,6 @@ class Example {
 Dart allows classes to extend another class,
 in the same way that JavaScript does.
 
-{:.include-lang}
 ```dart
 class Animal {
   int eyes;
@@ -2332,7 +2214,6 @@ is not actually overriding a superclass method.
 The parent method that is being overridden can
 still be called using the `super` keyword:
 
-{:.include-lang}
 ```dart
 class Cat extends Animal {
   ...
@@ -2345,7 +2226,6 @@ class Cat extends Animal {
 Animal animal = Cat();
 animal.makeNoise(); // Meow
                     // ???
-
 ```
 
 ### Classes as interfaces
@@ -2364,7 +2244,6 @@ While a class can only extend a single class,
 you can implement multiple interfaces at a time,
 even when the implementing class already extends another.
 
-{:.include-lang}
 ```dart
 class Consumer {
   consume() {
@@ -2384,7 +2263,6 @@ When implementing an interface,
 the `super` method can't be called
 as the method bodies are not inherited:
 
-{:.include-lang}
 ```dart
 class Cat implements Consumer {
   @override
@@ -2408,7 +2286,6 @@ which do not require a body and are instead required
 to be implemented when the class is either extended
 or its interface is implemented:
 
-{:.include-lang}
 ```dart
 abstract class Consumer {
   consume();
@@ -2448,8 +2325,6 @@ to merge additional objects into an existing object, after instantiating.
 
 The following examples show how JavaScript and Dart achieve similar behavior:
 
-
-{:.include-lang}
 ```js
 class Animal {}
 
@@ -2495,7 +2370,6 @@ dog.fly(); // `dog` lacks the `fly` method
 ```
 
 
-{:.include-lang}
 ```dart
 abstract class Animal {}
 
@@ -2521,13 +2395,10 @@ Bat().walk(); // Not using the Walker mixin
 Dog().fly(); // Not using the Flyer mixin
 ```
 
-
-
 Alternatively, you can replace the `class` keyword
 with `mixin` to prevent the mixin from being used
 as a regular class:
 
-{:.include-lang}
 ```dart
 mixin Walker {
   walk() => print('Walks legs');
@@ -2545,7 +2416,6 @@ The order in which they are added to a class matters.
 
 To give an example:
 
-{:.include-lang}
 ```dart
 class Bird extends Animal with Consumer, Flyer {
 ```
@@ -2571,7 +2441,6 @@ for existing classes.
 As an example, the following extension on the `String` class
 from the Dart SDK allows parsing of integers:
 
-{:.include-lang}
 ```dart
 extension NumberParsing on String {
   int parseInt() {
@@ -2586,7 +2455,6 @@ or its file must be imported.
 
 Use it as follows:
 
-{:.include-lang}
 ```dart
 import 'string_apis.dart'; // Import the file the extension is in
 var age = '42'.parseInt(); // Use the extension method.
@@ -2597,8 +2465,6 @@ var age = '42'.parseInt(); // Use the extension method.
 Getters and setters in Dart work exactly like
 their JavaScript counterparts:
 
-
-{:.include-lang}
 ```js
 class Person {
   _age = 0;
@@ -2623,7 +2489,6 @@ console.log(person.age);
 ```
 
 
-{:.include-lang}
 ```dart
 class Person {
   int _age = 0;
@@ -2664,7 +2529,6 @@ various browsers and runtimes for some time.
 To make a class member private in JavaScript,
 prefix its name with a pound (or hash) symbol (`#`).
 
-{:.include-lang}
 ```js
 class Animal {
   eyes; // Public field
@@ -2683,7 +2547,6 @@ class Animal {
 To make a class member private in Dart, prefix its name
 with an underscore (`_`).
 
-{:.include-lang}
 ```dart
 class Animal {
   int eyes; // Public field
@@ -2724,7 +2587,6 @@ This differs from labeling the field as nullable.
 * (Non-nullable) late fields throw a runtime error when
   accessed before they initialize. This should be avoided.
 
-{:.include-lang}
 ```dart
 class PetOwner {
   final String name;
@@ -2745,7 +2607,6 @@ class Pet {
 Use `late` for local variables only if unclear code results
 in the compiler being unable determine if the code initialized the variable.
 
-{:.include-lang}
 ```dart
 doSomething(int n, bool capture) {
   late List<Foo> captures;
@@ -2774,7 +2635,6 @@ after the method name.
 You can then use this type within the method
 as the return type or within the method’s parameters:
 
-{:.include-lang}
 ```dart
 Map<Object?, Object?> _cache = {};
 T cache<T>(T value) => (_cache[value] ??= value) as T;
@@ -2782,7 +2642,6 @@ T cache<T>(T value) => (_cache[value] ??= value) as T;
 
 Define multiple generic types by separating them with a comma:
 
-{:.include-lang}
 ```dart
 // Defining a method with multiple generics.
 T transform<T, Q>(T param1, Q param2) {
@@ -2802,7 +2661,6 @@ This allows you to tailor reusable classes to specific types.
 
 In the following example, the `Cache` class caches specific types:
 
-{:.include-lang}
 ```dart
 class Cache<T> {
   T getByKey(String key) {}
@@ -2825,7 +2683,6 @@ a family of types using `extends`. This ensures
 that your class is instantiated with a generic type
 that extends a specific type:
 
-{:.include-lang}
 ```dart
 class NumberManager<T extends num> {
    ...
@@ -2850,7 +2707,6 @@ which is used in some `List` class’s member types.
 When defining a `List` literal,
 you can explicitly define the generic type as follows:
 
-{:.include-lang}
 ```dart
 // Automatic type inference
 var objList = [5, 2.0]; // Type: List<num>
@@ -2864,7 +2720,6 @@ This is also true for `Map`s,
 which also define their key and value types
 using generics (`class Map<K, V>`):
 
-{:.include-lang}
 ```dart
 // Automatic type inference
 var map = {
@@ -2893,7 +2748,6 @@ above all declarations for public members.
 Define a doc comment by using three forward slashes
 instead of two (`///`):
 
-{:.include-lang}
 ```dart
 /// The number of characters in this chunk when unsplit.
 int get length => ...

--- a/src/_guides/language/coming-from/swift-to-dart.md
+++ b/src/_guides/language/coming-from/swift-to-dart.md
@@ -1,6 +1,7 @@
 ---
 title: Learning Dart as a Swift developer
 description: Leverage your Swift knowledge when learning Dart.
+body_class: highlight-languages
 ---
 
 This guide aims to leverage your Swift programming
@@ -94,7 +95,6 @@ As in Swift, Dart supports type inference where the
 compiler infers the type based on the value assigned
 to the variable:
 
-{:.include-lang}
 ```dart
 // String-typed variable.
 String name = 'Bob';
@@ -118,7 +118,6 @@ when the analyzer can implicitly infer the type][inference].
 
 [inference]: /guides/language/effective-dart/design#types
 
-{:.include-lang}
 ```dart
 // Declare a variable first:
 String name; 
@@ -131,7 +130,6 @@ var name = 'bob';
 The Swift equivalent of the above Dart code
 would look as follows:
 
-{:.include-lang}
 ```swift
 // Declare a variable first: 
 var name: String
@@ -172,7 +170,6 @@ in a compile-time error. Both of the following code
 snippets are valid, but subsequently setting `name`
 results in compilation errors.
 
-{:.include-lang}
 ```dart
 final String name;
 if (b1) {
@@ -182,7 +179,6 @@ if (b1) {
 }
 ```
 
-{:.include-lang}
 ```swift
 let name: String
 if (b1) {
@@ -199,7 +195,6 @@ One benefit of `const` is that it's fully evaluated
 at compile-time and can't be modified during the
 lifetime of the application.
 
-{:.include-lang}
 ```dart
 const bar = 1000000; // Unit of pressure (dynes/cm2)
 const double atm = 1.01325 * bar; // Standard atmosphere
@@ -208,7 +203,6 @@ const double atm = 1.01325 * bar; // Standard atmosphere
 A `const` variable defined at a class level
 needs to be marked as `static const`.
 
-{:.include-lang}
 ```dart
 class StandardAtmosphere {
   static const bar = 1000000; // Unit of pressure (dynes/cm2)
@@ -220,7 +214,6 @@ The `const` keyword isn't just for declaring
 constant variables; it can also be used to create
 constant values:
 
-{:.include-lang}
 ```dart
 var foo = const ['one', 'two', 'three'];
 foo.add('four'); // Error: foo contains a constant value.
@@ -238,7 +231,6 @@ You can also assign a constant value to a `final` field.
 You can't use the `final` field in a constant context,
 but you can use the constant. For example:
 
-{:.include-lang}
 ```dart
 final foo1 = const [1, 2, 3];
 const foo2 = [1, 2, 3]; // Equivalent to `const [1, 2, 3]`
@@ -308,7 +300,6 @@ for example, be turned into a `double` as follows:
 TODO: Use a different example here, such as rounding
 {% endcomment %}
 
-{:.include-lang}
 ```dart
 int intVariable = 3;
 double doubleVariable = intVariable.toDouble();
@@ -317,7 +308,6 @@ double doubleVariable = intVariable.toDouble();
 The same is accomplished in Swift using the
 specialized initializer:
 
-{:.include-lang}
 ```swift
 var intVariable: Int = 3
 var doubleVariable: Double = Double(intVariable)
@@ -328,7 +318,6 @@ Dart automatically converts the integer literal
 into a `double` value. The following code
 is perfectly fine:
 
-{:.include-lang}
 ```dart
 double doubleValue = 3;
 ```
@@ -337,7 +326,6 @@ Unlike Swift, in Dart you can compare an integer
 value to a double using the equality (`==`) operator,
 as shown below:
 
-{:.include-lang}
 ```dart
 int intVariable = 3;
 double doubleVariable = 3.0;
@@ -360,14 +348,12 @@ a `Character` type representing one character.
 A `String` can be defined with either single or
 double quotes, however, _single quotes are preferred_.
 
-{:.include-lang}
 ```dart
 String c = 'a'; // There isn't a specialized "Character" type
 String s1 = 'This is a String';
 String s2 = "This is also a String";
 ```
 
-{:.include-lang}
 ```swift
 let c: Character = "a"
 let s1: String = "This is a String"
@@ -383,7 +369,6 @@ using the backslash character.
 
 The following code shows some examples:
 
-{:.include-lang}
 ```dart
 final singleQuotes = 'I\'m learning Dart'; // I'm learning Dart
 final doubleQuotes = "Escaping the \" character"; // Escaping the " character
@@ -412,7 +397,7 @@ Dart has several ways to define multiline strings:
    Any neighboring string literals are automatically
    concatenated, even when spread over multiple lines:
 
-   {:.include-lang}
+
    ```dart
    final s1 = 'String '
      'concatenation'
@@ -425,7 +410,7 @@ Dart has several ways to define multiline strings:
    side of the string,
    the literal is allowed to span multiple lines:
 
-   {:.include-lang}
+
    ```dart
    final s2 = '''You can create
    multiline strings like this one.''';
@@ -438,7 +423,7 @@ Dart has several ways to define multiline strings:
    the `+` operator. This works with both string
    literals and string variables:
 
-   {:.include-lang}
+
    ```dart
    final name = 'John';
    final greeting = 'Hello ' + name + '!';
@@ -451,7 +436,6 @@ Insert expressions into the string literal using the
 allowing the curly braces to be omitted when the
 expression is a single identifier:
 
-{:.include-lang}
 ```dart
 var food = 'bread';
 var str = 'I eat $food'; // I eat bread
@@ -462,7 +446,6 @@ In Swift, you can achieve the same result by
 surrounding the variable or expression with
 parentheses and prefixing with a backslash: 
 
-{:.include-lang}
 ```swift
 let s = "string interpolation"
 let c = "Swift has \(s), which is very handy."
@@ -476,7 +459,6 @@ includes any special characters present in the string.
 You can do this in Dart by prefixing the string literal
 with the letter `r`, as shown in the following example.
 
-{:.include-lang}
 ```dart
 // Include the \n characters.
 final s1 = r'Includes the \n characters.';
@@ -493,7 +475,6 @@ final s4 = r"""
   """;
 ```
 
-{:.include-lang}
 ```swift
 let s1 = #"Includes the \n characters."#
 let s2 = #"""
@@ -509,7 +490,6 @@ compares whether two strings are equal.
 Two strings are equal if they contain the same
 sequence of code units.
 
-{:.include-lang}
 ```dart
 final s1 = 'String '
   'concatenation'
@@ -553,12 +533,10 @@ The null coalescing operator (`??`),
 and optional chaining operator (`?.`)
 are available in Dart and operate the same as in Swift:
 
-{:.include-lang}
 ```dart
 a = a ?? b;
 ```
 
-{:.include-lang}
 ```swift
 let str: String? = nil
 let count = str?.count ?? 0
@@ -575,7 +553,6 @@ with a nullable type when its current value is `null`.
 It's expressed as `a ??= b;` and is shorthand for
 the following:
 
-{:.include-lang}
 ```dart
 a = a ?? b;
 
@@ -583,7 +560,6 @@ a = a ?? b;
 a ??= b; 
 ```
 
-{:.include-lang}
 ```swift
 a = a ?? b
 ```
@@ -599,7 +575,6 @@ by placing it as a suffix to the expression.
 (Don't confuse this with Dart's "not" operator,
 which uses the same symbol):
 
-{:.include-lang}
 ```dart
 int? a = 5;
 
@@ -614,7 +589,6 @@ Like the `?.` operator,
 use the `!` operator when accessing properties
 or methods on an object:
 
-{:.include-lang}
 ```dart
 myObject!.someProperty;
 myObject!.someMethod();
@@ -638,7 +612,6 @@ a non-nullable `late` field throws a runtime error
 when observed before being initialized,
 a scenario you want to avoid in a well-behaved app.
 
-{:.include-lang}
 ```dart
 // Using null safety:
 class Coffee {
@@ -660,7 +633,6 @@ Note that `_temperature` can't ever be `null`.
 You can also use the `late` keyword to make
 initialization lazy when combining it with an initializer:
 
-{:.include-lang}
 ```dart
 class Weather {
   late int _temperature = _readThermometer();
@@ -678,7 +650,6 @@ the `final` variable when marking it as `late`,
 it can still be initialized only once.
 A second assignment results in a runtime error.
 
-{:.include-lang}
 ```dart
 late final int a;
 a = 1;
@@ -693,7 +664,6 @@ entry point. Dart uses the `main` function
 as an app's entry point. Every program must
 have a `main` function to be executable. For example:
 
-{:.include-lang}
 ```dart
 void main() {
   // main function is the entry point
@@ -701,7 +671,6 @@ void main() {
 }
 ```
 
-{:.include-lang}
 ```swift
 // main.swift file is the entry point
 print("hello world")
@@ -737,7 +706,6 @@ function call in a `try-catch` block.
 [errors]: {{site.dart-api}}/dart-core/Error-class.html
 [exceptions]: {{site.dart-api}}/dart-core/Exception-class.html
 
-{:.include-lang}
 ```dart
 try {
   // Create audio player object
@@ -755,7 +723,6 @@ catch {
 Similarly, Swift uses a `do-try-catch` block.
 For example:
 
-{:.include-lang}
 ```swift
 do {
   // Create audio player object
@@ -784,7 +751,6 @@ these aren't the default in Dart.
 The default parameter type in Dart is a
 positional parameter.
 
-{:.include-lang}
 ```dart
 int multiply(int a, int b) {
   return a * b;
@@ -795,7 +761,6 @@ The equivalent in Swift prefaces a parameter
 with an underscore to remove the need
 for an argument label.
 
-{:.include-lang}
 ```swift
 func multiply(_ a: Int, _ b: Int) -> Int {
   return a * b
@@ -807,7 +772,6 @@ they must be defined separately in a
 block of curly braces,
 after any positional parameters:
 
-{:.include-lang}
 ```dart
 int multiply(int a, int b, {int c = 1, int d = 1}) {
   return a * b * c * d;
@@ -820,7 +784,6 @@ multiply(3, 5, d: 3); // 45
 multiply(3, 5, c: 2, d: 3); // 90
 ```
 
-{:.include-lang}
 ```swift
 // The Swift equivalent
 func multiply(_ a: Int, _ b: Int, c: Int = 1, d: Int = 1) -> Int {
@@ -838,7 +801,6 @@ are covered in a later section.
 To make a named parameter required in Dart,
 you must prefix it with the `required` keyword:
 
-{:.include-lang}
 ```dart
 int multiply(int a, int b, { required int c }) {
   return a * b * c;
@@ -855,7 +817,6 @@ They must be listed after any required positional
 parameters and can't be used in conjunction
 with named parameters.
 
-{:.include-lang}
 ```dart
 int multiply(int a, int b, [int c = 1, int d = 1]) {
   return a * b * c * d;
@@ -866,7 +827,6 @@ multiply(3, 5, 2); // 30
 multiply(3, 5, 2, 3); // 90
 ```
 
-{:.include-lang}
 ```swift
 // The Swift equivalent
 func multiply(_ a: Int, _ b: Int, _ c: Int = 1, _ d: Int = 1) -> Int {
@@ -887,7 +847,6 @@ return a function from a function:
 
 [first class citizens]: https://en.wikipedia.org/wiki/First-class_citizen
 
-{:.include-lang}
 ```dart
 typedef int MultiplierFunction(int value);
 // Define a function that returns another function
@@ -902,7 +861,6 @@ MultiplierFunction multiplyByTwo = multiplyBy(2);
 print(multiplyByTwo(3)); // 6
 ```
 
-{:.include-lang}
 ```swift
 // The Swift equivalent of the Dart function below
 // Define a function that returns a closure
@@ -936,7 +894,6 @@ works like any other function.
 It allows you to use multiple lines, and it
 needs a return statement for any value to be returned.
 
-{:.include-lang}
 ```dart
 // Multi line anonymous function
 [1,2,3].map((element) { 
@@ -951,7 +908,6 @@ needs a return statement for any value to be returned.
   the returned `Iterator` to turn it back into a `List`. 
 {{site.alert.end}}
 
-{:.include-lang}
 ```swift
   // Swift equivalent anonymous function
   [1, 2, 3].map { $0 * 2 }
@@ -965,7 +921,6 @@ and where the value is returned.
 This omits the need for any braces or
 a return statement, as these are implied.
 
-{:.include-lang}
 ```dart
 // Single-line anonymous function
 [1,2,3].map((element) => element * 2).toList(); // [2, 4, 6]
@@ -975,7 +930,6 @@ The choice between the arrow syntax or
 curly braces is available for any function,
 not just anonymous functions.
 
-{:.include-lang}
 ```dart
 multiply(int a, int b) => a * b;
 
@@ -997,7 +951,6 @@ or add whole collections of items using `yield*`.
 The following example shows how to write a basic
 generator function:
 
-{:.include-lang}
 ```dart
 Iterable<int> listNumbers(int n) sync* {
   int k = 0;
@@ -1045,7 +998,6 @@ curly braces around flow control statements
 with no else clause and the whole if statement
 fits on one line, you can omit the braces if you prefer.
 
-{:.include-lang}
 ```swift
 var a = 1;
 // Parentheses for conditions are required in Dart.
@@ -1061,7 +1013,6 @@ if (a == 1) {
 if (a == 1) print('a == 1');
 ```
 
-{:.include-lang}
 ```swift
 let a = 1;
 if a == 1 {
@@ -1086,7 +1037,6 @@ Dart's `for-in` loop works like its Swift counterpart,
 and it can loop over any value that is an `Iterable`,
 as in the `List` example below:
 
-{:.include-lang}
 ```dart
 var list = [0, 1, 2, 3, 4];
 for (var i in list) {
@@ -1094,7 +1044,6 @@ for (var i in list) {
 }
 ```
 
-{:.include-lang}
 ```swift
 let array = [0, 1, 2, 3, 4]
 for i in array {
@@ -1109,7 +1058,6 @@ To achieve a similar effect, you can
 extract the map's entries as an `Iterable` type.
 Alternatively, you can use `Map.forEach`:
 
-{:.include-lang}
 ```dart
 Map<String, int> dict = {
   'Foo': 1,
@@ -1123,7 +1071,6 @@ dict.forEach((key, value) {
 });
 ```
 
-{:.include-lang}
 ```swift
 var dict:[String:Int] = [
   "Foo":1,
@@ -1141,7 +1088,6 @@ of new operators, but it does allow you to overload
 existing operators with the operator keyword.
 For example:
 
-{:.include-lang}
 ```dart
 class Vector {
   final double x;
@@ -1154,7 +1100,6 @@ class Vector {
 }
 ```
 
-{:.include-lang}
 ```swift
 struct Vector {
   let x: Double
@@ -1189,7 +1134,6 @@ use Dart's truncating division operator (`~/`).
   (_Floored_ meaning that the result is truncated
   and not rounded.) For example:
 
-{:.include-lang}
   ```dart
   assert(25 == 50.4 ~/ 2);
   assert(25 == 50.6 ~/ 2);
@@ -1205,7 +1149,6 @@ For example:
 
 [removed in Swift 3.0]: https://www.appsloveworld.com/swift/100/9/-is-deprecated-it-will-be-removed-in-swift-3
 
-{:.include-lang}
 ```dart
 assert(2 + 3 == 5);
 assert(2 - 3 == -1);
@@ -1247,7 +1190,6 @@ Use the typecast operator to cast an object
 to a particular type&mdash;if and only if&mdash;you're
 sure that the object is of that type. For example:
 
-{:.include-lang}
 ```dart
 (person as Employee).employeeNumber = 4204583;
 ```
@@ -1256,7 +1198,6 @@ Dart has only the single-type casting operator,
 which acts like Swift's `as!` operator.
 There's no equivalent for Swift's `as?` operator.
 
-{:.include-lang}
 ```swift
 (person as! Employee).employeeNumber = 4204583;
 ```
@@ -1270,14 +1211,12 @@ This also happens for null checks.
 Promotion only applies to _local_ variables,
 not to instance variables.
 
-{:.include-lang}
 ```dart
 if (person is Employee) {
   person.employeeNumber = 4204583;
 }
 ```
 
-{:.include-lang}
 ```swift
 // Swift requires the variable to be cast.
 if let person = person as? Employee {
@@ -1291,6 +1230,7 @@ The logical operators (such as AND (`&&`),
 OR (`||`) and NOT (`!`)) are identical
 in both languages. For example:
 
+{:.no-lang}
 ```dart
 if (!done && (col == 0 || col == 3)) {
   // ...Do something...
@@ -1317,7 +1257,6 @@ in both languages.
 
 For example: 
 
-{:.include-lang}
 ```dart
 final value = 0x22;
 final bitmask = 0x0f;
@@ -1337,12 +1276,10 @@ Both Dart and Swift contain a conditional operator
 (`?:`) for evaluating expressions that might otherwise
 require `if-else` statements:
 
-{:.include-lang}
 ```dart
 final displayLabel = canAfford ? 'Please pay below' : 'Insufficient funds';
 ```
 
-{:.include-lang}
 ```swift
 let displayLabel = canAfford ?  "Please pay below" : "Insufficient funds"
 ```
@@ -1359,7 +1296,6 @@ value of multiple properties, then calling
 multiple methods on a newly constructed object,
 all within a single chain using the cascade operator:
 
-{:.include-lang}
 ```dart
 Animal animal = Animal()
   ..name = ‘Bob'
@@ -1371,7 +1307,6 @@ print(animal.name); // "Bob"
 print(animal.age); // 5
 ```
 
-{:.include-lang}
 ```swift
 var animal = Animal()
 animal.name = "Bob"
@@ -1396,14 +1331,12 @@ separated by commas. The syntax between the two
 languages is very similar, however there are some
 subtle differences, shown in the following example:
 
-{:.include-lang}
 ```dart
 final List<String> list1 = <String>['one', 'two', 'three']; // Initialize list and specify full type
 final list2 = <String>['one', 'two', 'three']; // Initialize list using shorthand type
 final list3 = ['one', 'two', 'three']; // Dart can also infer the type
 ```
 
-{:.include-lang}
 ```swift
 var list1: Array<String> = ["one", "two", "three"] // Initialize array and specify the full type
 var list2: [String] = ["one", "two", "three"] // Initialize array using shorthand type
@@ -1415,7 +1348,6 @@ basic actions that you can perform on a Dart `List`.
 The first example shows how to retrieve a value
 from a list using the `index` operator:
 
-{:.include-lang}
 ```dart
 final fruits = ['apple', 'orange', 'pear'];
 final fruit = fruits[1];
@@ -1425,7 +1357,6 @@ To add a value to the back of the list,
 use the `add` method. To add another `List`
 use the `addAll` method:
 
-{:.include-lang}
 ```dart
 final fruits = ['apple', 'orange', 'pear'];
 fruits.add('peach');
@@ -1465,12 +1396,10 @@ you have several options to choose from:
   or content, making it behave just like a constant
   `Array` in Swift.
 
-{:.include-lang}
 ```dart
 final fruits = List<String>.unmodifiable(['apple', 'orange', 'pear']);
 ```
 
-{:.include-lang}
 ```swift
 let fruits = ["apple", "orange", "pear"]
 ```
@@ -1486,7 +1415,6 @@ For example, you can use the spread operator
 (`...`) to insert all the values of a list
 into another list, as shown below:
 
-{:.include-lang}
 ```dart
 final list = [1, 2, 3];
 final list2 = [0, ...list]; // [ 0, 1, 2, 3 ]
@@ -1497,7 +1425,6 @@ Though Swift has no spread operator,
 the equivalent to line 2 above would
 be the following:
 
-{:.include-lang}
 ```swift
 let list2 = [0] + list
 ```
@@ -1506,14 +1433,12 @@ If the expression to the right of the spread operator
 might be `null`, you can avoid exceptions by using
 a null-aware spread operator (`...?`):
 
-{:.include-lang}
 ```dart
 List<int>? list;
 final list2 = [0, ...?list]; //[ 0 ]
 assert(list2.length == 1);
 ```
 
-{:.include-lang}
 ```swift
 let list2 = [0] + list ?? []
 ```
@@ -1543,12 +1468,10 @@ can be stored in a `Set`.
 The following code snippets show the differences
 between initializing a `Set` in Dart and Swift:
 
-{:.include-lang}
 ```dart
 final abc = {'a', 'b', 'c'};
 ```
 
-{:.include-lang}
 ```swift
 var abc: Set<String> = ["a", "b", "c"]
 ```
@@ -1560,7 +1483,6 @@ To create an empty `Set`,
 precede the `{}` declaration with a type argument
 or assign `{}` to a variable of type `Set`:
 
-{:.include-lang}
 ```dart
 final names = <String>{};
 Set<String> alsoNames = {}; // This works, too.
@@ -1572,12 +1494,10 @@ Set<String> alsoNames = {}; // This works, too.
 Similar to `List`, `Set` also has an unmodifiable version.
 For example: 
 
-{:.include-lang}
 ```dart
 final abc = Set<String>.unmodifiable(['a', 'b', 'c']);
 ```
 
-{:.include-lang}
 ```swift
 let abc: Set<String> = ["a", "b", "c"]
 ```
@@ -1610,7 +1530,6 @@ before the object can be stored in a `Dictionary`.
 Here are a couple of simple `Map` and `Dictionary` examples,
 created using literals:
 
-{:.include-lang}
 ```dart
 final gifts = {
  'first': 'partridge',
@@ -1625,7 +1544,6 @@ final nobleGases = {
 };
 ```
 
-{:.include-lang}
 ```swift
 let gifts = [
    "first": "partridge",
@@ -1645,7 +1563,6 @@ of the basic actions that you can perform on a
 Dart `Map`. The first example shows how to
 retrieve a value from a `Map` using the `key` operator:
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 final gift = gifts['first']; // ‘partridge'
@@ -1654,7 +1571,6 @@ final gift = gifts['first']; // ‘partridge'
 Use the `containsKey` method to check whether a
 key is already present in the `Map`:
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 assert(gifts.containsKey('fifth')); // false
@@ -1665,7 +1581,6 @@ or update an entry in the `Map`. If the `Map`
 doesn't contain the key yet, the entry is added.
 If the key is present, the entry's value is updated:
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts['second'] = 'turtle'; // Gets added
@@ -1676,7 +1591,6 @@ To remove an entry from the `Map` use the `remove` method,
 and to remove all entries that satisfy a given test
 use the `removeWhere` method:
 
-{:.include-lang}
 ```dart
 final gifts = {'first': 'partridge'};
 gifts.remove('first');
@@ -1730,7 +1644,6 @@ Rather than the `init` keyword, Dart uses the full class name.
 The `new` keyword, once required for creating new
 class instances, is now optional and no longer recommended. 
 
-{:.include-lang}
 ```dart
 class Point {
   double x = 0;
@@ -1753,7 +1666,6 @@ Since writing code to assign all class fields
 in the constructor is often quite redundant,
 Dart has some syntactic sugar to make this easier:
 
-{:.include-lang}
 ```dart
 class Point {
   double x;
@@ -1771,7 +1683,6 @@ Point p = Point(3, 5);
 Similar to functions, constructors can also take
 optional positional or named parameters:
 
-{:.include-lang}
 ```dart
 class Point {
   ...
@@ -1794,7 +1705,6 @@ which run after any fields that are directly set
 using `this` in the constructor parameters,
 but still before the constructor body:
 
-{:.include-lang}
 ```dart
 class Point {
   ...
@@ -1817,7 +1727,6 @@ You have the option of using one unnamed constructor,
 but any additional constructors must be named.
 A class can also have only named constructors.
 
-{:.include-lang}
 ```dart
 class Point {
   double x;
@@ -1843,7 +1752,6 @@ Defining a constructor as `const` makes the class
 unmodifiable: all non-static fields in the class
 must be flagged as `final`. 
 
-{:.include-lang}
 ```dart
 class ImmutablePoint {
   final double x, y;
@@ -1855,7 +1763,6 @@ class ImmutablePoint {
 This also means you can use that class as a constant value,
 making the object a compile-time constant:
 
-{:.include-lang}
 ```dart
 const ImmutablePoint origin = ImmutablePoint(0, 0);
 ```
@@ -1866,7 +1773,6 @@ You can call constructors from other constructors,
 for example, to prevent code duplication or to
 add additional defaults for parameters:
 
-{:.include-lang}
 ```dart
 class Point {
   double x, y;
@@ -1885,7 +1791,6 @@ You can use factory constructors when you don't
 need to create a new class instance.
 One example is if a cached instance could be returned instead:
 
-{:.include-lang}
 ```dart
 class Logger {
   static final Map<String, Logger> _cache =
@@ -1906,7 +1811,6 @@ class Logger {
 In both Dart and Swift, methods are functions
 that provide behavior for an object. 
 
-{:.include-lang}
 ```dart
 void doSomething() { // This is a function
  // Implementation..
@@ -1919,7 +1823,6 @@ class Example {
 }
 ```
 
-{:.include-lang}
 ```swift
 func doSomething() { // This is a function
   // Implementation..
@@ -1943,7 +1846,6 @@ as the `get` and `set` keywords need to be defined
 inside of a property statement and can only be defined
 as a statement, not as an expression:
 
-{:.include-lang}
 ```dart
 class Rectangle {
   double left, top, width, height;
@@ -1959,7 +1861,6 @@ class Rectangle {
 }
 ```
 
-{:.include-lang}
 ```swift
 class Rectangle {
  var left, top, width, height: Double;
@@ -2011,7 +1912,6 @@ The following example declares an abstract class
 that has an abstract method and a method
 containing a default implementation:
 
-{:.include-lang}
 ```dart
 // This class is declared abstract and thus can't be instantiated.
 abstract class AbstractContainer {
@@ -2041,7 +1941,6 @@ and then provide the APIs required by the interfaces.
 Both Dart and Swift have a different ways of
 implementing interfaces. For example:
 
-{:.include-lang}
 ```dart
 abstract class Animal {
   int getLegs();
@@ -2057,7 +1956,6 @@ class Dog implements Animal {
 }
 ```
 
-{:.include-lang}
 ```swift
 protocol Animal {
    func getLegs() -> Int;
@@ -2082,7 +1980,6 @@ Class inheritance in Dart is very similar to Swift.
 In Dart, you can use `extends` to create a subclass,
 and `super` to refer to the superclass:
 
-{:.include-lang}
 ```dart
 abstract class Animal {
   // Define constructors, fields, methods...
@@ -2093,7 +1990,6 @@ class Dog extends Animal {
 }
 ```
 
-{:.include-lang}
 ```swift
 class Animal {
   // Define constructors, fields, methods...
@@ -2130,7 +2026,6 @@ The following example shows how this behavior is
 achieved in Dart, and how similar behavior is
 replicated in Swift:
 
-{:.include-lang}
 ```dart
 abstract class Animal {}
 
@@ -2159,7 +2054,6 @@ class Animal {
 }
 ```
 
-{:.include-lang}
 ```swift
 // Defining the "mixins"
 protocol Flyer {
@@ -2200,7 +2094,6 @@ Dog().fly(); // "dog" doesn't have the `fly` method
 Replacing the `class` keyword with `mixin`
 prevents the mixin from being used as a regular class.
 
-{:.include-lang}
 ```dart
 mixin Walker {
   walk() => print('Walks legs');
@@ -2227,7 +2120,6 @@ so the order in which they are added to a class matters.
 
 To give an example:
 
-{:.include-lang}
 ```dart
 class Bird extends Animal with Consumer, Flyer {
 ```
@@ -2250,14 +2142,12 @@ getters, setters, and operators&mdash;to existing types.
 The syntax in both Dart and Swift for creating an
 extension looks very similar:
 
-{:.include-lang}
 ```dart
 extension <name> on <type> {
   (<member definition>)*
 }
 ```
 
-{:.include-lang}
 ```swift
 extension <type> {
   (<member definition>)*
@@ -2268,7 +2158,6 @@ As an example, the following extension on
 the `String` class from the Dart SDK
 allows parsing of integers:
 
-{:.include-lang}
 ```dart
 extension NumberParsing on String {
   int parseInt() {
@@ -2279,7 +2168,6 @@ extension NumberParsing on String {
 print('21'.parseInt() * 2); // 42
 ```
 
-{:.include-lang}
 ```swift
 extension String {
   func parseInt() -> Int {
@@ -2313,7 +2201,6 @@ with another library. If the name begins with an underscore,
 the extension is only available within the library
 in which it's defined.
 
-{:.include-lang}
 ```dart
 // Hide "MyExtension" when importing types from
 // "path/to/file.dart".
@@ -2337,7 +2224,6 @@ constructors to a class, but you can add a
 static extension method that creates an instance
 of the type. Consider the following example: 
 
-{:.include-lang}
 ```dart
 class Person {
   Person(this.fullName);
@@ -2364,7 +2250,6 @@ the two languages. In Dart, you can use the
 `@override` annotation to indicate that you are
 intentionally overriding a member:
 
-{:.include-lang}
 ```dart
 class Animal {
   void makeNoise => print('Noise');
@@ -2379,7 +2264,6 @@ class Dog implements Animal {
 In Swift, you add the `override` keyword
 to the method definition:
 
-{:.include-lang}
 ```swift
 class Animal {
   func makeNoise() {
@@ -2408,7 +2292,6 @@ To define a generic type, place it between
 This type can then be used within the method
 (as the return type), or in the method's parameters:
 
-{:.include-lang}
 ```dart
 // Defining a method that uses generics.
 T transform<T>(T param) {
@@ -2429,7 +2312,6 @@ the return value is an `int`.
 Define multiple generics by separating them
 with a comma:
 
-{:.include-lang}
 ```dart
 // Defining a method with multiple generics.
 T transform<T, Q>(T param1, Q param2) {
@@ -2450,7 +2332,6 @@ which allows you to tailor reusable classes to specific types.
 In the following example,
 the `Cache` class is for caching specific types:
 
-{:.include-lang}
 ```dart
 class Cache<T> {
   T getByKey(String key) {}
@@ -2475,7 +2356,6 @@ family of types using `extends`. This ensures
 that your class is instantiated with a generic type
 that extends a specific type (and is similar to Swift):
 
-{:.include-lang}
 ```dart
 class NumberManager<T extends num> {
   // ...
@@ -2502,7 +2382,6 @@ which is used in some membery types of the `List` class's.
 When defining a `List` literal,
 you can explicitly define the generic type as follows:
 
-{:.include-lang}
 ```dart
 var objList = [5, 2.0]; // Type: List<num> // Automatic type inference
 var objList = <Object>[5, 2.0]; // Type: List<Object> // Explicit type definition
@@ -2513,7 +2392,6 @@ This is also true for a `Map`,
 which also define its `key` and `value` types
 using generics (`class Map<K, V>)`:
 
-{:.include-lang}
 ```dart
 // Automatic type inference
 var map = {
@@ -2569,7 +2447,6 @@ which is discussed in the next section.
 When you have a value that needs to be a `Future`,
 you can easily turn it into one using the `Future` class: 
 
-{:.include-lang}
 ```dart
 String str = 'String Value';
 Future<String> strFuture = Future<String>.value(str);
@@ -2597,7 +2474,6 @@ Rather, if an exception occurs in an async function,
 the returned `Future` fails with the exception,
 which can then be appropriately handled. 
 
-{:.include-lang}
 ```dart
 // Returns a future of a string, as the method is async
 Future<String> fetchString() async {
@@ -2614,7 +2490,6 @@ Future<String> fetchString() async {
 
 This async function can then be called as follows:
 
-{:.include-lang}
 ```dart
 String stringFuture = await fetchString();
 print(str); // "String Value"
@@ -2622,7 +2497,6 @@ print(str); // "String Value"
 
 The equivalent async function in Swift:
 
-{:.include-lang}
 ```swift
 func fetchString() async throws -> String {
   // Typically some other async operations would be done here.
@@ -2662,7 +2536,6 @@ evaluates to that value or throws that error.
 When it completes, the future's value is returned.
 You can only `await` in an `async` context, as in Swift.
 
-{:.include-lang}
 ```dart
 // We can only await futures within an async context.
 asyncFunction() async {
@@ -2675,7 +2548,6 @@ When the awaited future fails, an error object
 is thrown on the line with the `await` keyword.
 You can handle this using a regular `try-catch` block:
 
-{:.include-lang}
 ```dart
 // We can only await futures within an async context.
 Future<void> asyncFunction() async {
@@ -2721,7 +2593,6 @@ The `for` loop invokes the callback method
 for each item emitted, and ends when the stream
 completes or errors out:
 
-{:.include-lang}
 ```dart
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
@@ -2741,7 +2612,6 @@ the error is thrown at the line containing the
 `await` keyword, which you can handle with a
 `try-catch` statement:
 
-{:.include-lang}
 ```dart
 try {
   await for (final value in stream) { ... }
@@ -2755,7 +2625,6 @@ you can also call its `listen` method and
 provide a callback, which is called whenever
 the stream emits a value:
 
-{:.include-lang}
 ```dart
 Stream<int> stream = ...
 stream.listen((int value) {
@@ -2766,7 +2635,6 @@ stream.listen((int value) {
 The `listen` method has some optional callbacks
 for error handling, or for when the stream completes:
 
-{:.include-lang}
 ```dart
 stream.listen(
   (int value) { ... },
@@ -2783,7 +2651,6 @@ The `listen` method returns an instance of a
 `StreamSubscription`, which you can use to
 stop listening to the stream:
 
-{:.include-lang}
 ```dart
 StreamSubscription subscription = stream.listen(...);
 subscription.cancel();
@@ -2813,7 +2680,6 @@ emitted to this stream. In the following example,
 the function only continues once the newly yielded
 stream has completed:
 
-{:.include-lang}
 ```dart
 Stream<int> asynchronousNaturalsTo(int n) async* {
   int k = 0;
@@ -2852,7 +2718,6 @@ tools in Swift.
 As in Swift, you define a doc comment by
 using three forward slashes instead of two (`///`):
 
-{:.include-lang}
 ```dart
 /// The number of characters in this chunk when unsplit.
 int get length => ...
@@ -2861,7 +2726,6 @@ int get length => ...
 Surround types, parameter-, and method names
 with square brackets within doc comments. 
 
-{:.include-lang}
 ```dart
 /// Returns the [int] multiplication result of [a] * [b].
 multiply(int a, int b) => a * b;
@@ -2870,7 +2734,6 @@ multiply(int a, int b) => a * b;
 While there is support for JavaDoc-style doc comments,
 you should avoid them and use the `///` syntax. 
 
-{:.include-lang}
 ```dart
 /** 
  * The number of characters in this chunk when unsplit. 
@@ -2891,7 +2754,6 @@ are public by default. Private variables
 are prefixed with the underline character (`_`),
 and are enforced by the Dart compiler.
 
-{:.include-lang}
 ```dart
 final foo = 'this is a public property';
 final _foo = 'this is a private property';
@@ -2931,7 +2793,6 @@ In other words,
 private objects aren't shared across libraries.
 
 **animal.dart**
-{:.include-lang}
 ```dart
 library animals;
 
@@ -2945,7 +2806,6 @@ class _Animal {
 ```
 
 **parrot.dart**
-{:.include-lang}
 ```dart
 part of animals;
 

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <body class="{{page.layout}}{% if page.toc == false %} hide_toc{% endif %}{% if page.obsolete == true %} obsolete{% endif %}{% if site.show_banner == true %} show_banner{% endif %}">
+  <body class="{{page.layout}}{% if page.toc == false %} hide_toc{% endif %}{% if page.obsolete == true %} obsolete{% endif %}{% if site.show_banner == true %} show_banner{% endif %}{% if page.body_class %} {{ page.body_class }}{% endif %}">
     {% include cookie-notice.html %}
     {% include gtags.html %}
     {% include page-header.html %}

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -488,9 +488,9 @@ li.card {
 @include dart-style-for(fails-sa, $alert-danger-bg, $alert-danger-fg, '\2717  static analysis: error/warning');
 @include dart-style-for(runtime-success, $alert-success-bg, $alert-success-fg, '\2714  runtime: success');
 @include dart-style-for(runtime-fail, $alert-danger-bg, $alert-danger-fg, '\2717  runtime: error');
-@include dart-style-for('include-lang.language-dart', $pre-bg, $brand-primary, 'Dart');
-@include dart-style-for('include-lang.language-js', $pre-bg, #f1a85a, 'JavaScript');
-@include dart-style-for('include-lang.language-swift', $pre-bg, #f05137, 'Swift');
+@include dart-style-for('highlight-languages .language-dart:not(.no-lang)', $pre-bg, $brand-primary, 'Dart');
+@include dart-style-for('highlight-languages .language-js:not(.no-lang)', $pre-bg, #f1a85a, 'JavaScript');
+@include dart-style-for('highlight-languages .language-swift:not(.no-lang)', $pre-bg, #f05137, 'Swift');
 
 .muted {
   color: $gray;


### PR DESCRIPTION
This works by adding an extra class to the body on pages in which language tags should be included. Code blocks can add the `no-lang` class with `{:no-lang}` to avoid the language tag being added.

Classes which want the language tags to show up need to add `body_class: highlight-languages` to the front matter.