### PR TITLE
Add a dependency override for analyzer

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,6 @@ dev_dependencies:
     path: site-shared/packages/code_excerpter
   linkcheck: ^3.0.0
   lints: ^2.0.1
+
+dependency_overrides:
+  analyzer: 5.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,6 @@ dev_dependencies:
   lints: ^2.0.1
 
 dependency_overrides:
+  # TODO(parlough): Remove once https://github.com/dart-lang/sdk/issues/52159
+  # is resolved
   analyzer: 5.10.0


### PR DESCRIPTION
Pins analyzer to `5.10.0` due to an incompatibility between `5.11.0` and the latest published `dart_style`: https://github.com/dart-lang/sdk/issues/52159