### PR TITLE
Add semicolon to the example code to make it valid

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -916,7 +916,7 @@ for (const element of list) {
 
 ```dart
 for (final element in list) {
-  print(element)
+  print(element);
 }
 ```
 


### PR DESCRIPTION
Fix #4486