### PR TITLE
Clarify list pattern snippet

### DIFF
--- a/examples/language/lib/patterns/pattern_types.dart
+++ b/examples/language/lib/patterns/pattern_types.dart
@@ -81,15 +81,6 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion list
-    switch (obj) {
-      // Matches if obj is a list with two elements.
-      case [a, b]: // ...
-    }
-    // #enddocregion list
-  }
-
-  {
     // #docregion rest
     var [a, b, ..., c, d] = [1, 2, 3, 4, 5, 6, 7];
     // Prints "1 2 6 7".

--- a/src/language/pattern-types.md
+++ b/src/language/pattern-types.md
@@ -301,11 +301,15 @@ which results in a different match.
 A list pattern matches values that implement [`List`][], and then recursively
 matches its subpatterns against the list's elements to destructure them by position:
 
-<?code-excerpt "language/lib/patterns/pattern_types.dart (list)"?>
+<?code-excerpt "language/lib/patterns/switch.dart (list-pattern)"?>
 ```dart
+const a = 'a';
+const b = 'b';
 switch (obj) {
-  // Matches if obj is a list with two elements.
-  case [a, b]: // ...
+  // List pattern [a, b] matches obj first if obj is a list with two fields,
+  // then if its fields match the constant subpatterns 'a' and 'b'.
+  case [a, b]:
+    print('$a, $b');
 }
 ```  
 


### PR DESCRIPTION
Fixes #4938 

Instead of updating the snippet in `pattern_types.dart`, I just re-used the `docregion` from `switch.dart` that clarifies `a` and `b` are constants. So then I just got rid of the `list` `docregion` from `pattern_types.dart` because it's useless. 

(Granted, these types of fixes are just temporary solutions before we find a better way to indicate the surrounding context of a code snippet so users don't run into these issues anymore - see #4908)