### PR TITLE
Specify specific Dart versions in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,10 @@ RUN echo "alias lla='ls -lAhG --color=auto'" >> ~/.bashrc
 WORKDIR /root
 
 
-# google-chrome-stable
-
-
 # ============== DART ==============
 # See https://github.com/dart-lang/dart-docker
-# See https://github.com/dart-lang/setup-dart/blob/main/setup.sh
 FROM base as dart
-ARG DART_VERSION=latest
 ARG DART_CHANNEL=stable
-ENV DART_VERSION=$DART_VERSION
 ENV DART_CHANNEL=$DART_CHANNEL
 ENV DART_SDK=/usr/lib/dart
 ENV PATH=$DART_SDK/bin:$PATH
@@ -34,22 +28,28 @@ RUN set -eu; \
     case "$(dpkg --print-architecture)_${DART_CHANNEL}" in \
       amd64_stable) \
         DART_SHA256="05fba372d64932dffce90bbd45116b76806bf9adc6203967b56faf5c64b2b66c"; \
-        SDK_ARCH="x64";; \
+        SDK_ARCH="x64"; \
+        DART_VERSION="3.0.5";; \
       arm64_stable) \
         DART_SHA256="667b79593444cbe222a33c137ca943dced7a21ff2d61b8862f3b49e648c20533"; \
-        SDK_ARCH="arm64";; \
+        SDK_ARCH="arm64"; \
+        DART_VERSION="3.0.5";; \
       amd64_beta) \
         DART_SHA256="b4d251e51da2b963eae82136b37b83a050f175be82fc8d691b609cb8e030c13b"; \
-        SDK_ARCH="x64";; \
+        SDK_ARCH="x64"; \
+        DART_VERSION="3.1.0-163.1.beta";; \
       arm64_beta) \
         DART_SHA256="8c65c833fe84010670066450a404e81a9ee311b14cf560e8d6325fc9a351f8b4"; \
-        SDK_ARCH="arm64";; \
+        SDK_ARCH="arm64"; \
+        DART_VERSION="3.1.0-163.1.beta";; \
       amd64_dev) \
-        DART_SHA256="b7cbc357a975122ee317e565b953304f6c134084e04ee42031bbb4fb05b8a1e9"; \
-        SDK_ARCH="x64";; \
+        DART_SHA256="6bc2bea37b6d874b110f7a65dd92a64abca7c85bd885045b3d166f9a2efc48aa"; \
+        SDK_ARCH="x64"; \
+        DART_VERSION="3.1.0-227.0.dev";; \
       arm64_dev) \
-        DART_SHA256="bc3312a0b01501116c20d97af6e768791c9d4e62f9802aa43fd9533e978ce451"; \
-        SDK_ARCH="arm64";; \
+        DART_SHA256="faba944bda6d7aafcdcda62ab2530cc179abf1ae3f3cf9585422f39aca1e4b00"; \
+        SDK_ARCH="arm64"; \
+        DART_VERSION="3.1.0-227.0.dev";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,12 @@ BUILD_NAME ?= dart_dev_build
 BUILD_TAG ?= dart-dev
 BUILD_TARGET ?= build
 DART_CHANNEL ?= stable
-DART_VERSION ?= latest
 FIREBASE_PROJECT ?= default
 FIREBASE_CHANNEL ?= dart
 JEKYLL_SITE_HOST ?= 0.0.0.0
 JEKYLL_SITE_PORT ?= 4000
 
-# Here so Docker Compose does not complain, add any env 
+# Here so Docker Compose does not complain, add any env
 # overrides to this file. Blank is okay, it's ignored.
 # For example, add a FIREBASE_PROJECT if staging
 .env:
@@ -54,7 +53,6 @@ setup:
 	-docker compose down
 	-docker rmi ${BUILD_TAG}:${DART_CHANNEL}
 	docker compose build --no-cache site \
-	 --build-arg DART_VERSION=${DART_VERSION} \
 	 --build-arg DART_CHANNEL=${DART_CHANNEL}
 
 # Serve the Jekyll site with livereload and incremental builds
@@ -72,7 +70,6 @@ test:
 	DOCKER_BUILDKIT=1 docker build \
 		-t dart-tests:${DART_CHANNEL} \
 		--target dart-tests \
-		--build-arg DART_VERSION=${DART_VERSION} \
 		--build-arg DART_CHANNEL=${DART_CHANNEL} .
 	docker run --rm -v ${PWD}:/app dart-tests:${DART_CHANNEL}
 
@@ -83,7 +80,6 @@ build-image:
 		-t ${BUILD_TAG}:${BUILD_COMMIT} \
 		--no-cache \
 		--target ${BUILD_TARGET} \
-		--build-arg DART_VERSION=${DART_VERSION} \
 		--build-arg DART_CHANNEL=${DART_CHANNEL} \
 		--build-arg BUILD_CONFIGS=${BUILD_CONFIGS} .
 
@@ -142,7 +138,6 @@ emulate:
 # This outputs a bash case format to be copied to Dockerfile
 fetch-sums:
 	tool/fetch-dart-sdk-sums.sh \
-		--version ${DART_VERSION} \
 		--channel ${DART_CHANNEL}
 	tool/fetch-node-ppa-sum.sh
 

--- a/tool/fetch-dart-sdk-sums.sh
+++ b/tool/fetch-dart-sdk-sums.sh
@@ -44,6 +44,7 @@ for CHANNEL in $CHANNELS; do
     fi
     _filename="dartsdk-linux-${_arch}-release.zip"
     _urlNoFile="$BASEURL/$CHANNEL/release/$VERSION"
+    # Get the exact version from the json-formatted VERSION file:
     _version=$(curl -fsSL "$_urlNoFile/VERSION" | awk -F: '/version/{print $2}' | sed 's/[", ]//g')
     _url="$_urlNoFile/sdk/$_filename"
     curl -fsSLO $_url

--- a/tool/fetch-dart-sdk-sums.sh
+++ b/tool/fetch-dart-sdk-sums.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Use this file locally to update Dart SDK checksum values in the Dockerfile
-# Prints output similar to cases in Dockerfile for easy composition 
+# Prints output similar to cases in Dockerfile for easy composition
 # when having to update checksum values for updates dart SDK.
 set -eu -o pipefail
 TOOL_DIR="${TOOL_DIR:=$(dirname "$0")}"
@@ -43,13 +43,16 @@ for CHANNEL in $CHANNELS; do
       _arch='x64'
     fi
     _filename="dartsdk-linux-${_arch}-release.zip"
-    _url="$BASEURL/$CHANNEL/release/$VERSION/sdk/$_filename"
+    _urlNoFile="$BASEURL/$CHANNEL/release/$VERSION"
+    _version=$(curl -fsSL "$_urlNoFile/VERSION" | awk -F: '/version/{print $2}' | sed 's/[", ]//g')
+    _url="$_urlNoFile/sdk/$_filename"
     curl -fsSLO $_url
     _checksum=$(shasum -a 256 $_filename)
     read -a _fname_arr <<< "${_checksum}" # Read in string output as array
     _checkonly="${_fname_arr%:*}" # Remove filename portion of checksum output
     printf "$(yellow "  DART_SHA256=\"$_fname_arr\";") $ENDING"
-    printf "$(yellow "  SDK_ARCH=\"$_arch\";;") $ENDING"
+    printf "$(yellow "  SDK_ARCH=\"$_arch\";") $ENDING"
+    printf "$(yellow "  DART_VERSION=\"$_version\";;") $ENDING"
     rm $_filename
   done
 done


### PR DESCRIPTION
Previously the build broke with every new Dart release, reducing velocity and breaking unrelated PRs. This PR ties the Dockerfile to specific versions which can be updated as desired.

This does limit control from the `make` commands of specifying the dart version outside of the channel (`stable`, `beta`, or `dev`), but I've never used that functionality as you rarely need a specific Dart version. If someone needs to test one, they can adjust the version in the Docker file if they need to for their work.

Closes https://github.com/dart-lang/site-www/issues/4297
