### PR TITLE
Adjust style for page source and bug report icons

### DIFF
--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -662,10 +662,20 @@ ul.nav-list {
     $padding-x: bootstrap.$btn-padding-x * 0.5;
     padding-left: $padding-x;
     padding-right: $padding-x;
+    border: none;
+    box-shadow: none;
+
+    &:hover, &:focus-visible {
+      color: $brand-primary;
+    }
+
+    &:active {
+      color: lighten($brand-primary, 25%);
+    }
   }
 
-  .fa-sm {
-    font-size: 14px;
+  .material-icons {
+    font-size: 18px;
   }
 }
 


### PR DESCRIPTION
- (from site-shared) Switches to Material Icons to work towards removing Font Awesome which slows down site loading (https://github.com/dart-lang/site-www/issues/3790)
- Adds hover and active styles
- Replaces focus style which comes from the underlying bootstrap button but doesn't match the rest of the site.

<img width="84" alt="Example with page source focused" src="https://github.com/dart-lang/site-www/assets/18372958/9b2a7265-b92e-4dc3-a0f2-1884a7c2772a">