### PR TITLE
Add usage information to linter rule sections

### DIFF
--- a/src/_includes/linter-rules-section.md
+++ b/src/_includes/linter-rules-section.md
@@ -70,6 +70,19 @@ _This rule is available as of Dart {{lint.sinceDartSdk}}._
 
 {{lint.details}}
 
+#### Usage
+
+To enable the `{{lint.name}}` rule,
+add `{{lint.name}}` under **linter > rules** in your
+[`analysis_options.yaml`](https://dart.dev/guides/language/analysis-options)
+file:
+
+```yaml
+linter:
+  rules:
+    - {{lint.name}}
+```
+
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
<img width="934" alt="Example of usgae information for unnecessary_late" src="https://github.com/dart-lang/site-www/assets/18372958/f55cf982-0235-44d8-a324-18cc563abd15">

