### PR TITLE
Improve breadcrumbs style and enable for linter rules

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -11,15 +11,15 @@
       <article>
         <div class="content">
           {% include navigation-sub.html %}
-          {% if page.show_breadcrumbs -%}
-            {% include shared/breadcrumbs.html %}
-          {% endif -%}
-          <div>
+          <div id="site-content-title">
             {% include shared/page-github-links.html %}
             {% if page.underscore_breaker_titles -%}
             <h1>{{page.title | underscore_breaker}}</h1>
             {% else %}
             <h1>{{page.title }}</h1>
+            {% endif -%}
+            {% if page.show_breadcrumbs -%}
+              {% include shared/breadcrumbs.html %}
             {% endif -%}
           </div>
           {% include navigation-toc.html id='site-toc--inline' collapsible=true %}

--- a/src/_plugins/linter_page_generator.rb
+++ b/src/_plugins/linter_page_generator.rb
@@ -24,7 +24,8 @@ module Jekyll
           'layout' => 'linter-rule-standalone',
           'lint' => lint,
           'underscore_breaker_titles' => true,
-          'body_class' => 'generated-page'
+          'body_class' => 'generated-page',
+          'show_breadcrumbs' => true
         }
 
       end

--- a/src/_sass/core/_base.scss
+++ b/src/_sass/core/_base.scss
@@ -24,7 +24,7 @@ h1, .h1 {
   font-family: $site-font-family-gsans-display;
   font-size: bootstrap.$h1-font-size;
   margin-top: 0;
-  margin-bottom: 0.67em;
+  margin-bottom: 0;
 }
 
 h2, .h2 {

--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -92,6 +92,10 @@ i.fa-external-link-alt {
   }
 }
 
+#site-content-title {
+  margin-bottom: bootstrap.bs-spacer(6);
+}
+
 #page-footer {
   position: relative;
   z-index: 1000;
@@ -623,25 +627,24 @@ h3.popover-header {
   vertical-align: bottom;
 }
 
-.breadcrumb { // Override BS
-  font-size: bootstrap.$font-size-sm;
-  background-color: transparent;
-  padding: 0;
-  @at-root {
-    .breadcrumb-item {
-      + .breadcrumb-item {
-        padding-left: 0; // Fix BS 4.1 padding issue: push left padding into ::before for balance
-        &::before {
-          padding-left: bootstrap.$breadcrumb-item-padding;
-          @include md-icon-content(bootstrap.$breadcrumb-divider, 1rem + 2 * bootstrap.$breadcrumb-item-padding);
-        }
-      }
+// Overwrite bootstrap's breadcrumbs
+.breadcrumb {
+  align-items: center;
+}
 
-      &.active a {
-        color: bootstrap.$breadcrumb-active-color;
-        cursor: default;
-      }
+.breadcrumb-item {
+  align-items: center;
+  display: flex;
+
+  + .breadcrumb-item {
+    &::before {
+      font: $site-font-icon;
     }
+  }
+
+  &.active a {
+    color: bootstrap.$breadcrumb-active-color;
+    cursor: default; // Disable interactive cursor if already active
   }
 }
 

--- a/src/tools/linter-rules/all.md
+++ b/src/tools/linter-rules/all.md
@@ -2,6 +2,7 @@
 title: All linter rules
 description: Auto-generated configuration enabling all linter rules.
 toc: false
+show_breadcrumbs: true
 ---
 
 The following is an auto-generated list of all linter rules

--- a/src/tools/linter-rules/index.md
+++ b/src/tools/linter-rules/index.md
@@ -1,6 +1,7 @@
 ---
 title: Linter rules
 description: Details about the Dart linter and its style rules you can choose.
+show_breadcrumbs: true
 ---
 
 Use the Dart linter to identify possible problems in your Dart code.


### PR DESCRIPTION
We had a breadcrumbs style, but they were too small, in the wrong position, and placed incorrectly due to the h1 bottom margin. This PR adjusts the location and style to be more consistent with Flutter, below the h1 title, and a readable size to match other text.

Using this new functionality, this PR then enables breadcrumbs for the linter rule pages, so users can easily navigate back to the index page after learning more about a specific lint.

**Example:** https://dart-dev--pr5023-feature-linter-rule-jrf93owm.web.app/lints/avoid_dynamic_calls
<img width="507" alt="Example of avoid_dynamic_calls with breadcrumbs" src="https://github.com/dart-lang/site-www/assets/18372958/4c57a899-a39f-40c6-8be7-fe5c563e0c28">


Closes https://github.com/dart-lang/site-www/issues/5011