### PR TITLE
Expand on `mixin class`

### DIFF
--- a/src/language/mixins.md
+++ b/src/language/mixins.md
@@ -127,8 +127,8 @@ class Novice extends Musician { // Use Musician as a class
 } 
 ```
 
-By declaring `Musician` abstract, you force any type that uses
-it to define the abstract method its behavior depends on. 
+By declaring the `Musician` mixin as abstract, you force any type that uses
+it to define the abstract method upon which its behavior depends. 
 
 This is similar to how the `on` directive ensures a mixin has access to any
 interfaces it depends on by specifying the superclass of that interface.

--- a/src/language/mixins.md
+++ b/src/language/mixins.md
@@ -89,6 +89,50 @@ A `mixin` declaration defines a mixin. A `class` declaration defines a [class][]
 A `mixin class` declaration defines a class that is usable as both a regular class
 and a mixin, with the same name and the same type.
 
+Any restrictions that apply to classes and mixins also apply to mixin classes:
+
+- Mixins can't have `extends` or `with` clauses, so neither can a `mixin class`.
+- Classes can't have an `on` clause, so neither can a `mixin class`. 
+
+### `abstract mixin class`
+
+You can achieve similar behavior to the `on` directive for a mixin class. 
+Make the mixin class `abstract` and define the abstract methods its behavior 
+depends on:
+
+```dart
+abstract mixin class Musician {
+  // No 'on' clause, but an abstract method that other types must define if 
+  // they want to use (mix in or extend) Musician: 
+  void playInstrument(String instrumentName);
+
+  void playPiano() {
+    playInstrument('Piano');
+  }
+  void playFlute() {
+    playInstrument('Flute');
+  }
+}
+
+class Virtuoso with Musician { // Use Musician as a mixin
+  void playInstrument(String instrumentName) {
+    print('Plays with $instrumentName beautifully');
+  }  
+} 
+
+class Novice extends Musician { // Use Musician as a class
+  void playInstrument(String instrumentName) {
+    print('Plays with $instrumentName poorly');
+  }  
+} 
+```
+
+By declaring `Musician` abstract, you force any type that uses
+it to define the abstract method its behavior depends on. 
+
+This is similar to how the `on` directive ensures a mixin has access to any
+interfaces it depends on by specifying the superclass of that interface.
+
 [language version]: /guides/language/evolution#language-versioning
 [class]: /language/classes
 [class modifiers]: /language/class-modifiers

--- a/src/language/mixins.md
+++ b/src/language/mixins.md
@@ -89,7 +89,7 @@ A `mixin` declaration defines a mixin. A `class` declaration defines a [class][]
 A `mixin class` declaration defines a class that is usable as both a regular class
 and a mixin, with the same name and the same type.
 
-Any restrictions that apply to classes and mixins also apply to mixin classes:
+Any restrictions that apply to classes or mixins also apply to mixin classes:
 
 - Mixins can't have `extends` or `with` clauses, so neither can a `mixin class`.
 - Classes can't have an `on` clause, so neither can a `mixin class`. 
@@ -116,13 +116,13 @@ abstract mixin class Musician {
 
 class Virtuoso with Musician { // Use Musician as a mixin
   void playInstrument(String instrumentName) {
-    print('Plays with $instrumentName beautifully');
+    print('Plays the $instrumentName beautifully');
   }  
 } 
 
 class Novice extends Musician { // Use Musician as a class
   void playInstrument(String instrumentName) {
-    print('Plays with $instrumentName poorly');
+    print('Plays the $instrumentName poorly');
   }  
 } 
 ```


### PR DESCRIPTION
Fixes #4826 

I had trouble making the connection between what the `on` clause is for and how using `abstract` provides the same benefit. Here's what _I think_ the reason is (added to `mixins.md`), but I could be off:

> By declaring `Musician` abstract, you force any type that uses
it to define the abstract method its behavior depends on. 

> This is similar to how the `on` directive ensures a mixin has access to any
interfaces it depends on by specifying the superclass of that interface.

*Also not sure if I'mm using "interfaces" correctly there.

I assumed that this would be a common use case, so I put this explanation in its own subsection on the mixin page, "`abstract mixin class`".