### PR TITLE
Fix some misc broken external links

### DIFF
--- a/src/_guides/google-apis.md
+++ b/src/_guides/google-apis.md
@@ -15,7 +15,7 @@ on whether you're writing code for a Flutter app or another kind of Dart app.
 
 Flutter apps can choose from many officially supported plugins for
 popular Firebase products such as Analytics, Cloud Firestore,
-Cloud Functions, and Crashalytics.
+Cloud Functions, and Crashlytics.
 For a full list of these plugins, see [FlutterFire][].
 
 Other kinds of Dart apps can use
@@ -53,6 +53,6 @@ To find wrapper packages for Google client APIs, search for
 [`googleapis` package]: {{site.pub-pkg}}/googleapis
 [`gsheets` package]: {{site.pub-pkg}}/gsheets
 [gsheets-api-docs]: {{site.pub-api}}/gsheets/latest/gsheets/gsheets-library.html
-[gsheets-api-docs-gapi]: {{site.pub-api}}/googleapis/latest/sheets.v4/sheets.v4-library.html
+[gsheets-api-docs-gapi]: {{site.pub-api}}/googleapis/latest/sheets_v4/sheets_v4-library.html
 [flutter-google-apis]: https://flutter.dev/docs/development/data-and-backend/google-apis
 [server-sample]: https://github.com/dart-lang/samples/tree/main/server/google_apis

--- a/src/tools/pub/cmd/pub-token.md
+++ b/src/tools/pub/cmd/pub-token.md
@@ -63,8 +63,8 @@ that still doesn't prevent the command being logged.
 Most CI environments has a way to inject secrets into an environment
 variable:
 
-* [Github Actions](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
-* [GitLab](https://docs.gitlab.com/13.12/ee/ci/secrets/index.html).
+* [GitHub Actions](https://docs.github.com/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
+* [GitLab](https://docs.gitlab.com/ee/ci/secrets/).
 
 ## Listing credentials `dart pub token list`
 

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -6,6 +6,7 @@ localhost:(404\d|8080)
 
 # Sites which don't allow robots or break from rate limiting
 https://github.com
+https://twitter.com
 
 # FIXME(Temporary): linkcheck seems to be intermittently failing when accessing main.css
 # https://github.com/dart-lang/site-www/issues/1107


### PR DESCRIPTION
Caught by temporarily enabling external link checks with the linkchecker.

Also ignores Twitter, since it is failing to connect.
