### PR TITLE
Change the data type in the text to match the example

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -1585,7 +1585,7 @@ Pure JavaScript doesn't support immutability.
 Dart offers multiple ways to make collections like arrays, sets, or
 dictionaries immutable.
 
-* If the list is a compile-time constant and shouldn't
+* If the set is a compile-time constant and shouldn't
   be modified, use the `const` keyword:<br>
   `const fruits = <String>{'apple', 'orange', 'pear'};`
 * Assign the `Set` to a `final` field, meaning that

--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -1585,7 +1585,7 @@ Pure JavaScript doesn't support immutability.
 Dart offers multiple ways to make collections like arrays, sets, or
 dictionaries immutable.
 
-* If the set is a compile-time constant and shouldn't
+* If the collection is a compile-time constant and shouldn't
   be modified, use the `const` keyword:<br>
   `const fruits = <String>{'apple', 'orange', 'pear'};`
 * Assign the `Set` to a `final` field, meaning that


### PR DESCRIPTION
Problem: There is a `list` data type in the description text but the following example has the type of a `set`