### PR TITLE
[Dart 3] Remove 'Dart 3 beta' mention from archive

### DIFF
--- a/src/get-dart/archive/index.md
+++ b/src/get-dart/archive/index.md
@@ -60,23 +60,6 @@ experimental development use, not for production use.
 To download a main channel build, use a
 [main channel URL](#main-channel-url-scheme).
 
-<a id="dart-3-alpha"></a>
-## Dart 3 beta
-
-Dart 3 beta -- the preview of our next major release --
-is currently available in two ways:
-
-* For a standalone Dart SDK, use any **beta channel** Dart SDK
-  downloaded after 14 April 2023
-  (`dart --version` should report `3.0.0-417.1.beta` or later).
-
-* For the Dart SDK embedded in the Flutter SDK,
-  use any [Flutter **beta channel** SDK][]
-  downloaded after 19 April 2023 
-  (`dart --version` should report `3.0.0-417.1.beta` or later).
-
-[Flutter **beta channel** SDK]: https://docs.flutter.dev/release/upgrade#switching-flutter-channels
-
 ## Download URLs
 
 You can download zip files for any channel.

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -130,7 +130,7 @@ If the `pub get` step fails, check the [status of the dependencies][].
 If the `analyze` step fails, update your code to resolve the issues
 listed by the analyzer.
 
-[the download page]: /get-dart/archive#dart-3-beta
+[the download page]: /get-dart/archive
 [status of the dependencies]: /null-safety/migration-guide#check-dependency-status
 
 ### Dart 3 backwards compatibility


### PR DESCRIPTION
This section is no longer necessary as Dart 3 will be clearly indicated in the stable release section of the archive and the beta is over.

Closes https://github.com/dart-lang/site-www/issues/4791