### PR TITLE
Update web template name on "Get started: Web apps" page

### DIFF
--- a/src/_tutorials/web/get-started.md
+++ b/src/_tutorials/web/get-started.md
@@ -101,7 +101,7 @@ For a list of available IDEs, see the
 To create a web app from the command line, use these commands:
 
 ```terminal
-$ dart create -t web-simple quickstart
+$ dart create -t web quickstart
 ```
 
 <i class="material-icons">web</i>


### PR DESCRIPTION
The name of the web template changed from `web-simple` to just `web`:

```
mit-macbookpro7:webapp1 mit$ dart help create
Create a new Dart project.

Usage: dart create [arguments] <directory>
-h, --help                       Print this usage information.
-t, --template                   The project template to use.

          [console] (default)    A command-line application.
          [package]              A package containing shared Dart libraries.
          [server-shelf]         A server app using package:shelf.
          [web]                  A web app that uses only core Dart libraries.

```

Note: This hasn't been breaking anyone as `web-simple` is still supported as a hidden alias for `web`