### PR TITLE
Update `dart-lang/samples` links to point to new `main` branch

### DIFF
--- a/src/_guides/google-apis.md
+++ b/src/_guides/google-apis.md
@@ -55,4 +55,4 @@ To find wrapper packages for Google client APIs, search for
 [gsheets-api-docs]: {{site.pub-api}}/gsheets/latest/gsheets/gsheets-library.html
 [gsheets-api-docs-gapi]: {{site.pub-api}}/googleapis/latest/sheets.v4/sheets.v4-library.html
 [flutter-google-apis]: https://flutter.dev/docs/development/data-and-backend/google-apis
-[server-sample]: https://github.com/dart-lang/samples/tree/master/server/google_apis
+[server-sample]: https://github.com/dart-lang/samples/tree/main/server/google_apis

--- a/src/_guides/libraries/c-interop.md
+++ b/src/_guides/libraries/c-interop.md
@@ -1,8 +1,8 @@
 ---
 title: "C interop using dart:ffi"
 description: "To use C code in your Dart program, use the dart:ffi library."
-hw: "https://github.com/dart-lang/samples/tree/master/ffi/hello_world"
-samples: "https://github.com/dart-lang/samples/tree/master/ffi"
+hw: "https://github.com/dart-lang/samples/tree/main/ffi/hello_world"
+samples: "https://github.com/dart-lang/samples/tree/main/ffi"
 ---
 
 Dart mobile, command-line, and server apps 

--- a/src/_tutorials/server/cmdline.md
+++ b/src/_tutorials/server/cmdline.md
@@ -577,7 +577,7 @@ and the [args]({{argsAPI}}/args-library.html) package.
 For another example of a command line app, 
 see the [command_line][] sample.
 
-[command_line]: https://github.com/dart-lang/samples/tree/master/command_line
+[command_line]: https://github.com/dart-lang/samples/tree/main/command_line
 
 ## What next?
 

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -154,7 +154,7 @@ Check out these resources:
   * [Dart tools](/tools)
   * [IDEs](/tools#ides-and-editors)
 * Other examples of natively compiled apps
-  * [native_app](https://github.com/dart-lang/samples/tree/master/native_app)
+  * [native_app](https://github.com/dart-lang/samples/tree/main/native_app)
 
 If you get stuck, find help at [Community and support.](/community)
 

--- a/src/_tutorials/server/httpserver.md
+++ b/src/_tutorials/server/httpserver.md
@@ -25,12 +25,12 @@ Here are some resources for writing servers using Dart:
       [`shelf_router`][] packages.
     * Is deployable on Cloud Run.
 
-[cloud-sample]: https://github.com/dart-lang/samples/tree/master/server/google_apis
+[cloud-sample]: https://github.com/dart-lang/samples/tree/main/server/google_apis
 [`googleapis`]: {{site.pub-pkg}}/googleapis
 [`googleapis_auth`]: {{site.pub-pkg}}/googleapis_auth
 [`shelf`]: {{site.pub-pkg}}/shelf
 [`shelf_router`]: {{site.pub-pkg}}/shelf_router
 [`shelf_static`]: {{site.pub-pkg}}/shelf_static
-[simple-sample]: https://github.com/dart-lang/samples/tree/master/server/simple
+[simple-sample]: https://github.com/dart-lang/samples/tree/main/server/simple
 [Using Google APIs]: /guides/google-apis
 [Using Google Cloud]: /server/google-cloud

--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -463,7 +463,7 @@ see the following [isolate samples][]:
   which shows how to spawn a long-running isolate that
   receives and sends multiple times.
 
-{% assign samples = "https://github.com/dart-lang/samples/tree/master/isolates" %}
+{% assign samples = "https://github.com/dart-lang/samples/tree/main/isolates" %}
 
 [isolate samples]: {{ samples }}
 [send_and_receive.dart]: {{ samples }}/bin/send_and_receive.dart

--- a/src/language/extension-methods.md
+++ b/src/language/extension-methods.md
@@ -273,4 +273,4 @@ For more information about extension methods, see the following:
 
 [specification]: https://github.com/dart-lang/language/blob/master/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
 [article]: https://medium.com/dartlang/extension-methods-2d466cd8b308
-[sample]: https://github.com/dart-lang/samples/tree/master/extension_methods
+[sample]: https://github.com/dart-lang/samples/tree/main/extension_methods

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -201,7 +201,7 @@ For more information about null safety, see the following resources:
 * [Null safety FAQ][]
 * [Null safety sample code][calculate_lix]
 
-[calculate_lix]: https://github.com/dart-lang/samples/tree/master/null_safety/calculate_lix
+[calculate_lix]: https://github.com/dart-lang/samples/tree/main/null_safety/calculate_lix
 [migration guide]: /null-safety/migration-guide
 [Null safety FAQ]: /null-safety/faq
 [Null safety codelab]: /codelabs/null-safety

--- a/src/server/google-cloud.md
+++ b/src/server/google-cloud.md
@@ -81,7 +81,7 @@ If you _want_ to use App Engine, consider using the [`appengine` package][].
 [`appengine` package]: {{site.pub-pkg}}/appengine
 [ce]: https://cloud.google.com/compute/docs/containers
 [cr]: https://cloud.google.com/run/docs/quickstarts/build-and-deploy/other
-[server examples]: https://github.com/dart-lang/samples/tree/master/server
+[server examples]: https://github.com/dart-lang/samples/tree/main/server
 [GKE overview]: https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview
 [Dart Functions Framework]: {{site.pub-pkg}}/functions_framework
 [CloudEvents]: https://cloudevents.io/

--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -61,7 +61,7 @@ Refer to the [native_app][] sample for a simple example of using `dart compile`
 to compile a native app, 
 followed by examples of running the app.
 
-[native_app]: https://github.com/dart-lang/samples/tree/master/native_app
+[native_app]: https://github.com/dart-lang/samples/tree/main/native_app
 [dart-run]: /tools/dart-run
 
 ## Subcommands


### PR DESCRIPTION
The repository now has [`main`](https://github.com/dart-lang/samples) as its default branch.