### PR TITLE
Remove deprecated command from build_runner.md

### DIFF
--- a/src/tools/build_runner.md
+++ b/src/tools/build_runner.md
@@ -52,11 +52,11 @@ $ dart pub get
 
 ## Using built-in commands
 
-Here is an example of using the build_runner **build** command:
+The following is an example of using the build_runner **build** command:
 
 ```terminal
 $ # From a directory that contains a pubspec.yaml file:
-$ dart run build_runner build  # Dart SDK
+$ dart run build_runner build
 ```
 
 The build_runner package includes the following commands:

--- a/src/tools/build_runner.md
+++ b/src/tools/build_runner.md
@@ -52,7 +52,7 @@ $ dart pub get
 
 ## Using built-in commands
 
-Here is an example of using the build_runner **build** command for both Flutter and Dart projects:
+Here is an example of using the build_runner **build** command:
 
 ```terminal
 $ # From a directory that contains a pubspec.yaml file:

--- a/src/tools/build_runner.md
+++ b/src/tools/build_runner.md
@@ -52,14 +52,11 @@ $ dart pub get
 
 ## Using built-in commands
 
-How you use the build_runner commands depends on whether you're using
-the Dart SDK or the Flutter SDK.
-Here are examples of using the build_runner **build** command:
+Here is an example of using the build_runner **build** command for both Flutter and Dart projects:
 
 ```terminal
 $ # From a directory that contains a pubspec.yaml file:
 $ dart run build_runner build  # Dart SDK
-$ flutter pub run build_runner build  # Flutter SDK
 ```
 
 The build_runner package includes the following commands:


### PR DESCRIPTION
This PR removes deprecated `flutter run` command from `build_runner` description page.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
