### PR TITLE
Fix accidentally overriding label code block background

### DIFF
--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -488,9 +488,9 @@ li.card {
 @include dart-style-for(fails-sa, $alert-danger-bg, $alert-danger-fg, '\2717  static analysis: error/warning');
 @include dart-style-for(runtime-success, $alert-success-bg, $alert-success-fg, '\2714  runtime: success');
 @include dart-style-for(runtime-fail, $alert-danger-bg, $alert-danger-fg, '\2717  runtime: error');
-@include dart-style-for('highlight-languages .language-dart:not(.no-lang)', $pre-bg, $brand-primary, 'Dart');
-@include dart-style-for('highlight-languages .language-js:not(.no-lang)', $pre-bg, #f1a85a, 'JavaScript');
-@include dart-style-for('highlight-languages .language-swift:not(.no-lang)', $pre-bg, #f05137, 'Swift');
+@include dart-style-for('highlight-languages .language-dart:not(.no-lang)', inherit, $brand-primary, 'Dart');
+@include dart-style-for('highlight-languages .language-js:not(.no-lang)', inherit, #f1a85a, 'JavaScript');
+@include dart-style-for('highlight-languages .language-swift:not(.no-lang)', inherit, #f05137, 'Swift');
 
 .muted {
   color: $gray;


### PR DESCRIPTION
With the changes to add language labeled code blocks to the Coming from pages, I accidentally overrode the background style, which caused alert box's special handling for transparent code block backgrounds to not work like elsewhere on the site. This PR changes it so the code block simply inherits the correct and consistent style from the `<pre>`.

After fix:
<img width="926" alt="After fix example" src="https://user-images.githubusercontent.com/18372958/220547415-e5b24f3e-f8bb-4a91-bb25-1df372f9458a.png">

Before fix:
<img width="911" alt="Before fix example" src="https://user-images.githubusercontent.com/18372958/220547489-da44a7d1-f8df-4902-aa12-84d32936c8ae.png">
