### PR TITLE
Create "Glossary" page for diagnostics to link to 

### DIFF
--- a/src/resources/glossary.md
+++ b/src/resources/glossary.md
@@ -1,0 +1,19 @@
+---
+title: Glossary
+description: A glossary reference for terminology used across dart.dev
+sitemap: false
+---
+
+The following are definitions of terminology used across the Dart documentation.
+
+## Irrefutable patterns
+
+_Irrefutable patterns_ are patterns that always match. 
+Irrefutable patterns appear in _irrefutable contexts_: 
+_declaration context_ and _assignment context_.
+
+## Refutable patterns
+
+A _refutable pattern_ is a pattern that can be tested against a value to
+determine if the pattern matches the value. If not, the pattern _refutes_ the value.
+Refutable patterns appear in _matching contexts_.


### PR DESCRIPTION
Part of #4622 

This is a first PR to add a glossary page, specifically with definitions for the new patterns-related terms "refutable" and "irrefutable". New Dart 3 diagnostic messages need to point to these definitions, so I'm adding them now so the diagnostics can be committed: [`286524`](https://dart-review.googlesource.com/c/sdk/+/286524)

The page will remain hidden from the sitemap, though, until the remainder of the glossary content from https://dart.dev/tools/diagnostic-messages can move there too (it will eventually be added under "Resources" in the side nav).

That should only happen after the new diagnostics are complete, so we can simultaneously change all the pointers within the diagnostics to point to the new page. 


