### PR TITLE
No longer warn about caret syntax for SDK constraint

### DIFF
--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -273,17 +273,6 @@ dependencies:
   string_scanner: ^0.1.2
 ```
 
-Because caret syntax was introduced in Dart 1.8.3,
-it requires an [SDK constraint][]
-(using [traditional syntax](#traditional-syntax))
-to ensure that older versions of pub don't try to process it.
-For example:
-
-```yaml
-environment:
-  sdk: '>=1.8.3 <3.0.0'
-```
-
 ### Traditional syntax
 
 A version constraint that uses _traditional syntax_

--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -433,36 +433,36 @@ dependencies.
 [Language versioning]: /guides/language/evolution#language-versioning
 
 For example, the following constraint says that this package
-works with any Dart SDK that's version 2.12.0 or higher:
+works with any Dart SDK that's version 3.0.0 or higher:
 
 ```yaml
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ^3.0.0
 ```
 
 Pub tries to find the latest version of a package whose SDK constraint works
 with the version of the Dart SDK that you have installed.
 
-As of Dart 2.12, omitting the SDK constraint is an error.
+Omitting the SDK constraint is an error.
 When the pubspec has no SDK constraint,
-`pub get` fails with a message like the following:
+`dart pub get` fails with a message like the following:
 
 ```
 pubspec.yaml has no lower-bound SDK constraint.
 You should edit pubspec.yaml to contain an SDK constraint:
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '^3.0.0'
   
 See https://dart.dev/go/sdk-constraint
 ```
 
-{{site.alert.warning}}
-  Caret syntax (`^`) is a compact way to represent version ranges, 
-  but **don't use it for the SDK constraint.** 
-  Instead, **include an upper bound for the SDK** (`<3.0.0`, usually). 
-  For more information, 
-  see the [Caret syntax](/tools/pub/dependencies#caret-syntax) documentation.
+{{site.alert.version-note}}
+  Before Dart 2.19, pub disallowed caret syntax in SDK constraints.
+  In earlier versions, provide a complete range,
+  such as `'>=2.12.0 <3.0.0'`.
+  For more information, check out
+  the [Caret syntax](/tools/pub/dependencies#caret-syntax) documentation.
 {{site.alert.end}}
 
 

--- a/src/tools/pub/versioning.md
+++ b/src/tools/pub/versioning.md
@@ -162,7 +162,7 @@ dependencies:
 {{site.alert.note}}
   This example uses _caret syntax_ to express a range of versions.
   The string `^2.3.5` means 
-  "the range of all versions from 2.3.5  to 3.0.0, not including 3.0.0." 
+  "the range of all versions from 2.3.5 to 3.0.0, not including 3.0.0." 
   For more information, 
   see [Caret syntax](/tools/pub/dependencies#caret-syntax).
 {{site.alert.end}}


### PR DESCRIPTION
Closes https://github.com/dart-lang/site-www/issues/4693