### PR TITLE
Remove outdated Gitter link

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -36,9 +36,6 @@ Get answers and connect with Dart developers.
 [StackOverflow](https://stackoverflow.com/tags/dart)
 : The best place for how-to questions.
 
-[Gitter](https://gitter.im/dart-lang/home)
-: Chat with Dart team and community members.
-
 [Dart on Reddit](https://www.reddit.com/r/dartlang)
 : The subreddit for all things related to Dart.
 


### PR DESCRIPTION
The 4 Dart channels are no longer grouped with Gitter's full transition to Matrix, and the channels see little traffic. It doesn't seem like a great experience to direct users to 4 different channels where they may not get the support they need. Very few Dart team members are active there anymore as well, despite the description provided here.

Closes https://github.com/dart-lang/site-www/issues/4681