### PR TITLE
Update jquery to 3.7.0 release

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -73,8 +73,8 @@
     <link href="{{css}}" rel="stylesheet" type="text/css">
   {% endfor -%}
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js"
-          integrity="sha384-i61gTtaoovXtAbKjo903+O55Jkn2+RtzHtvNez+yI49HAASvznhe9sZyjaSHTau9"
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"
+          integrity="sha512-3gJwYpMe3QewGELv8k/BX9vcqhryRdzRMxVfq6ngyWXwo03GFEzjsUm8Q7RZcHPHksttq7/GFoxjCVUjkjvPdw=="
           crossorigin="anonymous"
           referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"


### PR DESCRIPTION
From 3.6.1, to include the latest bug fixes and performance improvements.

Read more at https://blog.jquery.com/