### PR TITLE
Add the 2.19 entry to the "What's new" page

### DIFF
--- a/src/_guides/index.md
+++ b/src/_guides/index.md
@@ -6,9 +6,9 @@ toc: false
 
 Welcome to the Dart documentation!
 For a list of changes to this site—new pages, new guidelines, and more—see
-the [What's new page][].
+the [What's new on dart.dev][] page.
 
-[What's new page]: /guides/whats-new
+[What's new on dart.dev]: /guides/whats-new
 
 Here are some of this site's most visited pages:
 

--- a/src/_guides/index.md
+++ b/src/_guides/index.md
@@ -6,9 +6,9 @@ toc: false
 
 Welcome to the Dart documentation!
 For a list of changes to this site—new pages, new guidelines, and more—see
-the [What's new on dart.dev][] page.
+the [What's new][] page.
 
-[What's new on dart.dev]: /guides/whats-new
+[What's new]: /guides/whats-new
 
 Here are some of this site's most visited pages:
 

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -284,6 +284,27 @@ see [Adding features to a class: mixins][] in the language tour.
 
 [Adding features to a class: mixins]: /guides/language/language-tour#adding-features-to-a-class-mixins
 
+### Dart 2.19
+
+Dart 2.19 introduced some precautions surrounding type inference.
+The cases covered are rare, but needed to be addressed to close
+loopholes and make way for more complex inference-related language
+features upcoming in the next major release. These include:
+
+* Flow analysis now flags code as unreachable due to `Never` and `Null` types.
+* Inaccessible private names can no longer delegate to `noSuchMethod`.
+* Cyclic dependencies now cause a compile-time error during top-level type inference.
+
+Dart 2.19 also introduced support for unnamed libraries. Library directives, used for appending library-level doc comments and annotations, can ([and should][]) now be written without a name:
+
+```dart
+/// A really great test library.
+@TestOn('browser')
+library;
+```
+
+[and should]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
+
 ## Language versioning
 
 A single Dart SDK can simultaneously support

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -284,30 +284,6 @@ see [Adding features to a class: mixins][] in the language tour.
 
 [Adding features to a class: mixins]: /guides/language/language-tour#adding-features-to-a-class-mixins
 
-### Dart 2.19
-
-Dart 2.19 introduced some precautions surrounding type inference.
-The cases covered are rare, but needed to be addressed to close
-loopholes and make way for more complex inference-related language
-features upcoming in the next major release. These include:
-
-* Flow analysis now flags more code as unreachable due to `Never` and `Null` types.
-* Inaccessible private names can no longer delegate to `noSuchMethod`.
-* Cyclic dependencies now cause a compile-time error during top-level type inference.
-
-Dart 2.19 also introduced support for unnamed libraries.
-Library directives, used for appending 
-library-level doc comments and annotations, 
-can ([and should][]) now be written without a name:
-
-```dart
-/// A really great test library.
-@TestOn('browser')
-library;
-```
-
-[and should]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
-
 ## Language versioning
 
 A single Dart SDK can simultaneously support

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -291,11 +291,14 @@ The cases covered are rare, but needed to be addressed to close
 loopholes and make way for more complex inference-related language
 features upcoming in the next major release. These include:
 
-* Flow analysis now flags code as unreachable due to `Never` and `Null` types.
+* Flow analysis now flags more code as unreachable due to `Never` and `Null` types.
 * Inaccessible private names can no longer delegate to `noSuchMethod`.
 * Cyclic dependencies now cause a compile-time error during top-level type inference.
 
-Dart 2.19 also introduced support for unnamed libraries. Library directives, used for appending library-level doc comments and annotations, can ([and should][]) now be written without a name:
+Dart 2.19 also introduced support for unnamed libraries.
+Library directives, used for appending 
+library-level doc comments and annotations, 
+can ([and should][]) now be written without a name:
 
 ```dart
 /// A really great test library.

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -66,12 +66,10 @@ we made the following changes to this site:
 * Accounted for [pub's transition to pub.dev][] from pub.dartlang.org.
 * Added documentation on [package screenshots][].
 * Improved the [explicit downcast section][] of The Dart type system page.
-* Increased analyzer and lint coverage:
-  * 
-  * 
-  * 
+* Increased [analyzer][] and [lint][] coverage:
+  * Included SDK information for linter rules.
+  * Added diagnostic and lint messages for 2.19 changes.
  
-
 [Fetch data from the internet]: /tutorials/server/fetch-data
 [Automated publishing of packages to pub.dev]: /tools/pub/automated-publishing
 [community resources section]: /community#additional-community-resources
@@ -99,6 +97,8 @@ we made the following changes to this site:
 [pub's transition to pub.dev]: /tools/pub/troubleshoot#pub-get-socket-error
 [package screenshots]: /tools/pub/pubspec#screenshots
 [explicit downcast section]: /guides/language/type-system#generic-type-assignment
+[analyzer]: /tools/diagnostic-messages
+[lint]: /tools/linter-rules
 
 ### Articles added to the Dart blog
 {: .no_toc}

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -1,5 +1,5 @@
 ---
-title: What’s new
+title: What’s new on dart.dev
 description: A list of what’s new on dart.dev and related sites.
 ---
 
@@ -16,6 +16,107 @@ and follow the [Dart blog][].
 [flutter-whats-new]: {{site.flutter-docs}}/whats-new
 [dart-announce]: https://groups.google.com/a/dartlang.org/d/forum/announce
 [Dart blog]: https://medium.com/dartlang
+
+## January 24, 2023: 2.19 + 3.0 alpha releases
+This section lists notable changes made from August 31, 2022,
+through January 24, 2023.
+For details about the 2.19 + 3.0 alpha releases,
+see [Dart FlutterForward + 3.0 alpha blog post][],
+and the [SDK changelog][].
+
+[Dart FlutterForward + 3.0 alpha blog post]: https://medium.com/dartlang/dart-3-alpha-f1458fb9d232
+[SDK changelog]: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#2190
+
+### Docs updated or added to dart.dev
+{: .no_toc}
+
+In addition to bug fixes and incremental improvements,
+we made the following changes to this site:
+
+* Introduced the [Fetch data from the internet][] tutorial about using `package:http`.
+* Added a page on [Automated publishing of packages to pub.dev][].
+* Included links to three new site translations in our [community resources section][]:
+  * [Korean version of this site (한국어)](https://dart-ko.dev/)
+  * [Simplified Chinese version of this site (简体中文版)](https://dart.cn)
+  * [Traditional Chinese version of this site (正體中文版)](https://dart.tw.gh.miniasp.com/)
+* Updated null safety content in preparation of Dart 3:
+  * Changed the version constraints in the [migration guide][] for Dart 3 compatibility.
+  * Added Dart 3 full sound null safety overview to the [Sound null safety][] page.
+  * Emphasized Dart 3's incompatibility with [unsound null safety][] in a note.
+* Introduced the new [Learning Dart as a Swift developer][] guide.
+* Replaced an Effective Dart section with more general guidance on [booleans and equality operators][]. 
+* Documented [content-hashing][] across the pub docs.
+* Began effort to overhaul [Zones][] page by changing examples to use `runZonedGuarded` instead of `onError`.
+* Updated content on libraries to cover new no-name declarations development:
+  * Effective Dart: [Documentation][], [Style][], and [Usage][]
+  * New library directive section in [The language tour][]
+* Improved clarity surrounding Dart's single-threaded or multi-threaded status:
+ * Removed the outdated `dart:io` page.
+ * Added two sections to the FAQ:
+   * [Is Dart single-threaded?][]
+   * [Is Dart single-threaded on the web?][]
+ * Expanded on [Dart's web concurrency capabilities][].
+* Rearranged and clarified [discussion][] of default values for optional and positional parameters.
+* Updated [Concurrency in Dart][] to default to new `Isolate.run()` function.
+* Documented specifying a file path when activating a package on the [`pub global` page][].
+* Rewrote [Learning Dart as a JavaScript developer][].
+* Added a brief overview of Dart DevTools to [`dart run` page][].
+* Provided more clarity around [operator precedence and associativity][] in the Language tour.
+* Expanded Library tour section on [Building URIs][] with URI http and factory constructor info.
+* Accounted for [pub's transition to pub.dev][] from pub.dartlang.org.
+* Added documentation on [package screenshots][].
+* Improved the [explicit downcast section][] of The Dart type system page.
+* Increased analyzer and lint coverage:
+ * 
+ * 
+ * 
+ 
+
+[Fetch data from the internet]: /tutorials/server/fetch-data
+[Automated publishing of packages to pub.dev]: /tools/pub/automated-publishing
+[community resources section]: /community#additional-community-resources
+[migration guide]: /null-safety/migration-guide
+[Sound null safety]: /null-safety#dart-3-and-null-safety
+[unsound null safety]: /null-safety/unsound-null-safety
+[Learning Dart as a Swift developer]: /guides/language/coming-from/swift-to-dart
+[booleans and equality operators]: /guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations
+[content-hashing]: /tools/pub/glossary#content-hashes
+[Zones]: /articles/archives/zones
+[Documentation]: /guides/language/effective-dart/documentation#consider-writing-a-library-level-doc-comment
+[Style]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
+[Usage]: /guides/language/effective-dart/usage#do-use-strings-in-part-of-directives
+[The language tour]: /guides/language/language-tour#the-library-directive
+[Is Dart single-threaded?]: /faq#q-is-dart-single-threaded
+[Is Dart single-threaded on the web?]: /faq#q-is-dart-single-threaded-on-the-web
+[Dart's concurrency capabilities]: /guides/language/concurrency#concurrency-on-the-web
+[discussion]: /guides/language/language-tour#parameters
+[Concurrency in Dart]: /guides/language/concurrency
+[`pub global` page]: /tools/pub/cmd/pub-global
+[Learning Dart as a JavaScript developer]: /guides/language/coming-from/js-to-dart
+[`dart run` page]: /tools/dart-run#debugging
+[operator precedence and associativity]: /guides/language/language-tour#operators
+[Building URIs]: /guides/libraries/library-tour#building-uris
+[pub's transition to pub.dev]: /tools/pub/troubleshoot#pub-get-socket-error
+[package screenshots]: /tools/pub/pubspec#screenshots
+[explicit downcast section]: /guides/language/type-system#generic-type-assignment
+
+### Articles added to the Dart blog
+{: .no_toc}
+
+We published the following articles on the Dart blog:
+
+* [Better isolate management with Isolate.run()][blog-1-24-23]
+* [Screenshots and automated publishing for pub.dev][blog-1-18-23]
+* [The road to Dart 3: A fully sound, null safe language][blog-12-8-22]
+* [Google Summer of Code 2022 Results][blog-11-3-22]
+* [Partnering with GitHub on supply chain security for Dart packages][blog-10-6-22]
+
+[blog-1-24-23]: https://medium.com/@mbelanger_65682/547ef3d6459b
+[blog-1-18-23]: https://medium.com/dartlang/screenshots-and-automated-publishing-for-pub-dev-9bceb19edf79
+[blog-12-8-22]: https://medium.com/dartlang/the-road-to-dart-3-afdd580fbefa
+[blog-11-3-22]: https://medium.com/dartlang/google-summer-of-code-2022-results-a3ce1c13c06c
+[blog-10-6-22]: https://medium.com/dartlang/partnering-with-github-on-an-supply-chain-security-485eed1fc388
+
 
 ## August 30, 2022: 2.18 release
 

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -35,9 +35,8 @@ we made the following changes to this site:
 
 * Introduced the [Fetch data from the internet][] tutorial about using `package:http`.
 * Added a page on [Automated publishing of packages to pub.dev][].
-* Included links to three new site translations in our [community resources section][]:
+* Included links to two new site translations in our [community resources section][]:
   * [Korean version of this site (한국어)](https://dart-ko.dev/)
-  * [Simplified Chinese version of this site (简体中文版)](https://dart.cn)
   * [Traditional Chinese version of this site (正體中文版)](https://dart.tw.gh.miniasp.com/)
 * Updated null safety content in preparation of Dart 3:
   * Changed the version constraints in the [migration guide][] for Dart 3 compatibility.
@@ -46,7 +45,8 @@ we made the following changes to this site:
 * Introduced the new [Learning Dart as a Swift developer][] guide.
 * Replaced an Effective Dart section with more general guidance on [booleans and equality operators][]. 
 * Documented [content-hashing][] across the pub docs.
-* Began effort to overhaul [Zones][] page by changing examples to use `runZonedGuarded` instead of `onError`.
+* Began effort to overhaul the [Zones][] page by
+  changing examples to use `runZonedGuarded` instead of `onError`.
 * Updated content on libraries to cover new no-name declarations development:
   * Effective Dart: [Documentation][], [Style][], and [Usage][]
   * New library directive section in [The language tour][]
@@ -67,7 +67,7 @@ we made the following changes to this site:
 * Added documentation on [package screenshots][].
 * Improved the [explicit downcast section][] of The Dart type system page.
 * Increased [analyzer][] and [lint][] coverage:
-  * Included SDK information for linter rules.
+  * Included SDK version support info for linter rules.
   * Added diagnostic and lint messages for 2.19 changes.
  
 [Fetch data from the internet]: /tutorials/server/fetch-data

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -17,14 +17,15 @@ and follow the [Dart blog][].
 [dart-announce]: https://groups.google.com/a/dartlang.org/d/forum/announce
 [Dart blog]: https://medium.com/dartlang
 
-## January 24, 2023: 2.19 + 3.0 alpha releases
+## January 25, 2023: 2.19 + 3.0 alpha releases
+
 This section lists notable changes made from August 31, 2022,
-through January 24, 2023.
+through January 25, 2023.
 For details about the 2.19 + 3.0 alpha releases,
-see [Dart FlutterForward + 3.0 alpha blog post][],
+see [Introducing Dart 3 alpha][],
 and the [SDK changelog][].
 
-[Dart FlutterForward + 3.0 alpha blog post]: https://medium.com/dartlang/dart-3-alpha-f1458fb9d232
+[Introducing Dart 3 alpha]: https://medium.com/dartlang/dart-3-alpha-f1458fb9d232
 [SDK changelog]: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#2190
 
 ### Docs updated or added to dart.dev
@@ -111,7 +112,7 @@ We published the following articles on the Dart blog:
 * [Google Summer of Code 2022 Results][blog-11-3-22]
 * [Partnering with GitHub on supply chain security for Dart packages][blog-10-6-22]
 
-[blog-1-24-23]: https://medium.com/dartlang/547ef3d6459b
+[blog-1-24-23]: https://medium.com/dartlang/better-isolate-management-with-isolate-run-547ef3d6459b
 [blog-1-18-23]: https://medium.com/dartlang/screenshots-and-automated-publishing-for-pub-dev-9bceb19edf79
 [blog-12-8-22]: https://medium.com/dartlang/the-road-to-dart-3-afdd580fbefa
 [blog-11-3-22]: https://medium.com/dartlang/google-summer-of-code-2022-results-a3ce1c13c06c

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -51,11 +51,11 @@ we made the following changes to this site:
   * Effective Dart: [Documentation][], [Style][], and [Usage][]
   * New library directive section in [The language tour][]
 * Improved clarity surrounding Dart's single-threaded or multi-threaded status:
- * Removed the outdated `dart:io` page.
- * Added two sections to the FAQ:
-   * [Is Dart single-threaded?][]
-   * [Is Dart single-threaded on the web?][]
- * Expanded on [Dart's web concurrency capabilities][].
+  * Removed the outdated `dart:io` page.
+  * Added two sections to the FAQ:
+    * [Is Dart single-threaded?][]
+    * [Is Dart single-threaded on the web?][]
+  * Expanded on [Dart's web concurrency capabilities][].
 * Rearranged and clarified [discussion][] of default values for optional and positional parameters.
 * Updated [Concurrency in Dart][] to default to new `Isolate.run()` function.
 * Documented specifying a file path when activating a package on the [`pub global` page][].
@@ -86,7 +86,7 @@ we made the following changes to this site:
 [The language tour]: /guides/language/language-tour#the-library-directive
 [Is Dart single-threaded?]: /faq#q-is-dart-single-threaded
 [Is Dart single-threaded on the web?]: /faq#q-is-dart-single-threaded-on-the-web
-[Dart's concurrency capabilities]: /guides/language/concurrency#concurrency-on-the-web
+[Dart's web concurrency capabilities]: /guides/language/concurrency#concurrency-on-the-web
 [discussion]: /guides/language/language-tour#parameters
 [Concurrency in Dart]: /guides/language/concurrency
 [`pub global` page]: /tools/pub/cmd/pub-global

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -1,5 +1,5 @@
 ---
-title: What’s new on dart.dev
+title: What’s new
 description: A list of what’s new on dart.dev and related sites.
 ---
 

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -79,11 +79,11 @@ we made the following changes to this site:
 [Learning Dart as a Swift developer]: /guides/language/coming-from/swift-to-dart
 [booleans and equality operators]: /guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations
 [content-hashing]: /tools/pub/glossary#content-hashes
-[Zones]: /articles/archives/zones
+[Zones]: /articles/archive/zones
 [Documentation]: /guides/language/effective-dart/documentation#consider-writing-a-library-level-doc-comment
 [Style]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
 [Usage]: /guides/language/effective-dart/usage#do-use-strings-in-part-of-directives
-[The language tour]: /guides/language/language-tour#the-library-directive
+[The language tour]: /guides/language/language-tour#library-directive
 [Is Dart single-threaded?]: /faq#q-is-dart-single-threaded
 [Is Dart single-threaded on the web?]: /faq#q-is-dart-single-threaded-on-the-web
 [Dart's web concurrency capabilities]: /guides/language/concurrency#concurrency-on-the-web

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -111,7 +111,7 @@ We published the following articles on the Dart blog:
 * [Google Summer of Code 2022 Results][blog-11-3-22]
 * [Partnering with GitHub on supply chain security for Dart packages][blog-10-6-22]
 
-[blog-1-24-23]: https://medium.com/@mbelanger_65682/547ef3d6459b
+[blog-1-24-23]: https://medium.com/dartlang/547ef3d6459b
 [blog-1-18-23]: https://medium.com/dartlang/screenshots-and-automated-publishing-for-pub-dev-9bceb19edf79
 [blog-12-8-22]: https://medium.com/dartlang/the-road-to-dart-3-afdd580fbefa
 [blog-11-3-22]: https://medium.com/dartlang/google-summer-of-code-2022-results-a3ce1c13c06c

--- a/src/_guides/whats-new.md
+++ b/src/_guides/whats-new.md
@@ -67,9 +67,9 @@ we made the following changes to this site:
 * Added documentation on [package screenshots][].
 * Improved the [explicit downcast section][] of The Dart type system page.
 * Increased analyzer and lint coverage:
- * 
- * 
- * 
+  * 
+  * 
+  * 
  
 
 [Fetch data from the internet]: /tutorials/server/fetch-data


### PR DESCRIPTION
Adds the 2.19 entry to the "What's new" page.

Fixes #4404 