### PR TITLE
Add redirect for pinned SDK packages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -161,6 +161,7 @@
       { "source": "/go/publishing-from-github", "destination": "/tools/pub/automated-publishing#publishing-packages-using-github-actions", "type": 301 },
       { "source": "/go/publishing-with-service-account", "destination": "/tools/pub/automated-publishing#publishing-from-google-cloud-build", "type": 301 },
       { "source": "/go/sdk-constraint", "destination": "/tools/pub/pubspec#sdk-constraints", "type": 301 },
+      { "source": "/go/sdk-version-pinning", "destination": "https://github.com/dart-lang/sdk/wiki/Flutter-Pinned-Packages", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
 


### PR DESCRIPTION
- add a go link to reference documentation for Flutter pinned packages (links to https://github.com/dart-lang/sdk/wiki/Flutter-Pinned-Packages)

This adds a redirect for `https://dart.dev/go/sdk-version-pinning` (some of our tools are now emitting this link).
