### PR TITLE
Folders named packages are no longer ignored by publishing.

### DIFF
--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -22,7 +22,6 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - package_api_docs
-    - prefer_final_in_for_each
     - prefer_single_quotes
     - sort_child_properties_last
     - sort_unnamed_constructors_first

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -224,7 +224,6 @@ with the following exceptions:
 
  * Any _hidden_ files or directories—that is, 
    files with names that begin with dot (`.`)
- * Any directories with the name `packages`
  * Files and directories ignored by a `.pubignore` or `.gitignore` file
 
 If you want different ignore rules for `git` and `dart pub publish`,


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/3948
