### PR TITLE
Update type_system example to use latest SDK constraint

### DIFF
--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -136,15 +136,15 @@ void funcCast() {
 
 void infNull() {
   // #docregion type-inf-null
-  List<int> ints = [1, 2, 3];
-  // ignore: non_bool_operand, undefined_operator
+  var ints = [1, 2, 3];
+  // ignore: non_bool_operand, undefined_operator, return_of_invalid_type_from_closure
   var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
   // #enddocregion type-inf-null
 }
 
 void infFix() {
   // #docregion type-inf-fix
-  List<int> ints = [1, 2, 3];
+  var ints = [1, 2, 3];
   var maximumOrNull =
       ints.fold<int?>(null, (a, b) => a == null || a < b ? b : a);
   // #enddocregion type-inf-fix

--- a/examples/type_system/pubspec.yaml
+++ b/examples/type_system/pubspec.yaml
@@ -2,7 +2,7 @@ name: type_system_examples
 description: dart.dev type system examples.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ^2.19.6
 
 dependencies:
   examples_util: {path: ../util}

--- a/src/_guides/language/sound-problems.md
+++ b/src/_guides/language/sound-problems.md
@@ -495,8 +495,8 @@ filterValues((x) => (x [!as String!]).contains('Hello'));
 
 ### Incorrect type inference
 
-On rare occasions, Dart's enhanced type inference might infer
-the wrong type for function literal arguments in a generic constructor invocation.
+On rare occasions, Dart's type inference might infer the 
+wrong type for function literal arguments in a generic constructor invocation.
 This primarily affects `Iterable.fold`.
 
 #### Example
@@ -507,7 +507,7 @@ type inference will infer that `a` has a type of `Null`:
 {:.fails-sa}
 <?code-excerpt "lib/common_fixes_analysis.dart (type-inf-null)"?>
 {% prettify dart tag=pre+code %}
-List<int> ints = [1, 2, 3];
+var ints = [1, 2, 3];
 var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
 {% endprettify %}
 
@@ -516,7 +516,7 @@ var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
 {:.passes-sa}
 <?code-excerpt "lib/common_fixes_analysis.dart  (type-inf-fix)"?>
 {% prettify dart tag=pre+code %}
-List<int> ints = [1, 2, 3];
+var ints = [1, 2, 3];
 var maximumOrNull =
     ints.fold<int?>(null, (a, b) => a == null || a < b ? b : a);
 {% endprettify %}


### PR DESCRIPTION
Have to also adjust for a new warning introduced with the new language version.