### PR TITLE
Add 2.19 to language evolution page

### DIFF
--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -287,15 +287,11 @@ see [Adding features to a class: mixins][] in the language tour.
 ### Dart 2.19
 
 Dart 2.19 introduced some precautions surrounding type inference.
-The cases covered are rare, but needed to be addressed to close
-loopholes and make way for more complex inference-related language
-features upcoming in the next major release. These include:
+These include:
 
-* Flow analysis now flags more cases as unreachable
-  due to `Never` and `Null` types.
-* Inaccessible private names can no longer delegate to `noSuchMethod`.
-* Cyclic dependencies now cause a compile-time error
-  during top-level type inference.
+* More flow analysis flags for unreachable code cases.
+* No longer delegate inaccessible private names to `noSuchMethod`.
+* Top-level type inference throws on cyclic dependencies.
 
 Dart 2.19 also introduced support for unnamed libraries.
 Library directives, used for appending

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -284,6 +284,27 @@ see [Adding features to a class: mixins][] in the language tour.
 
 [Adding features to a class: mixins]: /guides/language/language-tour#adding-features-to-a-class-mixins
 
+### Dart 2.19
+
+Dart 2.19 introduced some precautions surrounding type inference.
+The cases covered are rare, but needed to be addressed to close
+loopholes and make way for more complex inference-related language
+features upcoming in the next major release. These include:
+
+* Flow analysis now flags code as unreachable due to `Never` and `Null` types.
+* Inaccessible private names can no longer delegate to `noSuchMethod`.
+* Cyclic dependencies now cause a compile-time error during top-level type inference.
+
+Dart 2.19 also introduced support for unnamed libraries. Library directives, used for appending library-level doc comments and annotations, can ([and should][]) now be written without a name:
+
+```dart
+/// A really great test library.
+@TestOn('browser')
+library;
+```
+
+[and should]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
+
 ## Language versioning
 
 A single Dart SDK can simultaneously support

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -291,11 +291,14 @@ The cases covered are rare, but needed to be addressed to close
 loopholes and make way for more complex inference-related language
 features upcoming in the next major release. These include:
 
-* Flow analysis now flags code as unreachable due to `Never` and `Null` types.
+* Flow analysis now flags more cases as unreachable due to `Never` and `Null` types.
 * Inaccessible private names can no longer delegate to `noSuchMethod`.
 * Cyclic dependencies now cause a compile-time error during top-level type inference.
 
-Dart 2.19 also introduced support for unnamed libraries. Library directives, used for appending library-level doc comments and annotations, can ([and should][]) now be written without a name:
+Dart 2.19 also introduced support for unnamed libraries.
+Library directives, used for appending
+library-level doc comments and annotations,
+can ([and should][]) now be written without a name:
 
 ```dart
 /// A really great test library.

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -291,9 +291,11 @@ The cases covered are rare, but needed to be addressed to close
 loopholes and make way for more complex inference-related language
 features upcoming in the next major release. These include:
 
-* Flow analysis now flags more cases as unreachable due to `Never` and `Null` types.
+* Flow analysis now flags more cases as unreachable
+  due to `Never` and `Null` types.
 * Inaccessible private names can no longer delegate to `noSuchMethod`.
-* Cyclic dependencies now cause a compile-time error during top-level type inference.
+* Cyclic dependencies now cause a compile-time error
+  during top-level type inference.
 
 Dart 2.19 also introduced support for unnamed libraries.
 Library directives, used for appending


### PR DESCRIPTION
Adds a 2.19 entry to the [Language evolution](https://dart.dev/guides/language/evolution) page.

**Staged:** https://dart-dev--pr4544-2-19-lang-evolution-qw79orzf.web.app/guides/language/evolution#dart-219