### PR TITLE
Add back missing command in dcat example

### DIFF
--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -136,6 +136,7 @@ you can run the app from the command line over any text file,
 like `pubspec.yaml`:
 
 ```terminal
+$ dart run bin/dcat.dart -n pubspec.yaml
 1 name: dcat
 2 description: A sample command-line application.
 3 version: 1.0.0


### PR DESCRIPTION
Accidentally removed when updating the output in https://github.com/dart-lang/site-www/commit/f0ea037b83e4e921a9737239a8f10690d5775f59.