### PR TITLE
Don't use the shared includes for now

### DIFF
--- a/src/_includes/breadcrumbs.html
+++ b/src/_includes/breadcrumbs.html
@@ -1,0 +1,33 @@
+{% comment %}
+Embeds breadcrumb RDFa, follows ARIA guidelines. References:
+- https://developers.google.com/search/docs/data-types/breadcrumb
+- https://schema.org/BreadcrumbList
+- https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html
+- https://search.google.com/structured-data/testing-tool
+{% endcomment %}
+
+{% assign url = page.url | regex_replace: '/index$|/index.html$|/$' -%}
+
+{% if url.size > 0 -%}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb" vocab="http://schema.org/" typeof="BreadcrumbList">
+  {% assign position = 0 -%}
+  {% for crumb in breadcrumbs -%}
+    {% if forloop.first -%}
+      {% comment %}Skip site root{% endcomment -%}
+      {% continue -%}
+    {% endif -%}
+    <li class="breadcrumb-item {%- if forloop.last %} active {%- endif %}"
+      property="itemListElement" typeof="ListItem"
+      {%- if forloop.last %} aria-current="page"{% endif %}>
+      {%- comment %}Avoid spaces here, it messes up formatting{% endcomment -%}
+      <a href="{{ crumb.url | regex_replace: '/index$|/index.html$|/$' }}" property="item" typeof="WebPage">
+        {%- comment %}Avoid spaces here, it messes up formatting{% endcomment -%}
+        <span property="name">{{crumb.title}}</span>
+      </a>
+      <meta property="position" content="{{forloop.index0}}" />
+    </li>
+  {% endfor %}
+  </ol>
+</nav>
+{%- endif -%}

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -28,6 +28,6 @@
       </li>
     </ul>
 
-    {% include shared/sidenav-level-1.html nav=site.data.side-nav %}
+    {% include sidenav-level-1.html nav=site.data.side-nav %}
   </div>
 </div>

--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -1,0 +1,21 @@
+{% comment %}
+This include file requires the material icons fonts.
+Style the button pair using the `#page-github-links` selector.
+{% endcomment -%}
+
+{% assign repo = page.repo | default: site.repo.this -%}
+{% capture path -%} {{repo}}/tree/{{site.branch}}/{{site.source}}/{{page.path}} {%- endcapture -%}
+{% assign title = page.title | default: page.url -%}
+{% assign url = site.url | append: page.url -%}
+
+{% capture issueTitle -%} title=[PAGE ISSUE]: '{{title}}' {%- endcapture -%}
+
+<div id="page-github-links" class="btn-group" aria-label="Page GitHub links" role="group">
+  <a href="{{path}}" class="btn no-automatic-external" title="View page source" target="_blank" rel="noopener">
+    <i class="material-icons">description</i>
+  </a>
+  <a href="{{repo}}/issues/new?template=1_page_issue.yml&{{issueTitle}}&page-url={{url}}&page-source={{path}}" class="btn no-automatic-external" title="Report an issue with this page"
+    target="_blank" rel="noopener">
+    <i class="material-icons">bug_report</i>
+  </a>
+</div>

--- a/src/_includes/shared
+++ b/src/_includes/shared
@@ -1,1 +1,0 @@
-../_shared/_includes

--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -1,0 +1,37 @@
+{% comment %} Canonicalize page URL path {% endcomment -%}
+{% assign page_url_path = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' -%}
+
+{% assign active_entries = include.nav | active_nav_entry_index_array: page_url_path -%}
+{% assign show_entries_wo_pages = false -%}
+
+<ul class="nav flex-column">
+  {%- for entry1 in include.nav -%}
+
+    {% assign class1 = '' -%}
+    {% assign id1 = 'sidenav-' | append: forloop.index -%}
+    {% assign isActive1 = false -%}
+    {% if forloop.index == active_entries[0] -%}
+      {% assign isActive1 = true -%}
+      {% assign class1 = 'active' -%}
+    {% endif -%}
+
+    {% if isActive1 or entry1.expanded -%}
+      {% assign expanded = 'true' -%}
+      {% assign show = 'show' -%}
+    {% else -%}
+      {% assign class1 = 'collapsed' -%}
+      {% assign expanded = 'false' -%}
+      {% assign show = '' -%}
+    {% endif -%}
+
+    <li class="nav-item">
+      <a class="nav-link {{class1}}" data-toggle="collapse" href="#{{id1}}" role="button"
+        aria-expanded="{{expanded}}" aria-controls="{{id1}}"
+      >{{entry1.title}}</a>
+
+      <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id1}}">
+        {% include sidenav-level-2.html -%}
+      </ul>
+    </li>
+  {%- endfor -%}
+</ul>

--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -1,0 +1,61 @@
+{% for entry2 in entry1.children -%}
+
+{% assign class2 = 'nav-link' -%}
+{% assign isActive2 = false -%}
+{% if isActive1 and forloop.index == active_entries[1] -%}
+  {% assign isActive2 = true -%}
+  {% assign class2 = class2 | append: ' active' -%}
+{% endif -%}
+
+{% if entry2 == 'divider' -%}
+
+  <div class="dropdown-divider"></div>
+
+{%- elsif entry2.children == nil and entry2.permalink or show_entries_wo_pages -%}
+
+  <li class="nav-item">
+    <a class="{{class2}} {%- unless entry2.permalink %} disabled {%- endunless %}"
+      {%- if entry2.permalink %} href="{{entry2.permalink}}" {%- endif -%}
+      {%- if entry2.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry2.title}}
+    {%- if entry2.permalink == nil %} (TBC)
+    {%- elsif entry2.permalink contains '://' -%}
+      <span class="material-icons md-24">
+        open_in_new
+      </span>
+    {%- endif -%}
+    </a>
+  </li>
+
+{%- elsif entry2.children -%}
+
+  {% assign class2 = class2 | append: ' collapsable' -%}
+
+  {% if isActive2 or entry2.expanded -%}
+    {% assign expanded = 'true' -%}
+    {% assign show = 'show' -%}
+  {% else -%}
+    {% assign class2 = class2 | append: ' collapsed' -%}
+    {% assign expanded = 'false' -%}
+    {% assign show = '' -%}
+  {% endif -%}
+
+  {% assign id2 = id1 | append: '-' | append: forloop.index -%}
+  {% assign href = entry2.permalink -%}
+  {% unless href -%}
+    {% assign href = '#' | append: id2 -%}
+  {% endunless -%}
+
+  <li class="nav-item">
+    <a class="{{class2}}"
+      data-toggle="collapse" data-target="#{{id2}}"
+      href="{{href}}" role="button"
+      aria-expanded="{{expanded}}" aria-controls="{{id2}}"
+    >{{entry2.title}}
+    </a>
+    <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id2}}">
+      {% include sidenav-level-3.html -%}
+    </ul>
+  </li>
+{% endif -%}
+{% endfor %}

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -1,0 +1,61 @@
+{% for entry3 in entry2.children -%}
+
+{% assign class3 = 'nav-link' -%}
+{% assign isActive3 = false -%}
+{% if isActive2 and forloop.index == active_entries[2] -%}
+  {% assign isActive3 = true -%}
+  {% assign class3 = class3 | append: ' active' -%}
+{% endif -%}
+
+{% if entry3 == 'divider' -%}
+
+  <div class="dropdown-divider"></div>
+
+{%- elsif entry3.children == nil and entry3.permalink or show_entries_wo_pages -%}
+
+  <li class="nav-item">
+    <a class="{{class3}} {%- unless entry3.permalink %} disabled {%- endunless %}"
+      {%- if entry3.permalink %} href="{{entry3.permalink}}" {%- endif -%}
+      {%- if entry3.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry3.title}}
+    {%- if entry3.permalink == nil %} (TBC)
+    {%- elsif entry3.permalink contains '://' -%}
+      <span class="material-icons md-24">
+        open_in_new
+      </span>
+    {%- endif -%}
+    </a>
+  </li>
+
+{%- elsif entry3.children -%}
+
+  {% assign class3 = class3 | append: ' collapsable' -%}
+
+  {% if isActive3 or entry3.expanded -%}
+    {% assign expanded = 'true' -%}
+    {% assign show = 'show' -%}
+  {% else -%}
+    {% assign class3 = class3 | append: ' collapsed' -%}
+    {% assign expanded = 'false' -%}
+    {% assign show = '' -%}
+  {% endif -%}
+
+  {% assign id3 = id2 | append: '-' | append: forloop.index -%}
+  {% assign href = entry3.permalink -%}
+  {% unless href -%}
+    {% assign href = '#' | append: id3 -%}
+  {% endunless -%}
+
+  <li class="nav-item">
+    <a class="{{class3}}"
+      data-toggle="collapse" data-target="#{{id3}}"
+      href="{{href}}" role="button"
+      aria-expanded="{{expanded}}" aria-controls="{{id3}}"
+    >{{entry3.title}}
+    </a>
+    <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id3}}">
+      {% include sidenav-level-4.html -%}
+    </ul>
+  </li>
+{% endif -%}
+{% endfor -%}

--- a/src/_includes/sidenav-level-4.html
+++ b/src/_includes/sidenav-level-4.html
@@ -1,0 +1,25 @@
+{% for entry4 in entry3.children -%}
+  {% if entry4.permalink or show_entries_wo_pages -%}
+
+  {% assign class4 = 'nav-link' -%}
+  {% assign isActive4 = false -%}
+  {% if isActive3 and forloop.index == active_entries[3] -%}
+    {% assign isActive4 = true -%}
+    {% assign class4 = class4 | append: ' active' -%}
+  {% endif -%}
+
+  <li class="nav-item">
+    <a class="{{class4}} {%- unless entry4.permalink %} disabled {%- endunless %}"
+      {%- if entry4.permalink %} href="{{entry4.permalink}}" {%- endif -%}
+      {%- if entry4.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry4.title}}
+      {%- if entry4.permalink == nil %} (TBC)
+      {%- elsif entry4.permalink contains '://' -%}
+        <span class="material-icons md-24">
+          open_in_new
+        </span>
+      {%- endif -%}
+    </a>
+  </li>
+  {% endif -%}
+{% endfor -%}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -12,14 +12,14 @@
         <div class="content">
           {% include navigation-sub.html %}
           <div id="site-content-title">
-            {% include shared/page-github-links.html %}
+            {% include page-github-links.html %}
             {% if page.underscore_breaker_titles -%}
             <h1>{{page.title | underscore_breaker}}</h1>
             {% else %}
             <h1>{{page.title }}</h1>
             {% endif -%}
             {% if page.show_breadcrumbs -%}
-              {% include shared/breadcrumbs.html %}
+              {% include breadcrumbs.html %}
             {% endif -%}
           </div>
           {% include navigation-toc.html id='site-toc--inline' collapsible=true %}


### PR DESCRIPTION
The usage of these includes on dart.dev and docs.flutter.dev have diverged and will continue to. This PR copies the used ones to the local includes folder. This will allow easier atomic modifications of the files. We can eventually move them back to site-shared if/when their behavior stabilizes and is sufficient for both sites.

Should slightly reduce build time as well.

Contributes to https://github.com/dart-lang/site-www/issues/5177 by allowing for changes which only one site will support temporarily.