### PR TITLE
Move logical-or switch content to patterns page

### DIFF
--- a/examples/language/lib/patterns/switch.dart
+++ b/examples/language/lib/patterns/switch.dart
@@ -4,6 +4,18 @@ class Rect {
   Rect({required this.width, required this.height});
 }
 
+enum Color { red, yellow, blue, green }
+
+class Square {
+  int size;
+  Square({required this.size});
+}
+
+class Circle {
+  int size;
+  Circle({required this.size});
+}
+
 void main() {
   var number = 1;
   // #docregion constant-pattern
@@ -45,7 +57,28 @@ void main() {
         print('a = $a, b = $b');
 
       default:
-      // #enddocregion switch-statement
     }
+    // #enddocregion switch-statement
+  }
+
+  {
+    final color = Color.red;
+    // #docregion or-share-body
+    var isPrimary = switch (color) {
+      Color.red || Color.yellow || Color.blue => true,
+      _ => false
+    };
+    // #enddocregion or-share-body
+    isPrimary;
+  }
+
+  {
+    var shape = Circle(size: 5);
+    // #docregion or-share-guard
+    switch (shape) {
+      case Square(size: var s) || Circle(size: var s) when s > 0:
+        print('Non-empty symmetric shape');
+    }
+    // #enddocregion or-share-guard
   }
 }

--- a/examples/language/lib/patterns/switch.dart
+++ b/examples/language/lib/patterns/switch.dart
@@ -69,7 +69,7 @@ void main() {
       _ => false
     };
     // #enddocregion or-share-body
-    isPrimary;
+    print(isPrimary);
   }
 
   {

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -266,4 +266,4 @@ rather than exiting the entire switch.
 [any kind of pattern]: /language/pattern-types
 [destructure]: /language/patterns#destructuring
 [section on switch]: /language/patterns#switch-statements-and-expressions
-[logical-or patterns]: /language/patterns#or-pattern-swtich
+[logical-or patterns]: /language/patterns#or-pattern-switch

--- a/src/language/branches.md
+++ b/src/language/branches.md
@@ -122,7 +122,8 @@ switch (command) {
 }
 ```
 
-To learn more about patterns in case clauses, 
+You can use [logical-or patterns][] to allow cases to share a body or a guard.
+To learn more about patterns and case clauses, 
 check out the patterns documentation on [Switch statements and expressions][].
 
 [Switch statements and expressions]: /language/patterns#switch-statements-and-expressions
@@ -265,3 +266,4 @@ rather than exiting the entire switch.
 [any kind of pattern]: /language/pattern-types
 [destructure]: /language/patterns#destructuring
 [section on switch]: /language/patterns#switch-statements-and-expressions
+[logical-or patterns]: /language/patterns#or-pattern-swtich

--- a/src/language/pattern-types.md
+++ b/src/language/pattern-types.md
@@ -153,32 +153,6 @@ Subpatterns in a logical-or pattern can bind variables, but the branches must
 define the same set of variables, because only one branch will be evaluated when
 the pattern matches.
 
-{% comment %}
-[TODO: move the below content to the switch page, doesn't belong here]
-
-Logical-or patterns are useful for having multiple cases share a body in switch
-expressions or statements.
-
-```dart
-var isPrimary = switch (color) {
-  Color.red || Color.yellow || Color.blue => true,
-  _ => false
-};
-```
-
-Switch statements can have multiple cases share a body without using logical-or
-patterns, but they are still uniquely useful for allowing multiple cases to share
-a guard: 
-
-```dart
-switch (shape) {
-  case Square(size: var s) || Circle(size: var s) when s > 0:
-    print('Non-empty symmetric shape');
-}
-```
-
-{% endcomment %}
-
 ## Map
 
 `{"key": subpattern1, someConst: subpattern2}`

--- a/src/language/patterns.md
+++ b/src/language/patterns.md
@@ -171,11 +171,15 @@ switch (obj) {
     print('a = $a, b = $b');
 
   default:
+}
 ```
+
+<a id="or-pattern-swtich"></a>
 
 [Logical-or patterns][logical-or] are useful for having multiple cases share a
 body in switch expressions or statements:
 
+<?code-excerpt "language/lib/patterns/switch.dart (or-share-body)"?>
 ```dart
 var isPrimary = switch (color) {
   Color.red || Color.yellow || Color.blue => true,
@@ -187,6 +191,7 @@ Switch statements can have multiple cases share a body without using logical-or
 patterns, but they are still uniquely useful for allowing multiple cases to share
 a guard: 
 
+<?code-excerpt "language/lib/patterns/switch.dart (or-share-guard)"?>
 ```dart
 switch (shape) {
   case Square(size: var s) || Circle(size: var s) when s > 0:

--- a/src/language/patterns.md
+++ b/src/language/patterns.md
@@ -174,7 +174,7 @@ switch (obj) {
 }
 ```
 
-<a id="or-pattern-swtich"></a>
+<a id="or-pattern-switch"></a>
 
 [Logical-or patterns][logical-or] are useful for having multiple cases share a
 body in switch expressions or statements:
@@ -187,9 +187,9 @@ var isPrimary = switch (color) {
 };
 ```
 
-Switch statements can have multiple cases share a body without using logical-or
-patterns, but they are still uniquely useful for allowing multiple cases to share
-a guard: 
+Switch statements can have multiple cases share a body
+without using logical-or patterns, but they are
+still uniquely useful for allowing multiple cases to share a guard:
 
 <?code-excerpt "language/lib/patterns/switch.dart (or-share-guard)"?>
 ```dart

--- a/src/language/patterns.md
+++ b/src/language/patterns.md
@@ -152,6 +152,9 @@ They allow control flow to either:
 - Match and destructure the object being switched on.
 - Continue execution if the object doesn't match.
 
+The values that a pattern destructures in a case become local variables.
+Their scope is only within the body of that case.
+
 <?code-excerpt "language/lib/patterns/switch.dart (switch-statement)"?>
 ```dart
 switch (obj) {
@@ -170,8 +173,26 @@ switch (obj) {
   default:
 ```
 
-The values that a pattern destructures in a case become local variables.
-Their scope is only within the body of that case.
+[Logical-or patterns][logical-or] are useful for having multiple cases share a
+body in switch expressions or statements:
+
+```dart
+var isPrimary = switch (color) {
+  Color.red || Color.yellow || Color.blue => true,
+  _ => false
+};
+```
+
+Switch statements can have multiple cases share a body without using logical-or
+patterns, but they are still uniquely useful for allowing multiple cases to share
+a guard: 
+
+```dart
+switch (shape) {
+  case Square(size: var s) || Circle(size: var s) when s > 0:
+    print('Non-empty symmetric shape');
+}
+```
 
 ### For and for-in loops
 
@@ -376,7 +397,7 @@ This case pattern simultaneously validates that:
 [list]: /language/pattern-types#list
 [map]: /language/pattern-types#map
 [variable]: /language/pattern-types#variable
-[logical]: /language/pattern-types#logical-and
+[logical-or]: /language/pattern-types#logical-or
 [relational]: /language/pattern-types#relational
 [check]: /language/pattern-types#null-check
 [assert]: /language/pattern-types#null-assert


### PR DESCRIPTION
I left this in a comment on the patterns types page before the actual patterns page was ready, moving it now that everything's live. 

I thought about putting it in branches.md, but I think it's better in the patterns page because it's a little specific of a use case. Plus having it on the patterns page matches how the other uses sections are structured (explains where it can be used, then tells you why you might want to do that).

Added code excerpts too!