### PR TITLE
Rename `funcThatThrows` to `asyncErrorFunction`

### DIFF
--- a/examples/futures/lib/early_error_handlers.dart
+++ b/examples/futures/lib/early_error_handlers.dart
@@ -5,9 +5,9 @@ import 'package:futures_examples/util.dart';
 
 // #docregion bad
 void mainBad() {
-  Future<Object> future = funcThatThrows();
+  Future<Object> future = asyncErrorFunc();
 
-  // BAD: Too late to handle funcThatThrows() exception.
+  // BAD: Too late to handle asyncErrorFunc() exception.
   Future.delayed(const Duration(milliseconds: 500), () {
     future.then(ellipsis()).catchError(ellipsis());
   });
@@ -17,7 +17,7 @@ void mainBad() {
 // #docregion good
 void mainGood() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    funcThatThrows().then(ellipsis()).catchError(ellipsis()); // We get here.
+    asyncErrorFunc().then(ellipsis()).catchError(ellipsis()); // We get here.
   });
 }
 // #enddocregion good

--- a/examples/futures/lib/early_error_handlers.dart
+++ b/examples/futures/lib/early_error_handlers.dart
@@ -5,9 +5,9 @@ import 'package:futures_examples/util.dart';
 
 // #docregion bad
 void mainBad() {
-  Future<Object> future = asyncErrorFunc();
+  Future<Object> future = asyncErrorFunction();
 
-  // BAD: Too late to handle asyncErrorFunc() exception.
+  // BAD: Too late to handle asyncErrorFunction() exception.
   Future.delayed(const Duration(milliseconds: 500), () {
     future.then(ellipsis()).catchError(ellipsis());
   });
@@ -17,7 +17,9 @@ void mainBad() {
 // #docregion good
 void mainGood() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    asyncErrorFunc().then(ellipsis()).catchError(ellipsis()); // We get here.
+    asyncErrorFunction()
+        .then(ellipsis())
+        .catchError(ellipsis()); // We get here.
   });
 }
 // #enddocregion good

--- a/examples/futures/lib/simple.dart
+++ b/examples/futures/lib/simple.dart
@@ -24,9 +24,9 @@ void simpleCallbacks() {
 
   {
     // #docregion throws-then-catch
-    funcThatThrows().then(successCallback, onError: (e) {
+    asyncErrorFunc().then(successCallback, onError: (e) {
       handleError(e); // Original error.
-      anotherFuncThatThrows(); // Oops, new error.
+      anotherAsyncErrorFunc(); // Oops, new error.
     }).catchError(handleError); // Error from within then() handled.
     // #enddocregion throws-then-catch
   }
@@ -71,7 +71,7 @@ String doSomethingWith(dynamic value) {
   return 'value';
 }
 
-Future<Object> anotherFuncThatThrows() {
+Future<Object> anotherAsyncErrorFunc() {
   throw Exception('Also threw an exception');
 }
 

--- a/examples/futures/lib/simple.dart
+++ b/examples/futures/lib/simple.dart
@@ -24,9 +24,9 @@ void simpleCallbacks() {
 
   {
     // #docregion throws-then-catch
-    asyncErrorFunc().then(successCallback, onError: (e) {
+    asyncErrorFunction().then(successCallback, onError: (e) {
       handleError(e); // Original error.
-      anotherAsyncErrorFunc(); // Oops, new error.
+      anotherAsyncErrorFunction(); // Oops, new error.
     }).catchError(handleError); // Error from within then() handled.
     // #enddocregion throws-then-catch
   }
@@ -71,7 +71,7 @@ String doSomethingWith(dynamic value) {
   return 'value';
 }
 
-Future<Object> anotherAsyncErrorFunc() {
+Future<Object> anotherAsyncErrorFunction() {
   throw Exception('Also threw an exception');
 }
 

--- a/examples/futures/lib/util.dart
+++ b/examples/futures/lib/util.dart
@@ -2,7 +2,7 @@ String processValue(dynamic value) {
   return 'value';
 }
 
-Future<Object> asyncErrorFunc() async {
+Future<Object> asyncErrorFunction() async {
   throw Exception('Threw an exception');
 }
 

--- a/examples/futures/lib/util.dart
+++ b/examples/futures/lib/util.dart
@@ -2,7 +2,7 @@ String processValue(dynamic value) {
   return 'value';
 }
 
-Future<Object> funcThatThrows() {
+Future<Object> asyncErrorFunc() async {
   throw Exception('Threw an exception');
 }
 

--- a/examples/futures/lib/when_complete.dart
+++ b/examples/futures/lib/when_complete.dart
@@ -3,7 +3,7 @@ import 'package:futures_examples/util.dart';
 
 // #docregion with-error
 void withErrorMain() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with an error:
       .then((_) => print("Won't reach here"))
       // Future completes with the same error:
@@ -17,7 +17,7 @@ void withErrorMain() {
 
 // #docregion with-object
 void withObjectMain() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with an error:
       .then((_) => ellipsis())
       .catchError((e) {
@@ -30,7 +30,7 @@ void withObjectMain() {
 
 // #docregion when-complete-error
 void whenCompleteError() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with a value:
       .catchError(handleError)
       // Future completes with an error:

--- a/examples/futures/lib/when_complete.dart
+++ b/examples/futures/lib/when_complete.dart
@@ -3,7 +3,7 @@ import 'package:futures_examples/util.dart';
 
 // #docregion with-error
 void withErrorMain() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with an error:
       .then((_) => print("Won't reach here"))
       // Future completes with the same error:
@@ -17,7 +17,7 @@ void withErrorMain() {
 
 // #docregion with-object
 void withObjectMain() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with an error:
       .then((_) => ellipsis())
       .catchError((e) {
@@ -30,7 +30,7 @@ void withObjectMain() {
 
 // #docregion when-complete-error
 void whenCompleteError() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with a value:
       .catchError(handleError)
       // Future completes with an error:

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -93,14 +93,14 @@ between an error forwarded _to_ `then()`, and an error generated _within_
 
 <?code-excerpt "futures/lib/simple.dart (throws-then-catch)"?>
 ```dart
-funcThatThrows().then(successCallback, onError: (e) {
+asyncErrorFunc().then(successCallback, onError: (e) {
   handleError(e); // Original error.
-  anotherFuncThatThrows(); // Oops, new error.
+  anotherAsyncErrorFunc(); // Oops, new error.
 }).catchError(handleError); // Error from within then() handled.
 ```
 
-In the example above, `funcThatThrows()`'s Future's error is handled with the
-`onError` callback; `anotherFuncThatThrows()` causes `then()`'s Future to
+In the example above, `asyncErrorFunc()`'s Future's error is handled with the
+`onError` callback; `anotherAsyncErrorFunc()` causes `then()`'s Future to
 complete with an error; this error is handled by `catchError()`.
 
 In general, implementing two different error handling strategies is not
@@ -208,7 +208,7 @@ In the code below, `then()`'s Future completes with an error, so
 <?code-excerpt "futures/lib/when_complete.dart (with-error)" replace="/withErrorMain/main/g; "?>
 ```dart
 void main() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with an error:
       .then((_) => print("Won't reach here"))
       // Future completes with the same error:
@@ -227,7 +227,7 @@ handled by `catchError()`.  Because `catchError()`'s Future completes with
 <?code-excerpt "futures/lib/when_complete.dart (with-object)" replace="/ellipsis\(\)/.../g; /withObjectMain/main/g; "?>
 ```dart
 void main() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with an error:
       .then((_) => ...)
       .catchError((e) {
@@ -246,7 +246,7 @@ completes with that error:
 <?code-excerpt "futures/lib/when_complete.dart (when-complete-error)" replace="/whenCompleteError/main/g; "?>
 ```dart
 void main() {
-  funcThatThrows()
+  asyncErrorFunc()
       // Future completes with a value:
       .catchError(handleError)
       // Future completes with an error:
@@ -267,9 +267,9 @@ this code:
 <?code-excerpt "futures/lib/early_error_handlers.dart (bad)" replace="/ellipsis\(\)/.../g; /mainBad/main/g;"?>
 ```dart
 void main() {
-  Future<Object> future = funcThatThrows();
+  Future<Object> future = asyncErrorFunc();
 
-  // BAD: Too late to handle funcThatThrows() exception.
+  // BAD: Too late to handle asyncErrorFunc() exception.
   Future.delayed(const Duration(milliseconds: 500), () {
     future.then(...).catchError(...);
   });
@@ -277,16 +277,16 @@ void main() {
 ```
 
 In the code above, `catchError()` is not registered until half a second after
-`funcThatThrows()` is called, and the error goes unhandled.
+`asyncErrorFunc()` is called, and the error goes unhandled.
 
-The problem goes away if `funcThatThrows()` is called within the
+The problem goes away if `asyncErrorFunc()` is called within the
 `Future.delayed()` callback:
 
 <?code-excerpt "futures/lib/early_error_handlers.dart (good)" replace="/ellipsis\(\)/.../g; /mainGood/main/g;"?>
 ```dart
 void main() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    funcThatThrows().then(...).catchError(...); // We get here.
+    asyncErrorFunc().then(...).catchError(...); // We get here.
   });
 }
 ```

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -93,14 +93,14 @@ between an error forwarded _to_ `then()`, and an error generated _within_
 
 <?code-excerpt "futures/lib/simple.dart (throws-then-catch)"?>
 ```dart
-asyncErrorFunc().then(successCallback, onError: (e) {
+asyncErrorFunction().then(successCallback, onError: (e) {
   handleError(e); // Original error.
-  anotherAsyncErrorFunc(); // Oops, new error.
+  anotherAsyncErrorFunction(); // Oops, new error.
 }).catchError(handleError); // Error from within then() handled.
 ```
 
-In the example above, `asyncErrorFunc()`'s Future's error is handled with the
-`onError` callback; `anotherAsyncErrorFunc()` causes `then()`'s Future to
+In the example above, `asyncErrorFunction()`'s Future's error is handled with the
+`onError` callback; `anotherAsyncErrorFunction()` causes `then()`'s Future to
 complete with an error; this error is handled by `catchError()`.
 
 In general, implementing two different error handling strategies is not
@@ -208,7 +208,7 @@ In the code below, `then()`'s Future completes with an error, so
 <?code-excerpt "futures/lib/when_complete.dart (with-error)" replace="/withErrorMain/main/g; "?>
 ```dart
 void main() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with an error:
       .then((_) => print("Won't reach here"))
       // Future completes with the same error:
@@ -227,7 +227,7 @@ handled by `catchError()`.  Because `catchError()`'s Future completes with
 <?code-excerpt "futures/lib/when_complete.dart (with-object)" replace="/ellipsis\(\)/.../g; /withObjectMain/main/g; "?>
 ```dart
 void main() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with an error:
       .then((_) => ...)
       .catchError((e) {
@@ -246,7 +246,7 @@ completes with that error:
 <?code-excerpt "futures/lib/when_complete.dart (when-complete-error)" replace="/whenCompleteError/main/g; "?>
 ```dart
 void main() {
-  asyncErrorFunc()
+  asyncErrorFunction()
       // Future completes with a value:
       .catchError(handleError)
       // Future completes with an error:
@@ -267,9 +267,9 @@ this code:
 <?code-excerpt "futures/lib/early_error_handlers.dart (bad)" replace="/ellipsis\(\)/.../g; /mainBad/main/g;"?>
 ```dart
 void main() {
-  Future<Object> future = asyncErrorFunc();
+  Future<Object> future = asyncErrorFunction();
 
-  // BAD: Too late to handle asyncErrorFunc() exception.
+  // BAD: Too late to handle asyncErrorFunction() exception.
   Future.delayed(const Duration(milliseconds: 500), () {
     future.then(...).catchError(...);
   });
@@ -277,16 +277,16 @@ void main() {
 ```
 
 In the code above, `catchError()` is not registered until half a second after
-`asyncErrorFunc()` is called, and the error goes unhandled.
+`asyncErrorFunction()` is called, and the error goes unhandled.
 
-The problem goes away if `asyncErrorFunc()` is called within the
+The problem goes away if `asyncErrorFunction()` is called within the
 `Future.delayed()` callback:
 
 <?code-excerpt "futures/lib/early_error_handlers.dart (good)" replace="/ellipsis\(\)/.../g; /mainGood/main/g;"?>
 ```dart
 void main() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    asyncErrorFunc().then(...).catchError(...); // We get here.
+    asyncErrorFunction().then(...).catchError(...); // We get here.
   });
 }
 ```

--- a/src/_guides/libraries/futures-error-handling.md
+++ b/src/_guides/libraries/futures-error-handling.md
@@ -286,7 +286,9 @@ The problem goes away if `asyncErrorFunction()` is called within the
 ```dart
 void main() {
   Future.delayed(const Duration(milliseconds: 500), () {
-    asyncErrorFunction().then(...).catchError(...); // We get here.
+    asyncErrorFunction()
+        .then(...)
+        .catchError(...); // We get here.
   });
 }
 ```


### PR DESCRIPTION
The old name can be confused for a function with a synchronous `throw` instead of a function returning an future error or an `async` function with a `throw`.

Fixes #5007