### PR TITLE
Link to new `use_string_in_part_of_directives` lint from Effective Dart

### DIFF
--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -23,6 +23,8 @@ to cover `import` and `export` directives. The guidelines apply equally to both.
 
 ### DO use strings in `part of` directives
 
+{% include linter-rule-mention.md rule="use_string_in_part_of_directives" %}
+
 Many Dart developers avoid using `part` entirely. They find it easier to reason
 about their code when each library is a single file. If you do choose to use
 `part` to split part of a library out into another file, Dart requires the other


### PR DESCRIPTION
<img width="450" alt="Screenshot of added use_string_in_part_of_directives mention" src="https://github.com/dart-lang/site-www/assets/18372958/d0a8c460-60a2-4733-9fc8-ab803f3efae3">

<br>

**Staged:** https://dart-dev--pr4985-misc-part-of-string-bogw86yg.web.app/effective-dart/usage#do-use-strings-in-part-of-directives