### PR TITLE
Remove duplicated entries from merge handling

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -68,19 +68,6 @@ This content has moved to [Collections](/language/collections#spread-operator).
 
 This content has moves to [Collections](/language/collections#collection-operators).
 
-<a id="trailing-comma"></a>
-#### Trailing commas
-
-This content has moved to [Collection types](/language/collection-types#trailing-commas).
-
-#### Spread operator
-
-This content has moved to [Collection types](/language/collection-types#spread-operator).
-
-#### Collection operators
-
-This content has moves to [Collection types](/language/collection-types#collection-operators).
-
 ### Sets
 
 This content has moved to [Collections](/language/collections#sets).


### PR DESCRIPTION
One of the PRs was blocked on the other, and wasn't rebased when the first got in, causing these outdated entries to be reintroduced on accident.