### PR TITLE
Fix no_toc class hiding headers

### DIFF
--- a/src/_sass/components/_toc.scss
+++ b/src/_sass/components/_toc.scss
@@ -80,8 +80,7 @@
 .toc-entry.toc-h1,
 .toc-entry.toc-h4,
 .toc-entry.toc-h5,
-.toc-entry.toc-h6,
-.no_toc {
+.toc-entry.toc-h6 {
   display: none;
 }
 


### PR DESCRIPTION
`no_toc` shouldn't hide headers from the page, just the TOC entries themselves. This style was hiding them from the page, such as the subheaders on the [What's new](https://dart.dev/guides/whats-new) page, which are currently missing.

**Staged:** https://dart-dev--pr4515-fix-no-toc-kvl9s9gx.web.app/guides/whats-new