### PR TITLE
Fix Flutter compute link and mention

### DIFF
--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -318,7 +318,7 @@ setting up and managing worker isolates:
   instead of `Isolate.run()`.
   On the [web](#web), the `compute` function falls back
   to running the specified function on the current event loop.
-  Use `Isolate.run()` when targeting native platforms only
+  Use `Isolate.run()` when targeting native platforms only,
   for a more ergonomic API.
 {{site.alert.end}}
 

--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -314,7 +314,7 @@ setting up and managing worker isolates:
 
 {{site.alert.flutter-note}}
   If you're using Flutter,
-  consider using [Flutter's `compute` function][]
+  you can use [Flutter's `compute` function][]
   instead of `Isolate.run()`.
   On the [web](#web), the `compute` function falls back
   to running the specified function on the current event loop.

--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -314,17 +314,16 @@ setting up and managing worker isolates:
 
 {{site.alert.flutter-note}}
   If you're using Flutter,
-  consider using [Flutter's `compute()` function][]
+  consider using [Flutter's `compute` function][]
   instead of `Isolate.run()`.
-  The `compute` function
-  allows your code to work  on both
-  [native and non-native platforms][].
+  On the [web](#web), the `compute` function falls back
+  to running the specified function on the current event loop.
   Use `Isolate.run()` when targeting native platforms only
   for a more ergonomic API.
 {{site.alert.end}}
 
 [native and non-native platforms]: /overview#platform
-[Flutter's `compute()` function]: {{site.flutter-api}}/flutter/foundation/compute-constant.html
+[Flutter's `compute` function]: {{site.flutter-api}}/flutter/foundation/compute.html
 
 #### Running an existing method in a new isolate
 
@@ -488,6 +487,7 @@ is slower when isolates are in different groups.
   Flutter doesn't support `Isolate.spawnUri()`.
 {{site.alert.end}}
 
+<a id="web"></a>
 ## Concurrency on the web
 
 All Dart apps can use `async-await`, `Future`, and `Stream`


### PR DESCRIPTION
The goal is to make it clear that `compute` doesn't run on a different isolate or thread when on the web. Also removes the wording "consider" since I don't think it's worth pushing users towards.

Fixes https://github.com/dart-lang/site-www/issues/4789
Fixes https://github.com/dart-lang/site-www/issues/4912

Staged: https://dart-dev--pr4913-fix-flutter-compute-pt3d3d91.web.app/language/concurrency#implementing-a-simple-worker-isolate
