### PR TITLE
Scroll active sidenav entry into view on load

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -226,7 +226,6 @@ $(function() {
   }
 
   $(window).smartresize(fixNav);
-
   scrollSidebarIntoView();
 
   // Add external link indicators

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1,4 +1,3 @@
-
 function handleSearchShortcut(event) {
   const activeElement = document.activeElement;
   if (activeElement instanceof HTMLInputElement ||
@@ -30,6 +29,23 @@ function handleSearchShortcut(event) {
         .focus();
     // Prevent the initial slash from showing up in the search field
     event.preventDefault();
+  }
+}
+
+function scrollSidebarIntoView() {
+  const sidenav = document.getElementById('sidenav');
+  if (!sidenav) {
+    return;
+  }
+
+  const activeEntries = sidenav.querySelectorAll('a.nav-link.active');
+
+  if (activeEntries.length > 0) {
+    const activeEntry = activeEntries[activeEntries.length - 1];
+
+    sidenav.scrollTo({
+      top: activeEntry.offsetTop - window.innerHeight / 3,
+    });
   }
 }
 
@@ -210,6 +226,8 @@ $(function() {
   }
 
   $(window).smartresize(fixNav);
+
+  scrollSidebarIntoView();
 
   // Add external link indicators
   $('a[href^="http"], a[target="_blank"]')


### PR DESCRIPTION
Right now the sidenav always resets to scrolling to the top when loading the page, interrupting the user flow, especially when the active entry is below their view port. 

This PR adds JS code to automatically scroll the sidenav on load so that deepest active entry is in view.

Test by reducing browser height and opening a link further down the sidebar on the staged site.

Similar to the flutter/website change at https://github.com/flutter/website/pull/8050