### PR TITLE
Move and add code excerpts for new loops page

### DIFF
--- a/examples/language/analysis_options.yaml
+++ b/examples/language/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../analysis_options.yaml

--- a/examples/language/dart_test.yaml
+++ b/examples/language/dart_test.yaml
@@ -1,0 +1,1 @@
+include: ../dart_test_base_browser.yaml

--- a/examples/language/lib/control_flow/loops.dart
+++ b/examples/language/lib/control_flow/loops.dart
@@ -1,0 +1,77 @@
+final class Candidate {
+  String name = '';
+  int yearsExperience = 0;
+
+  void interview() {}
+}
+
+void miscDeclAnalyzedButNotTested() {
+  final candidates = <Candidate>[];
+
+  {
+    // #docregion collection
+    for (final candidate in candidates) {
+      candidate.interview();
+    }
+    // #enddocregion collection
+  }
+
+  {
+    // #docregion collection-for-pattern
+    for (final Candidate(:name, :yearsExperience) in candidates) {
+      print('$name has $yearsExperience of experience.');
+    }
+    // #enddocregion collection-for-pattern
+  }
+
+  {
+    bool isDone() => true;
+    bool doSomething() => true;
+    // #docregion while
+    while (!isDone()) {
+      doSomething();
+    }
+    // #enddocregion while
+  }
+
+  {
+    bool atEndOfPage() => true;
+    bool printLine() => true;
+    // #docregion do-while
+    do {
+      printLine();
+    } while (!atEndOfPage());
+    // #enddocregion do-while
+  }
+
+  {
+    bool shutDownRequested() => true;
+    bool processIncomingRequests() => true;
+    // #docregion while-break
+    while (true) {
+      if (shutDownRequested()) break;
+      processIncomingRequests();
+    }
+    // #enddocregion while-break
+  }
+
+  {
+    // #docregion for-continue
+    for (int i = 0; i < candidates.length; i++) {
+      var candidate = candidates[i];
+      if (candidate.yearsExperience < 5) {
+        continue;
+      }
+      candidate.interview();
+    }
+    // #enddocregion for-continue
+  }
+
+  {
+    // #docregion where
+    candidates
+        .where((c) => c.yearsExperience >= 5)
+        .forEach((c) => c.interview());
+    // #enddocregion where
+  }
+}

--- a/examples/language/pubspec.yaml
+++ b/examples/language/pubspec.yaml
@@ -1,0 +1,12 @@
+name: examples
+description: dart.dev example code.
+
+environment:
+  sdk: ^3.0.0-0
+
+dependencies:
+  examples_util: { path: ../util }
+
+dev_dependencies:
+  lints: ^2.1.0
+  test: ^1.24.2

--- a/examples/language/test/control_flow/loops_test.dart
+++ b/examples/language/test/control_flow/loops_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+import 'package:examples_util/print_matcher.dart' as m;
+
+void main() {
+  test('for', () {
+    // #docregion for
+    var message = StringBuffer('Dart is fun');
+    for (var i = 0; i < 5; i++) {
+      message.write('!');
+    }
+    // #enddocregion for
+    expect(message.toString(), 'Dart is fun!!!!!');
+  });
+
+  test('for-and-closures', () {
+    void testForEachClosures() {
+      // #docregion for-and-closures
+      var callbacks = [];
+      for (var i = 0; i < 2; i++) {
+        callbacks.add(() => print(i));
+      }
+
+      for (final c in callbacks) {
+        c();
+      }
+      // #enddocregion for-and-closures
+    }
+
+    expect(testForEachClosures, m.prints(['0', '1']));
+  });
+
+  test('forEach', () {
+    void testCollectionForEach() {
+      // #docregion for-each
+      var collection = [1, 2, 3];
+      collection.forEach(print); // 1 2 3
+      // #enddocregion for-each
+    }
+
+    expect(testCollectionForEach, m.prints([1, 2, 3]));
+  });
+}

--- a/examples/misc/lib/language_tour/control_flow.dart
+++ b/examples/misc/lib/language_tour/control_flow.dart
@@ -1,14 +1,6 @@
 import 'package:examples_util/nullable.dart';
 
-class Candidate {
-  int yearsExperience = 0;
-
-  void interview() {}
-}
-
 void miscDeclAnalyzedButNotTested() {
-  final candidates = <Candidate>[];
-
   {
     bool isRaining() => true;
     bool isSnowing() => true;
@@ -22,65 +14,6 @@ void miscDeclAnalyzedButNotTested() {
       car.putTopDown();
     }
     // #enddocregion if-else
-  }
-
-  {
-    // #docregion collection
-    for (final candidate in candidates) {
-      candidate.interview();
-    }
-    // #enddocregion collection
-  }
-
-  {
-    bool isDone() => true;
-    bool doSomething() => true;
-    // #docregion while
-    while (!isDone()) {
-      doSomething();
-    }
-    // #enddocregion while
-  }
-
-  {
-    bool atEndOfPage() => true;
-    bool printLine() => true;
-    // #docregion do-while
-    do {
-      printLine();
-    } while (!atEndOfPage());
-    // #enddocregion do-while
-  }
-
-  {
-    bool shutDownRequested() => true;
-    bool processIncomingRequests() => true;
-    // #docregion while-break
-    while (true) {
-      if (shutDownRequested()) break;
-      processIncomingRequests();
-    }
-    // #enddocregion while-break
-  }
-
-  {
-    // #docregion for-continue
-    for (int i = 0; i < candidates.length; i++) {
-      var candidate = candidates[i];
-      if (candidate.yearsExperience < 5) {
-        continue;
-      }
-      candidate.interview();
-    }
-    // #enddocregion for-continue
-  }
-
-  {
-    // #docregion where
-    candidates
-        .where((c) => c.yearsExperience >= 5)
-        .forEach((c) => c.interview());
-    // #enddocregion where
   }
 
   void executeClosed() {}

--- a/examples/misc/test/language_tour/control_flow_test.dart
+++ b/examples/misc/test/language_tour/control_flow_test.dart
@@ -1,45 +1,6 @@
 import 'package:test/test.dart';
-import 'package:examples_util/print_matcher.dart' as m;
 
 void main() {
-  test('for', () {
-    // #docregion for
-    var message = StringBuffer('Dart is fun');
-    for (var i = 0; i < 5; i++) {
-      message.write('!');
-    }
-    // #enddocregion for
-    expect(message.toString(), 'Dart is fun!!!!!');
-  });
-
-  test('for-and-closures', () {
-    void testForEachClosures() {
-      // #docregion for-and-closures
-      var callbacks = [];
-      for (var i = 0; i < 2; i++) {
-        callbacks.add(() => print(i));
-      }
-
-      for (final c in callbacks) {
-        c();
-      }
-      // #enddocregion for-and-closures
-    }
-
-    expect(testForEachClosures, m.prints(['0', '1']));
-  });
-
-  test('forEach', () {
-    void testCollectionForEach() {
-      // #docregion forEach
-      var collection = [1, 2, 3];
-      collection.forEach(print); // 1 2 3
-      // #enddocregion forEach
-    }
-
-    expect(testCollectionForEach, m.prints([1, 2, 3]));
-  });
-
   test('assert', () {
     // trick to make text nullable
     String? nullableText() => '';

--- a/src/language/loops.md
+++ b/src/language/loops.md
@@ -73,7 +73,7 @@ for (final Candidate(:name, :yearsExperience) in candidates) {
 
 Iterable classes also have a [forEach()][] method as another option:
 
-<?code-excerpt "language/test/control_flow/loops_test.dart (forEach)"?>
+<?code-excerpt "language/test/control_flow/loops_test.dart (for-each)"?>
 ```dart
 var collection = [1, 2, 3];
 collection.forEach(print); // 1 2 3

--- a/src/language/loops.md
+++ b/src/language/loops.md
@@ -19,7 +19,7 @@ You can also manipulate control flow in Dart using:
 
 You can iterate with the standard `for` loop. For example:
 
-<?code-excerpt "misc/test/language_tour/control_flow_test.dart (for)"?>
+<?code-excerpt "language/test/control_flow/loops_test.dart (for)"?>
 ```dart
 var message = StringBuffer('Dart is fun');
 for (var i = 0; i < 5; i++) {
@@ -30,7 +30,7 @@ for (var i = 0; i < 5; i++) {
 Closures inside of Dart’s `for` loops capture the _value_ of the index.
 This avoids a common pitfall found in JavaScript. For example, consider:
 
-<?code-excerpt "misc/test/language_tour/control_flow_test.dart (for-and-closures)"?>
+<?code-excerpt "language/test/control_flow/loops_test.dart (for-and-closures)"?>
 ```dart
 var callbacks = [];
 for (var i = 0; i < 2; i++) {
@@ -49,19 +49,20 @@ Sometimes you might not need to know the current iteration counter
 when iterating over an [`Iterable`][] type, like `List` or `Set`.
 In that case, use the `for-in` loop for cleaner code:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (collection)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (collection)"?>
 ```dart
 for (final candidate in candidates) {
   candidate.interview();
 }
 ```
 
-To process the values obtained from the iterable, you can also use a [pattern][]
-in a `for-in` loop:
+To process the values obtained from the iterable, 
+you can also use a [pattern][] in a `for-in` loop:
 
+<?code-excerpt "language/lib/control_flow/loops.dart (collection-for-pattern)"?>
 ```dart
-for (var (x, y) in listOfPairs) {
-  assert(x != y);
+for (final Candidate(:name, :yearsExperience) in candidates) {
+  print('$name has $yearsExperience of experience.');
 }
 ```
 
@@ -72,7 +73,7 @@ for (var (x, y) in listOfPairs) {
 
 Iterable classes also have a [forEach()][] method as another option:
 
-<?code-excerpt "misc/test/language_tour/control_flow_test.dart (forEach)"?>
+<?code-excerpt "language/test/control_flow/loops_test.dart (forEach)"?>
 ```dart
 var collection = [1, 2, 3];
 collection.forEach(print); // 1 2 3
@@ -83,7 +84,7 @@ collection.forEach(print); // 1 2 3
 
 A `while` loop evaluates the condition before the loop:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (while)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (while)"?>
 ```dart
 while (!isDone()) {
   doSomething();
@@ -92,7 +93,7 @@ while (!isDone()) {
 
 A `do`-`while` loop evaluates the condition *after* the loop:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (do-while)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (do-while)"?>
 ```dart
 do {
   printLine();
@@ -104,7 +105,7 @@ do {
 
 Use `break` to stop looping:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (while-break)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (while-break)"?>
 ```dart
 while (true) {
   if (shutDownRequested()) break;
@@ -114,7 +115,7 @@ while (true) {
 
 Use `continue` to skip to the next loop iteration:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (for-continue)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (for-continue)"?>
 ```dart
 for (int i = 0; i < candidates.length; i++) {
   var candidate = candidates[i];
@@ -128,7 +129,7 @@ for (int i = 0; i < candidates.length; i++) {
 If you’re using an [`Iterable`][] such as a list or set,
 how you write the previous example might differ:
 
-<?code-excerpt "misc/lib/language_tour/control_flow.dart (where)"?>
+<?code-excerpt "language/lib/control_flow/loops.dart (where)"?>
 ```dart
 candidates
     .where((c) => c.yearsExperience >= 5)


### PR DESCRIPTION
Mostly I moved the loops code excerpts to a new `/language` examples directory to give us an example as we add new code excerpts for `/language`, so they aren't hidden deeply under `misc`. My thinking is they will emulate the `/language` sidebar structure to make it easy to navigate.

This does however changes the new example in loops to also follow the candidates theme of the page and adds a code excerpt for that. Let me know what you think :)

Staged updated example: https://dart-dev--pr4838-feature-control-flow-copvea4t.web.app/language/loops#:~:text=To%20process%20the%20values%20obtained

Contributes to https://github.com/dart-lang/site-www/issues/4828