### PR TITLE
[alpha] Dart 3 alpha download instructions

### DIFF
--- a/src/get-dart/archive/index.md
+++ b/src/get-dart/archive/index.md
@@ -60,6 +60,21 @@ experimental development use, not for production use.
 To download a main channel build, use a
 [main channel URL](#main-channel-url-scheme).
 
+## Dart 3 alpha
+
+Dart 3 alpha -- the preview of our next major release --
+is currently available in two ways:
+
+* For a standalone Dart SDK, use any **dev channel** Dart SDK
+downloaded after 25 January 2023
+(Dart version `3.0.0-151.0.dev` or later).
+
+* For the Dart SDK embedded in the Flutter SDK,
+use any [Flutter **master channel** SDK][]
+downloaded after 25 January 2023 (this should give you
+Dart version `3.0.0-157.0.dev` or later).
+
+[Flutter **master channel** SDK]: https://docs.flutter.dev/development/tools/sdk/upgrading#switching-flutter-channels
 
 ## Download URLs
 

--- a/src/get-dart/archive/index.md
+++ b/src/get-dart/archive/index.md
@@ -72,7 +72,7 @@ downloaded after 25 January 2023
 * For the Dart SDK embedded in the Flutter SDK,
 use any [Flutter **master channel** SDK][]
 downloaded after 25 January 2023 
-(`dart --version` should report `3.0.0-157.0.dev` or later).
+(`dart --version` should report `3.0.0-151.0.dev` or later).
 
 [Flutter **master channel** SDK]: https://docs.flutter.dev/development/tools/sdk/upgrading#switching-flutter-channels
 

--- a/src/get-dart/archive/index.md
+++ b/src/get-dart/archive/index.md
@@ -67,12 +67,12 @@ is currently available in two ways:
 
 * For a standalone Dart SDK, use any **dev channel** Dart SDK
 downloaded after 25 January 2023
-(Dart version `3.0.0-151.0.dev` or later).
+(`dart --version` should report `3.0.0-151.0.dev` or later).
 
 * For the Dart SDK embedded in the Flutter SDK,
 use any [Flutter **master channel** SDK][]
-downloaded after 25 January 2023 (this should give you
-Dart version `3.0.0-157.0.dev` or later).
+downloaded after 25 January 2023 
+(`dart --version` should report `3.0.0-157.0.dev` or later).
 
 [Flutter **master channel** SDK]: https://docs.flutter.dev/development/tools/sdk/upgrading#switching-flutter-channels
 


### PR DESCRIPTION
Adding this to make it clear how to get Dart 3 alpha. Once we get to Dart 3 beta 1 we can remove this again.