### PR TITLE
Updated Language Evolution for chrono descending, plus clean up

### DIFF
--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -8,7 +8,7 @@ This page lists notable changes and additions to the
 Dart programming language.
 
 * To learn specific details about the most recent supported language version,
-check out the [language documentation][] or the [language specification][].
+  check out the [language documentation][] or the [language specification][].
 * For a full history of changes to the Dart SDK, see the [SDK changelog][].
 
 To use a language feature introduced after 2.0,
@@ -28,9 +28,10 @@ environment:
 [language versioning section]: #language-versioning
 
 {{site.alert.tip}}
-  To review the features being discussed, investigated, and added to
-  the Dart language,
-  check out the [language funnel][] tracker in the Dart language GitHub repo.
+  To review the features being discussed, investigated, and
+  added to the Dart language,
+  check out the [language funnel][] tracker
+  on the Dart language GitHub repo.
 {{site.alert.end}}
 
 
@@ -283,8 +284,8 @@ Widget build(BuildContext context) {
 ```
 
 The **[collection for][]** operator enables building repeated elements.
-The following example adds one `HeadingAction` element for each section
-in `sections`:
+The following example adds one `HeadingAction` element for 
+each section in `sections`:
 
 ```dart
 Widget build(BuildContext context) {
@@ -301,8 +302,7 @@ Widget build(BuildContext context) {
 _Released 26 February 2019_
 | [Dart 2.2 announcement](https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-support-for-set-literals-7e2ab19cc86d)
 
-Dart supports literal lists and maps, but Dart 2.2 added support for
-**[set literals][]**:
+Dart 2.2 added support for **[set literals][]**:
 
 ```dart
 const Set<String> currencies = {'EUR', 'USD', 'JPY'};
@@ -330,9 +330,10 @@ padding: const EdgeInsets.symmetric(
 _Released 22 February 2018_
 | [Dart 2.0 announcement](https://medium.com/dartlang/announcing-dart-2-80ba01f43b6)
 
-Dart 2.0 implemented a new **[sound type system][]**. Before Dart 2.0,
-types weren't fully sound, and Dart relied heavily on runtime type
-checking. Dart 1.x code had to be [migrated to Dart 2][].
+Dart 2.0 implemented a new **[sound type system][]**. 
+Before Dart 2.0, types weren't fully sound, and 
+Dart relied heavily on runtime type checking. 
+Dart 1.x code had to be [migrated to Dart 2][].
 
 ## Language versioning
 
@@ -381,7 +382,7 @@ Deriving the language version from the SDK version
 implies the following:
 
 * Whenever a minor version of the SDK ships, a new language version appears.
-  In practice, many of these language versions function in very
+  In practice, many of these language versions function in a very
   similar manner to previous versions with full compatibility.
   For example, the Dart 2.9 language works much like the Dart 2.8
   language.
@@ -395,8 +396,8 @@ implies the following:
 ### Per-library language version selection
 
 By default, every Dart file in a package uses the same language version.
-The pubspec YAML file identifies this language version as the lower SDK
-constraint.
+Dart identifies the default language version as the 
+lower-bound of the SDK constraint specified in the `pubspec.yaml` file.
 Sometimes, a Dart file might need to use an older language version.
 For example, you might not be able to migrate all the files in a package
 to null safety at the same time.

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -63,20 +63,19 @@ library;
 _Released 30 August 2022_
 | [Dart 2.18 announcement](https://medium.com/dartlang/dart-2-18-f4b3101f146c)
 
-Dart 2.18 enhanced type inference. 
-This change allows information flow between 
-arguments in generic function calls. 
-Before 2.18, if you didn't specify an
-argument's type in some methods, Dart reported errors. 
-These type errors cited potential null occurrences. 
-With 2.18, the compiler infers the argument type 
-from other values in an invocation. 
+Dart 2.18 enhanced type inference.
+This change allows information flow between arguments in generic function calls.
+Before 2.18, if you didn't specify an argument's type in some methods,
+Dart reported errors.
+These type errors cited potential null occurrences.
+With 2.18, the compiler infers the argument type
+from other values in an invocation.
 You don't need to specify the argument type inline.
 
 Dart 2.18 also discontinued support for mixin classes that don't extend
 `Object`.
 
-To learn more about Dart 2.18, check out:
+To learn more about these features, check out:
 
 * [Type argument inference][]
 * [Adding features to a class: mixins][]
@@ -85,7 +84,7 @@ To learn more about Dart 2.18, check out:
 [Adding features to a class: mixins]: /language/mixins
 
 ### Dart 2.17
-_Released 11 May 2022_ 
+_Released 11 May 2022_
 | [Dart 2.17 announcement](https://medium.com/dartlang/dart-2-17-b216bfc80c5d)
 
 Dart 2.17 expanded enum functionality with enhanced enums.
@@ -111,7 +110,7 @@ void main() {
 }
 ```
 
-To learn more about Dart 2.17, check out:
+To learn more about these features, check out:
 
 * [Enhanced enums][]
 * [Super parameters][]
@@ -125,8 +124,7 @@ To learn more about Dart 2.17, check out:
 _Released 3 February 2022_
 | [Dart 2.16 announcement](https://medium.com/dartlang/dart-2-15-7e7a598e508a)
 
-Dart 2.16 added no new features to the Dart language, but fixed one
-security vulnerability and made two breaking changes.
+Dart 2.16 added no new features to the Dart language.
 It did expand the Dart tools.
 
 ### Dart 2.15
@@ -144,6 +142,10 @@ Dart 2.14 added the unsigned shift (or _triple-shift_) operator (`>>>`).
 This new operator works like `>>`,
 except that it always fills the most significant bits with zeros.
 
+To learn more about these operators, check out [bitwise and shift operator][].
+
+[bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
+
 Dart 2.14 removed some restrictions on type arguments.
 You can pass type arguments to annotations and use a generic function
 type as a type argument.
@@ -155,10 +157,6 @@ late List<T Function<T>(T)> idFunctions;
 var callback = [<T>(T value) => value];
 late S Function<S extends T Function<T>(T)>(S) f;
 ```
-
-To learn more about these operators, check out [bitwise and shift operator][].
-
-[bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
 
 ### Dart 2.13
 _Released 19 May 2021_
@@ -193,6 +191,10 @@ Dart 2.10 added no new features to the Dart language.
 It did add an expanded [`dart` tool][dart-tool] similar to the
 Flutter SDK's [`flutter` tool][].
 
+### Dart 2.9
+
+Dart 2.9 added no new features to the Dart language.
+
 ### Dart 2.8
 _Released 6 May 2020_
 | [Dart 2.8 announcement](https://medium.com/dartlang/announcing-dart-2-8-7750918db0a)
@@ -209,11 +211,9 @@ _Released 11 December 2019_
 | [Dart 2.7 announcement](https://medium.com/dartlang/dart-2-7-a3710ec54e97)
 
 Dart 2.7 added support for **[extension methods][]**,
-enabling you to add functionality to any type—even types you don’t control—with
-the brevity and auto-complete experience of regular method calls.
-Because the tech preview for this feature was in 2.6,
-you can use extension methods without warnings if you
-specify 2.6.0 or a later release as the lower SDK constraint.
+enabling you to add functionality to any type
+—-even types you don’t control—-
+with the brevity and auto-complete experience of regular method calls.
 
 The following example extends the `String` class from
 `dart:core` with a new `parseInt()` method:
@@ -235,7 +235,23 @@ void main() {
 _Released 5 November 2019_
 | [Dart 2.6 announcement](https://medium.com/dartlang/dart2native-a76c815e6baf)
 
-Dart 2.6 added a new compiler that has since been retired.
+Dart 2.6 introduced a
+[breaking change (dart-lang/sdk#37985)](https://github.com/dart-lang/sdk/issues/37985).
+Inference changes when using Null values in a `FutureOr` context.
+Constraints of the forms similar to `Null <:FutureOr` now yield `Null`
+as the solution for `T`.
+
+For example: The following code now prints `Null`.
+Before Dart 2.6, it printed `dynamic`.
+The anonymous closure `() {}` returns the `Null` type.
+
+```dart
+import 'dart:async';
+
+void foo<T>(FutureOr<T> Function() f) { print(T); }
+
+main() { foo(() {}); }
+```
 
 ### Dart 2.5
 _Released 10 September 2019_
@@ -244,6 +260,24 @@ _Released 10 September 2019_
 Dart 2.5 didn't add any features to the Dart language, but it did add
 support for [calling native C code][] from Dart code
 using a new **core library, `dart:ffi`.**
+
+### Dart 2.4
+_Released 27 June 2019_
+
+
+Dart 2.4 introduces a breaking change
+[dart-lang/sdk#35097](https://github.com/dart-lang/sdk/issues/35097).
+
+Dart now enforces covariance of type variables used in super-interfaces.
+For example: Prior to this release Dart accepted, but now rejects,
+the following code:
+
+```dart
+class A<X> {};
+class B<X> extends A<void Function(X)> {};
+```
+
+You can now use the identifier async in asynchronous and generator functions.
 
 ### Dart 2.3
 _Released 8 May 2019_
@@ -282,7 +316,7 @@ Widget build(BuildContext context) {
 ```
 
 The **[collection for][]** operator enables building repeated elements.
-The following example adds one `HeadingAction` element for 
+The following example adds one `HeadingAction` element for
 each section in `sections`:
 
 ```dart
@@ -329,9 +363,9 @@ padding: const EdgeInsets.symmetric(
 _Released 22 February 2018_
 | [Dart 2.0 announcement](https://medium.com/dartlang/announcing-dart-2-80ba01f43b6)
 
-Dart 2.0 implemented a new **[sound type system][]**. 
-Before Dart 2.0, types weren't fully sound, and 
-Dart relied heavily on runtime type checking. 
+Dart 2.0 implemented a new **[sound type system][]**.
+Before Dart 2.0, types weren't fully sound, and
+Dart relied heavily on runtime type checking.
 Dart 1.x code had to be [migrated to Dart 2][].
 
 ## Language versioning
@@ -344,63 +378,63 @@ and it interprets the code according to that version.
 Language versioning becomes important on the rare occasions when Dart
 introduces an incompatible feature like [null safety][].
 When Dart introduces a breaking change, code that
-did compile might no longer compile. 
-Language versioning allows you to maintain compatibility
-by configuring each library's language version.
+did compile might no longer compile.
+Language versioning allows you to set each library's language version
+to maintain compatibility.
 
 In the case of null safety, Dart SDKs 2.12 through 2.19 allowed you
 to _choose_ to update your code to use null safety.
 Dart uses language versioning to permit non-null-safe code to run
 alongside null-safe code.
 This decision enabled migration from non-null-safe to null-safe code.
-To check out an example of how an app or package can migrate to a new
+To review an example of how an app or package can migrate to a new
 language version with an incompatible feature, check out
 [Migrating to null safety](/null-safety/migration-guide).
 
-Each package has a default language version, equal to the
-`<major>.<minor>` part of the **lower SDK constraint** in the pubspec.
+Each package has a default language version
+equal to the **lower bound of the SDK constraint** in the `pubspec.yaml` file.
 
-**For example:** the following entry in a `pubspec.yaml` file
-indicates that this package uses the Dart 2.18 language version.
+**For example:** The following entry in a `pubspec.yaml` file
+indicates that this package uses the Dart 2.18 language version or later.
 
 ```yaml
 environment:
   sdk: '>=2.18.0 <3.0.0'
 ```
 
-
 ### Language version numbers
 
-Dart language versions follow semantic versioning with
-a major version number and a minor version number.
-Dart language versions can include a patch number.
+Dart formats its language versions as two numbers separated with a period.
+It reads as a major version number and a minor version number.
+Though this appears to follow semantic versioning, it does not.
+Minor version numbers might introduce breaking changes.
+
+Dart releases might append a patch number to a language version.
 Patches should not change the language except for bug fixes.
 To illustrate: Dart 2.18.3 serves as the latest release of the
-Dart 2.18 SDK.
+Dart 2.18 SDK language version.
+
 Each Dart SDK supports all of the language versions within its major
 version number.
 That means that Dart SDK 2.18.3 supports language versions
 2.0 through 2.18 inclusive, but not Dart 1.x.
 
-Deriving the language version from the SDK version
-implies the following:
+Deriving the language version from the SDK version implies the following:
 
 * Whenever a minor version of the SDK ships, a new language version appears.
-  In practice, many of these language versions function in a very
-  similar manner to previous versions with full compatibility.
-  For example, the Dart 2.9 language works much like the Dart 2.8
-  language.
+  In practice, many of these language versions work in a very similar manner
+  to previous versions and have with full compatibility between them.
+  For example: The Dart 2.9 language works much like the Dart 2.8 language.
 
-* When a patch version of the SDK ships,
-  it cannot introduce any language features.
-  For example, because 2.18.3 belongs to language version 2.18,
-  it must remain compatible with 2.18.1 and 2.18.0.
-
+* When a patch release of the SDK ships,
+  it cannot introduce new language features.
+  For example: The 2.18.3 release _remains_ language version 2.18.
+  It must remain compatible with 2.18.2, 2.18.1, and 2.18.0.
 
 ### Per-library language version selection
 
 By default, every Dart file in a package uses the same language version.
-Dart identifies the default language version as the 
+Dart identifies the default language version as the
 lower-bound of the SDK constraint specified in the `pubspec.yaml` file.
 Sometimes, a Dart file might need to use an older language version.
 For example, you might not be able to migrate all the files in a package
@@ -431,8 +465,8 @@ except within the `@dart` and version strings.
 As the previous example shows,
 other comments can appear before the `@dart` comment.
 
-To learn how language versioning works, check out the
-[language versioning specification][language versioning feature].
+To learn how and why the Dart team developed this versioning method,
+check out the [language versioning specification][].
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
 [calling native C code]: /guides/libraries/c-interop
@@ -447,7 +481,7 @@ To learn how language versioning works, check out the
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language specification]: /guides/language/spec
 [language documentation]: /language
-[language versioning feature]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/feature-specification.md#dart-language-versioning
+[language versioning specification]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/feature-specification.md#dart-language-versioning
 [migrated to Dart 2]: /articles/archive/dart-2
 [null safety]: /null-safety
 [pub outdated]: /tools/pub/cmd/pub-outdated

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -20,7 +20,7 @@ set `2.12.0` as the lower constraint in the `pubspec.yaml` file.
 
 ```yaml
 environment:
-  sdk: ^2.12.0
+  sdk: '>=2.12.0 <3.0.0'
 ```
 
 [2.12]: #dart-212
@@ -63,12 +63,15 @@ library;
 _Released 30 August 2022_
 | [Dart 2.18 announcement](https://medium.com/dartlang/dart-2-18-f4b3101f146c)
 
-Dart 2.18 enhanced type inference. This change allows information flow between
-arguments in generic function calls. Before 2.18, if you didn't specify an
-argument's type in some methods, Dart returned errors. These type errors cited
-potential null occurrences. With 2.18, the compiler infers the argument type
-from other values in an invocation. You don't need to specify the argument type
-inline.
+Dart 2.18 enhanced type inference. 
+This change allows information flow between 
+arguments in generic function calls. 
+Before 2.18, if you didn't specify an
+argument's type in some methods, Dart reported errors. 
+These type errors cited potential null occurrences. 
+With 2.18, the compiler infers the argument type 
+from other values in an invocation. 
+You don't need to specify the argument type inline.
 
 Dart 2.18 also discontinued support for mixin classes that don't extend
 `Object`.
@@ -340,11 +343,12 @@ and it interprets the code according to that version.
 
 Language versioning becomes important on the rare occasions when Dart
 introduces an incompatible feature like [null safety][].
-When Dart introduces a breaking change, code that did compile
-might no longer compile. Using language versions allows you to indicate
-the compatibility of the code using the `pubspec.yaml` file.
+When Dart introduces a breaking change, code that
+did compile might no longer compile. 
+Language versioning allows you to maintain compatibility
+by configuring each library's language version.
 
-In the case of null safety, Dart versions 2.12 through 2.19 allowed you
+In the case of null safety, Dart SDKs 2.12 through 2.19 allowed you
 to _choose_ to update your code to use null safety.
 Dart uses language versioning to permit non-null-safe code to run
 alongside null-safe code.
@@ -361,7 +365,7 @@ indicates that this package uses the Dart 2.18 language version.
 
 ```yaml
 environment:
-  sdk: ^2.18.0
+  sdk: '>=2.18.0 <3.0.0'
 ```
 
 
@@ -390,7 +394,7 @@ implies the following:
 * When a patch version of the SDK ships,
   it cannot introduce any language features.
   For example, because 2.18.3 belongs to language version 2.18,
-  it must remain compatible with 2.17.1 and 2.17.0.
+  it must remain compatible with 2.18.1 and 2.18.0.
 
 
 ### Per-library language version selection
@@ -402,9 +406,9 @@ Sometimes, a Dart file might need to use an older language version.
 For example, you might not be able to migrate all the files in a package
 to null safety at the same time.
 
-The Dart 2.8 compiler introduced support for per-library language
-version selection.
-To opt to have a different language version, a [Dart library][] must
+Dart supports for per-library language version selection.
+To opt to have a different language version from
+the rest of a package, a [Dart library][] must
 include a comment in the following format:
 
 ```dart

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -142,9 +142,9 @@ Dart 2.14 added the unsigned shift (or _triple-shift_) operator (`>>>`).
 This new operator works like `>>`,
 except that it always fills the most significant bits with zeros.
 
-To learn more about these operators, check out [bitwise and shift operator][].
+To learn more about these operators, check out [bitwise and shift operators][].
 
-[bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
+[bitwise and shift operators]: /language/operators#bitwise-and-shift-operators
 
 Dart 2.14 removed some restrictions on type arguments.
 You can pass type arguments to annotations and use a generic function
@@ -188,10 +188,9 @@ _Released 1 October 2020_
 | [Dart 2.10 announcement](https://medium.com/dartlang/announcing-dart-2-10-350823952bd5)
 
 Dart 2.10 added no new features to the Dart language.
-It did add an expanded [`dart` tool][dart-tool] similar to the
-Flutter SDK's [`flutter` tool][].
 
 ### Dart 2.9
+_Released 5 August 2020_
 
 Dart 2.9 added no new features to the Dart language.
 
@@ -202,9 +201,6 @@ _Released 6 May 2020_
 Dart 2.8 didn't add any features to the Dart language. It did
 contain a number of preparatory [breaking changes][2.8 breaking changes]
 to improve nullability-related usability and performance for [null safety][].
-
-It improved the performance of the `pub` tool and
-added the [`pub outdated`][] command.
 
 ### Dart 2.7
 _Released 11 December 2019_
@@ -237,9 +233,8 @@ _Released 5 November 2019_
 
 Dart 2.6 introduced a
 [breaking change (dart-lang/sdk#37985)](https://github.com/dart-lang/sdk/issues/37985).
-Inference changes when using Null values in a `FutureOr` context.
-Constraints of the forms similar to `Null <:FutureOr` now yield `Null`
-as the solution for `T`.
+Constraints of the forms similar to `Null` serves as a subtype of `FutureOr`
+now yield `Null` as the solution for `T`.
 
 For example: The following code now prints `Null`.
 Before Dart 2.6, it printed `dynamic`.
@@ -277,7 +272,7 @@ class A<X> {};
 class B<X> extends A<void Function(X)> {};
 ```
 
-You can now use the identifier async in asynchronous and generator functions.
+You can now use `async` as an identifier in asynchronous and generator functions.
 
 ### Dart 2.3
 _Released 8 May 2019_
@@ -391,8 +386,8 @@ To review an example of how an app or package can migrate to a new
 language version with an incompatible feature, check out
 [Migrating to null safety](/null-safety/migration-guide).
 
-Each package has a default language version
-equal to the **lower bound of the SDK constraint** in the `pubspec.yaml` file.
+Each package has a default language version equal to the **lower bound**
+of the SDK constraint in the `pubspec.yaml` file.
 
 **For example:** The following entry in a `pubspec.yaml` file
 indicates that this package uses the Dart 2.18 language version or later.
@@ -406,7 +401,6 @@ environment:
 
 Dart formats its language versions as two numbers separated with a period.
 It reads as a major version number and a minor version number.
-Though this appears to follow semantic versioning, it does not.
 Minor version numbers might introduce breaking changes.
 
 Dart releases might append a patch number to a language version.

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -12,10 +12,10 @@ Dart programming language.
 * For a full history of changes to the Dart SDK, see the [SDK changelog][].
 
 To use a language feature introduced after 2.0,
-set [SDK constraints][] no lower than
+set an [SDK constraint][] no lower than
 the release when Dart first supported that feature.
 
-To use null safety, introduced in [2.12][],
+**For example:** To use null safety, introduced in [2.12][],
 set `2.12.0` as the lower constraint in the `pubspec.yaml` file.
 
 ```yaml
@@ -24,7 +24,7 @@ environment:
 ```
 
 [2.12]: #dart-212
-[SDK constraints]: /tools/pub/pubspec#sdk-constraints
+[SDK constraint]: /tools/pub/pubspec#sdk-constraints
 [language versioning section]: #language-versioning
 
 {{site.alert.tip}}
@@ -137,8 +137,7 @@ In particular, constructor tear-offs are now supported.
 _Released 8 September 2021_
 | [Dart 2.14 announcement](https://medium.com/dartlang/announcing-dart-2-14-b48b9bb2fb67)
 
-Dart 2.14 added the unsigned shift operator (`>>>`),
-known as _triple-shift_.
+Dart 2.14 added the unsigned shift (or _triple-shift_) operator (`>>>`).
 This new operator works like `>>`,
 except that it always fills the most significant bits with zeros.
 
@@ -154,7 +153,7 @@ var callback = [<T>(T value) => value];
 late S Function<S extends T Function<T>(T)>(S) f;
 ```
 
-To learn more about Dart 2.14, check out [bitwise and shift operator][].
+To learn more about these operators, check out [bitwise and shift operator][].
 
 [bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
 
@@ -195,12 +194,12 @@ Flutter SDK's [`flutter` tool][].
 _Released 6 May 2020_
 | [Dart 2.8 announcement](https://medium.com/dartlang/announcing-dart-2-8-7750918db0a)
 
-Dart 2.8 didn't add any features to the Dart language, but it did
+Dart 2.8 didn't add any features to the Dart language. It did
 contain a number of preparatory [breaking changes][2.8 breaking changes]
-to ensure great nullability-related usability and performance in the
-upcoming [null safety][] feature.
+to improve nullability-related usability and performance for [null safety][].
 
-It also contained a faster pub tool, and a new [pub outdated][] command.
+It improved the performance of the `pub` tool and
+added the [`pub outdated`][] command.
 
 ### Dart 2.7
 _Released 11 December 2019_
@@ -213,8 +212,8 @@ Because the tech preview for this feature was in 2.6,
 you can use extension methods without warnings if you
 specify 2.6.0 or a later release as the lower SDK constraint.
 
-The following example extends the `String` class from `dart:core` with a new
-`parseInt()` method:
+The following example extends the `String` class from
+`dart:core` with a new `parseInt()` method:
 
 ```dart
 extension ParseNumbers on String {
@@ -233,10 +232,7 @@ void main() {
 _Released 5 November 2019_
 | [Dart 2.6 announcement](https://medium.com/dartlang/dart2native-a76c815e6baf)
 
-Dart 2.6 didn't add any features to the Dart language, but it did add a
-**new tool, `dart2native`,** for compiling Dart code to native
-executables.
-This functionality has been folded into the [`dart compile`][] command.
+Dart 2.6 added a new compiler that has since been retired.
 
 ### Dart 2.5
 _Released 10 September 2019_
@@ -268,10 +264,9 @@ Widget build(BuildContext context) {
 }
 ```
 
-The **[collection if][]** operator enables adding elements that meet
-conditions.
-The following example adds a `FlatButton` element unless this element
-falls on the last page:
+The **[collection if][]** operator enables adding elements conditionally.
+The following example adds a `FlatButton` element unless
+the app displays the last page:
 
 ```dart
 Widget build(BuildContext context) {
@@ -312,10 +307,11 @@ const Set<String> currencies = {'EUR', 'USD', 'JPY'};
 _Released 15 November 2018_
 | [Dart 2.1 announcement](https://medium.com/dartlang/announcing-dart-2-1-improved-performance-usability-9f55fca6f31a)
 
-Dart 2.1 added support for **int-to-double conversion**, allowing developers to
-set `double` values using integer literals. This feature removed the annoyance
-of being forced to use a `double` literal (for example, `4.0`)
-when the value was conceptually an integer.
+Dart 2.1 added support for **int-to-double conversion**,
+allowing developers to set `double` values using integer literals.
+This feature removed the annoyance of being forced to use a
+`double` literal (for example, `4.0`)
+when the value was an integer in concept.
 
 In the following Flutter code, `horizontal` and `vertical` have type `double`:
 
@@ -344,20 +340,23 @@ and it interprets the code according to that version.
 
 Language versioning becomes important on the rare occasions when Dart
 introduces an incompatible feature like [null safety][].
-Before null safety, code could compile but might crash at runtime.
-With null safety, the code might no longer compile.
-Migrating your apps plus your own and other dependent packages
-to null safety might take a while.
-Dart uses language versioning to support using non-null-safe code
-alongside null-safe code.
+When Dart introduces a breaking change, code that did compile
+might no longer compile. Using language versions allows you to indicate
+the compatibility of the code using the `pubspec.yaml` file.
 
-For an example of how an app or package can migrate to a new language
-version with an incompatible feature, check out
+In the case of null safety, Dart versions 2.12 through 2.19 allowed you
+to _choose_ to update your code to use null safety.
+Dart uses language versioning to permit non-null-safe code to run
+alongside null-safe code.
+This decision enabled migration from non-null-safe to null-safe code.
+To check out an example of how an app or package can migrate to a new
+language version with an incompatible feature, check out
 [Migrating to null safety](/null-safety/migration-guide).
 
 Each package has a default language version, equal to the
 `<major>.<minor>` part of the **lower SDK constraint** in the pubspec.
-For example, the following entry in a `pubspec.yaml` file
+
+**For example:** the following entry in a `pubspec.yaml` file
 indicates that this package uses the Dart 2.18 language version.
 
 ```yaml

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -4,129 +4,206 @@ short-title: Language evolution
 description: Notable changes and additions to the Dart programming language.
 ---
 
-This page lists notable changes and additions to the Dart programming language.
-If you want details about the currently supported language, see the
-[language tour][] or the
-[language specification][].
-For a full history of changes to the Dart SDK, see the [SDK changelog][].
+This page lists notable changes and additions to the
+Dart programming language.
 
-To use a language feature that was introduced after 2.0,
-specify [SDK constraints][] that are no lower than
-the release when the feature was first supported.
-For example, to use null safety, which was [supported starting in 2.12][],
-the `pubspec.yaml` file can have 2.12.0 as the lower constraint:
+* To learn specific details about the most recent supported language version,
+check out the [language documentation][] or the [language specification][].
+* For a full history of changes to the Dart SDK, see the [SDK changelog][].
+
+To use a language feature introduced after 2.0,
+set [SDK constraints][] no lower than
+the release when Dart first supported that feature.
+
+To use null safety, introduced in [2.12][],
+set `2.12.0` as the lower constraint in the `pubspec.yaml` file.
 
 ```yaml
 environment:
   sdk: ">=2.12.0 <3.0.0"
 ```
 
-[supported starting in 2.12]: #dart-212
+[2.12]: #dart-212
 [SDK constraints]: /tools/pub/pubspec#sdk-constraints
 [language versioning section]: #language-versioning
 
 {{site.alert.tip}}
-  For a peek into current features being
-  discussed, investigated, and added to the Dart language,
-  see the [language funnel][] tracker in the Dart language GitHub repo.
+  To review the features being discussed, investigated, and added to
+  the Dart language,
+  check out the [language funnel][] tracker in the Dart language GitHub repo.
 {{site.alert.end}}
 
 
 ## Changes in each release
 
-### Dart 2.0
+### Dart 2.19
+_Released 25 January 2023_
 
-Dart 2.0 implemented a new **[sound type system][]**. Before
-Dart 2.0, types weren't fully sound, and Dart relied heavily on runtime type
-checking. Dart 1.x code had to be [migrated to Dart 2][].
+Dart 2.19 introduced some precautions surrounding type inference.
+These include:
 
-### Dart 2.1
+* More flow analysis flags for unreachable code cases.
+* No longer delegate inaccessible private names to `noSuchMethod`.
+* Top-level type inference throws on cyclic dependencies.
 
-Dart 2.1 added support for **int-to-double conversion**, allowing developers to
-set `double` values using integer literals. This feature removed the annoyance
-of being forced to use a `double` literal (for example, `4.0`)
-when the value was conceptually an integer.
-In the following Flutter code, `horizontal` and `vertical` have type `double`:
+Dart 2.19 also introduced support for unnamed libraries.
+Library directives, used for appending library-level doc comments and
+annotations, can and [should][] now be written without a name:
 
 ```dart
-padding: const EdgeInsets.symmetric(
-  horizontal: 4,
-  vertical: 8,
-)
+/// A really great test library.
+@TestOn('browser')
+library;
 ```
 
-### Dart 2.2
+[should]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
 
-Dart has always supported literal lists and maps, but
-Dart 2.2 added support for **[set literals][]**:
+### Dart 2.18
+_Released 30 August 2022_
+| [Dart 2.18 announcement](https://medium.com/dartlang/dart-2-18-f4b3101f146c)
+
+Dart 2.18 enhanced type inference. This change allows information flow between
+arguments in generic function calls. Before 2.18, if you didn't specify an
+argument's type in some methods, Dart returned errors. These type errors cited
+potential null occurrences. With 2.18, the compiler infers the argument type
+from other values in an invocation. You don't need to specify the argument type
+inline.
+
+Dart 2.18 also discontinued support for mixin classes that don't extend
+`Object`.
+
+To learn more about Dart 2.18, check out:
+
+* [Type argument inference][]
+* [Adding features to a class: mixins][]
+
+[Type argument inference]: /language/type-system#type-argument-inference
+[Adding features to a class: mixins]: /language/mixins
+
+### Dart 2.17
+_Released 11 May 2022_ 
+| [Dart 2.17 announcement](https://medium.com/dartlang/dart-2-17-b216bfc80c5d)
+
+Dart 2.17 expanded enum functionality with enhanced enums.
+Enhanced enums allow enum declarations to define members
+including fields, constructors, methods, getters, etc.
+
+Dart 2.17 added support for super-initializer parameters in
+constructors.
+Super parameters allow you to avoid having to manually pass each
+parameter into the super invocation of a non-redirecting constructor.
+You can instead use super parameters to forward parameters to a
+superclass constructor.
+
+Dart 2.17 removed some restrictions on named arguments.
+Named arguments can now be freely interleaved with positional arguments.
+As of Dart 2.17, you can write the following code:
 
 ```dart
-const Set<String> currencies = {'EUR', 'USD', 'JPY'};
-```
-### Dart 2.3
-
-Dart 2.3 added three operators designed to improve code that performs
-list manipulation, such as declarative UI code.
-
-The **[spread operator][]**
-enables unpacking the elements from one list into another.
-In the following example, the list returned by `buildMainElements()`
-is unpacked into the list being passed to the `children` argument:
-
-```dart
-Widget build(BuildContext context) {
-  return Column(children: [
-    Header(),
-    ...buildMainElements(),
-    Footer(),
-  ]);
+void main() {
+  test(skip: true, 'A test description', () {
+    // Very long function body here...
+  });
 }
 ```
 
-The **[collection if][]**
-operator enables adding elements conditionally.
-The following example adds a `FlatButton` element
-unless this is the last page:
+To learn more about Dart 2.17, check out:
+
+* [Enhanced enums][]
+* [Super parameters][]
+* [Named parameters][]
+
+[Enhanced enums]: /language/enum#declaring-enhanced-enums
+[Super parameters]: /language/constructors#super-parameters
+[Named parameters]: /language/functions#named-parameters
+
+### Dart 2.16
+_Released 3 February 2022_
+| [Dart 2.16 announcement](https://medium.com/dartlang/dart-2-15-7e7a598e508a)
+
+Dart 2.16 added no new features to the Dart language, but fixed one
+security vulnerability and made two breaking changes.
+It did expand the Dart tools.
+
+### Dart 2.15
+_Released 8 December 2021_
+| [Dart 2.15 announcement](https://medium.com/dartlang/dart-2-15-7e7a598e508a)
+
+Dart 2.15 improved support for function pointers, known as _tear-offs._
+In particular, constructor tear-offs are now supported.
+
+### Dart 2.14
+_Released 8 September 2021_
+| [Dart 2.14 announcement](https://medium.com/dartlang/announcing-dart-2-14-b48b9bb2fb67)
+
+Dart 2.14 added the unsigned shift operator (`>>>`),
+known as _triple-shift_.
+This new operator works like `>>`,
+except that it always fills the most significant bits with zeros.
+
+Dart 2.14 removed some restrictions on type arguments.
+You can pass type arguments to annotations and use a generic function
+type as a type argument.
+As of Dart 2.14, you can write the following code:
 
 ```dart
-Widget build(BuildContext context) {
-  return Column(children: [
-    Text(mainText),
-    if (page != pages.last)
-      FlatButton(child: Text('Next')),
-  ]);
-}
+@TypeHelper<int>(42, "The meaning")
+late List<T Function<T>(T)> idFunctions;
+var callback = [<T>(T value) => value];
+late S Function<S extends T Function<T>(T)>(S) f;
 ```
 
-The **[collection for][]**
-operator enables building repeated elements.
-The following example adds one `HeadingAction`
-element for each section in `sections`:
+To learn more about Dart 2.14, check out [bitwise and shift operator][].
 
-```dart
-Widget build(BuildContext context) {
-  return Column(children: [
-    Text(mainText),
-    for (var section in sections)
-      HeadingAction(section.heading),
-  ]);
-}
-```
+[bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
 
-### Dart 2.5
+### Dart 2.13
+_Released 19 May 2021_
+| [Dart 2.13 announcement](https://medium.com/dartlang/announcing-dart-2-13-c6d547b57067)
 
-Dart 2.5 didn't add any features to the Dart language, but it did add
-support for [calling native C code][] from Dart code
-using a new **core library, `dart:ffi`.**
+Dart 2.13 expanded support for **[type aliases][]** (`typedef`).
+Type aliases used to work only for function types
+but now work for any type.
+You can use the new name created with a type alias
+anywhere the original type could be used.
 
-### Dart 2.6
+Dart 2.13 improved the struct support in **[Dart FFI][]**,
+adding support for inline arrays and packed structs.
 
-Dart 2.6 didn't add any features to the Dart language, but it did add a
-**new tool, `dart2native`,** for compiling Dart code to
-native executables.
-This functionality has since been folded into the [`dart compile`][] command.
+### Dart 2.12
+_Released 3 March 2021_
+| [Dart 2.12 announcement](https://medium.com/dartlang/announcing-dart-2-12-499a6e689c87)
+
+Dart 2.12 added support for **[sound null safety][]**.
+When you opt into null safety, types in your code are non-nullable by default,
+meaning that variables can’t contain null unless you say they can.
+With null safety, your runtime null-dereference errors
+turn into edit-time analysis errors.
+
+In Dart 2.12, **[Dart FFI][]** graduated from beta to the stable channel.
+
+### Dart 2.10
+_Released 1 October 2020_
+| [Dart 2.10 announcement](https://medium.com/dartlang/announcing-dart-2-10-350823952bd5)
+
+Dart 2.10 added no new features to the Dart language.
+It did add an expanded [`dart` tool][dart-tool] similar to the
+Flutter SDK's [`flutter` tool][].
+
+### Dart 2.8
+_Released 6 May 2020_
+| [Dart 2.8 announcement](https://medium.com/dartlang/announcing-dart-2-8-7750918db0a)
+
+Dart 2.8 didn't add any features to the Dart language, but it did
+contain a number of preparatory [breaking changes][2.8 breaking changes]
+to ensure great nullability-related usability and performance in the
+upcoming [null safety][] feature.
+
+It also contained a faster pub tool, and a new [pub outdated][] command.
 
 ### Dart 2.7
+_Released 11 December 2019_
+| [Dart 2.7 announcement](https://medium.com/dartlang/dart-2-7-a3710ec54e97)
 
 Dart 2.7 added support for **[extension methods][]**,
 enabling you to add functionality to any type—even types you don’t control—with
@@ -151,160 +228,111 @@ void main() {
 }
 ```
 
-### Dart 2.8
+### Dart 2.6
+_Released 5 November 2019_
+| [Dart 2.6 announcement](https://medium.com/dartlang/dart2native-a76c815e6baf)
 
-Dart 2.8 didn't add any features to the Dart language, but it did
-contain a number of preparatory [breaking changes][2.8 breaking changes] to ensure great
-nullability-related usability and performance in the upcoming
-[null safety][] feature.
+Dart 2.6 didn't add any features to the Dart language, but it did add a
+**new tool, `dart2native`,** for compiling Dart code to native
+executables.
+This functionality has been folded into the [`dart compile`][] command.
 
-It also contained a faster pub tool, and a new [pub outdated][] command.
+### Dart 2.5
+_Released 10 September 2019_
+| [Dart 2.5 announcement](https://medium.com/dartlang/announcing-dart-2-5-super-charged-development-328822024970)
 
-### Dart 2.9
+Dart 2.5 didn't add any features to the Dart language, but it did add
+support for [calling native C code][] from Dart code
+using a new **core library, `dart:ffi`.**
 
-Dart 2.9 didn't add any features to the Dart language.
+### Dart 2.3
+_Released 8 May 2019_
+| [Dart 2.3 announcement](https://medium.com/dartlang/announcing-dart-2-3-optimized-for-building-user-interfaces-e84919ca1dff)
 
-### Dart 2.10
+Dart 2.3 added three operators designed to improve code that performs
+list manipulation, such as declarative UI code.
 
-Dart 2.10 didn't add any features to the Dart language,
-but it added an expanded [`dart` tool][dart-tool] that's 
-analogous to the Flutter SDK's [`flutter` tool][].
-
-### Dart 2.12
-
-Dart 2.12 added support for **[sound null safety][]**.
-When you opt into null safety, types in your code are non-nullable by default,
-meaning that variables can’t contain null unless you say they can.
-With null safety, your runtime null-dereference errors
-turn into edit-time analysis errors.
-
-In Dart 2.12, **[Dart FFI][]** graduated from beta to the stable channel.
-
-### Dart 2.13
-
-Dart 2.13 expanded support for **[type aliases][]** (`typedef`),
-which used to work only for function types
-but now work for any type.
-You can use the new name created with a type alias
-anywhere the original type could be used.
-
-Dart 2.13 also improved the struct support in **[Dart FFI][]**,
-adding support for inline arrays and packed structs.
-
-### Dart 2.14
-
-Dart 2.14 added the unsigned shift operator (`>>>`),
-also known as _triple-shift_.
-This new operator is similar to `>>`,
-except that it always fills the most significant bits with zeros.
-For more information, see the
-[bitwise and shift operator][] section of the language tour.
-
-[bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
-
-Dart 2.14 also removed some restrictions on type arguments.
-You can now pass type arguments to annotations,
-and you can use a generic function type as a type argument.
-All of the following code was invalid before 2.14,
-but is now allowed:
+The **[spread operator][]**
+enables unpacking the elements from one list into another.
+In the following example, the list returned by `buildMainElements()`
+is unpacked into the list being passed to the `children` argument:
 
 ```dart
-@TypeHelper<int>(42, "The meaning")
-late List<T Function<T>(T)> idFunctions;
-var callback = [<T>(T value) => value];
-late S Function<S extends T Function<T>(T)>(S) f;
-```
-
-### Dart 2.15
-
-Dart 2.15 improved support for function pointers,
-known as _tear-offs._
-In particular, constructor tear-offs are now supported.
-For details, see the [Dart 2.15 announcement][].
-
-[Dart 2.15 announcement]: https://medium.com/dartlang/dart-2-15-7e7a598e508a
-
-### Dart 2.16
-
-Dart 2.16 didn’t add any features to the Dart language.
-
-### Dart 2.17
-
-Dart 2.17 expanded enum functionality with enhanced enums.
-Enhanced enums allow enum declarations to define members 
-including fields, constructors, methods, getters, etc.
-For more information, see the
-[Enhanced enums][] section of the language tour.
-
-[Enhanced enums]: /language/enum#declaring-enhanced-enums
-
-Dart 2.17 also added support for super-initializer parameters in constructors.
-Super parameters allow you
-to avoid having to manually pass each parameter
-into the super invocation of a non-redirecting constructor.
-You can instead use super parameters to forward parameters
-to a superclass constructor.
-For more information, 
-see the language tour's documentation of [super parameters][].
-
-[super parameters]: /language/constructors#super-parameters
-
-Dart 2.17 also removed some restrictions on named arguments.
-Named arguments can now be freely interleaved with positional arguments.
-The following code was invalid before 2.17,
-but is now allowed:
-
-```dart
-void main() {
-  test(skip: true, 'A test description', () {
-    // Very long function body here...
-  });
+Widget build(BuildContext context) {
+  return Column(children: [
+    Header(),
+    ...buildMainElements(),
+    Footer(),
+  ]);
 }
 ```
 
-To learn more about named parameters and arguments, see the
-[Named parameters][] section of the language tour.
-
-[Named parameters]: /language/functions#named-parameters
-
-### Dart 2.18
-
-Dart 2.18 enhanced type inference. This change allows information flow between
-arguments in generic function calls. Before 2.18, if you didn't specify an
-argument's type in some methods, Dart returned errors. These type errors cited
-potential null occurrences. With 2.18, the compiler infers the argument type
-from other values in an invocation. You don't need to specify the argument type
-inline. To learn more, see [Type argument inference][].
-
-[Type argument inference]: /language/type-system#type-argument-inference
-
-Dart 2.18 also discontinued support for mixin classes that don't extend `Object`.
-To learn more about mixins,
-see [Adding features to a class: mixins][] in the language tour.
-
-[Adding features to a class: mixins]: /language/mixins
-
-### Dart 2.19
-
-Dart 2.19 introduced some precautions surrounding type inference.
-These include:
-
-* More flow analysis flags for unreachable code cases.
-* No longer delegate inaccessible private names to `noSuchMethod`.
-* Top-level type inference throws on cyclic dependencies.
-
-Dart 2.19 also introduced support for unnamed libraries.
-Library directives, used for appending
-library-level doc comments and annotations,
-can ([and should][]) now be written without a name:
+The **[collection if][]** operator enables adding elements that meet
+conditions.
+The following example adds a `FlatButton` element unless this element
+falls on the last page:
 
 ```dart
-/// A really great test library.
-@TestOn('browser')
-library;
+Widget build(BuildContext context) {
+  return Column(children: [
+    Text(mainText),
+    if (page != pages.last)
+      FlatButton(child: Text('Next')),
+  ]);
+}
 ```
 
-[and should]: /guides/language/effective-dart/style#dont-explicitly-name-libraries
+The **[collection for][]** operator enables building repeated elements.
+The following example adds one `HeadingAction` element for each section
+in `sections`:
+
+```dart
+Widget build(BuildContext context) {
+  return Column(children: [
+    Text(mainText),
+    for (var section in sections)
+      HeadingAction(section.heading),
+  ]);
+}
+```
+
+
+### Dart 2.2
+_Released 26 February 2019_
+| [Dart 2.2 announcement](https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-support-for-set-literals-7e2ab19cc86d)
+
+Dart supports literal lists and maps, but Dart 2.2 added support for
+**[set literals][]**:
+
+```dart
+const Set<String> currencies = {'EUR', 'USD', 'JPY'};
+```
+
+### Dart 2.1
+_Released 15 November 2018_
+| [Dart 2.1 announcement](https://medium.com/dartlang/announcing-dart-2-1-improved-performance-usability-9f55fca6f31a)
+
+Dart 2.1 added support for **int-to-double conversion**, allowing developers to
+set `double` values using integer literals. This feature removed the annoyance
+of being forced to use a `double` literal (for example, `4.0`)
+when the value was conceptually an integer.
+
+In the following Flutter code, `horizontal` and `vertical` have type `double`:
+
+```dart
+padding: const EdgeInsets.symmetric(
+  horizontal: 4,
+  vertical: 8,
+)
+```
+
+### Dart 2.0
+_Released 22 February 2018_
+| [Dart 2.0 announcement](https://medium.com/dartlang/announcing-dart-2-80ba01f43b6)
+
+Dart 2.0 implemented a new **[sound type system][]**. Before Dart 2.0,
+types weren't fully sound, and Dart relied heavily on runtime type
+checking. Dart 1.x code had to be [migrated to Dart 2][].
 
 ## Language versioning
 
@@ -313,23 +341,21 @@ multiple versions of the Dart language.
 The compiler determines what version the code is targeting,
 and it interprets the code according to that version.
 
-Language versioning is important on the rare occasions
-when Dart introduces an incompatible feature like [null safety][].
-Code that used to compile cleanly before null safety
-(but perhaps crash at runtime)
-might no longer compile once null safety is enabled.
-Because migrating your apps and packages—and all the packages they depend on—to
-null safety might take a while,
-Dart uses language versioning to support
-using non-null-safe code alongside null-safe code.
-For an example of how an app or package can migrate to
-a new language version
-with an incompatible feature (null safety, for example), see 
+Language versioning becomes important on the rare occasions when Dart
+introduces an incompatible feature like [null safety][].
+Before null safety, code could compile but might crash at runtime.
+With null safety, the code might no longer compile.
+Migrating your apps plus your own and other dependent packages
+to null safety might take a while.
+Dart uses language versioning to support using non-null-safe code
+alongside null-safe code.
+
+For an example of how an app or package can migrate to a new language
+version with an incompatible feature, check out
 [Migrating to null safety](/null-safety/migration-guide).
 
-Each package has a default language version,
-equal to the `<major>.<minor>` part of the
-**lower SDK constraint** in the pubspec.
+Each package has a default language version, equal to the
+`<major>.<minor>` part of the **lower SDK constraint** in the pubspec.
 For example, the following entry in a `pubspec.yaml` file
 indicates that this package uses the Dart 2.7 language version.
 
@@ -338,49 +364,47 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 ```
 
-
 ### Language version numbers
 
-Dart language versions are identified by a major and minor number
-that match the first two components of the Dart SDK.
-For example, the latest language version supported by
-the 2.7.3 Dart SDK is Dart 2.7.
-Each Dart SDK supports all of the language versions covered
-by its major version number.
-That means that the 2.7.3 Dart SDK supports language
-versions 2.7, 2.6, 2.5, and so on, down to 2.0.
+Dart language versions follow semantic versioning with
+a major version number and a minor version number.
+Dart language versions can include a patch number.
+Patches should not change the language except for bug fixes.
+To illustrate: Dart 2.18.3 serves as the latest release of the
+Dart 2.18 SDK.
+Each Dart SDK supports all of the language versions within its major
+version number.
+That means that Dart SDK 2.18.3 supports language versions
+2.0 through 2.18 inclusive, but not Dart 1.x.
 
 Deriving the language version from the SDK version
 implies the following:
 
-* Whenever a minor version of the SDK ships,
-  a new language version appears.
-  In practice, many of these language versions are very similar to
-  and entirely compatible with previous versions.
-  For example, the Dart 2.9 language is essentially identical to
-  the Dart 2.8 language.
+* Whenever a minor version of the SDK ships, a new language version appears.
+  In practice, many of these language versions function in very
+  similar manner to previous versions with full compatibility.
+  For example, the Dart 2.9 language works much like the Dart 2.8
+  language.
 
 * When a patch version of the SDK ships,
   it cannot introduce any language features.
-  For example, because 2.7.2 is language version 2.7,
-  it must be completely compatible with 2.7.1 and 2.7.0.
+  For example, because 2.18.3 belongs to language version 2.18,
+  it must remain compatible with 2.17.1 and 2.17.0.
 
 
 ### Per-library language version selection
 
-By default, every Dart file
-in a package uses the same language version—the language version
-indicated by the lower SDK constraint in the pubspec.
-Sometimes, however, a Dart file
-might need to use an older language version.
-For example,
-you might not be able to migrate all the files in a package
+By default, every Dart file in a package uses the same language version.
+The pubspec YAML file identifies this language version as the lower SDK
+constraint.
+Sometimes, a Dart file might need to use an older language version.
+For example, you might not be able to migrate all the files in a package
 to null safety at the same time.
 
-The Dart 2.8 compiler introduced support for
-per-library language version selection.
-A [Dart library][] can opt to have a different language version
-by using a comment of the following form:
+The Dart 2.8 compiler introduced support for per-library language
+version selection.
+To opt to have a different language version, a [Dart library][] must
+include a comment in the following format:
 
 ```dart
 // @dart = <major>.<minor>
@@ -395,15 +419,14 @@ import 'dart:math';
 ...
 ```
 
-The `@dart` string must be in a `//` comment
-(not `///` or `/*`),
+The `@dart` string must be in a `//` comment (not `///` or `/*`),
 and it must appear before any Dart code in the file.
 Whitespace (tabs and spaces) doesn't matter,
 except within the `@dart` and version strings.
-As the example above shows,
+As the previous example shows,
 other comments can appear before the `@dart` comment.
 
-For more information about how language versioning works, see the
+To learn how language versioning works, check out the
 [language versioning specification][language versioning feature].
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
@@ -418,7 +441,7 @@ For more information about how language versioning works, see the
 [`flutter` tool]: {{site.flutter-docs}}/reference/flutter-cli
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language specification]: /guides/language/spec
-[language tour]: /language
+[language documentation]: /language
 [language versioning feature]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/feature-specification.md#dart-language-versioning
 [migrated to Dart 2]: /articles/archive/dart-2
 [null safety]: /null-safety

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -233,7 +233,7 @@ _Released 5 November 2019_
 
 Dart 2.6 introduced a
 [breaking change (dart-lang/sdk#37985)](https://github.com/dart-lang/sdk/issues/37985).
-Constraints of the forms similar to `Null` serves as a subtype of `FutureOr`
+Constraints where `Null` serves as a subtype of `FutureOr<T>`
 now yield `Null` as the solution for `T`.
 
 For example: The following code now prints `Null`.
@@ -390,7 +390,7 @@ Each package has a default language version equal to the **lower bound**
 of the SDK constraint in the `pubspec.yaml` file.
 
 **For example:** The following entry in a `pubspec.yaml` file
-indicates that this package uses the Dart 2.18 language version or later.
+indicates that this package defaults to the Dart 2.18 language version.
 
 ```yaml
 environment:

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -20,7 +20,7 @@ set `2.12.0` as the lower constraint in the `pubspec.yaml` file.
 
 ```yaml
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^2.12.0
 ```
 
 [2.12]: #dart-212
@@ -358,12 +358,13 @@ version with an incompatible feature, check out
 Each package has a default language version, equal to the
 `<major>.<minor>` part of the **lower SDK constraint** in the pubspec.
 For example, the following entry in a `pubspec.yaml` file
-indicates that this package uses the Dart 2.7 language version.
+indicates that this package uses the Dart 2.18 language version.
 
 ```yaml
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ^2.18.0
 ```
+
 
 ### Language version numbers
 
@@ -415,7 +416,7 @@ For example:
 
 ```dart
 // Description of what's in this file.
-// @dart = 2.7
+// @dart = 2.17
 import 'dart:math';
 ...
 ```


### PR DESCRIPTION
This PR updates the Language Evolution page. I made some language updates, but re-sorted the versions as reverse chronological and added release dates and links to the release announcements.