### PR TITLE
Improve the archives build tool

### DIFF
--- a/tool/get-dart/archive/compile.sh
+++ b/tool/get-dart/archive/compile.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
 : ${TMP:=tmp}
 OUT_DIR="$TMP/download_archive"

--- a/tool/get-dart/archive/compile.sh
+++ b/tool/get-dart/archive/compile.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Enter the tool's directory as the working directory to avoid path conflicts under different environments.
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
 : ${TMP:=tmp}

--- a/tool/get-dart/archive/compile.sh
+++ b/tool/get-dart/archive/compile.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Enter the tool's directory as the working directory to avoid path conflicts under different environments.
+# Enter the tool's directory as the working directory
+# to avoid path conflicts under different environments.
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
 : ${TMP:=tmp}

--- a/tool/get-dart/dart_sdk_archive/lib/src/version_selector.dart
+++ b/tool/get-dart/dart_sdk_archive/lib/src/version_selector.dart
@@ -9,7 +9,7 @@ import 'package:sdk_builds/sdk_builds.dart';
 
 import 'operating_system.dart';
 
-const _storageBase = 'https://storage.googleapis.com/dart-archive';
+const _storageBase = '${storageBaseURL}dart-archive';
 
 class VersionSelector {
   final String channel;

--- a/tool/get-dart/dart_sdk_archive/lib/src/version_selector.dart
+++ b/tool/get-dart/dart_sdk_archive/lib/src/version_selector.dart
@@ -9,7 +9,7 @@ import 'package:sdk_builds/sdk_builds.dart';
 
 import 'operating_system.dart';
 
-const _storageBase = '${storageBaseURL}dart-archive';
+const _storageBase = '${storageBaseUrl}dart-archive';
 
 class VersionSelector {
   final String channel;

--- a/tool/get-dart/sdk_builds.dart/lib/src/dart_downloads.dart
+++ b/tool/get-dart/sdk_builds.dart/lib/src/dart_downloads.dart
@@ -8,6 +8,12 @@ import 'package:path/path.dart' as p;
 
 import 'version_info.dart';
 
+/// Define the storage base URL explicitly.
+///
+/// This will help to modify the base easily
+/// if any site is using a different storage base.
+const storageBaseUrl = 'https://storage.googleapis.com/';
+
 const _dartChannel = 'dart-archive';
 const _flavor = 'release';
 
@@ -25,7 +31,7 @@ class DartDownloads {
 
   DartDownloads._(http.Client client)
       : _client = client,
-        _api = storage.StorageApi(client);
+        _api = storage.StorageApi(client, rootUrl: storageBaseUrl);
 
   Future<Uri> createDownloadLink(
       String channel, String revision, String path) async {


### PR DESCRIPTION
* The change to `tool/get-dart/archive/compile.sh` is intended to `cd` into the script directory to make paths relatively stable regardless of where the tool has been run from.
* Changes to Dart files are making the storage base can be configured easily.

This also helps to build [the automatic compilation of dart.cn](https://github.com/cfug/dart.cn/blob/master/.github/workflows/compile_archive_js.yml).