### PR TITLE
Consistently use 'Google Sans' in sidenav

### DIFF
--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -120,6 +120,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 1;
+  font-family: $site-font-family-alt;
 
   .open_menu & {
     z-index: 10000;
@@ -136,7 +137,7 @@
     }
 
     .nav-link {
-      font-family: $site-font-family-base;
+      font-family: $site-font-family-alt;
       font-weight: 400;
       color: $site-color-body;
       font-size: $font-size-small;


### PR DESCRIPTION
Previously it was a mix of 'Google Sans' and 'Roboto'. This simplifies it to just 'Google Sans', matching other sites like docs.flutter.dev and m3.material.io.