### PR TITLE
Update gems including rouge for Dart 3 syntax highlighting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GEM
       forwardable-extended (~> 2.5)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.22.3)
-    google-protobuf (3.22.3-aarch64-linux)
-    google-protobuf (3.22.3-x86_64-linux)
+    google-protobuf (3.23.0)
+    google-protobuf (3.23.0-aarch64-linux)
+    google-protobuf (3.23.0-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
@@ -59,14 +59,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.0)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.3-aarch64-linux)
+    nokogiri (1.15.0-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.15.0-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -77,7 +77,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (4.1.0)
+    rouge (4.1.1)
     safe_yaml (1.0.5)
     sass-embedded (1.62.1)
       google-protobuf (~> 3.21)
@@ -108,4 +108,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.12
+   2.4.13


### PR DESCRIPTION
The main update here is the rouge update which includes support for syntax highlighting for Dart 3's new keywords from https://github.com/rouge-ruby/rouge/commit/6320e260e3c418715f510247f80542a8de6249d6