### PR TITLE
Account for Dart 3 deprecations and removals

### DIFF
--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -203,20 +203,12 @@ var s2 = """This is also a
 multi-line string.""";
 // #enddocregion triple-quotes
 
+// MOVE TO library tour?
 class SymbolExampleNotUsedYet {
   // #docregion symbols
-  // MOVE TO library tour?
-
   void main() {
     print(Function.apply(int.parse, ['11']));
     print(Function.apply(int.parse, ['11'], {#radix: 16}));
-    print(Function.apply(int.parse, ['11a'], {#onError: handleError}));
-    print(Function.apply(
-        int.parse, ['11a'], {#radix: 16, #onError: handleError}));
   }
-
-  int handleError(String source) {
-    return 0;
-  }
-// #enddocregion symbols
+  // #enddocregion symbols
 }

--- a/src/language/built-in-types.md
+++ b/src/language/built-in-types.md
@@ -383,18 +383,9 @@ The code from the following excerpt isn't actually what is being shown in the pa
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (symbols)"?>
 ```dart
-// MOVE TO library tour?
-
 void main() {
   print(Function.apply(int.parse, ['11']));
   print(Function.apply(int.parse, ['11'], {#radix: 16}));
-  print(Function.apply(int.parse, ['11a'], {#onError: handleError}));
-  print(Function.apply(
-      int.parse, ['11a'], {#radix: 16, #onError: handleError}));
-}
-
-int handleError(String source) {
-  return 0;
 }
 ```
 {% endcomment %}


### PR DESCRIPTION
I went through and looked for instances of all of the deprecations and removals in Dart 2.18, 2.19, and 3.

The only I could find was using the removed `onError` named argument in a symbols example that isn't even currently used.

Closes https://github.com/dart-lang/site-www/issues/4585