### PR TITLE
Fix a typo in the URL pointing to the Flutter `compute` constant

### DIFF
--- a/src/_guides/language/concurrency/index.md
+++ b/src/_guides/language/concurrency/index.md
@@ -324,7 +324,7 @@ setting up and managing worker isolates:
 {{site.alert.end}}
 
 [native and non-native platforms]: /overview#platform
-[Flutter's `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute.html
+[Flutter's `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute-constant.html
 
 #### Running an existing method in a new isolate
 


### PR DESCRIPTION
https://api.flutter.dev/flutter/foundation/compute.html returns a 404 but https://api.flutter.dev/flutter/foundation/compute-constant.html exists