### PR TITLE
Update link in native extension docs

### DIFF
--- a/src/server/c-interop-native-extensions.md
+++ b/src/server/c-interop-native-extensions.md
@@ -20,4 +20,4 @@ toc: false
 {{site.alert.end}}
 
 [`include/dart_api.h`]: https://github.com/dart-lang/sdk/blob/main/runtime/include/dart_api.h
-[examples]: https://github.com/fuzzybinary/dart-embedding-example
+[examples]: https://github.com/fuzzybinary/dart_shared_libray


### PR DESCRIPTION
I've deprecated the old embedding example for one that utilizes .dlls / .sos with a simpler interface. Updating the link to point to that repo instead.