### PR TITLE
Adjust focus of web difference mention for bitwise operands

### DIFF
--- a/examples/misc/test/language_tour/operators_test.dart
+++ b/examples/misc/test/language_tour/operators_test.dart
@@ -164,7 +164,7 @@ void main() {
     assert((value >> 4) == 0x02); // Shift right
 
     // Shift right example that results in different behavior on web
-    // due to negative operand:
+    // because the operand value changes when masked to 32 bits:
     assert((-value >> 4) == -0x03);
 
     assert((value >>> 4) == 0x02); // Unsigned shift right

--- a/src/language/operators.md
+++ b/src/language/operators.md
@@ -340,7 +340,7 @@ assert((value << 4) == 0x220); // Shift left
 assert((value >> 4) == 0x02); // Shift right
 
 // Shift right example that results in different behavior on web
-// due to negative operand:
+// because the operand value changes when masked to 32 bits:
 assert((-value >> 4) == -0x03);
 
 assert((value >>> 4) == 0x02); // Unsigned shift right


### PR DESCRIPTION
Applies the suggested changes from https://github.com/dart-lang/site-www/pull/5033#discussion_r1262361530 since the PR was accidentally merged prematurely.
