### PR TITLE
Fix new underscore fix filter to return unmodified text

### DIFF
--- a/src/_plugins/underscore_breaker.rb
+++ b/src/_plugins/underscore_breaker.rb
@@ -4,7 +4,7 @@ module UnderscoreBreaker
   # If `in_anchor` is `true`, it will only replace the inner text content.
   def underscore_breaker(string_to_break, in_anchor = false)
     # Only consider text which has underscores in it to keep this simpler
-    return unless string_to_break.include? '_'
+    return string_to_break unless string_to_break.include? '_'
     if in_anchor then
       # If the replacement is to be done inside an anchor,
       # we don't want to replace the href,


### PR DESCRIPTION
The content shouldn't be removed if there are no underscores. It should just be unmodified, so this modifies the plugin to return the text provided to the filter.