### PR TITLE
Hide page source button on generated lint pages

### DIFF
--- a/src/_plugins/linter_page_generator.rb
+++ b/src/_plugins/linter_page_generator.rb
@@ -23,7 +23,8 @@ module Jekyll
           'title' => basename,
           'layout' => 'linter-rule-standalone',
           'lint' => lint,
-          'underscore_breaker_titles' => true
+          'underscore_breaker_titles' => true,
+          'body_class' => 'generated-page'
         }
 
       end

--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -663,6 +663,11 @@ ul.nav-list {
 #page-github-links {
   float: right;
 
+  // Hide page source button on generated pages
+  .generated-page & a:first-child {
+    display: none;
+  }
+
   .btn {
     color: $site-color-body;
     $padding-x: bootstrap.$btn-padding-x * 0.5;


### PR DESCRIPTION
It does this by adding a class (`generated-page`) to the body of the generated linter rule pages, then removing the first of the two buttons when that class is present.

Closes https://github.com/dart-lang/site-www/issues/5016