### PR TITLE
Add missing id-token configuration to code examples

### DIFF
--- a/src/tools/pub/automated-publishing.md
+++ b/src/tools/pub/automated-publishing.md
@@ -110,7 +110,7 @@ on:
 jobs:
   publish:
     permissions:
-      id-token: write # This is required for authentication using OIDC
+      id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     # with:
     #   working-directory: path/to/package/within/repository
@@ -148,7 +148,7 @@ on:
 jobs:
   publish:
     permissions:
-      id-token: write # This is required for authentication using OIDC
+      id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -260,7 +260,7 @@ on:
 jobs:
   publish:
     permissions:
-      id-token: write # This is required for authentication using OIDC
+      id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       # Specify the github actions deployment environment

--- a/src/tools/pub/automated-publishing.md
+++ b/src/tools/pub/automated-publishing.md
@@ -109,6 +109,8 @@ on:
 # Publish using the reusable workflow from dart-lang.
 jobs:
   publish:
+    permissions:
+      id-token: write # This is required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     # with:
     #   working-directory: path/to/package/within/repository
@@ -257,6 +259,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      id-token: write # This is required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       # Specify the github actions deployment environment


### PR DESCRIPTION
Adds missing token permission configuration to examples of workflows using reusable publishing workflow. Without it the reusable workflow cannot request `id-token: write` permission because the caller workflow has `id-token: none` permission.

Fixes https://github.com/dart-lang/site-www/issues/5002

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
