### PR TITLE
Fix table wide tables in "Numbers in dart" page

### DIFF
--- a/src/_guides/language/numbers.md
+++ b/src/_guides/language/numbers.md
@@ -52,29 +52,29 @@ The following table shows how Dart numbers are usually implemented:
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Representation</th>
-    <th>Native <code>int</code></th>
-    <th>Native <code>double</code></th>
-    <th>Web <code>int</code></th>
-    <th>Web <code>double</code></th>
+      <th>Representation</th>
+      <th>Native <code>int</code></th>
+      <th>Native <code>double</code></th>
+      <th>Web <code>int</code></th>
+      <th>Web <code>double</code></th>
     </tr>
     <tr>
-    <td><a href="https://en.wikipedia.org/wiki/Two%27s_complement">
-      64-bit signed two’s complement</a>
-    </td>
-    <td>✅</td>
-    <td></td>
-    <td></td>
-    <td></td>
+      <td><a href="https://en.wikipedia.org/wiki/Two%27s_complement">
+        64-bit signed two’s complement</a>
+      </td>
+      <td>✅</td>
+      <td></td>
+      <td></td>
+      <td></td>
     </tr>
     <tr>
-    <td>
-      <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">64-bit floating point</a>
-    </td>
-    <td></td>
-    <td>✅</td>
-    <td>✅</td>
-    <td>✅</td>
+      <td>
+        <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">64-bit floating point</a>
+      </td>
+      <td></td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
     </tr>
   </table>
 </div>
@@ -162,44 +162,44 @@ they're approximations due to the loss of precision.
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Expression</th>
-    <th>Native</th>
-    <th>Web</th>
+      <th>Expression</th>
+      <th>Native</th>
+      <th>Web</th>
     </tr>
     <tr>
-    <td><code>math.pow(2, 53) - 1</code></td>
-    <td><code>9007199254740991</code></td>
-    <td><code>9007199254740991</code></td>
+      <td><code>math.pow(2, 53) - 1</code></td>
+      <td><code>9007199254740991</code></td>
+      <td><code>9007199254740991</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 53)</code></td>
-    <td><code>9007199254740992</code></td>
-    <td><code>9007199254740992</code></td>
+      <td><code>math.pow(2, 53)</code></td>
+      <td><code>9007199254740992</code></td>
+      <td><code>9007199254740992</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 53) + 1</code></td>
-    <td><code>9007199254740993</code></td>
-    <td><code>9007199254740992</code></td>
+      <td><code>math.pow(2, 53) + 1</code></td>
+      <td><code>9007199254740993</code></td>
+      <td><code>9007199254740992</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 62)</code></td>
-    <td><code>4611686018427387904</code></td>
-    <td><code>4611686018427388000</code></td>
+      <td><code>math.pow(2, 62)</code></td>
+      <td><code>4611686018427387904</code></td>
+      <td><code>4611686018427388000</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 63) - 1</code></td>
-    <td><code>9223372036854775807</code></td>
-    <td><code>9223372036854776000</code></td>
+      <td><code>math.pow(2, 63) - 1</code></td>
+      <td><code>9223372036854775807</code></td>
+      <td><code>9223372036854776000</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 63)</code></td>
-    <td><code>-9223372036854775808</code></td>
-    <td><code>9223372036854776000</code></td>
+      <td><code>math.pow(2, 63)</code></td>
+      <td><code>-9223372036854775808</code></td>
+      <td><code>9223372036854776000</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 64)</code></td>
-    <td><code>0</code></td>
-    <td><code>18446744073709552000</code></td>
+      <td><code>math.pow(2, 64)</code></td>
+      <td><code>0</code></td>
+      <td><code>18446744073709552000</code></td>
     </tr>
   </table>
 </div>
@@ -220,49 +220,49 @@ the identity expressions are usually different.
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Expression</th>
-    <th>Native</th>
-    <th>Web</th>
+      <th>Expression</th>
+      <th>Native</th>
+      <th>Web</th>
     </tr>
     <tr>
-    <td><code>1.0 == 1</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>1.0 == 1</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>identical(1.0, 1)</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>identical(1.0, 1)</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>0.0 == -0.0</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>0.0 == -0.0</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>identical(0.0, -0.0)</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>identical(0.0, -0.0)</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>double.nan == double.nan</code></td>
-    <td><code>false</code></td>
-    <td><code>false</code></td>
+      <td><code>double.nan == double.nan</code></td>
+      <td><code>false</code></td>
+      <td><code>false</code></td>
     </tr>
     <tr>
-    <td><code>identical(double.nan, double.nan)</code></td>
-    <td><code>true</code></td>
-    <td><code>false</code></td>
+      <td><code>identical(double.nan, double.nan)</code></td>
+      <td><code>true</code></td>
+      <td><code>false</code></td>
     </tr>
     <tr>
-    <td><code>double.infinity == double.infinity</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>double.infinity == double.infinity</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>identical(double.infinity, double.infinity)</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>identical(double.infinity, double.infinity)</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
   </table>
 </div>
@@ -288,74 +288,74 @@ it might change in the future.
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Expression</th>
-    <th>Native</th>
-    <th>Web</th>
+      <th>Expression</th>
+      <th>Native</th>
+      <th>Web</th>
     </tr>
     <tr>
-    <td><code>1 is int</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>1 is int</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>1 is double</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>1 is double</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>1.0 is int</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>1.0 is int</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>1.0 is double</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>1.0 is double</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>(0.5 + 0.5) is int</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>(0.5 + 0.5) is int</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>(0.5 + 0.5) is double</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>(0.5 + 0.5) is double</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>3.14 is int</code></td>
-    <td><code>false</code></td>
-    <td><code>false</code></td>
+      <td><code>3.14 is int</code></td>
+      <td><code>false</code></td>
+      <td><code>false</code></td>
     </tr>
     <tr>
-    <td><code>3.14 is double</code></td>
-    <td><code>true</code></td>
-    <td><code>true</code></td>
+      <td><code>3.14 is double</code></td>
+      <td><code>true</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>double.infinity is int</code></td>
-    <td><code>false</code></td>
-    <td><code>true</code></td>
+      <td><code>double.infinity is int</code></td>
+      <td><code>false</code></td>
+      <td><code>true</code></td>
     </tr>
     <tr>
-    <td><code>double.nan is int</code></td>
-    <td><code>false</code></td>
-    <td><code>false</code></td>
+      <td><code>double.nan is int</code></td>
+      <td><code>false</code></td>
+      <td><code>false</code></td>
     </tr>
     <tr>
-    <td><code>1.0.runtimeType</code></td>
-    <td><code>double</code></td>
-    <td><code>int</code></td>
+      <td><code>1.0.runtimeType</code></td>
+      <td><code>double</code></td>
+      <td><code>int</code></td>
     </tr>
     <tr>
-    <td><code>1.runtimeType</code></td>
-    <td><code>int</code></td>
-    <td><code>int</code></td>
+      <td><code>1.runtimeType</code></td>
+      <td><code>int</code></td>
+      <td><code>int</code></td>
     </tr>
     <tr>
-    <td><code>1.5.runtimeType</code></td>
-    <td><code>double</code></td>
-    <td><code>double</code></td>
+      <td><code>1.5.runtimeType</code></td>
+      <td><code>double</code></td>
+      <td><code>double</code></td>
     </tr>
   </table>
 </div>
@@ -378,34 +378,34 @@ are either negative or close to 32 bits:
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Expression</th>
-    <th>Native</th>
-    <th>Web</th>
+      <th>Expression</th>
+      <th>Native</th>
+      <th>Web</th>
     </tr>
     <tr>
-    <td><code>-1 >> 0</code></td>
-    <td><code>-1</code></td>
-    <td><code>4294967295</code></td>
+      <td><code>-1 >> 0</code></td>
+      <td><code>-1</code></td>
+      <td><code>4294967295</code></td>
     </tr>
     <tr>
-    <td><code>-1 ^ 2</code></td>
-    <td><code>-3</code></td>
-    <td><code>4294967293</code></td>
+      <td><code>-1 ^ 2</code></td>
+      <td><code>-3</code></td>
+      <td><code>4294967293</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 32).toInt()</code></td>
-    <td><code>4294967296</code></td>
-    <td><code>4294967296</code></td>
+      <td><code>math.pow(2, 32).toInt()</code></td>
+      <td><code>4294967296</code></td>
+      <td><code>4294967296</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 32).toInt() >> 1</code></td>
-    <td><code>2147483648</code></td>
-    <td><code>0</code></td>
+      <td><code>math.pow(2, 32).toInt() >> 1</code></td>
+      <td><code>2147483648</code></td>
+      <td><code>0</code></td>
     </tr>
     <tr>
-    <td><code>(math.pow(2, 32).toInt()-1) >> 1</code></td>
-    <td><code>2147483647</code></td>
-    <td><code>2147483647</code></td>
+      <td><code>(math.pow(2, 32).toInt()-1) >> 1</code></td>
+      <td><code>2147483647</code></td>
+      <td><code>2147483647</code></td>
     </tr>
   </table>
 </div>
@@ -420,44 +420,44 @@ converting the expressions in the first column can lead to different results.
 <div class="table-wrapper">
   <table class="table table-striped nowrap">
     <tr>
-    <th>Expression</th>
-    <th>Native <code>toString()</code></th>
-    <th>Web <code>toString()</code></th>
+      <th>Expression</th>
+      <th>Native <code>toString()</code></th>
+      <th>Web <code>toString()</code></th>
     </tr>
     <tr>
-    <td><code>1</code></td>
-    <td><code>"1"</code></td>
-    <td><code>"1"</code></td>
+      <td><code>1</code></td>
+      <td><code>"1"</code></td>
+      <td><code>"1"</code></td>
     </tr>
     <tr>
-    <td><code>1.0</code></td>
-    <td><code>"1.0"</code></td>
-    <td><code>"1"</code></td>
+      <td><code>1.0</code></td>
+      <td><code>"1.0"</code></td>
+      <td><code>"1"</code></td>
     </tr>
     <tr>
-    <td><code>(0.5 + 0.5)</code></td>
-    <td><code>"1.0"</code></td>
-    <td><code>"1"</code></td>
+      <td><code>(0.5 + 0.5)</code></td>
+      <td><code>"1.0"</code></td>
+      <td><code>"1"</code></td>
     </tr>
     <tr>
-    <td><code>1.5</code></td>
-    <td><code>"1.5"</code></td>
-    <td><code>"1.5"</code></td>
+      <td><code>1.5</code></td>
+      <td><code>"1.5"</code></td>
+      <td><code>"1.5"</code></td>
     </tr>
     <tr>
-    <td><code>-0</code></td>
-    <td><code>"0"</code></td>
-    <td><code>"-0.0"</code></td>
+      <td><code>-0</code></td>
+      <td><code>"0"</code></td>
+      <td><code>"-0.0"</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 0)</code></td>
-    <td><code>"1"</code></td>
-    <td><code>"1"</code></td>
+      <td><code>math.pow(2, 0)</code></td>
+      <td><code>"1"</code></td>
+      <td><code>"1"</code></td>
     </tr>
     <tr>
-    <td><code>math.pow(2, 80)</code></td>
-    <td><code>"0"</code></td>
-    <td><code>"1.2089258196146292e+24"</code></td>
+      <td><code>math.pow(2, 80)</code></td>
+      <td><code>"0"</code></td>
+      <td><code>"1.2089258196146292e+24"</code></td>
     </tr>
   </table>
 </div>

--- a/src/_guides/language/numbers.md
+++ b/src/_guides/language/numbers.md
@@ -49,33 +49,35 @@ In particular, Dart has two very different types of targets it compiles to:
 
 The following table shows how Dart numbers are usually implemented:
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Representation</th>
-   <th>Native <code>int</code></th>
-   <th>Native <code>double</code></th>
-   <th>Web <code>int</code></th>
-   <th>Web <code>double</code></th>
-  </tr>
-  <tr>
-   <td><a href="https://en.wikipedia.org/wiki/Two%27s_complement">
-     64-bit signed two’s complement</a>
-   </td>
-   <td>✅</td>
-   <td></td>
-   <td></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>
-     <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">64-bit floating point</a>
-   </td>
-   <td></td>
-   <td>✅</td>
-   <td>✅</td>
-   <td>✅</td>
-  </tr>
-</table>
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Representation</th>
+    <th>Native <code>int</code></th>
+    <th>Native <code>double</code></th>
+    <th>Web <code>int</code></th>
+    <th>Web <code>double</code></th>
+    </tr>
+    <tr>
+    <td><a href="https://en.wikipedia.org/wiki/Two%27s_complement">
+      64-bit signed two’s complement</a>
+    </td>
+    <td>✅</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    </tr>
+    <tr>
+    <td>
+      <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">64-bit floating point</a>
+    </td>
+    <td></td>
+    <td>✅</td>
+    <td>✅</td>
+    <td>✅</td>
+    </tr>
+  </table>
+</div>
 
 For native targets, you can assume that
 `int` maps to a signed 64-bit integer representation and
@@ -157,49 +159,50 @@ On the web, these values do not overflow
 because they are represented differently;
 they're approximations due to the loss of precision.
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Expression</th>
-   <th>Native</th>
-   <th>Web</th>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 53) - 1</code></td>
-   <td><code>9007199254740991</code></td>
-   <td><code>9007199254740991</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 53)</code></td>
-   <td><code>9007199254740992</code></td>
-   <td><code>9007199254740992</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 53) + 1</code></td>
-   <td><code>9007199254740993</code></td>
-   <td><code>9007199254740992</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 62)</code></td>
-   <td><code>4611686018427387904</code></td>
-   <td><code>4611686018427388000</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 63) - 1</code></td>
-   <td><code>9223372036854775807</code></td>
-   <td><code>9223372036854776000</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 63)</code></td>
-   <td><code>-9223372036854775808</code></td>
-   <td><code>9223372036854776000</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 64)</code></td>
-   <td><code>0</code></td>
-   <td><code>18446744073709552000</code></td>
-  </tr>
-</table>
-
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Expression</th>
+    <th>Native</th>
+    <th>Web</th>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 53) - 1</code></td>
+    <td><code>9007199254740991</code></td>
+    <td><code>9007199254740991</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 53)</code></td>
+    <td><code>9007199254740992</code></td>
+    <td><code>9007199254740992</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 53) + 1</code></td>
+    <td><code>9007199254740993</code></td>
+    <td><code>9007199254740992</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 62)</code></td>
+    <td><code>4611686018427387904</code></td>
+    <td><code>4611686018427388000</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 63) - 1</code></td>
+    <td><code>9223372036854775807</code></td>
+    <td><code>9223372036854776000</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 63)</code></td>
+    <td><code>-9223372036854775808</code></td>
+    <td><code>9223372036854776000</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 64)</code></td>
+    <td><code>0</code></td>
+    <td><code>18446744073709552000</code></td>
+    </tr>
+  </table>
+</div>
 
 ### Identity
 
@@ -214,54 +217,55 @@ The following table shows some expressions that use equality and identity.
 The equality expressions are the same on native and web;
 the identity expressions are usually different.
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Expression</th>
-   <th>Native</th>
-   <th>Web</th>
-  </tr>
-  <tr>
-   <td><code>1.0 == 1</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>identical(1.0, 1)</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>0.0 == -0.0</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>identical(0.0, -0.0)</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>double.nan == double.nan</code></td>
-   <td><code>false</code></td>
-   <td><code>false</code></td>
-  </tr>
-  <tr>
-   <td><code>identical(double.nan, double.nan)</code></td>
-   <td><code>true</code></td>
-   <td><code>false</code></td>
-  </tr>
-  <tr>
-   <td><code>double.infinity == double.infinity</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>identical(double.infinity, double.infinity)</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-</table>
-
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Expression</th>
+    <th>Native</th>
+    <th>Web</th>
+    </tr>
+    <tr>
+    <td><code>1.0 == 1</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>identical(1.0, 1)</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>0.0 == -0.0</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>identical(0.0, -0.0)</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>double.nan == double.nan</code></td>
+    <td><code>false</code></td>
+    <td><code>false</code></td>
+    </tr>
+    <tr>
+    <td><code>identical(double.nan, double.nan)</code></td>
+    <td><code>true</code></td>
+    <td><code>false</code></td>
+    </tr>
+    <tr>
+    <td><code>double.infinity == double.infinity</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>identical(double.infinity, double.infinity)</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+  </table>
+</div>
 
 ### Types and type checking
 
@@ -281,79 +285,80 @@ A side effect is that `double.infinity` is interpreted as an `int`.
 Because this is a platform-specific behavior,
 it might change in the future.
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Expression</th>
-   <th>Native</th>
-   <th>Web</th>
-  </tr>
-  <tr>
-   <td><code>1 is int</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>1 is double</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>1.0 is int</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>1.0 is double</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>(0.5 + 0.5) is int</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>(0.5 + 0.5) is double</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>3.14 is int</code></td>
-   <td><code>false</code></td>
-   <td><code>false</code></td>
-  </tr>
-  <tr>
-   <td><code>3.14 is double</code></td>
-   <td><code>true</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>double.infinity is int</code></td>
-   <td><code>false</code></td>
-   <td><code>true</code></td>
-  </tr>
-  <tr>
-   <td><code>double.nan is int</code></td>
-   <td><code>false</code></td>
-   <td><code>false</code></td>
-  </tr>
-  <tr>
-   <td><code>1.0.runtimeType</code></td>
-   <td><code>double</code></td>
-   <td><code>int</code></td>
-  </tr>
-  <tr>
-   <td><code>1.runtimeType</code></td>
-   <td><code>int</code></td>
-   <td><code>int</code></td>
-  </tr>
-  <tr>
-   <td><code>1.5.runtimeType</code></td>
-   <td><code>double</code></td>
-   <td><code>double</code></td>
-  </tr>
-</table>
-
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Expression</th>
+    <th>Native</th>
+    <th>Web</th>
+    </tr>
+    <tr>
+    <td><code>1 is int</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>1 is double</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>1.0 is int</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>1.0 is double</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>(0.5 + 0.5) is int</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>(0.5 + 0.5) is double</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>3.14 is int</code></td>
+    <td><code>false</code></td>
+    <td><code>false</code></td>
+    </tr>
+    <tr>
+    <td><code>3.14 is double</code></td>
+    <td><code>true</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>double.infinity is int</code></td>
+    <td><code>false</code></td>
+    <td><code>true</code></td>
+    </tr>
+    <tr>
+    <td><code>double.nan is int</code></td>
+    <td><code>false</code></td>
+    <td><code>false</code></td>
+    </tr>
+    <tr>
+    <td><code>1.0.runtimeType</code></td>
+    <td><code>double</code></td>
+    <td><code>int</code></td>
+    </tr>
+    <tr>
+    <td><code>1.runtimeType</code></td>
+    <td><code>int</code></td>
+    <td><code>int</code></td>
+    </tr>
+    <tr>
+    <td><code>1.5.runtimeType</code></td>
+    <td><code>double</code></td>
+    <td><code>double</code></td>
+    </tr>
+  </table>
+</div>
 
 ### Bitwise operations
 
@@ -370,39 +375,40 @@ The following table shows how native and web platforms
 treat bitwise and shift operators when the operands
 are either negative or close to 32 bits:
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Expression</th>
-   <th>Native</th>
-   <th>Web</th>
-  </tr>
-  <tr>
-   <td><code>-1 >> 0</code></td>
-   <td><code>-1</code></td>
-   <td><code>4294967295</code></td>
-  </tr>
-  <tr>
-   <td><code>-1 ^ 2</code></td>
-   <td><code>-3</code></td>
-   <td><code>4294967293</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 32).toInt()</code></td>
-   <td><code>4294967296</code></td>
-   <td><code>4294967296</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 32).toInt() >> 1</code></td>
-   <td><code>2147483648</code></td>
-   <td><code>0</code></td>
-  </tr>
-  <tr>
-   <td><code>(math.pow(2, 32).toInt()-1) >> 1</code></td>
-   <td><code>2147483647</code></td>
-   <td><code>2147483647</code></td>
-  </tr>
-</table>
-
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Expression</th>
+    <th>Native</th>
+    <th>Web</th>
+    </tr>
+    <tr>
+    <td><code>-1 >> 0</code></td>
+    <td><code>-1</code></td>
+    <td><code>4294967295</code></td>
+    </tr>
+    <tr>
+    <td><code>-1 ^ 2</code></td>
+    <td><code>-3</code></td>
+    <td><code>4294967293</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 32).toInt()</code></td>
+    <td><code>4294967296</code></td>
+    <td><code>4294967296</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 32).toInt() >> 1</code></td>
+    <td><code>2147483648</code></td>
+    <td><code>0</code></td>
+    </tr>
+    <tr>
+    <td><code>(math.pow(2, 32).toInt()-1) >> 1</code></td>
+    <td><code>2147483647</code></td>
+    <td><code>2147483647</code></td>
+    </tr>
+  </table>
+</div>
 
 ### String representation
 
@@ -411,49 +417,50 @@ On the web, Dart generally defers to JavaScript to convert a number to a string
 The following table demonstrates how
 converting the expressions in the first column can lead to different results.
 
-<table class="table table-striped nowrap">
-  <tr>
-   <th>Expression</th>
-   <th>Native <code>toString()</code></th>
-   <th>Web <code>toString()</code></th>
-  </tr>
-  <tr>
-   <td><code>1</code></td>
-   <td><code>"1"</code></td>
-   <td><code>"1"</code></td>
-  </tr>
-  <tr>
-   <td><code>1.0</code></td>
-   <td><code>"1.0"</code></td>
-   <td><code>"1"</code></td>
-  </tr>
-  <tr>
-   <td><code>(0.5 + 0.5)</code></td>
-   <td><code>"1.0"</code></td>
-   <td><code>"1"</code></td>
-  </tr>
-  <tr>
-   <td><code>1.5</code></td>
-   <td><code>"1.5"</code></td>
-   <td><code>"1.5"</code></td>
-  </tr>
-  <tr>
-   <td><code>-0</code></td>
-   <td><code>"0"</code></td>
-   <td><code>"-0.0"</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 0)</code></td>
-   <td><code>"1"</code></td>
-   <td><code>"1"</code></td>
-  </tr>
-  <tr>
-   <td><code>math.pow(2, 80)</code></td>
-   <td><code>"0"</code></td>
-   <td><code>"1.2089258196146292e+24"</code></td>
-  </tr>
-</table>
-
+<div class="table-wrapper">
+  <table class="table table-striped nowrap">
+    <tr>
+    <th>Expression</th>
+    <th>Native <code>toString()</code></th>
+    <th>Web <code>toString()</code></th>
+    </tr>
+    <tr>
+    <td><code>1</code></td>
+    <td><code>"1"</code></td>
+    <td><code>"1"</code></td>
+    </tr>
+    <tr>
+    <td><code>1.0</code></td>
+    <td><code>"1.0"</code></td>
+    <td><code>"1"</code></td>
+    </tr>
+    <tr>
+    <td><code>(0.5 + 0.5)</code></td>
+    <td><code>"1.0"</code></td>
+    <td><code>"1"</code></td>
+    </tr>
+    <tr>
+    <td><code>1.5</code></td>
+    <td><code>"1.5"</code></td>
+    <td><code>"1.5"</code></td>
+    </tr>
+    <tr>
+    <td><code>-0</code></td>
+    <td><code>"0"</code></td>
+    <td><code>"-0.0"</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 0)</code></td>
+    <td><code>"1"</code></td>
+    <td><code>"1"</code></td>
+    </tr>
+    <tr>
+    <td><code>math.pow(2, 80)</code></td>
+    <td><code>"0"</code></td>
+    <td><code>"1.2089258196146292e+24"</code></td>
+    </tr>
+  </table>
+</div>
 
 ## What should you do?
 


### PR DESCRIPTION
_Fixes: #5041_

Wrapped tables in `.table-wrapper` div.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
