### PR TITLE
Add video to 'dart fix' page

### DIFF
--- a/src/tools/dart-fix.md
+++ b/src/tools/dart-fix.md
@@ -9,12 +9,23 @@ finds and fixes two types of issues:
 
 * Analysis issues identified by [`dart analyze`][]
   that have associated automated fixes
-  (sometimes called _quick-fixes_ or _code actions_)
+  (sometimes called _quick-fixes_ or _code actions_).
 
 * Outdated API usages when updating to
   newer releases of the Dart and Flutter SDKs.
 
-{% include tools/dart-tool-note.md %}
+{{site.alert.tip}}
+  To learn about `dart fix` in a video format,
+  check out this deep dive on **Decoding Flutter**:
+
+  <iframe width="560" height="315" 
+  src="https://www.youtube.com/embed/OBIuSrg_Quo" title="Using 'dart fix' YouTube video" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen></iframe>
+{{site.alert.end}}  
+
+## Usage
 
 To preview proposed changes, use the `--dry-run` flag:
 
@@ -28,7 +39,7 @@ To apply the proposed changes, use the `--apply` flag:
 $ dart fix --apply
 ```
 
-## Customizing dart fix
+## Customization
 
 The `dart fix` command only applies fixes 
 when there is a "problem" identified by a diagnostic. 


### PR DESCRIPTION
Open to suggestions on layout, positioning, and wording!

<img width="956" alt="Tip showcasing 'dart fix' video" src="https://user-images.githubusercontent.com/18372958/230484147-7824117c-8416-4810-ae24-7962adb33f90.png">

**Staged:** https://dart-dev--pr4744-fix-4691-arngv2tn.web.app/tools/dart-fix

Closes https://github.com/dart-lang/site-www/issues/4691