### PR TITLE
Add a `/cl` redirect for gerrit CLs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -79,6 +79,8 @@
       { "source": "/books", "destination": "/resources/books", "type": 301 },
       { "source": "/bug", "destination": "https://dartbug.com", "type": 301 },
       { "source": "/bug/:rest*", "destination": "https://dartbug.com/:rest*", "type": 301 },
+      { "source": "/cl", "destination": "https://dart-review.googlesource.com/q/status:open+-is:wip", "type": 301 },
+      { "source": "/cl/:rest*", "destination": "https://dart-review.googlesource.com/c/sdk/+/:rest*", "type": 301 },
       { "source": "/cloud{,/**}", "destination": "/server/google-cloud", "type": 301 },
       { "source": "/codelabs/server{,/**}", "destination": "/tutorials/server/httpserver", "type": 301 },
       { "source": "/code-of-conduct", "destination": "/community/code-of-conduct", "type": 301 },


### PR DESCRIPTION
This will for example, enable https://dart.dev/cl/320141 to redirect to https://dart-review.googlesource.com/c/sdk/+/320141. This allows for shorter, more familiar, and more memorable links for sharing with users.

This follows a similar vein as the recent https://dart.dev/bug/53016 redirect functionality.

**Staged example:** https://dart-dev--pr5106-feature-cl-redirect-hdeqkjph.web.app/cl/320141