### PR TITLE
Update record equality example

### DIFF
--- a/examples/language/test/records_test.dart
+++ b/examples/language/test/records_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: unrelated_type_equality_checks
 import 'package:test/test.dart';
 // import 'package:examples_util/print_matcher.dart' as m;
 
@@ -95,8 +96,7 @@ void main() {
     (int x, int y, int z) point = (1, 2, 3);
     (int r, int g, int b) color = (1, 2, 3);
 
-    // OK:
-    point = color;
+    print(point == color); // Prints 'true'.
     // #enddocregion record-shape
     expect(point, (1, 2, 3));
   });
@@ -106,8 +106,7 @@ void main() {
     ({int x, int y, int z}) point = (x: 1, y: 2, z: 3);
     ({int r, int g, int b}) color = (r: 1, g: 2, b: 3);
 
-    // Compile error! These record don't have the same shape.
-    // point = color;
+    print(point == color); // Prints 'false'. Lint: Equals on unrelated types.
     // #enddocregion record-shape-mismatch
     point;
     color;

--- a/src/language/records.md
+++ b/src/language/records.md
@@ -144,13 +144,14 @@ and their corresponding fields have the same values.
 Since named field _order_ is not part of a record's shape, the order of named
 fields does not affect equality.
 
+For example:
+
 <?code-excerpt "language/test/records_test.dart (record-shape)"?>
 ```dart
 (int x, int y, int z) point = (1, 2, 3);
 (int r, int g, int b) color = (1, 2, 3);
 
-// OK:
-point = color;
+print(point == color); // Prints 'true'.
 ```
 
 <?code-excerpt "language/test/records_test.dart (record-shape-mismatch)"?>
@@ -158,8 +159,7 @@ point = color;
 ({int x, int y, int z}) point = (x: 1, y: 2, z: 3);
 ({int r, int g, int b}) color = (r: 1, g: 2, b: 3);
 
-// Compile error! These record don't have the same shape.
-// point = color;
+print(point == color); // Prints 'false'. Lint: Equals on unrelated types.
 ```
 
 Records automatically define `hashCode` and `==` methods based on the structure


### PR DESCRIPTION
Fixes #4874 

Added `// ignore_for_file: unrelated_type_equality_checks` to the excerpts file to deal with the lint; `point` and `color` aren't subtypes to be compared with `==`