### PR TITLE
Fix link in JNI docs

### DIFF
--- a/src/_guides/libraries/java-interop.md
+++ b/src/_guides/libraries/java-interop.md
@@ -16,7 +16,7 @@ to call Java and Kotlin APIs.
 {{site.alert.end}}
 
 `package:jni` allows Dart code to interact
-with Java through [JNI]({{page.jnidoc}}).
+with Java through [JNI][jnidoc].
 However, doing so involves a lot of boilerplate code,
 so you can use `package:jnigen` to automatically generate
 the Dart bindings for a given Java API.


### PR DESCRIPTION
Fix broken link to JNI. Currently the JNI link links back to the page itself. It should link to the official JNI page..

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
