### PR TITLE
Dart 3 in sidenav

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,3 +1,8 @@
+- title: Dart 3
+  expanded: false
+  children:
+    - title: Dart 3 migration guide
+      permalink: /resources/dart-3-migration
 - title: Tutorials & codelabs
   expanded: false
   children:
@@ -330,8 +335,6 @@
       permalink: /guides/language/evolution
     - title: Language specification
       permalink: /guides/language/spec    
-    - title: Dart 3 migration guide
-      permalink: /resources/dart-3-migration
     - title: Coming from ...
       expanded: false
       children:


### PR DESCRIPTION
I dislike how the migration guide is hidden at the moment. The banner announces Dart 3, which points to the blogpost, which I'm sure points back to the migration guide... but I feel like there should be a more obvious pointer to Dart 3 content.

I put a new Dart 3 bucket _right at the top_ of the sidenav:
<img width="241" alt="image" src="https://github.com/dart-lang/site-www/assets/111139605/e0d97293-f7f4-4376-be27-e51be8d7f4bd">

Right now, all that's under it is the migration guide:
<img width="261" alt="Pasted Graphic" src="https://github.com/dart-lang/site-www/assets/111139605/699c563e-2c0e-4929-a660-2aa0ace1705d">

Once @munificent 's class modifier guidance is ready, I think it should go under there too. Also, once the Dart 3 codelab (#4845) is ready, it should go there too:
<img width="257" alt="Pasted Graphic 1" src="https://github.com/dart-lang/site-www/assets/111139605/b720d349-df3e-4c08-8854-c5c0bb752afb">

What does everyone think about this? No links have to change so I think it's a very minor effort / major impact change we can make to emphasize important new content