### PR TITLE
Add Dart 3 to spec page

### DIFF
--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -8,26 +8,43 @@ Use this page to find the formal Dart language specification.
 For a gentler introduction to Dart, see the
 [language tour](/language).
 
-## Dart 2
+## Dart 3
 
-The Dart 2 language specification is available in PDF format:
+The Dart 3 language specification is in progress.
+You can find the in-progress specification in PDF format:
 
-  * [Formal specification (Dart 2.10)][formal spec]
-  * [Latest, in-progress specification][latest draft]
-    (produced from a [LaTeX file][])
+* [Latest, in-progress specification][latest draft]
+  (produced from a [LaTeX file][])
 
-[formal spec]: /guides/language/specifications/DartLangSpec-v2.10.pdf
 [latest draft]: https://spec.dart.dev/DartLangSpecDraft.pdf
 [LaTeX file]: https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex
 
-New language features are typically described using 
+New language features are typically described using
 informal language feature specifications in the [dart-lang/language][] repo:
-  * [Accepted informal proposals][]
-  * [Drafts of potential features][]
+
+* [Accepted informal proposals][]
+* [Drafts of potential features][]
 
 [dart-lang/language]: https://github.com/dart-lang/language
 [Accepted informal proposals]: https://github.com/dart-lang/language/tree/master/accepted
 [Drafts of potential features]: https://github.com/dart-lang/language/tree/master/working
+
+{{site.alert.info}}
+  Dart 3 changed the Dart language in a few ways,
+  primarily requiring [sound null safety](/null-safety).
+{{site.alert.end}}
+
+## Dart 2
+
+The Dart 2 language specification is available in PDF format:
+
+  * [Formal specification (Dart 2.10)][2-10 formal spec]
+
+[2-10 formal spec]: /guides/language/specifications/DartLangSpec-v2.10.pdf
+
+For information on Dart versions 2.12 and later, 
+which have support for [null safety](/null-safety), 
+check out the in-progress [Dart 3 specification](#dart-3).
 
 {{site.alert.info}}
   Dart 2 changed the Dart language in many ways, some of which are not


### PR DESCRIPTION
So I saw two ways to go about this change:

1. Separate Dart 3 from Dart 2, and keep the Dart 2 entry focused on versions 2.10 and earlier
2. Combine Dart 3 and 2, since the changes are minimal in terms of 2.12->2.19 vs 3.

I chose 1, since the separation felt less confusing, so users don't have to keep in mind a 2.12 vs before 2.12 world anymore. Open to other directions though :)

Staged: https://dart-dev--pr4792-dart-3-spec-ir63p46a.web.app/guides/language/spec

Closes https://github.com/dart-lang/site-www/issues/4793