### PR TITLE
Add exception to a rule for class that contains only static members.

### DIFF
--- a/src/effective-dart/design.md
+++ b/src/effective-dart/design.md
@@ -619,8 +619,8 @@ class _Favorites {
 In idiomatic Dart, classes define *kinds of objects*. A type that is never
 instantiated is a code smell.
 
-However, this isn't a hard rule. With constants and enum-like types, it may be
-natural to group them in a class.
+However, this isn't a hard rule. With constants, enum-like types and single-instance
+objects, it may be natural to group them in a class.
 
 {:.good}
 <?code-excerpt "design_bad.dart (class-only-static-exception)"?>


### PR DESCRIPTION
Classes like this happen so often that it worse mentioning them as exception:  https://api.dart.dev/stable/3.0.6/dart-developer/Service/Service.html