### PR TITLE
Enable strict liquid checks to catch potential issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ branch: main
 port: 4000
 source: src
 strict_front_matter: true
+liquid:
+  error_mode: strict
+  strict_filters: true
 future: true # In support of https://github.com/dart-lang/site-www/issues/1111
 sass:
   sass_dir: _sass

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -8,24 +8,24 @@ canonical: https://dart.dev/language
 noindex: true
 ---
 
-{% comment %}
-  !! NOTE:
-  
-  All new language content should go within the `/language` directory.
-  This file exists temporarily for legacy reasons so
-  links to the old language tour do not break.
-
-  In the short term, if you move content that is referenced here,
-  update the text and link in this file, as well as
-  the redirection map in `src/assets/js/language-tour-redirector.js`.
-{% endcomment -%}
-
 {{site.alert.warning}}
   The Dart language tour's content has been split across
   several different pages in the left side navigation under **Language**.
   To begin your journey learning Dart,
   check out [Introduction to the Dart language](/language).
 {{site.alert.end}}
+
+{% comment %}
+  !! NOTE:
+  
+  All new language content should go within the `/language` directory.
+  This file exists temporarily for legacy reasons so
+  links to the old language tour do not break.
+  
+  In the short term, if you move content that is referenced here,
+  update the text and link in this file, as well as
+  the redirection map in `src/assets/js/language-tour-redirector.js`.
+{% endcomment -%}
 
 ## A basic Dart program
 


### PR DESCRIPTION
They prevents potential issues from landing on the site, as the CI will catch them and indicate the issue, so they can be addressed before PRs land.