### PR TITLE
Add forward link from bottom type discussion to `Never` discussion

### DIFF
--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -331,8 +331,11 @@ In practice, this means:
     since that type means "could be any possible value except this one weirdly
     prohibited value `null`".
 
-*   On the rare occasion that you need a bottom type, use `Never` instead of
-    `Null`. If you don't know if you need a bottom type, you probably don't.
+*   On the rare occasion that you need a bottom type, use
+    `Never` instead of `Null`.
+    This is particularly useful to indicate a function never returns
+    to [help reachability analysis](#never-for-unreachable-code).
+    If you don't know if you need a bottom type, you probably don't.
 
 ## Ensuring correctness
 


### PR DESCRIPTION
I'm not too familiar with the type terminology or theory, but wanted to get this forward reference in to the very useful section discussing `Never`. Let me know if I should adjust the wording, thanks!

Closes https://github.com/dart-lang/site-www/issues/2545
