### PR TITLE
Adds Frameworks section to /server page

### DIFF
--- a/src/server/index.md
+++ b/src/server/index.md
@@ -31,6 +31,16 @@ that can help you develop command-line and server apps.
 : [Install the Dart SDK](/get-dart) to get the core Dart
   libraries and [tools](/tools).
 
+## Frameworks
+
+Server-side frameworks written in Dart.
+
+[Serverpod](https://serverpod.dev)
+: A scalable app server with support for code generation, authentication, real-time communication, databases, and caching.
+
+[Dart Frog](https://dartfrog.vgv.dev/)
+: A fast, minimalistic backend framework for Dart.
+
 More tools
 : The [Tools](/tools) page links to generally useful tools,
   such as Dart plugins for your favorite IDE or editor.

--- a/src/server/index.md
+++ b/src/server/index.md
@@ -33,10 +33,11 @@ that can help you develop command-line and server apps.
 
 ## Frameworks
 
-Server-side frameworks written in Dart.
+Server-side frameworks written in Dart:
 
 [Serverpod](https://serverpod.dev)
-: A scalable app server with support for code generation, authentication, real-time communication, databases, and caching.
+: A scalable app server that supports code generation,
+  authentication, real-time communication, databases, and caching.
 
 [Dart Frog](https://dartfrog.vgv.dev/)
 : A fast, minimalistic backend framework for Dart.


### PR DESCRIPTION
Adds a section with server-side frameworks to the dart.dev/server page.