### PR TITLE
Update most SDK constraints to 3.0 and make adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
             experimental: false
           - sdk: beta
             experimental: false
-          - sdk: stable
-            experimental: true
+#          - sdk: stable
+#            experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/examples/analysis/pubspec.yaml
+++ b/examples/analysis/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/analysis_alt/pubspec.yaml
+++ b/examples/analysis_alt/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/async_await/pubspec.yaml
+++ b/examples/async_await/pubspec.yaml
@@ -2,7 +2,7 @@ name: async_await
 description: dart.dev example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/concurrency/pubspec.yaml
+++ b/examples/concurrency/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/create_libraries/pubspec.yaml
+++ b/examples/create_libraries/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/extension_methods/pubspec.yaml
+++ b/examples/extension_methods/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 1.0.0
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/fetch_data/pubspec.yaml
+++ b/examples/fetch_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Fetch data example
 version: 0.0.1
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   http: ^0.13.5

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/html/pubspec.yaml
+++ b/examples/html/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 version: 0.0.1
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   html: any

--- a/examples/iterables/pubspec.yaml
+++ b/examples/iterables/pubspec.yaml
@@ -2,7 +2,7 @@ name: iterables_examples
 description: dart.dev example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -6,7 +6,7 @@
 // ignore_for_file: avoid_function_literals_in_foreach_calls, prefer_function_declarations_over_variables
 // ignore_for_file: prefer_adjacent_string_concatenation, prefer_is_not_empty, prefer_interpolation_to_compose_strings
 // ignore_for_file: unnecessary_this, always_declare_return_types, no_leading_underscores_for_local_identifiers
-// ignore_for_file: deprecated_colon_for_default_value, unchecked_use_of_nullable_value
+// ignore_for_file: unchecked_use_of_nullable_value
 
 // #docregion library-dir
 
@@ -192,12 +192,6 @@ void miscDeclAnalyzedButNotTested() {
     var buffers = charCodes.map((code) => StringBuffer(code));
     // #enddocregion use-tear-off
   };
-
-  {
-    // #docregion default-separator
-    void insert(Object item, {int at: 0}) {/* ... */}
-    // #enddocregion default-separator
-  }
 
   {
     // #docregion default-value-null

--- a/examples/misc/lib/language_tour/classes/orchestra.dart
+++ b/examples/misc/lib/language_tour/classes/orchestra.dart
@@ -16,11 +16,11 @@ mixin Musical {
 }
 // #enddocregion Musical
 
-abstract class Aggressive {
+mixin Aggressive {
   bool passive = false;
 }
 
-abstract class Demented {
+mixin Demented {
   bool dangerous = false;
 }
 

--- a/examples/misc/lib/language_tour/operators.dart
+++ b/examples/misc/lib/language_tour/operators.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, one_member_abstracts, dead_code
+// ignore_for_file: unused_local_variable, dead_code
 
 void miscDeclAnalyzedButNotTested() {
   (bool done, int col) {
@@ -45,7 +45,7 @@ void miscDeclAnalyzedButNotTested() {
 
 // Minimal class definitions in support of nested-cascades
 
-abstract class Builder<T> {
+mixin Builder<T> {
   T build();
 }
 

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -2,7 +2,7 @@ name: examples
 description: dart.dev example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   args: ^2.3.0

--- a/examples/non_promotion/pubspec.yaml
+++ b/examples/non_promotion/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev non-promotion examples.
 version: 0.0.1
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/null_safety_codelab/pubspec.yaml
+++ b/examples/null_safety_codelab/pubspec.yaml
@@ -2,7 +2,7 @@ name: null_safety_codelab_examples
 description: dart.dev example code for null safety codelab
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example utilities.
 version: 0.0.2
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dependencies:
   test: ^1.19.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: site_www
 homepage: https://dart.dev
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
   build_runner: ^2.3.2

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -940,9 +940,9 @@ var buffers = charCodes.map((code) => StringBuffer(code));
 
 {% include linter-rule-mention.md rule="prefer_equal_for_default_values" %}
 
-For legacy reasons, Dart allows both `:` and `=` as the default value separator
-for named parameters. For consistency with optional positional parameters, use
-`=`.
+Before Dart 3, Dart allowed both `:` and `=` 
+as the default value separator for named parameters. 
+For consistency with optional positional parameters, use `=`.
 
 {:.good}
 <?code-excerpt "usage_good.dart (default-separator)"?>
@@ -951,7 +951,6 @@ void insert(Object item, {int at = 0}) { ... }
 {% endprettify %}
 
 {:.bad}
-<?code-excerpt "usage_bad.dart (default-separator)"?>
 {% prettify dart tag=pre+code %}
 void insert(Object item, {int at: 0}) { ... }
 {% endprettify %}


### PR DESCRIPTION
Beyond updating the constraints, the primary change here is changing some classes to mixins and adjusting the [DO use = to separate a named parameter from its default value](https://dart.dev/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value) Effective Dart guideline. I've made an issue for future work there in https://github.com/dart-lang/site-www/issues/4787.