### PR TITLE
fixed typo in 'Class modifiers for API maintainers' page

### DIFF
--- a/src/language/class-modifiers-for-apis.md
+++ b/src/language/class-modifiers-for-apis.md
@@ -243,7 +243,7 @@ then the compiler knows the switch is exhaustive.
 
 ```dart
 // amigos.dart
-abstract class Amigo {}
+sealed class Amigo {}
 class Lucky extends Amigo {}
 class Dusty extends Amigo {}
 class Ned extends Amigo {}
@@ -280,7 +280,7 @@ But, unlike `base` and `final`, there is no *transitive* restriction:
 
 ```dart
 // amigo.dart
-abstract class Amigo {}
+sealed class Amigo {}
 class Lucky extends Amigo {}
 class Dusty extends Amigo {}
 class Ned extends Amigo {}


### PR DESCRIPTION
Fixes typo in the documentation. 
Replacing abstract modifier with sealed modifier.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.


