### PR TITLE
Switch to using dev(3.0-dev) instead of beta in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, beta]
+        sdk: [stable, dev]
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:

--- a/examples/analysis/analyzer-results-dev.txt
+++ b/examples/analysis/analyzer-results-dev.txt
@@ -2,7 +2,7 @@ Analyzing analysis...
 
   error - lib/strict_modes.dart:15:7 - The argument type 'dynamic' can't be assigned to the parameter type 'List<String>'. - argument_type_not_assignable
    info - lib/lint.dart:9:19 - Unnecessary empty statement. Try removing the empty statement or restructuring the code. - empty_statements
-   info - lib/lint.dart:17:7 - Close instances of `dart.core.Sink`. - close_sinks
+   info - lib/lint.dart:17:7 - Unclosed instance of 'Sink'. Try invoking 'close' in the function in which the 'Sink' was created. - close_sinks
    info - lib/strict_modes.dart:22:17 - The type argument(s) of 'Map' can't be inferred. Use explicit type argument(s) for 'Map'. - inference_failure_on_collection_literal
    info - lib/strict_modes.dart:33:3 - The generic type 'List<dynamic>' should have explicit type arguments but doesn't. Use explicit type arguments for 'List<dynamic>'. - strict_raw_type
 


### PR DESCRIPTION
All of our dependencies are updated to support Dart 3-alpha, with the most recent being linkcheck in https://github.com/filiph/linkcheck/pull/105 and https://github.com/dart-lang/site-www/pull/4502.

We can re-enable beta as well once a 3.0 build is released to beta.

Fixes https://github.com/dart-lang/site-www/issues/4424