### PR TITLE
Rearrange collections page

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -46,10 +46,10 @@
           permalink: /language/built-in-types
         - title: Collections
           permalink: /language/collections
-        - title: Typedefs
-          permalink: /language/typedefs
         - title: Generics
           permalink: /language/generics
+        - title: Typedefs
+          permalink: /language/typedefs
         - title: Type system
           permalink: /language/type-system 
     - title: Functions

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -517,7 +517,7 @@ and [`if` and `for`][control] for performing control flow while
 building the contents:
 
 [spread]: /language/collections#spread-operators
-[control]: /language/collections#collection-operators
+[control]: /language/collections#control-flow-operators
 
 {:.good}
 <?code-excerpt "usage_good.dart (spread-etc)"?>

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -465,8 +465,8 @@ check out the [language versioning specification][].
 
 [2.8 breaking changes]: https://github.com/dart-lang/sdk/issues/40686
 [calling native C code]: /guides/libraries/c-interop
-[collection for]: /language/collections#collection-operators
-[collection if]: /language/collections#collection-operators
+[collection for]: /language/collections#control-flow-operators
+[collection if]: /language/collections#control-flow-operators
 [Dart library]: /guides/libraries/create-library-packages#organizing-a-library-package
 [Dart FFI]: /guides/libraries/c-interop
 [extension methods]: /language/extension-methods

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -76,7 +76,7 @@ This content has moved to [Collections](/language/collections#spread-operator).
 
 #### Collection operators
 
-This content has moves to [Collections](/language/collections#collection-operators).
+This content has moves to [Collections](/language/collections#control-flow-operators).
 
 ### Sets
 

--- a/src/assets/js/language-tour-redirector.js
+++ b/src/assets/js/language-tour-redirector.js
@@ -15,7 +15,7 @@ const oldToNew = {
     'trailing-commas': '/language/collections#trailing-comma',
     'spread-operator': '/language/collections#spread-operators',
     'spread-operators': '/language/collections#spread-operators',
-    'collection-operators': '/language/collections#collection-operators',
+    'collection-operators': '/language/collections#control-flow-operators',
     'sets': '/language/collections#sets',
     'maps': '/language/collections#maps',
     'characters': '/language/built-in-types#runes-and-grapheme-clusters',

--- a/src/index.html
+++ b/src/index.html
@@ -115,7 +115,7 @@ js:
                                     A programming language optimized for building user
                                     interfaces with features such as <a href="/null-safety">sound null safety</a>,
                                     the <a href="/language/collections#spread-operators">spread operator</a> for
-                                    expanding collections, and <a href="/language/collections#collection-operators">collection if</a> for
+                                    expanding collections, and <a href="/language/collections#control-flow-operators">collection if</a> for
                                     customizing UI for each platform
                                 </div>
                             </div>
@@ -277,7 +277,7 @@ js:
                                     A programming language optimized for building user
                                     interfaces with features such as <a href="/null-safety">sound null safety</a>,
                                     the <a href="/language/collections#spread-operators">spread operator</a> for
-                                    expanding collections, and <a href="/language/collections#collection-operators">collection if</a> for
+                                    expanding collections, and <a href="/language/collections#control-flow-operators">collection if</a> for
                                     customizing UI for each platform
                                 </div>
                             </div>

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -3,6 +3,9 @@ title: Collections
 description: Summary of the different types of collections in Dart.
 ---
 
+Lists, sets, and maps are all collections in Dart. You can learn more about each
+in the [Collections][] section of the Library tour, and on the [Generics][] page.
+
 ## Lists
 
 Perhaps the most common collection in nearly every programming language
@@ -62,67 +65,6 @@ add `const` before the list literal:
 var constantList = const [1, 2, 3];
 // constantList[1] = 1; // This line will cause an error.
 ```
-
-### Spread operators
-
-Dart supports the **spread operator** (`...`) and the
-**null-aware spread operator** (`...?`),
-which provide a concise way to insert multiple values into a collection.
-
-For example, you can use the spread operator (`...`) to insert
-all the values of a list into another list:
-
-<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-spread)"?>
-```dart
-var list = [1, 2, 3];
-var list2 = [0, ...list];
-assert(list2.length == 4);
-```
-
-If the expression to the right of the spread operator might be null,
-you can avoid exceptions by using a null-aware spread operator (`...?`):
-
-<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-null-spread)"?>
-```dart
-var list2 = [0, ...?list];
-assert(list2.length == 1);
-```
-
-For more details and examples of using the spread operator, see the
-[spread operator proposal.][spread proposal]
-
-### Collection operators
-
-Dart also offers **collection if** and **collection for**,
-which you can use to build collections using conditionals (`if`)
-and repetition (`for`).
-
-Here's an example of using **collection if**
-to create a list with three or four items in it:
-
-<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-if)"?>
-```dart
-var nav = ['Home', 'Furniture', 'Plants', if (promoActive) 'Outlet'];
-```
-
-Here's an example of using **collection for**
-to manipulate the items of a list before
-adding them to another list:
-
-<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-for)"?>
-```dart
-var listOfInts = [1, 2, 3];
-var listOfStrings = ['#0', for (var i in listOfInts) '#$i'];
-assert(listOfStrings[1] == '#1');
-```
-
-For more details and examples of using collection `if` and `for`, see the
-[control flow collections proposal.][collections proposal]
-
-The List type has many handy methods for manipulating lists. For more
-information about lists, see the page on [generics][] and
-[Collections](/guides/libraries/library-tour#collections).
-
 
 ## Sets
 
@@ -194,17 +136,6 @@ final constantSet = const {
 };
 // constantSet.add('helium'); // This line will cause an error.
 ```
-
-Sets support spread operators (`...` and `...?`)
-and collection `if` and `for`,
-just like lists do.
-For more information, see the
-[list spread operator](#spread-operators) and
-[list collection operator](#collection-operators) discussions.
-
-For more information about sets, see
-[Generics](/language/generics) and
-[Sets](/guides/libraries/library-tour#sets).
 
 ## Maps
 
@@ -307,17 +238,65 @@ final constantMap = const {
 // constantMap[2] = 'Helium'; // This line will cause an error.
 ```
 
-Maps support spread operators (`...` and `...?`)
-and collection `if` and `for`, just like lists do.
-For details and examples, see the
-[spread operator proposal][spread proposal] and the
+## Operators
+
+### Spread operators
+
+Dart supports the **spread operator** (`...`) and the
+**null-aware spread operator** (`...?`) in list, map, and set literals.
+Spread operators provide a concise way to insert multiple values into a collection.
+
+For example, you can use the spread operator (`...`) to insert
+all the values of a list into another list:
+
+<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-spread)"?>
+```dart
+var list = [1, 2, 3];
+var list2 = [0, ...list];
+assert(list2.length == 4);
+```
+
+If the expression to the right of the spread operator might be null,
+you can avoid exceptions by using a null-aware spread operator (`...?`):
+
+<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-null-spread)"?>
+```dart
+var list2 = [0, ...?list];
+assert(list2.length == 1);
+```
+
+For more details and examples of using the spread operator, see the
+[spread operator proposal.][spread proposal]
+
+### Collection operators
+
+Dart also offers **collection if** and **collection for** for use in lists, maps,
+and sets. These operators build collections using conditionals (`if`)
+and repetition (`for`).
+
+Here's an example of using **collection if**
+to create a list with three or four items in it:
+
+<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-if)"?>
+```dart
+var nav = ['Home', 'Furniture', 'Plants', if (promoActive) 'Outlet'];
+```
+
+Here's an example of using **collection for**
+to manipulate the items of a list before
+adding them to another list:
+
+<?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-for)"?>
+```dart
+var listOfInts = [1, 2, 3];
+var listOfStrings = ['#0', for (var i in listOfInts) '#$i'];
+assert(listOfStrings[1] == '#1');
+```
+
+For more details and examples of using collection `if` and `for`, see the
 [control flow collections proposal.][collections proposal]
 
-For more information about maps, see the
-[generics][] section and
-the library tour's coverage of
-the [`Maps` API](/guides/libraries/library-tour#maps).
-
+[collections]: /guides/libraries/library-tour#collections
 [type inference]: /language/type-system#type-inference
 [`List`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
 [`Map`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -3,7 +3,9 @@ title: Collections
 description: Summary of the different types of collections in Dart.
 ---
 
-Dart has built-in support for list, set, and map [collections][], as well as the ability to declare them through [literals][].
+Dart has built-in support for list, set, and map [collections][].
+To learn more about configuring the types collections contain,
+check out [Generics][].
 
 ## Lists
 
@@ -65,7 +67,7 @@ var constantList = const [1, 2, 3];
 // constantList[1] = 1; // This line will cause an error.
 ```
 
-For more information about lists, refer to the
+For more information about lists, refer to the Lists section of the
 [Library tour](/guides/libraries/library-tour#lists).
 
 ## Sets
@@ -139,7 +141,7 @@ final constantSet = const {
 // constantSet.add('helium'); // This line will cause an error.
 ```
 
-For more information about sets, refer to the
+For more information about sets, refer to the Sets section of the
 [Library tour](/guides/libraries/library-tour#sets).
 
 ## Maps
@@ -243,7 +245,7 @@ final constantMap = const {
 // constantMap[2] = 'Helium'; // This line will cause an error.
 ```
 
-For more information about maps, refer to the
+For more information about maps, refer to the Maps section of the
 [Library tour](/guides/libraries/library-tour#maps).
 
 ## Operators

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -3,8 +3,7 @@ title: Collections
 description: Summary of the different types of collections in Dart.
 ---
 
-Lists, sets, and maps are all collections in Dart. You can learn more about each
-in the [Collections][] section of the Library tour, and on the [Generics][] page.
+Dart has built-in support for list, set, and map [collections][], as well as the ability to declare them through [literals][].
 
 ## Lists
 
@@ -65,6 +64,9 @@ add `const` before the list literal:
 var constantList = const [1, 2, 3];
 // constantList[1] = 1; // This line will cause an error.
 ```
+
+For more information about lists, refer to the
+[Library tour](/guides/libraries/library-tour#lists).
 
 ## Sets
 
@@ -136,6 +138,9 @@ final constantSet = const {
 };
 // constantSet.add('helium'); // This line will cause an error.
 ```
+
+For more information about sets, refer to the
+[Library tour](/guides/libraries/library-tour#sets).
 
 ## Maps
 
@@ -238,6 +243,9 @@ final constantMap = const {
 // constantMap[2] = 'Helium'; // This line will cause an error.
 ```
 
+For more information about maps, refer to the
+[Library tour](/guides/libraries/library-tour#maps).
+
 ## Operators
 
 ### Spread operators
@@ -268,11 +276,12 @@ assert(list2.length == 1);
 For more details and examples of using the spread operator, see the
 [spread operator proposal.][spread proposal]
 
-### Collection operators
+<a id="collection-operators"></a>
+### Control-flow operators
 
-Dart also offers **collection if** and **collection for** for use in lists, maps,
-and sets. These operators build collections using conditionals (`if`)
-and repetition (`for`).
+Dart also offers **collection if** and **collection for** for use in list, map,
+and set literals. You can use these operators to build collections using
+conditionals (`if`) and repetition (`for`).
 
 Here's an example of using **collection if**
 to create a list with three or four items in it:

--- a/src/language/variables.md
+++ b/src/language/variables.md
@@ -241,7 +241,7 @@ For more information on using `const` to create constant values, see
 [Instance variables]: /language/classes#instance-variables
 [DON’T use const redundantly]: /guides/language/effective-dart/usage#dont-use-const-redundantly
 [type checks and casts]: /language/operators#type-test-operators
-[collection `if`]: /language/collections#collection-operators
+[collection `if`]: /language/collections#control-flow-operators
 [spread operators]: /language/collections#spread-operators
 [Lists]: /language/collections#lists
 [Maps]: /language/collections#maps


### PR DESCRIPTION
The collections page was oddly organized.

For some reason, spread and collection operators were under the list section, even though they're applicable to all collections. So I moved them out to their own section.

Also, each collection section had the same few "learn more" lines at the bottom, all linking to the same resources, again applicable to all. So I consolidated all of that at the top.