### PR TITLE
Fix custom style on concurrency page applying incorrectly

### DIFF
--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -6,7 +6,7 @@ description: Use isolates to enable parallel code execution on multiple processo
 <?code-excerpt path-base="concurrency"?>
 
 <style>
-  #page-content img {
+  article img {
     padding: 15px 0;
   }
 </style>

--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -6,11 +6,9 @@ description: Use isolates to enable parallel code execution on multiple processo
 <?code-excerpt path-base="concurrency"?>
 
 <style>
-  img {
+  #page-content img {
     padding: 15px 0;
   }
-}
-
 </style>
 
 Dart supports concurrent programming with async-await, isolates, and


### PR DESCRIPTION
For one, it had an extra `}`, but it was applying to all images on the page, causing the navbar and other elements to unintentionally be resized due to extra image padding.

This PR removes the extra `}` while also making the custom style only apply to elements within the page's article.

Fixes #4508

**Staged:** https://dart-dev--pr4509-fix-concurrency-page-1tc3md9y.web.app/guides/language/concurrency