### PR TITLE
Fix 'Conditional expressions' textual redirect

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -176,7 +176,7 @@ This content has moved to [Operators](/language/operators#bitwise-and-shift-oper
 
 ### Conditional expressions
 
-This content has moved to [Operators](/language/operators#conditional-operators).
+This content has moved to [Operators](/language/operators#conditional-expressions).
 
 <a id="cascade"></a>
 ### Cascade notation


### PR DESCRIPTION
This entry should point to [Conditional expressions](https://dart.dev/language/operators#conditional-expressions), there is no **Conditional operators** entry on the linked page.