### PR TITLE
Update part file link

### DIFF
--- a/src/resources/glossary.md
+++ b/src/resources/glossary.md
@@ -237,6 +237,9 @@ supertype of all the other overridden methods.
 ## Part file
 
 A part file is a Dart source file that contains a `part of` directive.
+For usage guidance, see the [Effective Dart][part] entry.
+
+[part]: /effective-dart/usage#do-use-strings-in-part-of-directives
 
 ## Potentially non-nullable
 

--- a/src/tools/pub/glossary.md
+++ b/src/tools/pub/glossary.md
@@ -154,7 +154,7 @@ All other dependencies are [transitive dependencies](#transitive-dependency).
 A library is a single compilation unit, made up of a single primary file and any
 optional number of [parts][]. Libraries have their own private scope.
 
-[parts]: /effective-dart/usage#do-use-strings-in-part-of-directives
+[parts]: /resources/glossary#part-file
 
 ## Lockfile
 


### PR DESCRIPTION
Idk if this is useful or not, but this updates a link in the pub glossary to point from the Effective Dart entry on part files, to the glossary entry. 

I had this as a To-Do on #4622. I think it makes sense in the effort to utilize the glossary and make it more ubiquitous, but since this particular entry isn't filled out a ton, it just points to the Effective Dart entry anyway.

I think that's ok though, as we want the glossary to function as a set of definitions for other content to point to, and not extensive explanations.