### PR TITLE
Korean version of dart.dev URL added

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -74,6 +74,7 @@ Learn how to
 
 Our wonderful community has provided these resources:
 
+* [Korean version of this site (한국어)](https://dart-ko.dev/)
 * [Simplified Chinese version of this site (简体中文版)](https://dart.cn)
 * [Traditional Chinese version of this site (正體中文版)](https://dart.tw.gh.miniasp.com/)
 


### PR DESCRIPTION
한국어 means Korean language.


Closes https://github.com/dart-lang/site-www/issues/4476