### PR TITLE
Update language repository links to use `main` branch

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -151,7 +151,7 @@
       { "source": "/go/dart2js-info", "destination": "https://github.com/dart-lang/sdk/tree/main/pkg/dart2js_info", "type": 301 },
       { "source": "/go/dartdoc-options-file", "destination": "https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml", "type": 301 },
       { "source": "/go/data-driven-fixes", "destination": "https://github.com/flutter/flutter/wiki/Data-driven-Fixes", "type": 301 },
-      { "source": "/go/dot-packages-deprecation", "destination": "https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md", "type": 301 },
+      { "source": "/go/dot-packages-deprecation", "destination": "https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md", "type": 301 },
       { "source": "/go/experiments", "destination": "/tools/experiment-flags", "type": 301 },
       { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
       { "source": "/go/ffi", "destination": "/guides/libraries/c-interop", "type": 301 },

--- a/src/_articles/archive/dart-2.md
+++ b/src/_articles/archive/dart-2.md
@@ -210,4 +210,4 @@ environment:
 [testing]: /guides/testing
 [Updating your pub package to Dart 2,]: https://filiph.medium.com/updating-your-pub-package-to-dart-2-cd8ca343b1be
 [Using constructors]: /language/classes#using-constructors
-[sync async start]: https://github.com/dart-lang/language/blob/master/archive/newsletter/20170915.md#synchronous-async-start
+[sync async start]: https://github.com/dart-lang/language/blob/main/archive/newsletter/20170915.md#synchronous-async-start

--- a/src/_guides/language/analysis-options.md
+++ b/src/_guides/language/analysis-options.md
@@ -236,7 +236,7 @@ info - The type argument(s) of 'Map' can't be inferred - inference_failure_on_co
   for an exhaustive list of inference failure conditions.
 {{site.alert.end}}
 
-[Conditions for strict inference failure]: https://github.com/dart-lang/language/blob/master/resources/type-system/strict-inference.md#conditions-for-strict-inference-failure
+[Conditions for strict inference failure]: https://github.com/dart-lang/language/blob/main/resources/type-system/strict-inference.md#conditions-for-strict-inference-failure
 
 `strict-raw-types: <bool>`
 : A value of `true` ensures that the type inference engine never chooses

--- a/src/_guides/language/evolution.md
+++ b/src/_guides/language/evolution.md
@@ -473,7 +473,7 @@ check out the [language versioning specification][].
 [language funnel]: https://github.com/dart-lang/language/projects/1
 [language specification]: /guides/language/spec
 [language documentation]: /language
-[language versioning specification]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/feature-specification.md#dart-language-versioning
+[language versioning specification]: https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/feature-specification.md#dart-language-versioning
 [migrated to Dart 2]: /articles/archive/dart-2
 [null safety]: /null-safety
 [SDK changelog]: https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md

--- a/src/_guides/language/spec.md
+++ b/src/_guides/language/spec.md
@@ -18,7 +18,7 @@ The Dart 2 language specification is available in PDF format:
 
 [formal spec]: /guides/language/specifications/DartLangSpec-v2.10.pdf
 [latest draft]: https://spec.dart.dev/DartLangSpecDraft.pdf
-[LaTeX file]: https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex
+[LaTeX file]: https://github.com/dart-lang/language/blob/main/specification/dartLangSpec.tex
 
 New language features are typically described using 
 informal language feature specifications in the [dart-lang/language][] repo:
@@ -26,8 +26,8 @@ informal language feature specifications in the [dart-lang/language][] repo:
   * [Drafts of potential features][]
 
 [dart-lang/language]: https://github.com/dart-lang/language
-[Accepted informal proposals]: https://github.com/dart-lang/language/tree/master/accepted
-[Drafts of potential features]: https://github.com/dart-lang/language/tree/master/working
+[Accepted informal proposals]: https://github.com/dart-lang/language/tree/main/accepted
+[Drafts of potential features]: https://github.com/dart-lang/language/tree/main/working
 
 {{site.alert.info}}
   Dart 2 changed the Dart language in many ways, some of which are not

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -312,7 +312,7 @@ For more details and examples of using collection `if` and `for`, see the
 [`List`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/List-class.html
 [`Map`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Map-class.html
 [Using constructors]: /language/classes#using-constructors
-[collections proposal]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
-[spread proposal]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
+[collections proposal]: https://github.com/dart-lang/language/blob/main/accepted/2.3/control-flow-collections/feature-specification.md
+[spread proposal]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md
 [generics]: /language/generics
 [`Set`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Set-class.html

--- a/src/language/extend.md
+++ b/src/language/extend.md
@@ -112,7 +112,7 @@ and the dynamic type of the receiver has an implementation of `noSuchMethod()`
 that's different from the one in class `Object`.
 
 For more information, see the informal
-[noSuchMethod forwarding specification.](https://github.com/dart-lang/language/blob/master/archive/feature-specifications/nosuchmethod-forwarding.md)
+[noSuchMethod forwarding specification.](https://github.com/dart-lang/language/blob/main/archive/feature-specifications/nosuchmethod-forwarding.md)
 
 [parameterized types]: /language/generics#restricting-the-parameterized-type
 [operators]: /language/methods#operators

--- a/src/language/extension-methods.md
+++ b/src/language/extension-methods.md
@@ -271,6 +271,6 @@ For more information about extension methods, see the following:
 * [Feature specification][specification]
 * [Extension methods sample][sample]
 
-[specification]: https://github.com/dart-lang/language/blob/master/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
+[specification]: https://github.com/dart-lang/language/blob/main/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
 [article]: https://medium.com/dartlang/extension-methods-2d466cd8b308
 [sample]: https://github.com/dart-lang/samples/tree/main/extension_methods

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -396,7 +396,7 @@ To migrate a package by hand, follow these steps:
    $ dart pub get
    ```
 
-   [package configuration file]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md
+   [package configuration file]: https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md
 
    Running `dart pub get` with a lower SDK constraint of at least `2.12.0`
    sets the default language version of

--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -525,7 +525,7 @@ reached when `object` is a list.
 For null safety, we've taken this limited analysis and made it [much more
 powerful in several ways.][flow analysis]
 
-[flow analysis]: https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md
+[flow analysis]: https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md
 
 ### Reachability analysis
 

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -139,7 +139,7 @@ If you want to incrementally migrate a package by hand, follow these steps:
    $ dart pub get
    ```
 
-   [package configuration file]: https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md
+   [package configuration file]: https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md
 
    Running `dart pub get` with a lower SDK constraint of `2.12.0`
    sets the default language version of

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -175,7 +175,7 @@ Inside or outside of Google, [every Flutter app][FlutterShowcase] uses Dart.
 [SDK issues]: https://github.com/dart-lang/sdk/issues
 [language issues]: https://github.com/dart-lang/language/issues
 [language funnel]: https://github.com/dart-lang/language/projects/1
-[language process]: https://github.com/dart-lang/language/blob/master/doc/life_of_a_language_feature.md
+[language process]: https://github.com/dart-lang/language/blob/main/doc/life_of_a_language_feature.md
 [pub]: {{site.pub}}
 [announcement]: https://blog.chromium.org/2013/11/dart-10-stable-sdk-for-structured-web.html
 [lang]: /language

--- a/src/resources/glossary.md
+++ b/src/resources/glossary.md
@@ -21,4 +21,4 @@ If not, the pattern _refutes_, or denies, the match.
 Refutable patterns appear in [_matching contexts_][pattern context].
 
 
-[pattern context]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/0546-patterns/feature-specification.md#pattern-context
+[pattern context]: https://github.com/dart-lang/language/blob/main/accepted/future-releases/0546-patterns/feature-specification.md#pattern-context

--- a/src/tools/diagnostic-messages.md
+++ b/src/tools/diagnostic-messages.md
@@ -158,7 +158,7 @@ condition is `true` and the path in which the condition is `false`.
 For additional details, see the
 [specification of definite assignment][definiteAssignmentSpec].
 
-[definiteAssignmentSpec]: https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md
+[definiteAssignmentSpec]: https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md
 
 ### Mixin application
 


### PR DESCRIPTION
Looks like the repository switched over sometime in the past few days :)