### PR TITLE
Remove This Week in Dart link for now

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -24,9 +24,6 @@ our [code of conduct](/community/code-of-conduct).
 [Dart blog](https://medium.com/dartlang)
 : The latest news and insights from a diverse group of Dart users.
 
-[This Week in Dart](https://thisweekindart.dev/)
-: A community ran, weekly newsletter covering the Dart ecosystem.
-
 ## Join the conversation
 
 Get answers and connect with Dart developers.


### PR DESCRIPTION
As I've been busy with other work, I'm not able to update it as much as I would like currently. I hope to revive it in the future, but for now, let's not link to potentially outdated information. 