### PR TITLE
[Dart 3] Records

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -44,6 +44,8 @@
       children:
         - title: Built-in types
           permalink: /language/built-in-types
+        - title: Records
+          permalink: /language/records
         - title: Collections
           permalink: /language/collections
         - title: Typedefs

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1304,15 +1304,18 @@ or [record]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Futu
 of futures.
 
 These extensions return a future with the resulting values of all the provided
-futures. Unlike `Future.wait()`, if any future in the collection completes with
+futures. Unlike `Future.wait`, if any future in the collection completes with
 an error, `wait` completes with a [`ParallelWaitError`][] that allows the caller
-to handle individual errors and dispose successful results if necessary:
+to handle individual errors and dispose successful results if necessary.
+
+A common use case is wanting to know when all the futures complete, and handle
+any errors, but not necessarily caring about the result of each individual future:
 
 ```dart
 void main() async {
-  Future<bool> delete() async =>  ...
-  Future<bool> copy() async =>  ...
-  Future<bool> errorResult() async =>  ...
+  Future<void> delete() async =>  ...
+  Future<void> copy() async =>  ...
+  Future<void> errorResult() async =>  ...
 
   try {      // Wait for each future in list.
     
@@ -1320,20 +1323,20 @@ void main() async {
 
     } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {
 
-    print(e.values[0]);    // Prints result of future
-    print(e.values[1]);    // Prints result of future
-    print(e.values[2]);    // Prints null
+    print(e.values[0]);    // Prints successful future
+    print(e.values[1]);    // Prints successful future
+    print(e.values[2]);    // Prints null when the result is an error
 
-    print(e.errors[0]);    // Prints null
-    print(e.errors[1]);    // Prints null
+    print(e.errors[0]);    // Prints null when the result is succesful
+    print(e.errors[1]);    // Prints null when the result is succesful
     print(e.errors[2]);    // Prints error
   }
 
 }
 ```
 
-Waiting on a record of futures enables the same functionality, with the additional 
-benefit that the futures can be of different types:
+Waiting on a _record_ of futures enables the same functionality, with the additional 
+benefit that the futures can be of different types: 
 
 ```dart
 void main() async {
@@ -1349,8 +1352,18 @@ void main() async {
       (AsyncError?, AsyncError?, AsyncError?)> catch (e) {
     // ...
     }
+
+  // Do something with the results:
+  var deleteInt  = result.$1;
+  var copyString = result.$2;
+  var errorBool  = result.$3;
 }
 ```
+
+Waiting for a record of futures should be used when you need the individual
+result values from each future
+(otherwise, just use `wait` on an iterable as described in the previous example).
+
 
 ### Stream
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1293,9 +1293,9 @@ await Future.wait([
 print('Done with all the long steps!');
 ```
 
-`Future.wait()` returns a future which will complete once all the provided
-futures have completed, either with their results, or with an error if any of
-the provided futures fail. 
+`Future.wait()` returns a future which completes once all the provided
+futures have completed. It completes either with their results,
+or with an error if any of the provided futures fail. 
 
 #### Handling errors for multiple futures
 
@@ -1303,23 +1303,25 @@ You can also wait for parallel operations on an [iterable]({{site.dart-api}}/{{s
 or [record]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/FutureRecord2/wait.html)
 of futures.
 
-These extensions return a future with the resulting values of all the provided
-futures. Unlike `Future.wait`, if any future in the collection completes with
-an error, `wait` completes with a [`ParallelWaitError`][] that allows the caller
-to handle individual errors and dispose successful results if necessary.
+These extensions return a future with the resulting values of all provided
+futures. Unlike `Future.wait`, they also let you handle errors. 
 
-A common use case is wanting to know when all the futures complete, and handle
-any errors, but not necessarily caring about the result of each individual future:
+If any future in the collection completes with an error, `wait` completes with a
+[`ParallelWaitError`][]. This allows the caller to handle individual errors and
+dispose successful results if necessary.
+
+Use `wait` on an _iterable_ of futures when you _don't_ need the result values
+from each individual future:
 
 ```dart
 void main() async {
   Future<void> delete() async =>  ...
   Future<void> copy() async =>  ...
   Future<void> errorResult() async =>  ...
-
-  try {      // Wait for each future in list.
-    
-    var results = await [delete(), copy(), errorResult()].wait;    // List of futures
+  
+  try {
+    // Wait for each future in a list, returns a list of futures:
+    var results = await [delete(), copy(), errorResult()].wait;
 
     } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {
 
@@ -1335,8 +1337,8 @@ void main() async {
 }
 ```
 
-Waiting on a _record_ of futures enables the same functionality, with the additional 
-benefit that the futures can be of different types: 
+Use `wait` on a _record_ of futures when you _do_ need the individual result values
+from each future. This also provides the additional benefit that the futures can be of different types:
 
 ```dart
 void main() async {
@@ -1345,7 +1347,7 @@ void main() async {
   Future<bool> errorResult() async =>  ...
 
   try {    
-    // Record of futures
+    // Wait for each future in a record, returns a record of futures:
     (int, String, bool) result = await (delete(), copy(), errorResult()).wait;
   
   } on ParallelWaitError<(int?, String?, bool?),
@@ -1359,11 +1361,6 @@ void main() async {
   var errorBool  = result.$3;
 }
 ```
-
-Waiting for a record of futures should be used when you need the individual
-result values from each future
-(otherwise, just use `wait` on an iterable as described in the previous example).
-
 
 ### Stream
 

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1293,6 +1293,60 @@ await Future.wait([
 print('Done with all the long steps!');
 ```
 
+`Future.wait()` returns a future which will complete once all the provided
+futures have completed, either with their results, or with an error if any of
+the provided futures fail. 
+
+#### Handling errors for multiple futures
+
+You can also wait for parallel operations on an [iterable]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/FutureIterable/wait.html)
+or [record]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/FutureRecord2/wait.html)
+of futures.
+
+These extensions return a future with the resulting values of the provided futures.
+Unlike `Future.wait()`, if any future in the collection completes with an error,
+`wait` completes with a [`ParallelWaitError`][] that allows the caller to
+handle individual errors and dispose successful results if necessary:
+
+```dart
+void main() async {
+  Future<bool> delete() async =>  ...
+  Future<bool> copy() async =>  ...
+  Future<bool> causesError() async =>  ...
+
+  try {
+    await [delete(), copy(), causesError()].wait;    // List of futures
+    Expect.fail("Didn't throw");
+  } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {   
+    print(e.values[0]);    // Prints result of future
+    print(e.values[1]);    // Prints result of future
+    print(e.values[2]);    // Prints null
+
+    print(e.errors[0]);    // Prints null
+    print(e.errors[1]);    // Prints null
+    print(e.errors[2]);    // Preints error
+  }
+}
+```
+
+Waiting on a record of futures enables the same functionality, with the additional 
+feature that the futures can be of different types:
+
+```dart
+void main() async {
+  Future<int>    delete() async =>  ...
+  Future<String> copy() async =>  ...
+  Future<bool>   causesError() async =>  ...
+
+  try {
+    await (delete(), copy(), causesError()).wait;    // Record of futures
+    Expect.fail("Didn't throw");
+  } on ParallelWaitError<(int?, String?, bool?),
+      (AsyncError?, AsyncError?, AsyncError?)> catch (e) {
+    // ...
+    }
+}
+```
 
 ### Stream
 
@@ -1757,6 +1811,7 @@ To learn more about the Dart language, see the
 [NativeFinalizer]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-ffi/NativeFinalizer-class.html
 [NoSuchMethodError]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/NoSuchMethodError-class.html
 [Object]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Object-class.html
+[`ParallelWaitError`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/ParallelWaitError-class.html
 [Pattern]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Pattern-class.html
 [Random]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-math/Random-class.html
 [RegExp]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/RegExp-class.html

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1303,44 +1303,48 @@ You can also wait for parallel operations on an [iterable]({{site.dart-api}}/{{s
 or [record]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/FutureRecord2/wait.html)
 of futures.
 
-These extensions return a future with the resulting values of the provided futures.
-Unlike `Future.wait()`, if any future in the collection completes with an error,
-`wait` completes with a [`ParallelWaitError`][] that allows the caller to
-handle individual errors and dispose successful results if necessary:
+These extensions return a future with the resulting values of all the provided
+futures. Unlike `Future.wait()`, if any future in the collection completes with
+an error, `wait` completes with a [`ParallelWaitError`][] that allows the caller
+to handle individual errors and dispose successful results if necessary:
 
 ```dart
 void main() async {
   Future<bool> delete() async =>  ...
   Future<bool> copy() async =>  ...
-  Future<bool> causesError() async =>  ...
+  Future<bool> errorResult() async =>  ...
 
-  try {
-    await [delete(), copy(), causesError()].wait;    // List of futures
-    Expect.fail("Didn't throw");
-  } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {   
+  try {      // Wait for each future in list.
+    
+    var results = await [delete(), copy(), errorResult()].wait;    // List of futures
+
+    } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {
+
     print(e.values[0]);    // Prints result of future
     print(e.values[1]);    // Prints result of future
     print(e.values[2]);    // Prints null
 
     print(e.errors[0]);    // Prints null
     print(e.errors[1]);    // Prints null
-    print(e.errors[2]);    // Preints error
+    print(e.errors[2]);    // Prints error
   }
+
 }
 ```
 
 Waiting on a record of futures enables the same functionality, with the additional 
-feature that the futures can be of different types:
+benefit that the futures can be of different types:
 
 ```dart
 void main() async {
-  Future<int>    delete() async =>  ...
+  Future<int> delete() async =>  ...
   Future<String> copy() async =>  ...
-  Future<bool>   causesError() async =>  ...
+  Future<bool> errorResult() async =>  ...
 
-  try {
-    await (delete(), copy(), causesError()).wait;    // Record of futures
-    Expect.fail("Didn't throw");
+  try {    
+    // Record of futures
+    (int, String, bool) result = await (delete(), copy(), errorResult()).wait;
+  
   } on ParallelWaitError<(int?, String?, bool?),
       (AsyncError?, AsyncError?, AsyncError?)> catch (e) {
     // ...

--- a/src/_guides/libraries/library-tour.md
+++ b/src/_guides/libraries/library-tour.md
@@ -1310,8 +1310,8 @@ If any future in the collection completes with an error, `wait` completes with a
 [`ParallelWaitError`][]. This allows the caller to handle individual errors and
 dispose successful results if necessary.
 
-Use `wait` on an _iterable_ of futures when you _don't_ need the result values
-from each individual future:
+When you _don't_ need the result values from each individual future,
+use `wait` on an _iterable_ of futures:
 
 ```dart
 void main() async {
@@ -1337,8 +1337,9 @@ void main() async {
 }
 ```
 
-Use `wait` on a _record_ of futures when you _do_ need the individual result values
-from each future. This also provides the additional benefit that the futures can be of different types:
+When you _do_ need the individual result values from each future,
+use `wait` on a _record_ of futures.
+This provides the additional benefit that the futures can be of different types:
 
 ```dart
 void main() async {

--- a/src/language/built-in-types.md
+++ b/src/language/built-in-types.md
@@ -8,6 +8,7 @@ The Dart language has special support for the following:
 - [Numbers](#numbers) (`int`, `double`)
 - [Strings](#strings) (`String`)
 - [Booleans](#booleans) (`bool`)
+- [Records][] (`(value1, value2)`)
 - [Lists][] (`List`, also known as *arrays*)
 - [Sets][] (`Set`)
 - [Maps][] (`Map`)
@@ -396,6 +397,7 @@ Symbol literals are compile-time constants.
 
 
 
+[Records]: /language/records
 [Lists]: /language/collections#lists
 [Sets]: /language/collections#sets
 [Maps]: /language/collections#maps

--- a/src/language/functions.md
+++ b/src/language/functions.md
@@ -440,6 +440,13 @@ foo() {}
 assert(foo() == null);
 ```
 
+A function can return multiple values by aggregating them in a [record][].
+
+```dart
+(String, int) foo() {
+  return ('something', 42);
+}
+```
 
 ## Generators
 
@@ -489,6 +496,7 @@ Iterable<int> naturalsDownFrom(int n) sync* {
 
 [`Iterable`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Iterable-class.html
 [`Stream`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/Stream-class.html
+[record]: /language/records#multiple-returns
 
 [Function API reference]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Function-class.html
 [Callable classes]: /language/callable-classes

--- a/src/language/functions.md
+++ b/src/language/functions.md
@@ -440,7 +440,7 @@ foo() {}
 assert(foo() == null);
 ```
 
-A function can return multiple values by aggregating them in a [record][].
+To return multiple values in a function, aggregate the values in a [record][].
 
 ```dart
 (String, int) foo() {

--- a/src/language/records.md
+++ b/src/language/records.md
@@ -1,0 +1,120 @@
+---
+title: Records
+description: Summary of the record data structure in Dart.
+toc: false
+---
+
+Records are an anonymous, immutable, aggregate type. Like other [collection types][], 
+they let you bundle multiple objects into a single object. Unlike other collection 
+types, records are fixed-sized, heterogeneous, and typed.
+
+Records are real values; you can store them in variables, pass them to and from
+functions, and store them in lists.
+
+## Record syntax
+
+Records are comma-delimited lists of named or positional fields,
+enclosed in parenthesis:
+
+```dart
+var record = ('first', a: 2, b: true, 'last');    // Record expression
+```
+
+Named fields inside record type annotations go inside a brace-delimited section
+of type and name pairs:
+
+```dart
+(Sring, {int a, bool b}, String?) record;    // Record type annotation
+```
+Naming fields in record type annotations is optional for documentation purposes.
+The names don't need to match any record expression corresponding to the type.
+
+## Record fields
+
+Record fields are accessible through built-in getters. Records are immutable,
+so fields do not have setters. 
+
+Named fields expose getters of the same name. Positional fields expose getters
+of the name `$<position>`, skipping named fields:
+
+```dart
+print(record.$1);    // Prints '123'
+print(record.a);     // Prints 2
+print(record.b);     // Prints true
+print(record.$2);    // Prints 'last'
+```
+
+To streamline record field access even more, see the page on [Patterns][].
+
+{% comment %}
+    TODO: link to patterns page, specifically records destructuring section.
+{% endcomment %}
+
+## Record types
+
+There is no explicit record type; records are
+structurally typed based on the types of their fields.
+
+Each field in a record has its own type, which can be different from other
+fields' types in the same record. Records are transparent to the type system.
+The type system remembers and applies each fields' type wherever it is
+accessed from the record:
+
+```dart
+var oneField = record.$1;       // oneField is a String
+var anotherField = record.a;    // anotherField is an int 
+```
+
+If two unrelated libraries create records with the same set of fields,
+the type system understands that those records are the same type even though the
+libraries are not coupled to each other.
+
+## Record equality
+
+Two records are equal if they have the same _shape_ (set of fields),
+and their corresponding fields have the same values.
+Named field order does not affect a record's shape:
+
+```dart
+var a = (x: 1, 2);
+var b = (2, x: 1);
+assert(a == b);        // True
+```
+
+Records automatically define `hashCode` and `==` methods structurally based on
+their fields.
+
+{% comment %}
+    Example of record as a composite hash key in map? Supposedly a benefit of
+    record value semantice.
+{% endcomment %}
+
+## Multiple returns
+
+Records allow functions to return multiple values bundled together:
+
+```dart
+(String, int) userInfo(Map<String, dynamic> json) {
+  return (json['name'] as String, json['age'] as int);
+}
+
+main() {
+  var info = userInfo(json);
+  var name = info.$1;
+  var age  = info.$2;
+}
+```
+
+The only ways to accomplish multiple returns otherwise are
+either to create a class (which is verbose), or use
+another collection type like List or Map (which lose type safety).
+
+{{site.alert.note}}
+  Records' multiple-return and heterogenous-type characteristics enable
+  parallelization of Futures of different types, which you can read about in the
+  [Library tour][].
+{{site.alert.end}}
+
+[collection types]: /language/collections
+[Patterns]: /language
+[Library tour]: /guides/libraries/library-tour#handling-errors-for-multiple-futures

--- a/src/language/records.md
+++ b/src/language/records.md
@@ -1,7 +1,6 @@
 ---
 title: Records
 description: Summary of the record data structure in Dart.
-toc: false
 ---
 
 Records are an anonymous, immutable, aggregate type. Like other [collection types][], 
@@ -14,15 +13,16 @@ functions, and store them in lists.
 ## Record syntax
 
 _Records expressions_ are comma-delimited lists of named or positional fields,
-enclosed in parenthesis:
+enclosed in parentheses:
 
 ```dart
-var record = ('first', a: 2, b: true, 'last');    // Record expression
+// Record expression:
+var record = ('first', a: 2, b: true, 'last');
 ```
 
-_Record type annotations_ are comma-delimited lists of types enclosed in parenthesis.
-The `(int, int)` statements here are record type annotations used as a return
-type and as parameter types:
+_Record type annotations_ are comma-delimited lists of types enclosed in parentheses.
+The `(int, int)` statements in the following example are record type annotations
+used as a return type and as parameter types:
 
 ```dart
 (int, int) swap((int, int) record) {
@@ -31,20 +31,40 @@ type and as parameter types:
 }
 ```
 
-Named fields inside _record type annotations_ go inside a brace-delimited section
-of type and name pairs, after all positional fields:
+Named fields inside _record type annotations_ mirror how [named parameters and arguments][]
+work in functions. They go inside a curly brace-delimited
+section of type-and-name pairs, after all positional fields:
 
 ```dart
-// Record type annotation in a variable declaration
+// Record type annotation in a variable declaration:
 (String, String?, {int a, bool b}) record;
 ```
 
 Naming fields in record type annotations is optional for documentation purposes.
-The names of those named fields are not optional, though,  
-once you create a record with named fields. The field names become part of the
-[record's type definition](#record-types). They can be omitted, but not replaced.
+Once you create a record from a type annotation with named fields using a record
+expression, the names become part of the [record's type definition](#record-types),
+or its _shape_:
 
-For more information, see the [Record equality](#record-equality) section.
+```dart 
+  ({int x, int y}) someRecord = (x: 1, y: 2);
+// ^^^^^^^^^^^^^^^              ^^^^^^^^^^^^
+// type annotation              expression
+```
+
+They can be ommitted from the creation expression, but not replaced
+with other names.
+
+```dart
+// Type annotation:
+({int x, int y}) someRecord;
+// Record expression creating record from type annotation, omitting names:
+someRecord = (1, 2);
+// Prints 1, 2:
+print(someRecord.x, someRecord.y);
+```
+
+For more information and examples, check out [Record types](#record-types) and
+[Record equality](#record-equality).
 
 ## Record fields
 
@@ -57,7 +77,7 @@ of the name `$<position>`, skipping named fields:
 ```dart
 var record = ('first', a: 2, b: true, 'last');
 
-print(record.$1);    // Prints '123'
+print(record.$1);    // Prints 'first'
 print(record.a);     // Prints 2
 print(record.b);     // Prints true
 print(record.$2);    // Prints 'last'
@@ -75,9 +95,9 @@ There is no type declaration for individual record types. Records are structural
 typed based on the types of their fields. A record's _shape_ (the set of its fields,
 the fields' types, and their names, if any) uniquely determines the type of a record. 
 
-Each field in a record has its own type, which can be different from other
-fields' types in the same record. The type system is aware of each
-field's type wherever it is accessed from the record:
+Each field in a record has its own type. Field types can differ within the same
+record. The type system is aware of each field's type wherever it is accessed
+from the record:
 
 ```dart
 (num, Object) pair = (42, "a");
@@ -86,8 +106,8 @@ var first = pair.$1;     // static type `num`, runtime type `int`
 var second = pair.$2;    // static type `Object`, runtime type `String`
 ```
 
-If two unrelated libraries create records with the same set of fields,
-the type system understands that those records are the same type even though the
+Consider two unrelated libraries that create records with the same set of fields.
+The type system understands that those records are the same type even though the
 libraries are not coupled to each other.
 
 ## Record equality
@@ -95,7 +115,7 @@ libraries are not coupled to each other.
 Two records are equal if they have the same _shape_ (set of fields),
 and their corresponding fields have the same values.
 Since named field _order_ is not part of a record's shape, the order of named
-fields does not affect equality:
+fields does not affect equality.
 
 ```dart
 (int x, int y, int z) point = (1, 2, 3);
@@ -113,18 +133,14 @@ point = color;
 point = color;
 ```
 
-Records automatically define `hashCode` and `==` methods structurally based on
-their fields.
+Records automatically define `hashCode` and `==` methods based on the structure
+of their fields.
 
 ## Multiple returns
 
 Records allow functions to return multiple values bundled together.
-Using [pattern matching][], you can retrieve record values from a return by
-destructuring them directly into local variables:
-
-{% comment %}
-    TODO: link to patterns page, specifically records destructuring section.
-{% endcomment %}
+To retrieve record values from a return,
+destructure the values into local variables using [pattern matching][].
 
 ```dart
 // Returns multiple values in a record:
@@ -144,9 +160,10 @@ void main() {
 }
 ```
 
-Other ways to accomplish multiple returns are
-either to create a class (which is more verbose), or use
-another collection type like `List` or `Map` (which loses type safety).
+You can return multiple values from a function without records,
+but other methods come with downsides.
+For example, creating a class is much more verbose, and using other collection
+types like `List` or `Map` loses type safety. 
 
 {{site.alert.note}}
   Records' multiple-return and heterogenous-type characteristics enable
@@ -158,3 +175,4 @@ another collection type like `List` or `Map` (which loses type safety).
 [Patterns]: /language
 [pattern matching]: /language
 [Library tour]: /guides/libraries/library-tour#handling-errors-for-multiple-futures
+[named parameters and arguments]: /language/functions#named-parameters

--- a/src/language/records.md
+++ b/src/language/records.md
@@ -21,8 +21,8 @@ var record = ('first', a: 2, b: true, 'last');
 ```
 
 _Record type annotations_ are comma-delimited lists of types enclosed in parentheses.
-The `(int, int)` statements in the following example are record type annotations
-used as a return type and as parameter types:
+You can use record type annotations to define return types and parameter types.
+For example, the following `(int, int)` statements are record type annotations:
 
 ```dart
 (int, int) swap((int, int) record) {
@@ -31,7 +31,8 @@ used as a return type and as parameter types:
 }
 ```
 
-Named fields inside _record type annotations_ mirror how [named parameters and arguments][]
+Named fields inside _record type annotations_ mirror how
+[named parameters and arguments][]
 work in functions. They go inside a curly brace-delimited
 section of type-and-name pairs, after all positional fields:
 

--- a/src/language/records.md
+++ b/src/language/records.md
@@ -20,15 +20,31 @@ enclosed in parenthesis:
 var record = ('first', a: 2, b: true, 'last');    // Record expression
 ```
 
+_Record type annotations_ are comma-delimited lists of types enclosed in parenthesis.
+The `(int, int)` statements here are record type annotations used as a return
+type and as parameter types:
+
+```dart
+(int, int) swap((int, int) record) {
+  var (a, b) = record;
+  return (b, a);
+}
+```
+
 Named fields inside _record type annotations_ go inside a brace-delimited section
 of type and name pairs, after all positional fields:
 
 ```dart
-(String, String?, {int a, bool b}) record;    // Record type annotation
+// Record type annotation in a variable declaration
+(String, String?, {int a, bool b}) record;
 ```
-Naming fields in record type annotations is optional for documentation purposes,
-but the names of named fields are not optional. For more information,
-see the [Record equality](#record-equality) section.
+
+Naming fields in record type annotations is optional for documentation purposes.
+The names of those named fields are not optional, though,  
+once you create a record with named fields. The field names become part of the
+[record's type definition](#record-types). They can be omitted, but not replaced.
+
+For more information, see the [Record equality](#record-equality) section.
 
 ## Record fields
 
@@ -78,7 +94,7 @@ libraries are not coupled to each other.
 
 Two records are equal if they have the same _shape_ (set of fields),
 and their corresponding fields have the same values.
-Since named field order is not part of a record's shape, the order of named
+Since named field _order_ is not part of a record's shape, the order of named
 fields does not affect equality:
 
 ```dart
@@ -102,7 +118,9 @@ their fields.
 
 ## Multiple returns
 
-Records allow functions to return multiple values bundled together. Using [pattern matching][], you can retrieve record values from a return by destructuring them directly into local variables:
+Records allow functions to return multiple values bundled together.
+Using [pattern matching][], you can retrieve record values from a return by
+destructuring them directly into local variables:
 
 {% comment %}
     TODO: link to patterns page, specifically records destructuring section.
@@ -127,7 +145,7 @@ void main() {
 ```
 
 Other ways to accomplish multiple returns are
-either to create a class (which is verbose), or use
+either to create a class (which is more verbose), or use
 another collection type like `List` or `Map` (which loses type safety).
 
 {{site.alert.note}}


### PR DESCRIPTION
Reviewers: 
- New records page
- Added library tour section on new future extensions
- Added mention of records on Built-in types page
- Added mention of records to Return values section of Functions page
---
Major issues / questions:
- Composite map key example for records in value semantics section?
- Future extensions:
  - Unsure about attempt at examples
  - Unsure whether I captured the purpose / the difference between regular `wait` and the new `wait` properties
- Should there be a section on Records alone in the Library tour? I didn't add one because there's not a lot to say based on the [API docs](https://api.dart.dev/stable/2.19.6/dart-core/Record-class.html)

---
TODO:
- Change code to actual code excerpts
- In `/language/records#record-fields`, need to change link on "Patterns" to section on destructuring records, once that's written

--- 
Fixes #4176 
Fixes #4692 