### PR TITLE
Update Unsound Null Safety Docs

### DIFF
--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -4,9 +4,10 @@ description: Mixing language versions lets you migrate to null safety at your ow
 ---
 
 {{site.alert.version-note}}
-Dart 3 (onnwards) does not support code without
-null safety or with only unsound null safety: all code must be soundly null
-safe. To learn more, see the [Dart 3 sound null safety tracking issue][].
+Dart 3 and later does not support code without
+null safety or with unsound null safety.
+All code must be soundly null safe.
+To learn more, check out the [Dart 3 sound null safety tracking issue][].
 {{site.alert.end}}
 
 A Dart program may contain some libraries that

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -3,19 +3,16 @@ title: Unsound null safety
 description: Mixing language versions lets you migrate to null safety at your own pace, with some of the benefits of null safety.
 ---
 
+{{site.alert.version-note}}
+Dart 3 (onnwards) does not support code without
+null safety or with only unsound null safety: all code must be soundly null
+safe. To learn more, see the [Dart 3 sound null safety tracking issue][].
+{{site.alert.end}}
+
 A Dart program may contain some libraries that
 are [null safe][] and some that aren't.
 These **mixed-version programs**
 rely on **unsound null safety**.
-
-{{site.alert.warn}}
-Dart 3---planned for a mid-2023 release---requires sound null safety. 
-It will prevent code from running without
-null safety, or with unsound null safety.
-All existing code must be [migrated][] to sound null safety
-to be compatible with Dart 3.
-To learn more, see the [Dart 3 sound null safety tracking issue][].
-{{site.alert.end}}
 
 [null safe]: /null-safety
 [migrated]: /null-safety#migrate


### PR DESCRIPTION
The warning alert box at the top of https://dart.dev/null-safety/unsound-null-safety refers to Dart 3 as unpublished. I've converted this to a version note.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
