### PR TITLE
Update the name of the dart_community discord

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -33,7 +33,7 @@ Get answers and connect with Dart developers.
 [StackOverflow](https://stackoverflow.com/tags/dart)
 : The best place for how-to questions.
 
-[The `dart_community` Discord](https://discord.gg/Qt6DgfAWWx)
+[The dart_community Discord](https://discord.gg/Qt6DgfAWWx)
 : Chat with and get help from other Dart developers.
 
 [Dart on Reddit](https://www.reddit.com/r/dartlang)

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -33,11 +33,11 @@ Get answers and connect with Dart developers.
 [StackOverflow](https://stackoverflow.com/tags/dart)
 : The best place for how-to questions.
 
+[The `dart_community` Discord](https://discord.gg/Qt6DgfAWWx)
+: Chat with and get help from other Dart developers.
+
 [Dart on Reddit](https://www.reddit.com/r/dartlang)
 : The subreddit for all things related to Dart.
-
-[The Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx)
-: Chat with and get help from other Dart developers.
 
 #### Google Groups
 


### PR DESCRIPTION
The Dart community Discord has renamed to dart_community to match Dart's package/file naming scheme :) 