### PR TITLE
Add 3.0.3 `dart:async` interface changes to migration guide

### DIFF
--- a/src/resources/dart-3-migration.md
+++ b/src/resources/dart-3-migration.md
@@ -427,6 +427,19 @@ They have been applied to a number of classes in the core libraries.
 This is a [*versioned* change](#unversioned-vs-versioned-changes), 
 that only applies to language version 3.0 or later.
 
+#### `dart:async`
+
+* The following declarations can only be implemented, not extended:
+
+  - `StreamConsumer`
+  - `StreamIterator`
+  - `StreamTransformer`
+  - `MultiStreamController`
+
+  None of these declarations contained any implementation to inherit.
+  They are marked as `interface` to signify that
+  they are only intended as interfaces.
+
 #### `dart:core`
 
 * The `Function` type can no longer be implemented, extended or mixed in.


### PR DESCRIPTION
These changes were part of the `3.0.3` release: https://github.com/dart-lang/sdk/blob/stable/CHANGELOG.md#303---2023-02-07

The explanatory text was copied from similar `dart:core` changes below.

**Staged:** https://dart-dev--pr5075-misc-add-dart-async-y7czvyj4.web.app/resources/dart-3-migration#dartasync-1
