### PR TITLE
Annotate Dart code block as Dart, not Swift

### DIFF
--- a/src/_guides/language/coming-from/swift-to-dart.md
+++ b/src/_guides/language/coming-from/swift-to-dart.md
@@ -998,7 +998,7 @@ curly braces around flow control statements
 with no else clause and the whole if statement
 fits on one line, you can omit the braces if you prefer.
 
-```swift
+```dart
 var a = 1;
 // Parentheses for conditions are required in Dart.
 if (a == 1) {


### PR DESCRIPTION
Dart code block is annotated as Swift code, which is incorrect. Fix this by annotating Dart code block as Dart code