### PR TITLE
Extend local caching to more file types

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,7 @@
       {
         "source": "**/*.@(jpg|jpeg|gif|png|md|txt|json|webp|webm|svg|css|js)",
         "headers": [
-          { "key": "Cache-Control", "value": "max-age=86400" },
+          { "key": "Cache-Control", "value": "max-age=3600" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }
         ]
       },

--- a/firebase.json
+++ b/firebase.json
@@ -5,9 +5,9 @@
     "trailingSlash": false,
     "headers": [
       {
-        "source": "**/*.@(jpg|jpeg|gif|png|md|txt|json)",
+        "source": "**/*.@(jpg|jpeg|gif|png|md|txt|json|webp|webm|svg|css|js)",
         "headers": [
-          { "key": "Cache-Control", "value": "max-age=3600" },
+          { "key": "Cache-Control", "value": "max-age=86400" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }
         ]
       },


### PR DESCRIPTION
This expands local caching to also cache `webp` images, `webm` videos (used in home page), `svg` images, as well as `css` and `js` files. We append cache busts to our styles on build as well as some scripts as necessary.