### PR TITLE
Remove old language tour TODOs now tracked elsewhere

### DIFF
--- a/src/language/built-in-types.md
+++ b/src/language/built-in-types.md
@@ -46,10 +46,6 @@ Some other types also have special roles in the Dart language:
 * `void`: Indicates that a value is never used.
   Often used as a return type.
 
-{% comment %}
-[TODO: move/add for-in coverage to language tour?]
-{% endcomment %}
-
 The `Object`, `Object?`, `Null`, and `Never` classes
 have special roles in the class hierarchy.
 Learn about these roles in [Understanding null safety][].

--- a/src/language/constructors.md
+++ b/src/language/constructors.md
@@ -239,10 +239,6 @@ Besides invoking a superclass constructor, you can also initialize
 instance variables before the constructor body runs. Separate
 initializers with commas.
 
-{% comment %}
-[TODO #2950: Maybe change example or point to discussion of ! (in map section?).]
-{% endcomment %}
-
 <?code-excerpt "misc/lib/language_tour/classes/point_alt.dart (initializer-list)"?>
 ```dart
 // Initializer list sets instance variables before

--- a/src/language/generics.md
+++ b/src/language/generics.md
@@ -111,9 +111,6 @@ angle brackets (`<...>`) just after the class name. For example:
 var nameSet = Set<String>.from(names);
 ```
 
-{% comment %}[TODO #2950: It isn't idiomatic to use a constructor for an empty Map.
-Change to a class that doesn't have literal support.]{% endcomment %}
-
 The following code creates a map that has integer keys and values of
 type View:
 

--- a/src/language/keywords.md
+++ b/src/language/keywords.md
@@ -47,10 +47,6 @@ The following table lists the words that the Dart language treats specially.
 [catch]: /language/error-handling#catch
 [class]: /language/classes#instance-variables
 [const]: /language/variables#final-and-const
-{% comment %}
-  [TODO #2950: Make sure that points to a place that talks about const constructors,
-  as well as const literals and variables.]
-{% endcomment %}
 [continue]: /language/loops#break-and-continue
 [covariant]: /guides/language/sound-problems#the-covariant-keyword
 [default]: /language/branches#switch
@@ -103,9 +99,6 @@ The following table lists the words that the Dart language treats specially.
 [typedef]: /language/typedefs
 [var]: /language/variables
 [void]: /language/built-in-types
-{% comment %}
-  TODO #2950: Add coverage of void to the language tour.
-{% endcomment %}
 [when]: /language/branches#when
 [with]: /language/mixins
 [while]: /language/loops#while-and-do-while


### PR DESCRIPTION
Closes https://github.com/dart-lang/site-www/issues/2950

These issues are now tracked elsewhere, including:

- https://github.com/dart-lang/site-www/issues/5036
- https://github.com/dart-lang/site-www/issues/5037
- https://github.com/dart-lang/site-www/issues/2093
- https://github.com/dart-lang/site-www/issues/4350