### PR TITLE
Fix document about understanding-null-safety

### DIFF
--- a/src/null-safety/understanding-null-safety/index.md
+++ b/src/null-safety/understanding-null-safety/index.md
@@ -813,7 +813,7 @@ print(notAString?.length?.isEven);
 This is annoying, but, worse, it obscures important information. Consider:
 
 ```dart
-// Using null safety:
+// Without null safety:
 showGizmo(Thing? thing) {
   print(thing?.doohickey?.gizmo);
 }


### PR DESCRIPTION
The example code seems to be about "without null safety".