### PR TITLE
Remove now unnecessary glibc version mention

### DIFF
--- a/src/get-dart/index.md
+++ b/src/get-dart/index.md
@@ -66,11 +66,6 @@ The Dart SDK is supported on Windows, Linux, and macOS.
 * **Supported architectures:** x64, IA32, ARM64, ARM, RISC-V (RV64GC).<br>
   Support for RISC-V is in preview, and is available only in the dev and beta channels.
 
-{{site.alert.note}}
-  The arm support requires glibc 2.23 or newer due to a
-  [dynamic linker bug](https://sourceware.org/bugzilla/show_bug.cgi?id=14341).
-{{site.alert.end}}
-
 ### macOS
 
 * **Supported versions:** Latest three major versions.


### PR DESCRIPTION
Even Ubuntu LTS 16 and 18, which are already out of standard support [have the minimum version](https://launchpad.net/ubuntu/xenial/+source/glibc).

As for the Raspberry Pi issue that prompted the mention:

[Quoting](https://github.com/dart-lang/site-www/pull/4304#issuecomment-1328297924) Tim:

> I was wondering about this today. I did a little research, and it looks like glibc 2.23 (the bugfixed version) was released in 2016 (https://sourceware.org/glibc/wiki/Release/2.23). All downloadable versions of RPi are fixed, and have been since 2020. Even the legacy archive no longer contains broken versions: https://downloads.raspberrypi.org/raspios_oldstable_armhf/images/
> 
> I think it might now be safe to remove this, since the affected audience is primarily Raspberry Pi users who haven't upgraded for 2+ years (so they're unsupported by RPi), and there's a trivial upgrade for anyone affected.

This was a year ago, so all downloadable versions have been fixed for 3 or more years now. The mention just causes potential confusion or extra work to check for users.