### PR TITLE
Update Effective Dart TOC for boolean literal guideline changes

### DIFF
--- a/src/_guides/language/effective-dart/_readme.md
+++ b/src/_guides/language/effective-dart/_readme.md
@@ -1,0 +1,16 @@
+# Effective Dart writing guidelines
+
+## TOC
+
+If you add a guideline or update the header of one,
+you will need to regenerate the table of contents
+found at [Summary of all rules][]
+and commit the resulting generated file.
+
+To do so, run the following from the repository root directory:
+
+```terminal
+$ dart run tool/effective-dart-rules/bin/main.dart
+```
+
+[Summary of all rules]: https://dart.dev/guides/language/effective-dart#summary-of-all-rules

--- a/src/_guides/language/effective-dart/toc.md
+++ b/src/_guides/language/effective-dart/toc.md
@@ -3,7 +3,7 @@
     To re-generate it, please run the following command from root of
     the project:
 
-      $ dart run deploy/effective-dart-rules/bin/main.dart
+      $ dart run tool/effective-dart-rules/bin/main.dart
 
     {% endcomment %}
     
@@ -101,7 +101,7 @@
 
 * <a href='/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null'>DON'T explicitly initialize variables to <code>null</code>.</a>
 * <a href='/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
-* <a href='/guides/language/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value'>PREFER using <code>??</code> to convert <code>null</code> to a boolean value.</a>
+* <a href='/guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations'>DON'T use <code>true</code> or <code>false</code> in equality operations</a>
 * <a href='/guides/language/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized'>AVOID <code>late</code> variables if you need to check whether they are initialized.</a>
 * <a href='/guides/language/effective-dart/usage#consider-assigning-a-nullable-field-to-a-local-variable-to-enable-type-promotion'>CONSIDER assigning a nullable field to a local variable to enable type promotion.</a>
 


### PR DESCRIPTION
@MaryaBelanger I somehow completely forgot to check or let you know, but when adding or updating an Effective Dart guideline, we need to regenerate the TOC included on the Effective Dart page under [Summary of all rules](https://dart.dev/guides/language/effective-dart#summary-of-all-rules).

This PR updates the TOC for the [?? guideline updates](https://github.com/dart-lang/site-www/commit/c22c592bbc43a16ec069036de91612d38e6d8fc5) and adds a hidden README file with instructions on updating it.

I plan to do some follow-up updates to the Effective Dart TOC, so I will look into including a check during site build that makes sure it's up to date.

\cc @atsansone So you're aware as well.