### PR TITLE
Remove no longer used properties from sidenav data file

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -2,14 +2,12 @@
   expanded: false
   children:
     - title: Tutorials
-      urlExactMatch: true
       match-page-url-exactly: true
       permalink: /tutorials
     - title: Codelabs
       expanded: true
       children:
         - title: List of Dart codelabs
-          urlExactMatch: true
           match-page-url-exactly: true
           permalink: /codelabs
         - title: Language cheatsheet
@@ -86,7 +84,6 @@
       expanded: false
       children:
         - title: Sound null safety
-          urlExactMatch: true
           match-page-url-exactly: true
           permalink: /null-safety
         - title: Migrating to null safety
@@ -102,7 +99,6 @@
   expanded: false
   children:
     - title: Overview
-      urlExactMatch: true
       match-page-url-exactly: true
       permalink: /guides/language/effective-dart
     - title: Style
@@ -118,7 +114,6 @@
   expanded: false
   children:
     - title: Overview
-      urlExactMatch: true
       match-page-url-exactly: true
       permalink: /guides/libraries
     - title: Tour
@@ -189,7 +184,6 @@
     - title: Command-line & server apps
       children:
         - title: Overview
-          urlExactMatch: true
           match-page-url-exactly: true
           permalink: /server
         - title: Get started
@@ -207,7 +201,6 @@
     - title: Web apps
       children:
         - title: Overview
-          urlExactMatch: true
           match-page-url-exactly: true
           permalink: /web
         - title: Get started
@@ -232,7 +225,6 @@
   expanded: false
   children:
   - title: Overview
-    urlExactMatch: true
     match-page-url-exactly: true
     permalink: /tools
   - title: Editors & debuggers
@@ -246,7 +238,6 @@
       - title: DartPad
         children:
           - title: Overview
-            urlExactMatch: true
             match-page-url-exactly: true
             permalink: /tools/dartpad
           - title: DartPad in tutorials
@@ -262,7 +253,6 @@
           permalink: /tools/sdk
         - title: dart
           permalink: /tools/dart-tool
-          urlExactMatch: true
         - title: dart analyze
           permalink: /tools/dart-analyze
         - title: dart compile
@@ -351,8 +341,3 @@
       permalink: https://flutter.dev
     - title: Package site
       permalink: https://pub.dev
-
-# - title: Books
-#   permalink: /resources/books
-# - title: Videos
-#   permalink: /resources/videos


### PR DESCRIPTION
These were used in an old `sidenav.yml` include but we haven't used that since https://github.com/dart-lang/site-www/pull/1572