### PR TITLE
Add linguist overrides to increase language accuracy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Allow dart files in examples/ to be detectable
+examples/**/*.dart -linguist-documentation
+
+# Prevent generated JS files from being detectable
+*.dart.js -linguist-detectable


### PR DESCRIPTION
Currently the repository is being displayed as primarily JavaScript, I believe due to `examples/` being considered documentation and generated JS being detected.

These changes following the [linguist override guide](https://github.com/github/linguist/blob/master/docs/overrides.md) should hopefully get the Dart code in `examples` properly detected and any dart2js files ignored.