### PR TITLE
Fix incorrect class modifier highlighting in sidenav

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -87,8 +87,9 @@
         - title: Callable objects
           permalink: /language/callable-objects
     - title: Class modifiers
-      children: 
+      children:
         - title: Overview & usage
+          match-page-url-exactly: true
           permalink: /language/class-modifiers
         - title: Class modifiers for API maintainers
           permalink: /language/class-modifiers-for-apis


### PR DESCRIPTION
Our currently activenav system ended up highlighting the overview page since `/language/class-modifiers-for-apis` contains  `/language/class-modifiers`. This is a temporary work around until I finalize an updated system for docs.flutter.dev and here.

**Previously:**
<img width="300" alt="Incorrectly highlighting overview" src="https://github.com/dart-lang/site-www/assets/18372958/89dd1215-82d2-42d5-8261-5e8ea8168645">
<br>
**After(fixed):**
<img width="300" alt="Correctly highlighting API doc entry" src="https://github.com/dart-lang/site-www/assets/18372958/852f79fb-5347-46df-8d1f-e0f8e74a010a">
