### PR TITLE
Remove mentions of now non-existent `flutter format` command

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -46,9 +46,10 @@ follow the [Customizing static analysis][] instructions.
 
 Dart provides [`dart fix`][] to find and fix errors.
 
-Dart also provides a code formatter similar to JavaScript tools like [Prettier][].
-To format code in any Dart project, run [`dart format`](/tools/dart-format) on
-your command line. In Flutter, use `flutter format`.
+Dart also provides a code formatter similar to
+JavaScript tools like [Prettier][].
+To format code in any Dart project, run
+[`dart format`](/tools/dart-format) on your command line.
 The IDE plugins for Dart and Flutter also provide this ability.
 
 Dart supports trailing commas for comma-separated lists of collections,

--- a/src/_guides/libraries/writing-package-pages.md
+++ b/src/_guides/libraries/writing-package-pages.md
@@ -384,7 +384,7 @@ Some additional tips include:
 *   Supply alt text for images.
 *   Be succinct. Don't say please.
 *   Keep the line length &lt;= 80 chars.
-*   Format code correctly (as `dart format` or `flutter format` would).
+*   Format code correctly (as `dart format` would).
 
 To learn more about good README practices,
 see these resources:


### PR DESCRIPTION
The command was deprecated a while ago, errors in 3.10, and is set to be fully removed in the next release.