### PR TITLE
Fix dev channel build for info changed to warning

### DIFF
--- a/examples/analysis/analyzer-results-dev.txt
+++ b/examples/analysis/analyzer-results-dev.txt
@@ -4,6 +4,6 @@ Analyzing analysis...
 warning - lib/strict_modes.dart:22:17 - The type argument(s) of 'Map' can't be inferred. Use explicit type argument(s) for 'Map'. - inference_failure_on_collection_literal
    info - lib/lint.dart:9:19 - Unnecessary empty statement. Try removing the empty statement or restructuring the code. - empty_statements
    info - lib/lint.dart:17:7 - Unclosed instance of 'Sink'. Try invoking 'close' in the function in which the 'Sink' was created. - close_sinks
-   info - lib/strict_modes.dart:33:3 - The generic type 'List<dynamic>' should have explicit type arguments but doesn't. Use explicit type arguments for 'List<dynamic>'. - strict_raw_type
+warning - lib/strict_modes.dart:33:3 - The generic type 'List<dynamic>' should have explicit type arguments but doesn't. Use explicit type arguments for 'List<dynamic>'. - strict_raw_type
 
 5 issues found.

--- a/examples/analysis/analyzer-results-dev.txt
+++ b/examples/analysis/analyzer-results-dev.txt
@@ -2,8 +2,8 @@ Analyzing analysis...
 
   error - lib/strict_modes.dart:15:7 - The argument type 'dynamic' can't be assigned to the parameter type 'List<String>'. - argument_type_not_assignable
 warning - lib/strict_modes.dart:22:17 - The type argument(s) of 'Map' can't be inferred. Use explicit type argument(s) for 'Map'. - inference_failure_on_collection_literal
+warning - lib/strict_modes.dart:33:3 - The generic type 'List<dynamic>' should have explicit type arguments but doesn't. Use explicit type arguments for 'List<dynamic>'. - strict_raw_type
    info - lib/lint.dart:9:19 - Unnecessary empty statement. Try removing the empty statement or restructuring the code. - empty_statements
    info - lib/lint.dart:17:7 - Unclosed instance of 'Sink'. Try invoking 'close' in the function in which the 'Sink' was created. - close_sinks
-warning - lib/strict_modes.dart:33:3 - The generic type 'List<dynamic>' should have explicit type arguments but doesn't. Use explicit type arguments for 'List<dynamic>'. - strict_raw_type
 
 5 issues found.


### PR DESCRIPTION
This diagnostic changed from a `info` diagnostic to `warning` in the most recent `dev` build.