### PR TITLE
Use deps.dev for OpenSSF scorecard result link

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ then rerun your setup/build again.
 
 [Build Status SVG]: https://github.com/dart-lang/site-www/workflows/build/badge.svg
 [OpenSSF Scorecard SVG]: https://api.securityscorecards.dev/projects/github.com/dart-lang/site-www/badge
-[Scorecard Results]: https://api.securityscorecards.dev/projects/github.com/dart-lang/site-www
+[Scorecard Results]: https://deps.dev/project/github/dart-lang%2Fsite-www
 [cloning]: https://help.github.com/articles/cloning-a-repository
 [DartPad]: https://dartpad.dev
 [Firebase]: https://firebase.google.com/


### PR DESCRIPTION
This is linked to by the OpenSSF scorecard badge at the top of the README. The previous link was to unformatted JSON. Instead, this links to deps.dev which formats the results and in the future may include other information.