### PR TITLE
[Dart 3] Update build_runner examples

### DIFF
--- a/examples/build_runner_usage/pubspec.yaml
+++ b/examples/build_runner_usage/pubspec.yaml
@@ -2,10 +2,10 @@ name: build_runner_usage
 description: dart.dev build_runner example code.
 
 environment:
-  sdk: ^2.19.4
+  sdk: ^3.0.0-0
 
 dev_dependencies:
-  args: ^2.2.0
-  build_runner: ^2.1.0
-  build_test: ^2.1.0
+  args: ^2.4.0
+  build_runner: ^2.4.1
+  build_test: ^2.1.7
   lints: ^2.0.0

--- a/src/tools/build_runner.md
+++ b/src/tools/build_runner.md
@@ -38,8 +38,8 @@ to your app's pubspec:
 ```yaml
 dev_dependencies:
   # ···
-  build_runner: ^2.1.0
-  build_test: ^2.1.0
+  build_runner: ^2.4.1
+  build_test: ^2.1.7
 ```
 
 Depending on **build_test** is optional; do it if you'll be testing your code.

--- a/src/tools/webdev.md
+++ b/src/tools/webdev.md
@@ -2,7 +2,6 @@
 title: webdev
 description: Command-line tools for Dart web development.
 ---
-<!--?code-excerpt path-base="examples/ng/doc"?-->
 
 This page explains how to use `webdev` to compile your app and
 `build_runner` to test your app.
@@ -42,13 +41,12 @@ If you're testing the app, it must also depend on **build_test**.
 To depend on these packages, add the following [dev_dependencies][] to
 your app's `pubspec.yaml` file:
 
-<!--?code-excerpt "quickstart/pubspec.yaml (build dependencies)"?-->
 ```yaml
   dev_dependencies:
     # ···
-    build_runner: ^2.1.0
-    build_test: ^2.1.0
-    build_web_compilers: ^3.0.0
+    build_runner: ^2.4.1
+    build_test: ^2.1.7
+    build_web_compilers: ^4.0.3
 ```
 
 As usual after `pubspec.yaml` changes, run `dart pub get` or 


### PR DESCRIPTION
We have to update the lower constraint on the build dependencies due to some incompatibilities. 

Contributes to https://github.com/dart-lang/site-www/issues/4693