### PR TITLE
Update various SDK constraints and constraint examples

### DIFF
--- a/examples/analysis/pubspec.yaml
+++ b/examples/analysis/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/analysis_alt/pubspec.yaml
+++ b/examples/analysis_alt/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/async_await/pubspec.yaml
+++ b/examples/async_await/pubspec.yaml
@@ -2,7 +2,7 @@ name: async_await
 description: dart.dev example code.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/build_runner_usage/pubspec.yaml
+++ b/examples/build_runner_usage/pubspec.yaml
@@ -2,7 +2,7 @@ name: build_runner_usage
 description: dart.dev build_runner example code.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   args: ^2.2.0

--- a/examples/concurrency/pubspec.yaml
+++ b/examples/concurrency/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.19.0-0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/create_libraries/pubspec.yaml
+++ b/examples/create_libraries/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/extension_methods/pubspec.yaml
+++ b/examples/extension_methods/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/fetch_data/pubspec.yaml
+++ b/examples/fetch_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Fetch data example
 version: 0.0.1
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   http: ^0.13.5

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/html/pubspec.yaml
+++ b/examples/html/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 0.0.1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   html: any

--- a/examples/iterables/pubspec.yaml
+++ b/examples/iterables/pubspec.yaml
@@ -2,7 +2,7 @@ name: iterables_examples
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ">=2.19.0-0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   args: ^2.3.0

--- a/examples/non_promotion/pubspec.yaml
+++ b/examples/non_promotion/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev non-promotion examples.
 version: 0.0.1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/null_safety_codelab/pubspec.yaml
+++ b/examples/null_safety_codelab/pubspec.yaml
@@ -2,7 +2,7 @@ name: null_safety_codelab_examples
 description: dart.dev example code for null safety codelab
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/type_system/pubspec.yaml
+++ b/examples/type_system/pubspec.yaml
@@ -2,7 +2,7 @@ name: type_system_examples
 description: dart.dev type system examples.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/type_system/pubspec.yaml
+++ b/examples/type_system/pubspec.yaml
@@ -2,7 +2,7 @@ name: type_system_examples
 description: dart.dev type system examples.
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example utilities.
 version: 0.0.2
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   test: ^1.19.0

--- a/examples/vector_victor/pubspec.yaml
+++ b/examples/vector_victor/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 # dependencies:
 #   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: site_www
 homepage: https://dart.dev
 
 environment:
-  sdk: '>=2.18.4 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.3.2

--- a/src/_tutorials/libraries/shared-pkgs.md
+++ b/src/_tutorials/libraries/shared-pkgs.md
@@ -86,7 +86,7 @@ version: 1.0.0
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 # dependencies:
 #   path: ^1.8.0

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -126,7 +126,7 @@ you cannot un-migrate a file once it has been migrated.
 If you want to incrementally migrate a package by hand, follow these steps:
 
 1. Edit the package's `pubspec.yaml` file,
-   setting the minimum SDK constraint to `2.12.0`:
+   setting the minimum SDK constraint to at least `2.12.0`:
 
    ```yaml
    environment:

--- a/src/tools/pub/automated-publishing.md
+++ b/src/tools/pub/automated-publishing.md
@@ -182,7 +182,7 @@ $ cat pubspec.yaml
 package: my_package_name
 version: 1.2.3            # must match the version number used in the git tag
 environment:
-  sdk: ^2.18.0
+  sdk: ^2.19.0
 
 $ git tag v1.2.3          # assuming my tag pattern is: 'v{{version}}'
 $ git push origin v1.2.3  # triggers the action that publishes my package.

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -120,7 +120,7 @@ homepage: https://example-pet-store.com/newtify
 documentation: https://example-pet-store.com/newtify/docs
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   
 dependencies:
   efts: ^2.0.4
@@ -440,11 +440,11 @@ dependencies.
 [language evolution page]: /guides/language/evolution
 
 For example, the following constraint says that this package
-works with any Dart SDK that's version 2.10.0 or higher:
+works with any Dart SDK that's version 2.12.0 or higher:
 
 ```yaml
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 ```
 
 Pub tries to find the latest version of a package whose SDK constraint works
@@ -459,7 +459,9 @@ pubspec.yaml has no lower-bound SDK constraint.
 You should edit pubspec.yaml to contain an SDK constraint:
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
+  
+See https://dart.dev/go/sdk-constraint
 ```
 
 {{site.alert.warning}}

--- a/tool/dart_tools/pubspec.yaml
+++ b/tool/dart_tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tools
 description: Dart-based tools for site-www
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   path: ^1.8.0

--- a/tool/dartpad_picker/pubspec.yaml
+++ b/tool/dartpad_picker/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartpad_picker
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.0

--- a/tool/effective_dart_rules/pubspec.yaml
+++ b/tool/effective_dart_rules/pubspec.yaml
@@ -3,7 +3,7 @@ description: Builds a file with all the rules in the different sections of Effec
 version: 0.0.3
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   html_unescape: ^2.0.0

--- a/tool/get-dart/archive/pubspec.yaml
+++ b/tool/get-dart/archive/pubspec.yaml
@@ -2,7 +2,7 @@ name: download_archive
 description: Display a list of downloads for dart.dev.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   dart_sdk_archive:

--- a/tool/get-dart/dart_sdk_archive/pubspec.yaml
+++ b/tool/get-dart/dart_sdk_archive/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_sdk_archive
 description: An absolute bare-bones web app.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   http: ^0.13.1

--- a/tool/get-dart/sdk_builds.dart/pubspec.yaml
+++ b/tool/get-dart/sdk_builds.dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: sdk_builds
 description: Utilities for accessing builds of the Dart SDK.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   googleapis: ^9.0.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: site_scripts
 description: Utility scripts
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   crypto: ^3.0.1


### PR DESCRIPTION
Most are updated to 2.19 while others to 2.12, since we should avoid having ones below 2.12 as examples.