### PR TITLE
Tweaks to experiment-flags.md

### DIFF
--- a/src/tools/experiment-flags.md
+++ b/src/tools/experiment-flags.md
@@ -26,6 +26,23 @@ $ dart run --enable-experiment=super-mixins,no-slow-checks bin/main.dart
 ```
 
 
+## Using experiment flags with the Dart analyzer (command-line and IDE)
+
+To enable experiments affecting analysis,
+use the `enable-experiment` key in the [analysis options file][].
+Here's an example of enabling the experiments
+`super-mixins` and `no-slow-checks` in `analysis_options.yaml`:
+
+[analysis options file]: /guides/language/analysis-options#the-analysis-options-file
+
+```yaml
+analyzer:
+  enable-experiment:
+    - super-mixins
+    - no-slow-checks
+```
+
+
 ## Using experiment flags with IDEs
 
 To enable experiments related to running or debugging apps in IDEs,
@@ -76,23 +93,6 @@ For more information, consult the instructions for
 [Android Studio run/debug configurations.][AS instructions]
 
 [AS instructions]: https://developer.android.com/studio/run/rundebugconfig
-
-
-## Using experiment flags with the Dart analyzer (command-line and IDE)
-
-To enable experiments affecting analysis,
-use the `enable-experiment` key in the [analysis options file][].
-Here's an example of enabling the experiments
-`super-mixins` and `no-slow-checks` in `analysis_options.yaml`:
-
-[analysis options file]: /guides/language/analysis-options#the-analysis-options-file
-
-```yaml
-analyzer:
-  enable-experiment:
-    - super-mixins
-    - no-slow-checks
-```
 
 
 ## More information


### PR DESCRIPTION
Swap the order of the sections to pull up the analyzer part, which is always used when using flags, and thus more important.