### PR TITLE
Update summary text regarding linter and IDEs

### DIFF
--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -70,7 +70,7 @@ to perform static analysis.
 You can customize static analysis to look for a variety of potential
 problems, including errors and warnings specified in the
 [Dart language spec](/guides/language/spec).
-You can also configure the linter, one of the analyzer's plugins,
+You can also configure linter rules,
 to ensure that your code complies with the
 [Dart Style Guide](/guides/language/effective-dart/style)
 and other suggested guidelines in
@@ -78,7 +78,7 @@ and other suggested guidelines in
 [Dart compiler (`dart compile`)](/tools/dart-compile),
 [`dart analyze`](/tools/dart-analyze),
 [`flutter analyze`]({{site.flutter-docs}}/testing/debugging#the-dart-analyzer),
-and [JetBrains IDEs](/tools/jetbrains-plugin)
+and [Editors and IDEs](/tools#ides-and-editors)
 use the analyzer package to evaluate your code.
 
 This document explains how to customize the behavior of the analyzer

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -78,7 +78,7 @@ and other suggested guidelines in
 [Dart compiler (`dart compile`)](/tools/dart-compile),
 [`dart analyze`](/tools/dart-analyze),
 [`flutter analyze`]({{site.flutter-docs}}/testing/debugging#the-dart-analyzer),
-and [Editors and IDEs](/tools#ides-and-editors)
+and [IDEs and editors](/tools#ides-and-editors)
 use the analyzer package to evaluate your code.
 
 This document explains how to customize the behavior of the analyzer


### PR DESCRIPTION
* Change text around "analyzer's plugin"
* Change link for IDEs, as JetBrains IDEs are not the only ones which use the analyzer package.

Fixes https://github.com/dart-lang/site-www/issues/4595