### PR TITLE
Remove reflection mention from metadata(annotation) page

### DIFF
--- a/src/language/metadata.md
+++ b/src/language/metadata.md
@@ -62,7 +62,6 @@ void doSomething() {
 
 Metadata can appear before a library, class, typedef, type parameter,
 constructor, factory, function, field, parameter, or variable
-declaration and before an import or export directive. You can
-retrieve metadata at runtime using reflection.
+declaration and before an import or export directive.
 
 [Extending a class]: /language/extend


### PR DESCRIPTION
We don't mention runtime reflection anywhere else within the language tour since it is not so much related to the language itself. It is also not supported by all platforms, nor stable in any. To avoid any incorrect assumptions, this PR just drops the mention. 