### PR TITLE
Simplify note about not needing to import `dart:async`

### DIFF
--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1120,8 +1120,8 @@ use it, import dart:async:
 import 'dart:async';
 ```
 
-{{site.alert.version-note}}
-  As of Dart 2.1, you don't need to import dart:async to use the Future and
+{{site.alert.note}}
+  You don't need to import dart:async to use the Future and
   Stream APIs, because dart:core exports those classes.
 {{site.alert.end}}
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1120,7 +1120,7 @@ use it, import dart:async:
 import 'dart:async';
 ```
 
-{{site.alert.note}}
+{{site.alert.tip}}
   You don't need to import dart:async to use the Future and
   Stream APIs, because dart:core exports those classes.
 {{site.alert.end}}


### PR DESCRIPTION
Dart 2.1 was a long time ago now, so this doesn't need to be a version note.