### PR TITLE
[2.19] New `pub add` yaml syntax

### DIFF
--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -6,7 +6,7 @@ description: Use dart pub add to add a dependency.
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 ```nocode
-$ dart pub add <package>[:<constraint>] [<package2>[:<constraint2>]... ] [options]
+$ dart pub add [dev:]<package>[:<constraint>] [[dev:]<package>[:<constraint>]... ] [options]
 ```
 
 This command adds the specified packages to the `pubspec.yaml` as dependencies, 
@@ -19,6 +19,7 @@ and then calling `dart pub get`:
 ```terminal
 $ dart pub add http
 ```
+## Version constraint
 
 By default, `dart pub add` uses the
 latest stable version of the package from the [pub.dev site]({{site.pub}}).
@@ -37,7 +38,26 @@ $ dart pub add foo:'>2.0.0 <3.0.1'
 If `dart pub add <package>:<constraint>` is an existing dependency,
 it will update the constraint.
 
-## YAML syntax
+## `dev` dependency
+
+The `dev:` prefix adds the package as a [dev dependency][],
+instead of as a regular dependency.
+
+[dev dependency]: /tools/pub/dependencies#dev-dependencies
+
+```terminal
+$ dart pub add dev:foo           # adds newest compatible stable version of foo
+$ dart pub add dev:foo:^2.0.0    # adds specified constraint of foo
+$ dart pub add foo dev:bar`      # adds regular dependency foo and dev dependency bar simultaneously
+```
+
+_Previously the `-d, --dev` option_:
+
+```terminal
+$ dart pub add --dev foo
+```
+
+## YAML descriptor
 
 {{site.alert.version-note}}
   YAML-formatted descriptor syntax was added in Dart 2.19.
@@ -59,27 +79,8 @@ The syntax reflects how dependencies are written in `pubspec.yaml`.
 '<package>:{"<source>":"<descriptor>"[,"<source>":"<descriptor>"],"version":"<constraint>"}'
 ```
 
-The new syntax cannot be used in conjunction with any of the optional
-arguments it replaces. Their new, corresponding YAML arguments are listed below.
-
-### `dev`
-
-Adds the package as a [dev dependency][],
-instead of as a regular dependency.
-
-[dev dependency]: /tools/pub/dependencies#dev-dependencies
-
-```terminal
-$ dart pub add dev:foo           # adds newest compatible stable version of foo
-$ dart pub add dev:foo:^2.0.0    # adds specified constraint of foo
-$ dart pub add foo dev:bar`      # adds regular dependency foo and dev dependency bar simultaneously
-```
-
-_Previously the `-d, --dev` option_:
-
-```terminal
-$ dart pub add --dev foo
-```
+The `descriptor` syntax cannot be used in conjunction with any of the optional
+arguments it replaces. Their new, corresponding YAML sources are listed below.
 
 ### `git` 
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -3,21 +3,16 @@ title: dart pub add
 description: Use dart pub add to add a dependency.
 ---
 
-version note: Introduced in 2.19, this is the recommended method for add now, others will be deprecated (see old section)
-
-
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 ```nocode
 $ dart pub add <package>[:<constraint>] [<package2>[:<constraint2>]... ] [options]
-$ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor]
-       ...]
 ```
 
 This command adds the specified packages to the `pubspec.yaml` as dependencies, 
-and then gets the dependencies. 
+and then gets the dependencies.  
 
-For example, the following command is equivalent to
+The following example command is equivalent to
 editing `pubspec.yaml` to add the `http` package, 
 and then calling `dart pub get`:
 
@@ -31,91 +26,140 @@ For example, if 0.13.3 is the latest stable version of the `http` package,
 then `dart pub add http` adds
 `http: ^0.13.3` under `dependencies` in the pubspec.
 
-if `dart pub add foo:<constraint>` is an existing dependency, will update the constraint rather than fail.
+You can also specify a constraint or constraint range
 
-It can add multiple packages from different sources, 
-and have some packages be dev dependencies while others are not. 
+```terminal
+$ dart pub add foo:2.0.0
+$ dart pub add foo:'>=2.0.0'
+$ dart pub add foo:'>2.0.0 <3.0.1'
+```
 
-[dev dependency]: /tools/pub/dependencies#dev-dependencies
+If `dart pub add <package>:<constraint>` is an existing dependency,
+it will update the constraint.
 
-## YAML syntax
+## YAML descriptor
 
-`descriptor` is a yaml-formatted descriptor, as it would be written in pubspec.yaml in the dependencies section
-foo:{<source>:<descriptor>,"version":"<constraint>"}
+{{site.alert.version-note}}
+  YAML-formatted descriptor syntax was added in Dart 2.19.
+  The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
+  We still support these arguments, but the documented method is now yaml-descriptor only.
+{{site.alert.end}}
 
+The YAML descriptor reflects how dependencies are written in `pubspec.yaml`.
 
-For example:
-  * Add a hosted dependency at newest compatible stable version:
-    `$topLevelProgram pub add foo`
-  * Add a hosted dev dependency at newest compatible stable version:
-    `$topLevelProgram pub add dev:foo`
-  * Add a hosted dependency with the given constraint
-    `$topLevelProgram pub add foo:^1.2.3`
-  * Add multiple dependencies:
-    `$topLevelProgram pub add foo dev:bar`
-  * Add a path dependency:
-    `$topLevelProgram pub add 'foo{"path":"../foo"}'`
-  * Add a hosted dependency:
-    `$topLevelProgram pub add 'foo{"hosted":"my-pub.dev"}'`
-  * Add an sdk dependency:
-    `$topLevelProgram pub add 'foo{"sdk":"flutter"}'`
-  * Add a git dependency:
-    `$topLevelProgram pub add 'foo{"git":"https://github.com/foo/foo"}'`
-  * Add a git dependency with a path and ref specified:
-    `$topLevelProgram pub add /
-      'foo{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'`
+```nocode
+$ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor]
+       ...]
+```
 
+Within the `descriptor` you can add a package with specific constraints or other sources:
+```nocode
+'<package>:{"<source>":"<descriptor>"[,"<source>":"<descriptor>"],"version":"<constraint>"}'
+```
 
+The `descriptor` syntax cannot be used in conjunction with any of the optional arguments it replaces.
+Their new corresponding yaml sources are listed below.
 
-  /// Examples:
-  /// ```
-  /// retry
-  /// retry:2.0.0
-  /// dev:retry:^2.0.0
-  /// retry:'>=2.0.0'
-  /// retry:'>2.0.0 <3.0.1'
-  /// 'retry:>2.0.0 <3.0.1'
-  /// retry:any
-  /// 'retry:{"path":"../foo"}'
-  /// 'retry:{"git":{"url":"../foo","ref":"branchname"},"version":"^1.2.3"}'
-  /// 'retry:{"sdk":"flutter"}'
-  /// 'retry:{"hosted":"mypub.dev"}'
-  /// ```
+### `dev` {#d---dev}
 
-### `dev:`
-
-To add a [dev dependency][], use the `dev:` prefix:
+Adds the package as a [dev dependency][],
+instead of as a regular dependency.
 
 [dev dependency]: /tools/pub/dependencies#dev-dependencies
 
 ```terminal
-$ dart pub add dev:test
+$ dart pub add dev:foo           # adds newest compatible stable version of foo
+$ dart pub add dev:foo:^2.0.0    # adds specified constraint of foo
+$ dart pub add foo dev:bar`      # adds regular dependency foo and dev dependency bar simultaneously
 ```
 
-### `hosted`
+_Previously the `-d, --dev` option_:
 
-### `path`
-
-### `sdk`
-
-### `git`
+```terminal
+$ dart pub add --dev foo
+```
 
 ### `git` 
 
-#### `path`
+Adds a git dependency. 
 
-#### `ref`
+```terminal
+# dart pub add 'foo{"git":"https://github.com/foo/foo"}'
+```
 
-#### `url`
+You can also specify the repository, and the branch or commit, or exact location, within that repository:
 
+```terminal
+# dart pub add 'foo{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
+```
+
+#### `url` {#git-urlgit_repo_url}
+
+Depends on the package in the
+[specified Git repository](/tools/pub/dependencies#git-packages).
+
+```terminal
+# dart pub add 'foo{"git":"https://github.com/foo/foo"}'
+```
+
+_Previously the `--git-url=<git_repo_url>` option_:
+
+```terminal
+$ dart pub add http --git-url=https://github.com/my/http.git
+```
+
+#### `ref` {#git-refbranch_or_commit}
+
+With `url`, depends on the specified branch or commit of a Git repo.
+
+_Previously the `--git-ref=<branch_or_commit>` option_:
+
+```terminal
+$ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
+```
+
+#### `path` {#git-pathdirectory_path}
+
+With `url`, specifies the location of a package within a Git repo.
+
+_Previously the `--git-path=<directory_path>` option_.
+
+### `hosted` {#hosted-urlpackage_server_url}
+
+Adds a hosted dependency that depends on
+the package server at the specified URL
+
+```terminal
+$ dart pub add 'foo:{"hosted":"my-pub.dev"}'
+```
+
+_Previously the `--hosted-url=<package_server_url>` option_
+
+### `path` {#pathdirectory_path}
+
+Adds path dependency on a locally stored package.
+
+```terminal 
+$ dart pub add 'foo:{"path":"../foo"}'
+```
+
+_Previously the `--path=<directory_path>` option_.
+
+### `sdk` {#sdksdk_name}
+
+Adds a package with the specified SDK dependency.
+
+```terminal
+$ dart pub add 'foo:{"sdk":"flutter"}'
+```
+
+_Previously the `--sdk=<sdk_name>` option_:
+
+```terminal
+$ dart pub add foo --sdk=flutter
+```
 
 ## Options
-
-The `descriptor` used to be given with args like `--path`, `--sdk`,
-`--git-<option>`.
-
-We still support these arguments, but now the documented way to give the
-descriptor is to give a yaml-descriptor as in pubspec.yaml.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
@@ -127,67 +171,6 @@ For options that apply to all pub commands, see
   will add both the `test` and `http` packages 
   as dev dependencies.
 {{site.alert.end}}
-
-### `-d, --dev`
-
-_See yaml section_
-
-Adds the package as a dev dependency,
-instead of as a regular dependency.
-
-To add a [dev dependency][], use the `--dev` option:
-
-[dev dependency]: /tools/pub/dependencies#dev-dependencies
-
-```terminal
-$ dart pub add --dev test
-```
-
-### `--git-url=`_`<git_repo_url>`_
-
-_hidden/deprecated in favor of new syntax_
-
-Depends on the package in the
-[specified Git repository](/tools/pub/dependencies#git-packages).
-
-```terminal
-$ dart pub add http --git-url=https://github.com/my/http.git
-```
-
-### `--git-ref=`_`<branch_or_commit>`_
-
-_hidden/deprecated in favor of new syntax_
-
-With `--git-url`, depends on the specified branch or commit of a Git repo.
-
-```terminal
-$ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
-```
-
-### `--git-path=`_`<directory_path>`_
-
-_hidden/deprecated in favor of new syntax_
-
-With `--git-url`, specifies the location of a package within a Git repo.
-
-### `--hosted-url=`_`<package_server_url>`_
-
-_hidden/deprecated in favor of new syntax_
-
-Depends on the package server at the specified URL.
-
-### `--path=`_`<directory_path>`_
-
-_hidden/deprecated in favor of new syntax_
-
-Depends on a locally stored package.
-
-### `--sdk=`_`<sdk_name>`_
-
-_hidden/deprecated in favor of new syntax_
-
-Depends on a package that's shipped with the specified SDK
-(example: `--sdk=flutter`).
 
 ### `--[no-]offline`
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -42,7 +42,7 @@ it will update the constraint.
 {{site.alert.version-note}}
   YAML-formatted descriptor syntax was added in Dart 2.19.
   The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
-  We still support these arguments, but the documented method is now yaml-descriptor only.
+  We still support these arguments, but the documented method is now YAML-descriptor only.
 {{site.alert.end}}
 
 The YAML descriptor reflects how dependencies are written in `pubspec.yaml`.
@@ -58,7 +58,7 @@ Within the `descriptor` you can add a package with specific constraints or other
 ```
 
 The `descriptor` syntax cannot be used in conjunction with any of the optional arguments it replaces.
-Their new corresponding yaml sources are listed below.
+Their new corresponding YAML sources are listed below.
 
 ### `dev`
 
@@ -84,23 +84,19 @@ $ dart pub add --dev foo
 Adds a git dependency. 
 
 ```terminal
-# dart pub add 'foo{"git":"https://github.com/foo/foo"}'
+# dart pub add 'foo:{"git":"https://github.com/foo/foo"}'
 ```
 
 You can also specify the repository, and the branch or commit, or exact location, within that repository:
 
 ```terminal
-# dart pub add 'foo{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
+# dart pub add 'foo:{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
 ```
 
 #### `url`
 
 Depends on the package in the
 [specified Git repository](/tools/pub/dependencies#git-packages).
-
-```terminal
-# dart pub add 'foo{"git":"https://github.com/foo/foo"}'
-```
 
 _Previously the `--git-url=<git_repo_url>` option_:
 
@@ -133,7 +129,7 @@ the package server at the specified URL
 $ dart pub add 'foo:{"hosted":"my-pub.dev"}'
 ```
 
-_Previously the `--hosted-url=<package_server_url>` option_
+_Previously the `--hosted-url=<package_server_url>` option_.
 
 ### `path`
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -3,14 +3,19 @@ title: dart pub add
 description: Use dart pub add to add a dependency.
 ---
 
+version note: Introduced in 2.19, this is the recommended method for add now, others will be deprecated (see old section)
+
+
 _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 
 ```nocode
 $ dart pub add <package>[:<constraint>] [<package2>[:<constraint2>]... ] [options]
+$ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor]
+       ...]
 ```
 
-This command adds the specified packages to the pubspec as dependencies, 
-and then gets the dependencies.
+This command adds the specified packages to the `pubspec.yaml` as dependencies, 
+and then gets the dependencies. 
 
 For example, the following command is equivalent to
 editing `pubspec.yaml` to add the `http` package, 
@@ -26,15 +31,91 @@ For example, if 0.13.3 is the latest stable version of the `http` package,
 then `dart pub add http` adds
 `http: ^0.13.3` under `dependencies` in the pubspec.
 
-To add a [dev dependency][], use the `--dev` option:
+if `dart pub add foo:<constraint>` is an existing dependency, will update the constraint rather than fail.
+
+It can add multiple packages from different sources, 
+and have some packages be dev dependencies while others are not. 
+
+[dev dependency]: /tools/pub/dependencies#dev-dependencies
+
+## YAML syntax
+
+`descriptor` is a yaml-formatted descriptor, as it would be written in pubspec.yaml in the dependencies section
+foo:{<source>:<descriptor>,"version":"<constraint>"}
+
+
+For example:
+  * Add a hosted dependency at newest compatible stable version:
+    `$topLevelProgram pub add foo`
+  * Add a hosted dev dependency at newest compatible stable version:
+    `$topLevelProgram pub add dev:foo`
+  * Add a hosted dependency with the given constraint
+    `$topLevelProgram pub add foo:^1.2.3`
+  * Add multiple dependencies:
+    `$topLevelProgram pub add foo dev:bar`
+  * Add a path dependency:
+    `$topLevelProgram pub add 'foo{"path":"../foo"}'`
+  * Add a hosted dependency:
+    `$topLevelProgram pub add 'foo{"hosted":"my-pub.dev"}'`
+  * Add an sdk dependency:
+    `$topLevelProgram pub add 'foo{"sdk":"flutter"}'`
+  * Add a git dependency:
+    `$topLevelProgram pub add 'foo{"git":"https://github.com/foo/foo"}'`
+  * Add a git dependency with a path and ref specified:
+    `$topLevelProgram pub add /
+      'foo{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'`
+
+
+
+  /// Examples:
+  /// ```
+  /// retry
+  /// retry:2.0.0
+  /// dev:retry:^2.0.0
+  /// retry:'>=2.0.0'
+  /// retry:'>2.0.0 <3.0.1'
+  /// 'retry:>2.0.0 <3.0.1'
+  /// retry:any
+  /// 'retry:{"path":"../foo"}'
+  /// 'retry:{"git":{"url":"../foo","ref":"branchname"},"version":"^1.2.3"}'
+  /// 'retry:{"sdk":"flutter"}'
+  /// 'retry:{"hosted":"mypub.dev"}'
+  /// ```
+
+### `dev:`
+
+To add a [dev dependency][], use the `dev:` prefix:
 
 [dev dependency]: /tools/pub/dependencies#dev-dependencies
 
 ```terminal
-$ dart pub add --dev test
+$ dart pub add dev:test
 ```
 
+### `hosted`
+
+### `path`
+
+### `sdk`
+
+### `git`
+
+### `git` 
+
+#### `path`
+
+#### `ref`
+
+#### `url`
+
+
 ## Options
+
+The `descriptor` used to be given with args like `--path`, `--sdk`,
+`--git-<option>`.
+
+We still support these arguments, but now the documented way to give the
+descriptor is to give a yaml-descriptor as in pubspec.yaml.
 
 For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
@@ -49,10 +130,22 @@ For options that apply to all pub commands, see
 
 ### `-d, --dev`
 
+_See yaml section_
+
 Adds the package as a dev dependency,
 instead of as a regular dependency.
 
+To add a [dev dependency][], use the `--dev` option:
+
+[dev dependency]: /tools/pub/dependencies#dev-dependencies
+
+```terminal
+$ dart pub add --dev test
+```
+
 ### `--git-url=`_`<git_repo_url>`_
+
+_hidden/deprecated in favor of new syntax_
 
 Depends on the package in the
 [specified Git repository](/tools/pub/dependencies#git-packages).
@@ -63,6 +156,8 @@ $ dart pub add http --git-url=https://github.com/my/http.git
 
 ### `--git-ref=`_`<branch_or_commit>`_
 
+_hidden/deprecated in favor of new syntax_
+
 With `--git-url`, depends on the specified branch or commit of a Git repo.
 
 ```terminal
@@ -71,17 +166,25 @@ $ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
 
 ### `--git-path=`_`<directory_path>`_
 
+_hidden/deprecated in favor of new syntax_
+
 With `--git-url`, specifies the location of a package within a Git repo.
 
 ### `--hosted-url=`_`<package_server_url>`_
+
+_hidden/deprecated in favor of new syntax_
 
 Depends on the package server at the specified URL.
 
 ### `--path=`_`<directory_path>`_
 
+_hidden/deprecated in favor of new syntax_
+
 Depends on a locally stored package.
 
 ### `--sdk=`_`<sdk_name>`_
+
+_hidden/deprecated in favor of new syntax_
 
 Depends on a package that's shipped with the specified SDK
 (example: `--sdk=flutter`).

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -19,6 +19,7 @@ and then calling `dart pub get`:
 ```terminal
 $ dart pub add http
 ```
+
 ## Version constraint
 
 By default, `dart pub add` uses the
@@ -48,7 +49,7 @@ instead of as a regular dependency.
 ```terminal
 $ dart pub add dev:foo           # adds newest compatible stable version of foo
 $ dart pub add dev:foo:^2.0.0    # adds specified constraint of foo
-$ dart pub add foo dev:bar`      # adds regular dependency foo and dev dependency bar simultaneously
+$ dart pub add foo dev:bar       # adds regular dependency foo and dev dependency bar simultaneously
 ```
 
 _Previously the `-d, --dev` option_:
@@ -57,7 +58,7 @@ _Previously the `-d, --dev` option_:
 $ dart pub add --dev foo
 ```
 
-## YAML descriptor
+## Source descriptor
 
 {{site.alert.version-note}}
   YAML-formatted descriptor syntax was added in Dart 2.19.

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -10,7 +10,7 @@ $ dart pub add <package>[:<constraint>] [<package2>[:<constraint2>]... ] [option
 ```
 
 This command adds the specified packages to the `pubspec.yaml` as dependencies, 
-and then gets the dependencies.  
+and then retrieves the dependencies to resolve `pubspec.yaml`.  
 
 The following example command is equivalent to
 editing `pubspec.yaml` to add the `http` package, 
@@ -30,7 +30,7 @@ You can also specify a constraint or constraint range
 
 ```terminal
 $ dart pub add foo:2.0.0
-$ dart pub add foo:'>=2.0.0'
+$ dart pub add foo:'^2.0.0'
 $ dart pub add foo:'>2.0.0 <3.0.1'
 ```
 
@@ -60,7 +60,7 @@ Within the `descriptor` you can add a package with specific constraints or other
 The `descriptor` syntax cannot be used in conjunction with any of the optional arguments it replaces.
 Their new corresponding yaml sources are listed below.
 
-### `dev` {#d---dev}
+### `dev`
 
 Adds the package as a [dev dependency][],
 instead of as a regular dependency.
@@ -93,7 +93,7 @@ You can also specify the repository, and the branch or commit, or exact location
 # dart pub add 'foo{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
 ```
 
-#### `url` {#git-urlgit_repo_url}
+#### `url`
 
 Depends on the package in the
 [specified Git repository](/tools/pub/dependencies#git-packages).
@@ -108,7 +108,7 @@ _Previously the `--git-url=<git_repo_url>` option_:
 $ dart pub add http --git-url=https://github.com/my/http.git
 ```
 
-#### `ref` {#git-refbranch_or_commit}
+#### `ref`
 
 With `url`, depends on the specified branch or commit of a Git repo.
 
@@ -118,13 +118,13 @@ _Previously the `--git-ref=<branch_or_commit>` option_:
 $ dart pub add http --git-url=https://github.com/my/http.git --git-ref=tmpfixes
 ```
 
-#### `path` {#git-pathdirectory_path}
+#### `path`
 
 With `url`, specifies the location of a package within a Git repo.
 
 _Previously the `--git-path=<directory_path>` option_.
 
-### `hosted` {#hosted-urlpackage_server_url}
+### `hosted`
 
 Adds a hosted dependency that depends on
 the package server at the specified URL
@@ -135,7 +135,7 @@ $ dart pub add 'foo:{"hosted":"my-pub.dev"}'
 
 _Previously the `--hosted-url=<package_server_url>` option_
 
-### `path` {#pathdirectory_path}
+### `path`
 
 Adds path dependency on a locally stored package.
 
@@ -145,7 +145,7 @@ $ dart pub add 'foo:{"path":"../foo"}'
 
 _Previously the `--path=<directory_path>` option_.
 
-### `sdk` {#sdksdk_name}
+### `sdk`
 
 Adds a package with the specified SDK dependency.
 
@@ -165,7 +165,9 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 {{site.alert.note}}
-  Any specified options will apply to all the packages
+  The previous `pub add` syntax for options
+  (without YAML descriptors) applies the
+  specified options to all the packages
   included in an invocation of the command.
   For example, `dart pub add test http --dev` 
   will add both the `test` and `http` packages 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -26,7 +26,7 @@ For example, if 0.13.3 is the latest stable version of the `http` package,
 then `dart pub add http` adds
 `http: ^0.13.3` under `dependencies` in the pubspec.
 
-You can also specify a constraint or constraint range
+You can also specify a constraint or constraint range:
 
 ```terminal
 $ dart pub add foo:2.0.0
@@ -37,28 +37,30 @@ $ dart pub add foo:'>2.0.0 <3.0.1'
 If `dart pub add <package>:<constraint>` is an existing dependency,
 it will update the constraint.
 
-## YAML descriptor
+## YAML syntax
 
 {{site.alert.version-note}}
   YAML-formatted descriptor syntax was added in Dart 2.19.
   The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
-  We still support these arguments, but the documented method is now YAML-descriptor only.
+  We still support these arguments, but the recommended method is now
+  YAML-descriptor only.
 {{site.alert.end}}
 
-The YAML descriptor reflects how dependencies are written in `pubspec.yaml`.
+The YAML descriptor syntax allows you to add multiple packages from different
+sources, and apply different options and contraints to each. 
 
 ```nocode
-$ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor]
-       ...]
+$ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor] ...]
 ```
 
-Within the `descriptor` you can add a package with specific constraints or other sources:
+The syntax reflects how dependencies are written in `pubspec.yaml`.
+
 ```nocode
 '<package>:{"<source>":"<descriptor>"[,"<source>":"<descriptor>"],"version":"<constraint>"}'
 ```
 
-The `descriptor` syntax cannot be used in conjunction with any of the optional arguments it replaces.
-Their new corresponding YAML sources are listed below.
+The new syntax cannot be used in conjunction with any of the optional
+arguments it replaces. Their new, corresponding YAML arguments are listed below.
 
 ### `dev`
 
@@ -81,13 +83,14 @@ $ dart pub add --dev foo
 
 ### `git` 
 
-Adds a git dependency. 
+Adds a [git dependency](/tools/pub/dependencies#git-packages).
 
 ```terminal
 # dart pub add 'foo:{"git":"https://github.com/foo/foo"}'
 ```
 
-You can also specify the repository, and the branch or commit, or exact location, within that repository:
+You can specify the repository, and the branch or commit, or exact location,
+within that repository:
 
 ```terminal
 # dart pub add 'foo:{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
@@ -95,8 +98,7 @@ You can also specify the repository, and the branch or commit, or exact location
 
 #### `url`
 
-Depends on the package in the
-[specified Git repository](/tools/pub/dependencies#git-packages).
+Depends on the package in the specified Git repository.
 
 _Previously the `--git-url=<git_repo_url>` option_:
 
@@ -123,7 +125,7 @@ _Previously the `--git-path=<directory_path>` option_.
 ### `hosted`
 
 Adds a hosted dependency that depends on
-the package server at the specified URL
+the package server at the specified URL.
 
 ```terminal
 $ dart pub add 'foo:{"hosted":"my-pub.dev"}'
@@ -133,7 +135,7 @@ _Previously the `--hosted-url=<package_server_url>` option_.
 
 ### `path`
 
-Adds path dependency on a locally stored package.
+Adds a [path dependency]() on a locally stored package.
 
 ```terminal 
 $ dart pub add 'foo:{"path":"../foo"}'
@@ -141,9 +143,11 @@ $ dart pub add 'foo:{"path":"../foo"}'
 
 _Previously the `--path=<directory_path>` option_.
 
+[path dependency]: /tools/pub/dependencies#path-packages
+
 ### `sdk`
 
-Adds a package with the specified SDK dependency.
+Adds a package from the specified SDK source.
 
 ```terminal
 $ dart pub add 'foo:{"sdk":"flutter"}'


### PR DESCRIPTION
Fixes #4514 

`add` has a new yaml syntax that mostly replaces the `--option` arguments. You can still use the old syntax and arguments, which I tried to maintain in this rewrite, but the better way is to use yaml (and the old way will be eventually deprecated(?))

Honestly, this rewrite got a little bloated/messy and I'm not sure if I like it. It was hard to preserve the old syntax and document the new (though we decided [it's important to preserve the old syntax](https://github.com/dart-lang/site-www/issues/4514#issuecomment-1399330752)). The way I restructure it is:
- Basic `add` intro
  - Still works, so didn't change 
  - Except elaborating on constraint options a little more, which might be unnecessary and  can be removed if we want.
- YAML section (new)
  - Introduce the new syntax
  - Sub sections for yaml sources
    - Each source corresponds to an old --option, so at the end of each section there's a line that says _Previously <--option>_
    - If the old option had an example, I preserved it
    - In case any of the options' sections were linked to, I preserved the section heading anchor with the new section names
- Options section (old)
  - There are still options that work, that haven't been replaced by yaml, so those are still there
  - As mentioned, the replaced options info are now in the source sections 