### PR TITLE
Improve links

### DIFF
--- a/src/_guides/language/index.md
+++ b/src/_guides/language/index.md
@@ -33,7 +33,7 @@ These two resources are popular with both beginning Dart developers and experts.
     Learn about and practice writing asynchronous code, using DartPad.
   * [Streams](/tutorials/language/streams)<br>
     A beginner's guide to handling sequences of asynchronous events.
-* [Language articles](/articles/language)<br>
+* [Language articles](/articles)<br>
   Articles about language features such as mixins and asynchrony support.
 * [Specification](/guides/language/spec)<br>
   A definitive, highly technical description of the Dart language.

--- a/src/_guides/testing.md
+++ b/src/_guides/testing.md
@@ -108,7 +108,7 @@ Dart plugins exist for many [commonly used IDEs](/tools/#ides-and-editors).
 
 Dart DevTools is a suite of performance tools for Dart and Flutter.
 For details, see the
-[Dart DevTools documentation.](/tools/dart-devtools/)
+[Dart DevTools documentation.](/tools/dart-devtools)
 
 
 ### Continuous integration

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -113,7 +113,7 @@ with the [`dart create`](/tools/dart-create) command.
    $ cd dcat
    ```
    
-3. Inside the `dcat` directory, use [pub](/tools/pub) 
+3. Inside the `dcat` directory, use [dart pub add](/tools/pub/cmd/pub-add) 
    to add the `args` package as a dependency. This adds `args` to 
    the list of your dependencies found in the `pubspec.yaml` file.
 

--- a/src/codelabs/async-await.md
+++ b/src/codelabs/async-await.md
@@ -1093,7 +1093,7 @@ are some suggestions for where to go next:
 If you're interested in using embedded DartPads, like this codelab does, see
 [best practices for using DartPad in tutorials][].
 
-[best practices for using DartPad in tutorials]: /resources/dartpad-best-practices
+[best practices for using DartPad in tutorials]: /tools/dartpad/dartpad-best-practices
 [Dart videos]: https://www.youtube.com/playlist?list=PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J
 [article]: https://medium.com/dartlang/dart-asynchronous-programming-isolates-and-event-loops-bffc3e296a6a
 [Future]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Future-class.html

--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -547,7 +547,7 @@ are some suggestions for where to go next:
 -   [Get the Dart SDK](/get-dart).
 
 If you're interested in using embedded DartPads, like this codelab does, see
-[best practices for using DartPad in tutorials](/resources/dartpad-best-practices).
+[best practices for using DartPad in tutorials](/tools/dartpad/dartpad-best-practices).
 If you're interested in improving this codelab, see
 [issue #3093][].
 

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -124,7 +124,7 @@ types.
 
 In type theory lingo, the `Null` type was treated as a subtype of all types:
 
-<img src="understanding-null-safety/hierarchy-before.png" width="335">
+<img src="/understanding-null-safety/hierarchy-before.png" width="335">
 
 The set of operations—getters, setters, methods, and
 operators—allowed on some expressions are defined by its type. If the type
@@ -140,7 +140,7 @@ Null safety eliminates that problem at the root by changing the type hierarchy.
 The `Null` type still exists, but it's no longer a subtype of all types.
 Instead, the type hierarchy looks like this:
 
-<img src="understanding-null-safety/hierarchy-after.png" width="344">
+<img src="/understanding-null-safety/hierarchy-after.png" width="344">
 
 Since `Null` is no longer a subtype, no type except the special `Null` class
 permits the value `null`. We've made all types *non-nullable by default*. If you
@@ -202,7 +202,7 @@ problems. We model this by making every nullable type a supertype of its
 underlying type. You can also safely pass `null` to something expecting a nullable type, so
 `Null` is also a subtype of every nullable type:
 
-<img src="understanding-null-safety/nullable-hierarchy.png" width="235">
+<img src="/understanding-null-safety/nullable-hierarchy.png" width="235">
 
 But going the other direction and passing a nullable type to something expecting
 the underlying non-nullable type is unsafe. Code that expects a `String` may
@@ -281,7 +281,7 @@ returns. With the removal of implicit downcasts, this becomes a compile error.
 Where were we? Right, OK, so it's as if we've taken the universe of types in
 your program and split them into two halves:
 
-<img src="understanding-null-safety/bifurcate.png" width="668">
+<img src="/understanding-null-safety/bifurcate.png" width="668">
 
 There is a region of non-nullable types. Those types let you access all of the
 interesting methods, but can never ever contain `null`. And then there is a
@@ -322,7 +322,7 @@ subtype of it. Dart has no *named* top type. If you need a top type, you want
 `Object?`. Likewise, `Null` is no longer the bottom type. If it was, everything
 would still be nullable. Instead, we've added a new bottom type named `Never`:
 
-<img src="understanding-null-safety/top-and-bottom.png" width="360">
+<img src="/understanding-null-safety/top-and-bottom.png" width="360">
 
 In practice, this means:
 

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -124,7 +124,7 @@ types.
 
 In type theory lingo, the `Null` type was treated as a subtype of all types:
 
-<img src="/understanding-null-safety/hierarchy-before.png" width="335">
+<img src="/null-safety/understanding-null-safety/hierarchy-before.png" width="335">
 
 The set of operations—getters, setters, methods, and
 operators—allowed on some expressions are defined by its type. If the type
@@ -140,7 +140,7 @@ Null safety eliminates that problem at the root by changing the type hierarchy.
 The `Null` type still exists, but it's no longer a subtype of all types.
 Instead, the type hierarchy looks like this:
 
-<img src="/understanding-null-safety/hierarchy-after.png" width="344">
+<img src="/null-safety/understanding-null-safety/hierarchy-after.png" width="344">
 
 Since `Null` is no longer a subtype, no type except the special `Null` class
 permits the value `null`. We've made all types *non-nullable by default*. If you
@@ -202,7 +202,7 @@ problems. We model this by making every nullable type a supertype of its
 underlying type. You can also safely pass `null` to something expecting a nullable type, so
 `Null` is also a subtype of every nullable type:
 
-<img src="/understanding-null-safety/nullable-hierarchy.png" width="235">
+<img src="/null-safety/understanding-null-safety/nullable-hierarchy.png" width="235">
 
 But going the other direction and passing a nullable type to something expecting
 the underlying non-nullable type is unsafe. Code that expects a `String` may
@@ -281,7 +281,7 @@ returns. With the removal of implicit downcasts, this becomes a compile error.
 Where were we? Right, OK, so it's as if we've taken the universe of types in
 your program and split them into two halves:
 
-<img src="/understanding-null-safety/bifurcate.png" width="668">
+<img src="/null-safety/understanding-null-safety/bifurcate.png" width="668">
 
 There is a region of non-nullable types. Those types let you access all of the
 interesting methods, but can never ever contain `null`. And then there is a
@@ -322,7 +322,7 @@ subtype of it. Dart has no *named* top type. If you need a top type, you want
 `Object?`. Likewise, `Null` is no longer the bottom type. If it was, everything
 would still be nullable. Instead, we've added a new bottom type named `Never`:
 
-<img src="/understanding-null-safety/top-and-bottom.png" width="360">
+<img src="/null-safety/understanding-null-safety/top-and-bottom.png" width="360">
 
 In practice, this means:
 

--- a/src/server/index.md
+++ b/src/server/index.md
@@ -67,7 +67,7 @@ You might find the following tutorials helpful.
 [Dart API]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}})
 : API reference for dart:* libraries.
 
-[dart:io section of the library tour](/guides/libraries/library-tour/#dartio)
+[dart:io section of the library tour](/guides/libraries/library-tour#dartio)
 : Shows how to use the major features of the dart:io library.
   You can use the dart:io library in command-line scripts, servers, and
   non-web [Flutter apps.]({{site.flutter}})

--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -4,7 +4,7 @@ description: Command-line tool for compiling Dart source code.
 ---
 
 Use the `dart compile` command to compile
-a Dart program to a [target platform](/platforms).
+a Dart program to a [target platform](/overview#platform).
 The output—which you specify using a subcommand—can 
 either include a [Dart runtime][] or be a _module_
 (also known as a _snapshot_).

--- a/src/web/dart-2.md
+++ b/src/web/dart-2.md
@@ -92,6 +92,6 @@ information about changes in Dart 2, and how to migrate your code from Dart 1.x.
 [angular-examples/quickstart/web/index.html]: https://github.com/googlearchive/quickstart/compare/4.x...master#diff-8f62b6ced28d3396b501d2e89a2e7cb761d16cd7dc977aebece03d4a5da5c24e
 [angular-examples/toh-5]: https://github.com/googlearchive/toh-5/compare/4.x...master
 [build]: https://github.com/dart-lang/build
-[dart-2]: /dart-2
+[dart-2]: /articles/archive/dart-2
 [Documentation changelog]: https://web.archive.org/web/20181003225323/https://webdev.dartlang.org/changelog
 [Transforming code]: https://github.com/dart-lang/build/blob/master/docs/transforming_code.md


### PR DESCRIPTION
This PR helps the build process to build dart.cn.

* Remove redirect links.
* Remove `/` at the end of URLs.
* Add `/` for relative resources source.