### PR TITLE
Clarify switch expression usage

### DIFF
--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -131,10 +131,18 @@ check out the patterns documentation on [Switch statements and expressions][].
 
 A `switch` _expression_ produces a value based on the expression
 body of whichever case matches. 
-You can use a switch expression wherever Dart allows expressions,
-_except_ at the start of an expression statement.
-Not all switch statments need to return a value into some expression statement.
-If yours doesn't, use a [switch _statement_](#switch-statements) rather than an expression.
+You can use a switch expression wherever Dart allows expressions*, for example:
+
+```dart
+var x = switch (y) { ... };
+
+print(switch (x) { ... };
+
+return switch (x) { ... };
+```
+
+*You _can't_ use a switch expression at the start of an expression statement.
+Instead, use a [switch statement](#switch-statements).
 
 Switch expressions allow you to rewrite a switch _statement_ like this:
 

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -133,8 +133,8 @@ A `switch` _expression_ produces a value based on the expression
 body of whichever case matches. 
 You can use a switch expression wherever Dart allows expressions,
 _except_ at the start of an expression statement.
-If your switch doesn't need to return a value into some expression statement,
-use a [switch _statement_](#switch-statements) instead of an expression.
+Not all switch statments need to return a value into some expression statement.
+If yours doesn't, use a [switch _statement_](#switch-statements) rather than an expression.
 
 Switch expressions allow you to rewrite a switch _statement_ like this:
 

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -129,20 +129,14 @@ check out the patterns documentation on [Switch statements and expressions][].
 
 ### Switch expressions
 
-A `switch` expression is similar to a `switch` statement, but you can use them
-anywhere you can use an expression. They produce a value based on the expression
-body of whichever case matches.
+A `switch` _expression_ produces a value based on the expression
+body of whichever case matches. 
+You can use a switch expression wherever Dart allows expressions,
+_except_ at the start of an expression statement.
+If your switch doesn't need to return a value into some expression statement,
+use a [switch _statement_](#switch-statements) instead of an expression.
 
-The syntax of a `switch` expression differs from `switch` statement syntax:
-
-- Cases _do not_ start with the `case` keyword.
-- A case body is a single expression instead of a series of statements.
-- Each case must have a body; there is no implicit fallthrough for empty cases.
-- Case patterns are separated from their bodies using `=>` instead of `:`.
-- Cases are separated by `,` (and an optional trailing `,` is allowed).
-- Default cases can _only_ use `_`, instead of allowing both `default` and `_`.
-
-Switch expressions allow you to rewrite a _statement_ like this:
+Switch expressions allow you to rewrite a switch _statement_ like this:
 
 ```dart
 // Where slash, star, comma, semicolon, etc., are constant variables...
@@ -169,6 +163,15 @@ token = switch (charCode) {
   _ => throw invalid()
 };
 ```
+
+The syntax of a `switch` expression differs from `switch` statement syntax:
+
+- Cases _do not_ start with the `case` keyword.
+- A case body is a single expression instead of a series of statements.
+- Each case must have a body; there is no implicit fallthrough for empty cases.
+- Case patterns are separated from their bodies using `=>` instead of `:`.
+- Cases are separated by `,` (and an optional trailing `,` is allowed).
+- Default cases can _only_ use `_`, instead of allowing both `default` and `_`.
 
 {{site.alert.version-note}}
     Switch expressions require a [language version][] of at least 3.0.

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -131,7 +131,8 @@ check out the patterns documentation on [Switch statements and expressions][].
 
 A `switch` _expression_ produces a value based on the expression
 body of whichever case matches. 
-You can use a switch expression wherever Dart allows expressions*, for example:
+You can use a switch expression wherever Dart allows expressions,
+_except_ at the start of an expression statement. For example:
 
 ```dart
 var x = switch (y) { ... };
@@ -141,8 +142,8 @@ print(switch (x) { ... });
 return switch (x) { ... };
 ```
 
-*You _can't_ use a switch expression at the start of an expression statement.
-Instead, use a [switch statement](#switch-statements).
+If you want to use a switch at the start of an expression statement,
+use a [switch statement](#switch-statements).
 
 Switch expressions allow you to rewrite a switch _statement_ like this:
 

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -136,7 +136,7 @@ You can use a switch expression wherever Dart allows expressions*, for example:
 ```dart
 var x = switch (y) { ... };
 
-print(switch (x) { ... };
+print(switch (x) { ... });
 
 return switch (x) { ... };
 ```


### PR DESCRIPTION
I don't think "return a value into some expression statement" in lines 136 and 137 _exactly_ makes sense:

> If your switch doesn't need to return a value into some expression statement,
use a [switch _statement_](#switch-statements) instead of an expression.

I could also just say "if you need to start an expression statement with a switch, use a switch statement" if that's clearer. This seems to be where the confusion is.

Fixes #4865 

Didn't change the bullet list, just moved it below the example since it's kind of weird to list out the syntax differences without having shown an example yet.