### PR TITLE
Update patterns.md to fix example

### DIFF
--- a/src/language/patterns.md
+++ b/src/language/patterns.md
@@ -60,10 +60,10 @@ For example, the individual fields of any [collection-type][] pattern could be
 <?code-excerpt "language/lib/patterns/switch.dart (list-pattern)"?>
 ```dart
 switch (obj) {
-  // List pattern [a, b] matches obj first if obj is a list with two fields,
+  // List pattern ['a', 'b'] matches obj first if obj is a list with two fields,
   // then if its fields match the constant subpatterns 'a' and 'b'.
-  case [a, b]:
-    print('$a, $b');
+  case ['a', 'b']:
+    print('pattern matched');
 }
 ```
 


### PR DESCRIPTION
Update to the example so that it's accurate and compiles. Previously, it would not compile since `a` and `b` were being treated as variables, but didn't have a type, `var`, or `final` keyword prefixing it. I updated the example to match a constant 'a' and 'b', like the pre-existing comment describes. Tested on dartpad.dev.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

(note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback)
