### PR TITLE
Account for new `dart:core` annotations and clarify deprecated existence

### DIFF
--- a/src/language/metadata.md
+++ b/src/language/metadata.md
@@ -16,8 +16,8 @@ annotation begins with the character `@`, followed by either a reference
 to a compile-time constant (such as `deprecated`) or a call to a
 constant constructor.
 
-Three annotations are available to all Dart code: 
-`@Deprecated`, `@deprecated`, and `@override`. 
+Four annotations are available to all Dart code: 
+[`@Deprecated`][], [`@deprecated`][], [`@override`][], and [`@pragma`][]. 
 For examples of using `@override`,
 see [Extending a class][].
 Here’s an example of using the `@Deprecated` annotation:
@@ -36,6 +36,10 @@ class Television {
   // ···
 }
 {% endprettify %}
+
+You can use `@deprecated` if you don't want to specify a message.
+However, we [recommend][dep-lint] always
+specifying a message with `@Deprecated`.
 
 You can define your own metadata annotations. Here’s an example of
 defining a `@Todo` annotation that takes two arguments:
@@ -65,4 +69,9 @@ constructor, factory, function, field, parameter, or variable
 declaration and before an import or export directive. You can
 retrieve metadata at runtime using reflection.
 
+[`@Deprecated`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Deprecated-class.html
+[`@deprecated`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/deprecated-constant.html
+[`@override`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/override-constant.html
+[`@pragma`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/pragma-class.html
+[dep-lint]: /tools/linter-rules/provide_deprecation_message
 [Extending a class]: /language/extend


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/5164