### PR TITLE
Fixed typos in isolate code snippets

### DIFF
--- a/examples/concurrency/lib/async_number_of_keys.dart
+++ b/examples/concurrency/lib/async_number_of_keys.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+// #docregion
 const String filename = 'with_keys.json';
 
-// #docregion
 void main() async {
   // Read some data.
   final fileData = await _readFileAsync();

--- a/examples/concurrency/lib/simple_isolate_closure.dart
+++ b/examples/concurrency/lib/simple_isolate_closure.dart
@@ -2,9 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+// #docregion main
 const String filename = 'with_keys.json';
 
-// #docregion main
 void main() async {
   // Read some data.
   final jsonData = await Isolate.run(() async {

--- a/examples/concurrency/lib/simple_worker_isolate.dart
+++ b/examples/concurrency/lib/simple_worker_isolate.dart
@@ -2,9 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+// #docregion main
 const String filename = 'with_keys.json';
 
-// #docregion main
 void main() async {
   // Read some data.
   final jsonData = await Isolate.run(_readAndParseJson);

--- a/examples/concurrency/lib/sync_number_of_keys.dart
+++ b/examples/concurrency/lib/sync_number_of_keys.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+// #docregion
 const String filename = 'with_keys.json';
 
-// #docregion
 void main() {
   // Read some data.
   final fileData = _readFileSync();

--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -103,6 +103,8 @@ that blocks while waiting for file I/O:
 
 <?code-excerpt "lib/sync_number_of_keys.dart"?>
 ```dart
+const String filename = 'with_keys.json';
+
 void main() {
   // Read some data.
   final fileData = _readFileSync();
@@ -123,6 +125,8 @@ Here’s similar code, but with changes (highlighted) to make it asynchronous:
 
 <?code-excerpt "lib/async_number_of_keys.dart" replace="/async|await|readAsString\(\)/[!$&!]/g; /Future<\w+\W/[!$&!]/g;"?>
 {% prettify dart tag=pre+code %}
+const String filename = 'with_keys.json';
+
 void main() [!async!] {
   // Read some data.
   final fileData = [!await!] _readFileAsync();
@@ -341,6 +345,8 @@ The main isolate contains the code that spawns a new isolate:
 
 <?code-excerpt "lib/simple_worker_isolate.dart (main)"?>
 ```dart
+const String filename = 'with_keys.json';
+
 void main() async {
   // Read some data.
   final jsonData = await Isolate.run(_readAndParseJson);
@@ -410,6 +416,8 @@ function literal, or closure, directly in the main isolate.
 
 <?code-excerpt "lib/simple_isolate_closure.dart (main)"?>
 ```dart
+const String filename = 'with_keys.json';
+
 void main() async {
   // Read some data.
   final jsonData = await Isolate.run(() async {


### PR DESCRIPTION
Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes #5063 - Fixed typo in Isolate code snippets, where the variable declaration for `filename` was not included in the snippet.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
