### PR TITLE
Document how non-late instance variable initializers can't access `this`

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2799,6 +2799,7 @@ see [Getters and setters](#getters-and-setters).
 If you initialize a non-`late` instance variable where it's declared,
 the value is set when the instance is created,
 which is before the constructor and its initializer list execute.
+As a result, non-`late` instance variable initializers can't access `this`.
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class+main)" replace="/(double .*?;).*/$1/g" plaster="none"?>
 ```dart


### PR DESCRIPTION
Most mentions of this limitation in the language tour have this in a note, but it fit rather naturally with this preceding text.

Fixes #2183