### PR TITLE
Update linkcheck to null-safe release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,5 @@ dev_dependencies:
     path: site-shared/packages/code_excerpt_updater
   code_excerpter:
     path: site-shared/packages/code_excerpter
-  linkcheck: ^2.0.19
+  linkcheck: ^3.0.0
   lints: ^2.0.1


### PR DESCRIPTION
To support running and building the site with Dart 3, all of our dependencies need to support strong null safety, with linkcheck being the last one remaining.

So I went ahead and updated linkcheck to support null safety in https://github.com/filiph/linkcheck/pull/105 and after some local testing on `dart-lang/site-www` and `flutter/website`, the version seems to be ready to switch to.