### PR TITLE
Rename 'Collection types' to 'Collections'

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -179,6 +179,7 @@
       { "source": "/install/**", "destination": "/get-dart", "type": 301 },
       { "source": "/install/archive", "destination": "/get-dart/archive", "type": 301 },
       { "source": "/jobs", "destination": "https://docs.flutter.dev/jobs", "type": 301 },
+      { "source": "/language/collection-types", "destination": "/language/collections", "type": 301 },
       { "source": "/language-tour", "destination": "/guides/language/language-tour", "type": 301 },
       { "source": "/linter/lints/:lint*", "destination": "/tools/linter-rules#:lint", "type": 301 },
       { "source": "/lints", "destination": "/tools/linter-rules", "type": 301 },

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -46,8 +46,8 @@
       children:
         - title: Built-in types
           permalink: /language/built-in-types
-        - title: Collection types
-          permalink: /language/collection-types
+        - title: Collections
+          permalink: /language/collections
         - title: Typedefs
           permalink: /language/typedefs
         - title: Generics

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -516,8 +516,8 @@ for including the contents of other collections,
 and [`if` and `for`][control] for performing control flow while
 building the contents:
 
-[spread]: /language/collection-types#spread-operators
-[control]: /language/collection-types#collection-operators
+[spread]: /language/collections#spread-operators
+[control]: /language/collections#collection-operators
 
 {:.good}
 <?code-excerpt "usage_good.dart (spread-etc)"?>

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -408,8 +408,8 @@ For more information about how language versioning works, see the
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
 [calling native C code]: /guides/libraries/c-interop
-[collection for]: /language/collection-types#collection-operators
-[collection if]: /language/collection-types#collection-operators
+[collection for]: /language/collections#collection-operators
+[collection if]: /language/collections#collection-operators
 [Dart library]: /guides/libraries/create-library-packages#organizing-a-library-package
 [`dart compile`]: /tools/dart-compile
 [Dart FFI]: /guides/libraries/c-interop
@@ -424,8 +424,8 @@ For more information about how language versioning works, see the
 [null safety]: /null-safety
 [pub outdated]: /tools/pub/cmd/pub-outdated
 [SDK changelog]: https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md
-[set literals]: /language/collection-types#sets
+[set literals]: /language/collections#sets
 [sound null safety]: /null-safety
 [sound type system]: /language/type-system
-[spread operator]: /language/collection-types#spread-operators
+[spread operator]: /language/collections#spread-operators
 [type aliases]: /language/typedefs

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -59,15 +59,15 @@ This content has moved to [Collections](/language/collections#lists).
 <a id="trailing-comma"></a>
 #### Trailing commas
 
-This content has moved to [Collection types](/language/collection-types#trailing-commas).
+This content has moved to [Collections](/language/collections#trailing-commas).
 
 #### Spread operator
 
-This content has moved to [Collection types](/language/collection-types#spread-operator).
+This content has moved to [Collections](/language/collections#spread-operator).
 
 #### Collection operators
 
-This content has moves to [Collection types](/language/collection-types#collection-operators).
+This content has moves to [Collections](/language/collections#collection-operators).
 
 ### Sets
 

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -56,6 +56,19 @@ This content has moved to [Built-in types](/language/built-in-types#booleans).
 
 This content has moved to [Collection types](/language/collection-types#lists).
 
+<a id="trailing-comma"></a>
+#### Trailing commas
+
+This content has moved to [Collections](/language/collections#trailing-commas).
+
+#### Spread operator
+
+This content has moved to [Collections](/language/collections#spread-operator).
+
+#### Collection operators
+
+This content has moves to [Collections](/language/collections#collection-operators).
+
 ### Sets
 
 This content has moved to [Collection types](/language/collection-types#sets).
@@ -64,6 +77,7 @@ This content has moved to [Collection types](/language/collection-types#sets).
 
 This content has moved to [Collection types](/language/collection-types#maps).
 
+<a id="characters"></a>
 ### Runes and grapheme clusters
 
 This content has moved to [Built-in types](/language/built-in-types#runes-and-grapheme-clusters).
@@ -83,6 +97,10 @@ This content has moved to [Functions](/language/functions#parameters).
 #### Named parameters
 
 This content has moved to [Functions](/language/functions#named-parameters).
+
+#### Default parameters
+
+This content has moved to [Functions](/language/functions#default-parameters).
 
 #### Optional positional parameters
 
@@ -148,6 +166,7 @@ This content has moved to [Operators](/language/operators#bitwise-and-shift-oper
 
 This content has moved to [Operators](/language/operators#conditional-operators).
 
+<a id="cascade"></a>
 ### Cascade notation
 
 This content has moved to [Operators](/language/operators#cascade-notation).
@@ -246,7 +265,6 @@ This content has moved to [Constructors](/language/constructors#named-constructo
 
 This content has moved to [Constructors](/language/constructors#invoking-a-non-default-superclass-constructor).
 
-<a name="super-parameters"></a>
 ### Super parameters
 
 This content has moved to [Constructors](/language/constructors#super-parameters).
@@ -305,8 +323,7 @@ This content has moved to [Classes](/language/classes#implicit-interfaces).
 
 This content has moved to [Extend a class](/language/extend).
 
-<a name="overridable-operators"></a>
-
+<a id="overridable-operators"></a>
 #### Overriding members
 
 This content has moved to [Extend a class](/language/extend#overriding-members).
@@ -318,7 +335,6 @@ This content has moved to [Extend a class](/language/extend#nosuchmethod).
 ### Extension methods
 
 This content has moved to [Extension methods](/language/extension-methods).
-
 
 <a id="enums"></a>
 ### Enumerated types
@@ -336,7 +352,6 @@ This content has moved to [Enumerated types](/language/enum#declaring-enhanced-e
 #### Using enums
 
 This content has moved to [Enumerated types](/language/enum#using-enums).
-
 
 <a id="mixins"></a>
 ### Adding features to a class: mixins

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -54,7 +54,7 @@ This content has moved to [Built-in types](/language/built-in-types#booleans).
 
 ### Lists
 
-This content has moved to [Collection types](/language/collection-types#lists).
+This content has moved to [Collection types](/language/collections#lists).
 
 <a id="trailing-comma"></a>
 #### Trailing commas
@@ -71,11 +71,11 @@ This content has moves to [Collection types](/language/collection-types#collecti
 
 ### Sets
 
-This content has moved to [Collection types](/language/collection-types#sets).
+This content has moved to [Collection types](/language/collections#sets).
 
 ### Maps
 
-This content has moved to [Collection types](/language/collection-types#maps).
+This content has moved to [Collection types](/language/collections#maps).
 
 <a id="characters"></a>
 ### Runes and grapheme clusters

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -54,7 +54,7 @@ This content has moved to [Built-in types](/language/built-in-types#booleans).
 
 ### Lists
 
-This content has moved to [Collection types](/language/collections#lists).
+This content has moved to [Collections](/language/collections#lists).
 
 <a id="trailing-comma"></a>
 #### Trailing commas
@@ -71,11 +71,11 @@ This content has moves to [Collection types](/language/collection-types#collecti
 
 ### Sets
 
-This content has moved to [Collection types](/language/collections#sets).
+This content has moved to [Collections](/language/collections#sets).
 
 ### Maps
 
-This content has moved to [Collection types](/language/collections#maps).
+This content has moved to [Collections](/language/collections#maps).
 
 <a id="characters"></a>
 ### Runes and grapheme clusters

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -59,15 +59,15 @@ This content has moved to [Collection types](/language/collection-types#lists).
 <a id="trailing-comma"></a>
 #### Trailing commas
 
-This content has moved to [Collections](/language/collections#trailing-commas).
+This content has moved to [Collection types](/language/collection-types#trailing-commas).
 
 #### Spread operator
 
-This content has moved to [Collections](/language/collections#spread-operator).
+This content has moved to [Collection types](/language/collection-types#spread-operator).
 
 #### Collection operators
 
-This content has moves to [Collections](/language/collections#collection-operators).
+This content has moves to [Collection types](/language/collection-types#collection-operators).
 
 ### Sets
 

--- a/src/index.html
+++ b/src/index.html
@@ -114,8 +114,8 @@ js:
                                 <div class="bullet-text">
                                     A programming language optimized for building user
                                     interfaces with features such as <a href="/null-safety">sound null safety</a>,
-                                    the <a href="/language/collection-types#spread-operators">spread operator</a> for
-                                    expanding collections, and <a href="/language/collection-types#collection-operators">collection if</a> for
+                                    the <a href="/language/collections#spread-operators">spread operator</a> for
+                                    expanding collections, and <a href="/language/collections#collection-operators">collection if</a> for
                                     customizing UI for each platform
                                 </div>
                             </div>
@@ -276,8 +276,8 @@ js:
                                 <div class="bullet-text">
                                     A programming language optimized for building user
                                     interfaces with features such as <a href="/null-safety">sound null safety</a>,
-                                    the <a href="/language/collection-types#spread-operators">spread operator</a> for
-                                    expanding collections, and <a href="/language/collection-types#collection-operators">collection if</a> for
+                                    the <a href="/language/collections#spread-operators">spread operator</a> for
+                                    expanding collections, and <a href="/language/collections#collection-operators">collection if</a> for
                                     customizing UI for each platform
                                 </div>
                             </div>

--- a/src/language/built-in-types.md
+++ b/src/language/built-in-types.md
@@ -396,9 +396,9 @@ Symbol literals are compile-time constants.
 
 
 
-[Lists]: /language/collection-types#lists
-[Sets]: /language/collection-types#sets
-[Maps]: /language/collection-types#maps
+[Lists]: /language/collections#lists
+[Sets]: /language/collections#sets
+[Maps]: /language/collections#maps
 [asynchrony support]: /language/async
 [iteration]: /guides/libraries/library-tour#iteration
 [generator functions]: /language/generators

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -1,6 +1,6 @@
 ---
-title: Collection types
-description: Summary of collection types in Dart.
+title: Collections
+description: Summary of types of collections in Dart.
 ---
 
 ## Lists

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -1,6 +1,6 @@
 ---
 title: Collections
-description: Summary of types of collections in Dart.
+description: Summary of the different types of collections in Dart.
 ---
 
 ## Lists

--- a/src/language/control-flow.md
+++ b/src/language/control-flow.md
@@ -298,7 +298,7 @@ the arguments to `assert` aren't evaluated.
 [forEach()]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable/forEach.html
 [`Iterable`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
 [Enumerated types]: /language/enum
-[trailing comma]: /language/collection-types#lists
+[trailing comma]: /language/collections#lists
 [`AssertionError`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
 [Flutter debug mode]: {{site.flutter-docs}}/testing/debugging#debug-mode-assertions
 [webdev serve]: /tools/webdev#serve

--- a/src/language/enum.md
+++ b/src/language/enum.md
@@ -153,7 +153,7 @@ print(Color.blue.name); // 'blue'
 ```
 
 [`Enum`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Enum-class.html
-[trailing commas]: /language/collection-types#lists
+[trailing commas]: /language/collections#lists
 [classes]: /language/classes
 [mixins]: /language/mixins
 [generative constructors]: /language/constructors#constant-constructors

--- a/src/language/functions.md
+++ b/src/language/functions.md
@@ -445,4 +445,4 @@ assert(foo() == null);
 [if statement]: /language/control-flow#if-and-else
 [conditional expression]: /language/operators#conditional-expressions
 [Flutter]: {{site.flutter}}
-[trailing commas]: /language/collection-types#lists
+[trailing commas]: /language/collections#lists

--- a/src/language/variables.md
+++ b/src/language/variables.md
@@ -241,8 +241,8 @@ For more information on using `const` to create constant values, see
 [Instance variables]: /language/classes#instance-variables
 [DON’T use const redundantly]: /guides/language/effective-dart/usage#dont-use-const-redundantly
 [type checks and casts]: /language/operators#type-test-operators
-[collection `if`]: /language/collection-types#collection-operators
-[spread operators]: /language/collection-types#spread-operators
-[Lists]: /language/collection-types#lists
-[Maps]: /language//collection-types#maps
+[collection `if`]: /language/collections#collection-operators
+[spread operators]: /language/collections#spread-operators
+[Lists]: /language/collections#lists
+[Maps]: /language/collections#maps
 [Classes]: /language/classes


### PR DESCRIPTION
Blocked on https://github.com/dart-lang/site-www/pull/4647

"Collection types" makes me think of the generic type of a collection rather than collections themselves.

Overall, I think "Collections" is more intuitive. I suppose it could be "Built-in collections" but let me know what you think.