### PR TITLE
Update diagnostic messages with some recent cleanup

### DIFF
--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -2303,7 +2303,7 @@ literal contains `a.zero`, which is imported using a `deferred` import:
 {% prettify dart tag=pre+code %}
 import 'a.dart' deferred as a;
 
-var l = const [[!a.zero!]];
+var l = const [a.[!zero!]];
 {% endprettify %}
 
 #### Common fixes
@@ -2937,7 +2937,7 @@ being initialized using the constant `math.pi` from the library
 {% prettify dart tag=pre+code %}
 import 'dart:math' deferred as math;
 
-const pi = [!math.pi!];
+const pi = math.[!pi!];
 {% endprettify %}
 
 #### Common fixes
@@ -7465,10 +7465,6 @@ void f() {
 }
 {% endprettify %}
 
-If type arguments shouldn't be required for the class, then mark the class
-with the `[optionalTypeArgs][meta-optionalTypeArgs]` annotation (from
-`package:meta`):
-
 ### import_internal_library
 
 _The library '{0}' is internal and can't be imported._
@@ -8226,7 +8222,7 @@ class C {
   const C(double d);
 }
 
-@C([!math.pi!])
+@C(math.[!pi!])
 void f () {}
 {% endprettify %}
 
@@ -12505,7 +12501,7 @@ import 'a.dart' deferred as a;
 
 void f(int x) {
   switch (x) {
-    case [!a.zero!]:
+    case a.[!zero!]:
       // ...
       break;
   }
@@ -12626,7 +12622,7 @@ library imported using a deferred import:
 {% prettify dart tag=pre+code %}
 import 'a.dart' deferred as a;
 
-void f({int x = [!a.zero!]}) {}
+void f({int x = a.[!zero!]}) {}
 {% endprettify %}
 
 #### Common fixes


### PR DESCRIPTION
Updated as of https://github.com/dart-lang/sdk/commit/8e07d492ddbb53f5061e768a7d38f65dd3c5e88d

Includes fixes for diagnostic highlighting targets and removal of some incomplete text.