### PR TITLE
Direct users to bitwise operation platform differences

### DIFF
--- a/examples/misc/test/language_tour/operators_test.dart
+++ b/examples/misc/test/language_tour/operators_test.dart
@@ -159,13 +159,18 @@ void main() {
     assert((value & ~bitmask) == 0x20); // AND NOT
     assert((value | bitmask) == 0x2f); // OR
     assert((value ^ bitmask) == 0x2d); // XOR
+
     assert((value << 4) == 0x220); // Shift left
     assert((value >> 4) == 0x02); // Shift right
+
+    // Shift right example that results in different behavior on web
+    // due to negative operand:
+    assert((-value >> 4) == -0x03);
+
     assert((value >>> 4) == 0x02); // Unsigned shift right
-    assert((-value >> 4) == -0x03); // Shift right
     assert((-value >>> 4) > 0); // Unsigned shift right
     // #enddocregion op-bitwise
-  });
+  }, testOn: 'vm');
 
   test('if-null', () {
     // #docregion if-null

--- a/src/language/operators.md
+++ b/src/language/operators.md
@@ -317,6 +317,13 @@ you’d use these bitwise and shift operators with integers.
 | `>>>`                       | Unsigned shift right
 {:.table .table-striped}
 
+{{site.alert.end}}
+  The behavior of bitwise operations with large or negative operands
+  might differ between platforms.
+  To learn more, check out
+  [Bitwise operations platform differences][].
+{{site.alert.end}}
+
 Here’s an example of using bitwise and shift operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (op-bitwise)"?>
@@ -328,10 +335,15 @@ assert((value & bitmask) == 0x02); // AND
 assert((value & ~bitmask) == 0x20); // AND NOT
 assert((value | bitmask) == 0x2f); // OR
 assert((value ^ bitmask) == 0x2d); // XOR
+
 assert((value << 4) == 0x220); // Shift left
 assert((value >> 4) == 0x02); // Shift right
+
+// Shift right example that results in different behavior on web
+// due to negative operand:
+assert((-value >> 4) == -0x03);
+
 assert((value >>> 4) == 0x02); // Unsigned shift right
-assert((-value >> 4) == -0x03); // Shift right
 assert((-value >>> 4) > 0); // Unsigned shift right
 ```
 
@@ -340,6 +352,7 @@ assert((-value >>> 4) > 0); // Unsigned shift right
   requires a [language version][] of at least 2.14.
 {{site.alert.end}}
 
+[Bitwise operations platform differences]: /guides/language/numbers#bitwise-operations
 
 ## Conditional expressions
 

--- a/src/language/operators.md
+++ b/src/language/operators.md
@@ -317,7 +317,7 @@ you’d use these bitwise and shift operators with integers.
 | `>>>`                       | Unsigned shift right
 {:.table .table-striped}
 
-{{site.alert.end}}
+{{site.alert.note}}
   The behavior of bitwise operations with large or negative operands
   might differ between platforms.
   To learn more, check out


### PR DESCRIPTION
I didn't want to repeat too much of what was covered on the number semantics page or focus too much on the platform differences, so I did my best to find a minimal balance. Let me know what you think.

If we want to cover more of what @eernstg mentioned in https://github.com/dart-lang/site-www/issues/5020#issuecomment-1617650660, such as potential workarounds, that would be best as a follow-up expansion on the number semantics page rather than here.

**Staged:** https://dart-dev--pr5033-fix-5020-spu2i1id.web.app/language/operators#bitwise-and-shift-operators

Closes https://github.com/dart-lang/site-www/issues/5020