### PR TITLE
Say cascade operator is left associative in language tour

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1710,7 +1710,7 @@ You can implement many of these [operators as class members](#_operators).
 | logical OR                              | `||`                                                                                                                                                                                              | Left          |
 | if null                                 | `??`                                                                                                                                                                                              | Left          |
 | conditional                             | <code><em>expr1</em> ? <em>expr2</em> : <em>expr3</em></code>                                                                                                                                     | Right         |
-| cascade                                 | `..` &nbsp;&nbsp; `?..`                                                                                                                                                                           | Right         |
+| cascade                                 | `..` &nbsp;&nbsp; `?..`                                                                                                                                                                           | Left          |
 | assignment                              | `=`    `*=`    `/=`    `+=`    `-=`    `&=`    `^=`    <em>etc.</em>                                                                                                                              | Right         |
 {:.table .table-striped}
 


### PR DESCRIPTION
The update adding associativity to the operator table in the language tour marked it as right associative.