### PR TITLE
Improve word breaking/wrapping in TOC on underscores

### DIFF
--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -11,7 +11,7 @@
   {% assign topStyle = 'toc-collapsible toc-collapsed' %}
 {% endif %}
 {% if include.extendToc -%}
-  {% assign toc = toc | underscore_breaker %}
+  {% assign toc = toc | underscore_breaker: true %}
   {% assign toc = toc | replace: '<ul>', '<ul class="nav">' %}
   {% assign toc = toc | replace: '<ul class="section-nav">', '<ul class="section-nav nav">' %}
   {% assign toc = toc | replace: 'class="toc-entry', 'class="toc-entry nav-item' %}

--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -11,6 +11,7 @@
   {% assign topStyle = 'toc-collapsible toc-collapsed' %}
 {% endif %}
 {% if include.extendToc -%}
+  {% assign toc = toc | underscore_breaker %}
   {% assign toc = toc | replace: '<ul>', '<ul class="nav">' %}
   {% assign toc = toc | replace: '<ul class="section-nav">', '<ul class="section-nav nav">' %}
   {% assign toc = toc | replace: 'class="toc-entry', 'class="toc-entry nav-item' %}

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -1,6 +1,6 @@
 module UnderscoreBreaker
   def underscore_breaker(string_to_break)
-    return string_to_break.gsub('_', '_<wbr />')
+    return string_to_break.gsub('_', '_<wbr>')
   end
 end
 

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -2,10 +2,10 @@ module UnderscoreBreaker
   # Adds `<wbr>` after underscores to allow the browser
   # to more intelligently wrap identifiers and text split with underscores.
   # If `in_anchor` is `true`, it will only replace the inner text content.
-  def underscore_breaker(string_to_break, in_achor = false)
+  def underscore_breaker(string_to_break, in_anchor = false)
     # Only consider text which has underscores in it to keep this simpler
     return unless string_to_break.include? '_'
-    if in_achor then
+    if in_anchor then
       # If the replacement is to be done inside an anchor,
       # we don't want to replace the href,
       # just the inner text content.

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -1,5 +1,12 @@
 module UnderscoreBreaker
-  def underscore_breaker(string_to_break)
+  def underscore_breaker(string_to_break, in_achor = false)
+    return unless string_to_break.include? '_'
+    if in_achor then
+      return string_to_break.gsub(/>([a-zA-Z_]*?)</) do |match|
+        ">#{$1.gsub('_', '_<wbr>')}<"
+      end
+    end
+
     return string_to_break.gsub('_', '_<wbr>')
   end
 end

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -1,7 +1,13 @@
 module UnderscoreBreaker
+  # Adds `<wbr>` after underscores to allow the browser
+  # to more intelligently wrap identifiers and text split with underscores.
+  # If `in_anchor` is `true`, it will only replace the inner text content.
   def underscore_breaker(string_to_break, in_achor = false)
     return unless string_to_break.include? '_'
     if in_achor then
+      # If the replacement is to be done inside an anchor,
+      # we don't want to replace the href,
+      # just the inner text content.
       return string_to_break.gsub(/>([a-zA-Z_]*?)</) do |match|
         ">#{$1.gsub('_', '_<wbr>')}<"
       end

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -3,6 +3,7 @@ module UnderscoreBreaker
   # to more intelligently wrap identifiers and text split with underscores.
   # If `in_anchor` is `true`, it will only replace the inner text content.
   def underscore_breaker(string_to_break, in_achor = false)
+    # Only consider text which has underscores in it to keep this simpler
     return unless string_to_break.include? '_'
     if in_achor then
       # If the replacement is to be done inside an anchor,

--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -1,0 +1,7 @@
+module UnderscoreBreaker
+  def underscore_breaker(string_to_break)
+    return string_to_break.gsub('_', '_<wbr />')
+  end
+end
+
+Liquid::Template.register_filter(UnderscoreBreaker)


### PR DESCRIPTION
Currently in the right-hand TOC (table of contents), on long strings with underscores (`_`), such as on the linter rules and diagnostic messages page, the entries are just wrapped/broken on the first character necessary. This PR introduces a line break opportunity element ([`<wbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)) after each underscore (`_`) in the TOC. This allows the browser to prefer to wrap just after an underscore if its needed. This results in the following benefits:

- Words aren't broken in half, making the entries easier to read
- The underscore being at the end indicates to the reader that the entry continues on the next line
- It looks nicer and more consistent

I've accomplished this with a new Liquid filter named `underscore_breaker`, which can be used later for pages with underscores in the title, such as if we move diagnostics to their own individual pages.

To see the improvements, visit the old linter rule and diagnostic pages, with your screen wide enough to see the side-TOC.

**Modified linter rules:** https://dart-dev--pr4562-fix-toc-underscore-b-shb9fnjz.web.app/tools/linter-rules
Original linter rules: https://dart.dev/tools/linter-rules

**Modified diagnostic messages:** https://dart-dev--pr4562-fix-toc-underscore-b-shb9fnjz.web.app/tools/diagnostic-messages
Original diagnostic messages: https://dart.dev/tools/diagnostic-messages