### PR TITLE
Fix 404 background

### DIFF
--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -48,18 +48,21 @@
   }
 }
 
-body.homepage #cookie-notice {
-  background-color: $site-color-dark-background;
+body.homepage, .error {
 
-  .container {
-    p {
-      color: white;
-      
-      a {
-        color: $site-color-card-link;
+  #cookie-notice {
+    background-color: $site-color-dark-background;
 
-        &:hover, &:focus, &:active {
-          color: darken($site-color-card-link, 20%);
+    .container {
+      p {
+        color: white;
+
+        a {
+          color: $site-color-card-link;
+
+          &:hover, &:focus, &:active {
+            color: darken($site-color-card-link, 20%);
+          }
         }
       }
     }

--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -733,7 +733,7 @@ body.error {
   }
 
   background-color: #132030;
-  background-image: asset_url('404-bg-pattern.jpg');
+  background-image: url('/assets/img/404-bg-pattern.jpg');
   color: #8d9399;
 
   @media(min-width: 1600px) {


### PR DESCRIPTION
The 404 used to have a background but it looks like it's been broken for at least a few years since the `asset_url` function was likely from when we had a different asset system.

You can see this by visiting https://dart.dev/404 and noticing there is no background, then visiting this change staged at https://dart-dev--pr4928-fix-404-background-g8pk17ku.web.app/404.

I guess we never noticed, because the people who know it should be there don't look at the 404 page a lot? Oops 😅 

**Edit:** I've also updated this PR so the cookie banner is appropriately the darker color on the 404 page similar to the homepage.