### PR TITLE
Add more accurately named lint redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -188,6 +188,8 @@
       { "source": "/language/control-flow", "destination": "/language/loops", "type": 301 },
       { "source": "/language/enum", "destination": "/language/enums", "type": 301 },
       { "source": "/language/generators", "destination": "/language/functions#generators", "type": 301 },
+      { "source": "/lint", "destination": "/tools/linter-rules", "type": 301 },
+      { "source": "/lint/:lint*", "destination": "/tools/linter-rules#:lint", "type": 301 },
       { "source": "/linter/lints/:lint*", "destination": "/tools/linter-rules#:lint", "type": 301 },
       { "source": "/lints", "destination": "/tools/linter-rules", "type": 301 },
       { "source": "/lints/:lint*", "destination": "/tools/linter-rules#:lint", "type": 301 },


### PR DESCRIPTION
Originally, I set up `/lints/<name>`, but that was before `package:lints` existed. For a short link, it seems like `/lint/<rule>` is more accurate.
  
