### PR TITLE
Document 'dart pub add' support for adding dependency overrides

### DIFF
--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -51,7 +51,7 @@ to use version `1.0.0` of the package,
 run the following command:
 
 ```terminal
-dart pub add override:foo:1.0.0
+$ dart pub add override:foo:1.0.0
 ```
 
 This adds the override to your `pubspec.yaml` file:

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -56,7 +56,7 @@ $ dart pub add override:foo:1.0.0
 
 This adds the override to your `pubspec.yaml` file:
 
-```
+```yaml
 dependency_overrides:
 foo: 1.0.0
 ```

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -39,7 +39,7 @@ $ dart pub add foo:'>2.0.0 <3.0.1'
 If `dart pub add <package>:<constraint>` is an existing dependency,
 it will update the constraint.
 
-## Adding Dependency Overrides
+## Dependency overrides
 
 Starting in Dart 3, `dart pub add` supports adding dependency overrides in a similar fashion to dev dependencies. To add a dependency override, use the following syntax:
 `dart pub add override:<package>:<version>`

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -58,7 +58,7 @@ This adds the override to your `pubspec.yaml` file:
 
 ```yaml
 dependency_overrides:
-foo: 1.0.0
+  foo: 1.0.0
 ```
 
 ## `dev` dependency

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -39,7 +39,7 @@ $ dart pub add foo:'>2.0.0 <3.0.1'
 If `dart pub add <package>:<constraint>` is an existing dependency,
 it will update the constraint.
 
-### Adding Dependency Overrides
+## Adding Dependency Overrides
 
 Starting in Dart 3, `dart pub add` supports adding dependency overrides in a similar fashion to dev dependencies. To add a dependency override, use the following syntax:
 `dart pub add override:<package>:<version>`
@@ -81,10 +81,10 @@ $ dart pub add --dev foo
 ## Source descriptor
 
 {{site.alert.version-note}}
-YAML-formatted descriptor syntax was added in Dart 2.19.
-The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
-We still support these arguments, but the recommended method is now
-YAML-descriptor only.
+  YAML-formatted descriptor syntax was added in Dart 2.19.
+  The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
+  We still support these arguments, but the recommended method is now
+  YAML-descriptor only.
 {{site.alert.end}}
 
 The YAML descriptor syntax allows you to add multiple packages from different
@@ -187,13 +187,13 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 {{site.alert.note}}
-The previous `pub add` syntax for options
-(without YAML descriptors) applies the
-specified options to all the packages
-included in an invocation of the command.
-For example, `dart pub add test http --dev`
-will add both the `test` and `http` packages
-as dev dependencies.
+  The previous `pub add` syntax for options
+  (without YAML descriptors) applies the
+  specified options to all the packages
+  included in an invocation of the command.
+  For example, `dart pub add test http --dev`
+  will add both the `test` and `http` packages
+  as dev dependencies.
 {{site.alert.end}}
 
 ### `--[no-]offline`
@@ -212,6 +212,6 @@ in immediate dependencies (`--precompile`).
 To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
-_Problems?_
-See [Troubleshooting Pub](/tools/pub/troubleshoot).
+  *Problems?*
+  See [Troubleshooting Pub](/tools/pub/troubleshoot).
 {{site.alert.end}}

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -46,7 +46,7 @@ include a [source descriptor](#source-descriptor).
 
 [dependency override]: /tools/pub/dependencies#dependency-overrides
 
-**For example**, to override all references to `package:foo`
+**For example:** To override all references to `package:foo`
 to use version `1.0.0` of the package,
 run the following command:
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -41,8 +41,10 @@ it will update the constraint.
 
 ## Dependency overrides
 
-Starting in Dart 3, `dart pub add` supports adding dependency overrides in a similar fashion to dev dependencies. To add a dependency override, use the following syntax:
-`dart pub add override:<package>:<version>`
+To specify a [dependency override][], add the `override:` prefix and
+include a [source descriptor](#source-descriptor).
+
+[dependency override]: /tools/pub/dependencies#dependency-overrides
 
 For example, to add an override for the `foo` package version `1.0.0`, run the following command:
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -9,11 +9,11 @@ _Add_ is one of the commands of the [pub tool](/tools/pub/cmd).
 $ dart pub add [dev:]<package>[:<constraint>] [[dev:]<package>[:<constraint>]... ] [options]
 ```
 
-This command adds the specified packages to the `pubspec.yaml` as dependencies, 
-and then retrieves the dependencies to resolve `pubspec.yaml`.  
+This command adds the specified packages to the `pubspec.yaml` as dependencies,
+and then retrieves the dependencies to resolve `pubspec.yaml`.
 
 The following example command is equivalent to
-editing `pubspec.yaml` to add the `http` package, 
+editing `pubspec.yaml` to add the `http` package,
 and then calling `dart pub get`:
 
 ```terminal
@@ -39,6 +39,26 @@ $ dart pub add foo:'>2.0.0 <3.0.1'
 If `dart pub add <package>:<constraint>` is an existing dependency,
 it will update the constraint.
 
+### Adding Dependency Overrides
+
+Starting in Dart 3, `dart pub add` supports adding dependency overrides in a similar fashion to dev dependencies. To add a dependency override, use the following syntax:
+`dart pub add override:<package>:<version>`
+
+For example, to add an override for the `foo` package version `1.0.0`, run the following command:
+
+```
+dart pub add override:foo:1.0.0
+```
+
+This will add an override to your `pubspec.yaml` file:
+
+```
+dependency_overrides:
+foo: 1.0.0
+```
+
+Note that dependency overrides can conflict with the normal dependency resolution process and should be used with caution.
+
 ## `dev` dependency
 
 The `dev:` prefix adds the package as a [dev dependency][],
@@ -61,14 +81,14 @@ $ dart pub add --dev foo
 ## Source descriptor
 
 {{site.alert.version-note}}
-  YAML-formatted descriptor syntax was added in Dart 2.19.
-  The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
-  We still support these arguments, but the recommended method is now
-  YAML-descriptor only.
+YAML-formatted descriptor syntax was added in Dart 2.19.
+The descriptor replaces arguments like `--path`, `--sdk`, `--git-<option>`, etc.
+We still support these arguments, but the recommended method is now
+YAML-descriptor only.
 {{site.alert.end}}
 
 The YAML descriptor syntax allows you to add multiple packages from different
-sources, and apply different options and contraints to each. 
+sources, and apply different options and contraints to each.
 
 ```nocode
 $ dart pub add [options] [dev:]<package>[:descriptor] [[dev:]<package>[:descriptor] ...]
@@ -83,7 +103,7 @@ The syntax reflects how dependencies are written in `pubspec.yaml`.
 The `descriptor` syntax cannot be used in conjunction with any of the optional
 arguments it replaces. Their new, corresponding YAML sources are listed below.
 
-### `git` 
+### `git`
 
 Adds a [git dependency](/tools/pub/dependencies#git-packages).
 
@@ -139,7 +159,7 @@ _Previously the `--hosted-url=<package_server_url>` option_.
 
 Adds a [path dependency]() on a locally stored package.
 
-```terminal 
+```terminal
 $ dart pub add 'foo:{"path":"../foo"}'
 ```
 
@@ -167,13 +187,13 @@ For options that apply to all pub commands, see
 [Global options](/tools/pub/cmd#global-options).
 
 {{site.alert.note}}
-  The previous `pub add` syntax for options
-  (without YAML descriptors) applies the
-  specified options to all the packages
-  included in an invocation of the command.
-  For example, `dart pub add test http --dev` 
-  will add both the `test` and `http` packages 
-  as dev dependencies.
+The previous `pub add` syntax for options
+(without YAML descriptors) applies the
+specified options to all the packages
+included in an invocation of the command.
+For example, `dart pub add test http --dev`
+will add both the `test` and `http` packages
+as dev dependencies.
 {{site.alert.end}}
 
 ### `--[no-]offline`
@@ -192,6 +212,6 @@ in immediate dependencies (`--precompile`).
 To prevent precompilation, use `--no-precompile`.
 
 {{site.alert.info}}
-  *Problems?*
-  See [Troubleshooting Pub](/tools/pub/troubleshoot).
+_Problems?_
+See [Troubleshooting Pub](/tools/pub/troubleshoot).
 {{site.alert.end}}

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -54,7 +54,7 @@ run the following command:
 dart pub add override:foo:1.0.0
 ```
 
-This will add an override to your `pubspec.yaml` file:
+This adds the override to your `pubspec.yaml` file:
 
 ```
 dependency_overrides:

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -61,8 +61,6 @@ dependency_overrides:
 foo: 1.0.0
 ```
 
-Note that dependency overrides can conflict with the normal dependency resolution process and should be used with caution.
-
 ## `dev` dependency
 
 The `dev:` prefix adds the package as a [dev dependency][],

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -50,7 +50,7 @@ include a [source descriptor](#source-descriptor).
 to use version `1.0.0` of the package,
 run the following command:
 
-```
+```terminal
 dart pub add override:foo:1.0.0
 ```
 

--- a/src/tools/pub/cmd/pub-add.md
+++ b/src/tools/pub/cmd/pub-add.md
@@ -46,7 +46,9 @@ include a [source descriptor](#source-descriptor).
 
 [dependency override]: /tools/pub/dependencies#dependency-overrides
 
-For example, to add an override for the `foo` package version `1.0.0`, run the following command:
+**For example**, to override all references to `package:foo`
+to use version `1.0.0` of the package,
+run the following command:
 
 ```
 dart pub add override:foo:1.0.0


### PR DESCRIPTION
Hey there! I've created a PR that adds documentation for the new functionality of dart pub add to add dependency overrides. The documentation is now available on the v3.0 branch. Please take a look and let me know if you have any feedback or suggestions. Thank you!