### PR TITLE
Consistently use straight quotation marks

### DIFF
--- a/src/_articles/archive/converters-and-codecs.md
+++ b/src/_articles/archive/converters-and-codecs.md
@@ -18,13 +18,13 @@ core library that provides a set of converters
 and useful tools to build new converters.
 Examples of converters provided by the library include those
 for commonly used encodings such as JSON and UTF-8.
-In this document, we show how Dart’s
+In this document, we show how Dart's
 converters work and how you can create your own efficient converters
 that fit into the Dart world.
 
 ## Big picture
 
-Dart’s conversion architecture is
+Dart's conversion architecture is
 based on _converters_, which translate from one representation to another.
 When conversions are reversible, two converters are grouped together into a
 _codec_ (coder-decoder). The term codec is frequently used for audio and
@@ -67,7 +67,7 @@ The base implementation of
 [Codec]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/Codec-class.html)
 for these two members
 provides a solid default implementation
-and implementers usually don’t need to worry about them.
+and implementers usually don't need to worry about them.
 
 The `encode()` and `decode()`
 methods, too, may be left untouched, but they can be extended for additional
@@ -112,7 +112,7 @@ the `convert()` method.
 
 Such a minimal converter works in synchronous settings, but
 does not work when used with chunks (either synchronously or asynchronously). In
-particular, such a simple converter doesn’t work as a transformer (one of the
+particular, such a simple converter doesn't work as a transformer (one of the
 nicer features of Converters). A fully implemented converter implements the
 [StreamTransformer]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/StreamTransformer-class.html)
 interface and can thus be given to the `Stream.transform()` method.
@@ -128,7 +128,7 @@ File.openRead().transform(utf8.decoder).
 
 The concept of chunked conversions can be confusing, but at its core, it is
 relatively simple. When a chunked conversion (including a stream
-transformation) is started, the converter’s
+transformation) is started, the converter's
 [startChunkedConversion]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/Converter/startChunkedConversion.html)
 method is invoked with an output-
 sink as argument. The method then returns an input sink into which the caller
@@ -278,7 +278,7 @@ not break the extended sinks._
 This section shows all the steps needed to create a simple encryption
 converter and how a custom ChunkedConversionSink can improve performance.
 
-Let’s start with the simple synchronous converter,
+Let's start with the simple synchronous converter,
 whose encryption routine simply rotates bytes by the given key:
 
 {% prettify dart tag=pre+code %}
@@ -389,7 +389,7 @@ main(args) {
 
 For many purposes, the current version of Rot is sufficient. That is, the
 benefit of improvements would be outweighed by the cost of more complex code
-and test requirements. Let’s assume, however,
+and test requirements. Let's assume, however,
 that the performance of the converter is critical
 (it's on the hot path and up on the profile).
 We furthermore assume that
@@ -399,7 +399,7 @@ the cost of allocating a new list for every chunk is killing performance
 We start by making the allocation cost cheaper: by using a
 [typed byte-list]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-typed_data/Uint8List-class.html)
 we can reduce the size of the allocated list by a factor of 8 (on 64-bit
-machines). This one line change doesn’t remove the allocation, but makes it much
+machines). This one line change doesn't remove the allocation, but makes it much
 cheaper.
 
 We can also avoid the allocation altogether if we overwrite the input. In
@@ -452,7 +452,7 @@ main() {
 In this small example, performance isn't visibly different,
 but internally the
 chunked conversion avoids allocating new lists for the individual chunks.
-For two small chunks, it doesn’t make a difference, but
+For two small chunks, it doesn't make a difference, but
 if we implement this for the stream transformer,
 encrypting a bigger file can be noticeably faster.
 
@@ -522,7 +522,7 @@ and benefit from it.
 
 But we are not done yet.
 
-Although we won’t make the cipher faster anymore,
+Although we won't make the cipher faster anymore,
 we can improve the output side of our Rot converter.
 Take, for instance, the fusion of two encryptions:
 
@@ -608,7 +608,7 @@ class _RotSink extends CipherSink {
 }
 {% endprettify %}
 
-With these changes our super secure, double cipher won’t allocate any new lists
+With these changes our super secure, double cipher won't allocate any new lists
 and our work is done.
 
 Thanks to Lasse Reichstein Holst Nielsen, Anders Johnsen, and Matias Meno who

--- a/src/_articles/archive/numeric-computation.md
+++ b/src/_articles/archive/numeric-computation.md
@@ -30,7 +30,7 @@ Just following a few simple rules can give you 50-100% speed improvements.
 
 Follow the guidelines in this article
 to get the most performance from the Dart VM in numerical applications.
-You’ll learn about the four different number representations,
+You'll learn about the four different number representations,
 how integer and floating-point numerical computation occurs,
 and how to pick the best container for your data.
 
@@ -147,7 +147,7 @@ Examples include:
 
 The list `b` is an object list,
 meaning it can store any object—for example, a String object or null.
-This means that each entry in a List is as wide as the CPU’s pointer type.
+This means that each entry in a List is as wide as the CPU's pointer type.
 
 #### Typed lists
 
@@ -174,7 +174,7 @@ Some examples:
 In both the object list and typed list examples,
 the lists named `a` are holding the same values.
 Same for the lists named `b`.
-What’s different is how the values are stored in memory
+What's different is how the values are stored in memory
 and how they are accessed.
 More on this later.
 
@@ -200,7 +200,7 @@ The first representation, smi,
 is the same size as a pointer on your platform, minus 1 bit.
 On a 32-bit machine, a smi holds a 31-bit signed integer.
 On a 64-bit machine, a smi holds a 63-bit signed integer.
-A smi doesn’t require a memory allocation to be created
+A smi doesn't require a memory allocation to be created
 and is stored directly in a field.
 The VM can do this by storing twice the numeric value,
 guaranteeing the low bit being 0.
@@ -245,7 +245,7 @@ Now consider this Dart code:
 
     entity.x = entity.x * entity.scale;
 
-It’s converted into the VM instructions shown in the following figure.
+It's converted into the VM instructions shown in the following figure.
 Each VM instruction can return a value
 shown as v1, v2, and so on.
 
@@ -296,7 +296,7 @@ For example:
     a = (b << c) & 0x3FFFFFFF;
 
 The VM knows that the result can be stored in a smi,
-and it generates code that doesn’t check whether
+and it generates code that doesn't check whether
 a mint is needed to store the result.
 The constant 0x3FFFFFFF is the maximum positive smi on 32-bit architectures.
 0x3FFFFFFFFFFFFFFF is the equivalent constant on 64-bit architectures.
@@ -362,7 +362,7 @@ and better CPU cache performance:
 * Typed lists can be much more dense.
   For example, if you know you need only 8 bits of precision
   you can use an Int8List,
-  using much less memory and making better use of your CPU’s cache.
+  using much less memory and making better use of your CPU's cache.
 
 In general and specifically because of the above caveats,
 it is always a good idea to benchmark 
@@ -391,7 +391,7 @@ Thus, bigints are significantly more expensive than smis or mints.
 
 **Performance tip:**
 Avoid bigint whenever possible.
-The VM doesn’t optimize operations on bigint instances.
+The VM doesn't optimize operations on bigint instances.
 
 
 ### Doubles
@@ -502,7 +502,7 @@ Each entry in the array always holds the value directly.
 Typed lists can be much denser,
 providing better memory and CPU cache usage.
 Typed lists are also faster to process at garbage collection time
-because they don’t have to be scanned for object pointers.
+because they don't have to be scanned for object pointers.
 
 ![Illustration of a typed list's memory, containing the numbers 4, 1.0, and 2.0 (and no pointers)](images/10.png)
 

--- a/src/_articles/archive/zones.md
+++ b/src/_articles/archive/zones.md
@@ -67,8 +67,8 @@ Zones make the following tasks possible:
   or saving a stack trace.
 
 You might have encountered something similar to zones in other languages.
-_Domains_ in Node.js were an inspiration for Dart’s zones.
-Java’s _thread-local storage_
+_Domains_ in Node.js were an inspiration for Dart's zones.
+Java's _thread-local storage_
 also has some similarities.
 Closest of all is Brian Ford's JavaScript port of Dart zones,
 [zone.js](https://github.com/btford/zone.js/), which he describes in
@@ -129,7 +129,7 @@ runs in
 even though it's attached to a future that itself runs in
 <span class="zone2">zone #2</span>.
 
-Child zones don’t completely replace their parent zone.
+Child zones don't completely replace their parent zone.
 Instead new zones are nested inside their surrounding zone.
 For example,
 <span class="zone2">zone #2</span> contains
@@ -357,7 +357,7 @@ runZoned(() {
 }, zoneValues: { #key: 499 });
 {% endprettify %}
 
-To read zone-local values, use the zone’s index operator and the value's key:
+To read zone-local values, use the zone's index operator and the value's key:
 <code>[<em>key</em>]</code>.
 Any object can be used as a key, as long as it has compatible
 `operator ==` and `hashCode` implementations.
@@ -378,7 +378,7 @@ runZoned(() {
 {% endprettify %}
 
 A zone inherits zone-local values from its parent zone,
-so adding nested zones doesn’t accidentally drop existing values.
+so adding nested zones doesn't accidentally drop existing values.
 Nested zones can, however, shadow parent values.
 
 {{site.alert.important}}
@@ -417,7 +417,7 @@ main() {
 {% endprettify %}
 
 This program works,
-but let’s assume that you now want to know
+but let's assume that you now want to know
 which file each line comes from,
 and that you can't just add a filename argument to `splitLinesStream()`.
 With zone-local values you can add the filename to the returned string

--- a/src/_articles/libraries/creating-streams.md
+++ b/src/_articles/libraries/creating-streams.md
@@ -119,7 +119,7 @@ Often, a transforming method is all you need.
 However, if you need even more control over the transformation,
 you can specify a
 [StreamTransformer]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-async/StreamTransformer-class.html)
-with `Stream`’s `transform()` method.
+with `Stream`'s `transform()` method.
 The platform libraries provide stream transformers for many common tasks.
 For example, the following code uses the `utf8.decoder` and `LineSplitter`
 transformers provided by the dart:convert library.

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -1,4 +1,4 @@
-Once you’re ready to move beyond DartPad and develop real apps,
+Once you're ready to move beyond DartPad and develop real apps,
 you need an SDK.
 You can either download the Dart SDK directly
 (as described below)

--- a/src/brand.md
+++ b/src/brand.md
@@ -50,9 +50,9 @@ rules governing the proper use of the Dart trademarks.
 
 **DO:**
 
-* Use the “Dart” name as an adjective and never as a verb or in the plural form.
-* When using “Dart” as an adjective, follow it with a generic term, 
-  for example, “the Dart SDK” or “the Dart platform.”
+* Use the "Dart" name as an adjective and never as a verb or in the plural form.
+* When using "Dart" as an adjective, follow it with a generic term, 
+  for example, "the Dart SDK" or "the Dart platform."
 * Distinguish the "Dart" name from the surrounding text in some way.
   Capitalize the first letter, capitalize or italicize the entire mark,
   place the mark in quotes, use a different type style or font for the mark.
@@ -73,7 +73,7 @@ rules governing the proper use of the Dart trademarks.
   This includes varying the spelling of the "Dart" name, or displaying
   the Dart logo with color variations or unapproved visual elements. 
 * Don't combine the Google name with the "Dart" name to form a unitary
-  brand (e.g., don’t use the phrases "Google Dart" or "Google’s Dart").
+  brand (e.g., don't use the phrases "Google Dart" or "Google's Dart").
   You may use the Google name in full text to accurately describe the
   Dart SDK (e.g., "The Dart SDK by Google").
 * Don't register the Dart trademarks or any trademarks, logos,

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -92,7 +92,7 @@ reference them inside single quotes, with a space in between.
 ## Nullable variables
 
 Dart enforces sound null safety.
-This means values can’t be null unless you say they can be.
+This means values can't be null unless you say they can be.
 In other words, types default to non-nullable.
 
 For example, consider the following code.
@@ -504,7 +504,7 @@ bool hasEmpty = aListOfStrings.any((s) {
 });
 ```
 
-Here’s a simpler way to write that code:
+Here's a simpler way to write that code:
 
 <?code-excerpt "misc/test/cheatsheet/arrow_functions_test.dart (has-empty-short)"?>
 ```dart
@@ -1218,7 +1218,7 @@ This is a chance to get more practice with the ?? operator!
 
 ## Exceptions
 
-Dart code can throw and catch exceptions. In contrast to Java, all of Dart’s exceptions are unchecked
+Dart code can throw and catch exceptions. In contrast to Java, all of Dart's exceptions are unchecked
 exceptions. Methods don't declare which exceptions they might throw, and you aren't required to catch
 any exceptions.
 
@@ -1984,9 +1984,9 @@ IntegerSingle, IntegerDouble, or IntegerTriple as appropriate.
 
 ## Redirecting constructors
 
-Sometimes a constructor’s only purpose is to redirect to
+Sometimes a constructor's only purpose is to redirect to
 another constructor in the same class.
-A redirecting constructor’s body is empty,
+A redirecting constructor's body is empty,
 with the constructor call appearing after a colon (`:`).
 
 <?code-excerpt "misc/lib/cheatsheet/redirecting_constructors.dart (redirecting-constructors)"?>

--- a/src/codelabs/iterables.md
+++ b/src/codelabs/iterables.md
@@ -964,7 +964,7 @@ Use `map()` to create a String with the values of `user.name` and `user.age`.
 
 ## Exercise: Putting it all together
 
-It’s time to practice what you learned, in one final exercise.
+It's time to practice what you learned, in one final exercise.
 
 This exercise provides the class `EmailAddress`,
 which has a constructor that takes a string.

--- a/src/codelabs/null-safety.md
+++ b/src/codelabs/null-safety.md
@@ -7,10 +7,10 @@ js: [{url: 'https://dartpad.dev/inject_embed.dart.js', defer: true}]
 <?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n)*\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
 <?code-excerpt plaster="none"?>
 
-This codelab teaches you about Dart’s [null-safe type system](/null-safety).
+This codelab teaches you about Dart's [null-safe type system](/null-safety).
 Dart introduced null safety as an optional setting in Dart 2.12.
 Dart 3 requires null safety.
-With null safety, values can’t be `null` unless you say they can be.
+With null safety, values can't be `null` unless you say they can be.
 
 This codelab covers the following material:
 

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -307,7 +307,7 @@ but shouldn't be used for several reasons:
 * Because it's not evidently `null` related, 
   it can easily be mistaken for the non-nullable case,
   where the equality operator is redundant and can be removed.
-  That’s only true when the boolean expression on the left
+  That's only true when the boolean expression on the left
   has no chance of producing null, but not when it can.
 
 * The boolean logic is confusing. If `nullableBool` is null, 
@@ -319,7 +319,7 @@ The logic is much clearer too;
 the result of the expression being `null` is the same as the boolean literal.
 
 Using a null-aware operator such as `??` on a variable inside a condition
-doesn’t promote the variable to a non-nullable type. 
+doesn't promote the variable to a non-nullable type. 
 If you want the variable to be promoted inside the body of the `if` statement,
 it's better to use an explicit `!= null` check instead of `??`. 
 

--- a/src/guides/language/cheatsheet.md
+++ b/src/guides/language/cheatsheet.md
@@ -12,10 +12,10 @@ For an interactive guide to these features and more, see the
 
 ## Using literals
 
-### `‘Substitution ${val}’`
+### `'Substitution ${val}'`
 
 Puts the value of `val` into a string literal.
-Equivalent: `‘Substitution’ + val`
+Equivalent: `'Substitution' + val`
 
 ### `<type>[ ]`
 
@@ -109,7 +109,7 @@ factory Point(int x, int y) => ...;
 ```
 
 Use `factory` when implementing a constructor that
-doesn’t always create a new instance.
+doesn't always create a new instance.
 
 
 ### Named constructor

--- a/src/guides/language/coming-from/js-to-dart.md
+++ b/src/guides/language/coming-from/js-to-dart.md
@@ -107,7 +107,7 @@ To learn more, check out [Built-in types][] in the [Dart Language Tour][].
 
 All non-`Null` types in Dart are subtypes of Object.
 All values are also objects.
-Dart doesn't use “primitive types” like JavaScript.
+Dart doesn't use "primitive types" like JavaScript.
 By contrast, Dart normalizes or _canonicalizes_ number, boolean
 and `null` values.
 This means only one `int` value with the numerical value `1` exists.
@@ -1589,8 +1589,8 @@ dictionaries immutable.
   be modified, use the `const` keyword:<br>
   `const fruits = <String>{'apple', 'orange', 'pear'};`
 * Assign the `Set` to a `final` field, meaning that
-  the `Set` itself doesn’t have to be a compile-time constant.
-  This ensures that the field can’t be overridden with
+  the `Set` itself doesn't have to be a compile-time constant.
+  This ensures that the field can't be overridden with
   another `Set`, but it still allows the size or the contents
   of the `Set` to be modified:<br>
   `final fruits = <String>{'apple', 'orange', 'pear'};`
@@ -1742,7 +1742,7 @@ Future<String> strFuture = Future<String>.value(str);
 #### Async/Await
 
 If you're familiar with promises in JavaScript,
-you’re likely also familiar with the `async`/`await` syntax.
+you're likely also familiar with the `async`/`await` syntax.
 This syntax is identical in Dart: functions are marked `async`,
 and `async` functions always return a `Future`.
 If the function returns a `String` and is marked `async`,
@@ -1782,7 +1782,7 @@ stringFuture.then((String str) {
 });
 ```
 
-Obtain a future’s value using the `await` keyword.
+Obtain a future's value using the `await` keyword.
 As in JavaScript, this removes the need to call `then`
 on the `Future` to obtain its value,
 and it allows you to write asynchronous code in a
@@ -1808,7 +1808,7 @@ To learn more about `Future`s and the
 
 ### Streams
 
-Another tool in Dart’s async toolbox is `Stream`s.
+Another tool in Dart's async toolbox is `Stream`s.
 While JavaScript has its own concept of streams,
 Dart's are more akin to `Observable`s,
 as found in the commonly used `rxjs` library.
@@ -1971,7 +1971,7 @@ classes are a standard feature of the language.
 This section covers defining and using classes in Dart
 and how they differ from JavaScript.
 
-### “this” context
+### "this" context
 
 The `this` keyword in Dart is more straightforward
 than in JavaScript. In Dart, you can't bind functions
@@ -2230,7 +2230,7 @@ animal.makeNoise(); // Meow
 
 ### Classes as interfaces
 
-Like JavaScript, Dart doesn’t have a
+Like JavaScript, Dart doesn't have a
 separate definition for interfaces. However,
 unlike JavaScript, all class definitions double
 as an interface; you can implement a class as
@@ -2624,7 +2624,7 @@ In the preceding example, the compiler does not know to assign
 
 ## Generics
 
-While JavaScript doesn’t offer generics,
+While JavaScript doesn't offer generics,
 Dart does to improve type safety and reduce code duplication.
 
 ### Generic methods
@@ -2633,7 +2633,7 @@ You can apply generics to methods.
 To define a generic type parameter, place it between angle brackets `< >`
 after the method name.
 You can then use this type within the method
-as the return type or within the method’s parameters:
+as the return type or within the method's parameters:
 
 ```dart
 Map<Object?, Object?> _cache = {};
@@ -2701,8 +2701,8 @@ This helps when Dart cannot infer the type or infer the type correctly.
 
 For example, the `List` class has a generic definition:
 `class List<E>`. The type parameter `E` refers to the type of
-the list’s contents. Normally, this type is automatically inferred,
-which is used in some `List` class’s member types.
+the list's contents. Normally, this type is automatically inferred,
+which is used in some `List` class's member types.
 (For example, its first getter returns a value of type `E`.)
 When defining a `List` literal,
 you can explicitly define the generic type as follows:

--- a/src/guides/language/coming-from/swift-to-dart.md
+++ b/src/guides/language/coming-from/swift-to-dart.md
@@ -1294,7 +1294,7 @@ all within a single chain using the cascade operator:
 
 ```dart
 Animal animal = Animal()
-  ..name = ‘Bob'
+  ..name = 'Bob'
   ..age = 5
   ..feed()
   ..walk();
@@ -1561,7 +1561,7 @@ retrieve a value from a `Map` using the `key` operator:
 
 ```dart
 final gifts = {'first': 'partridge'};
-final gift = gifts['first']; // ‘partridge'
+final gift = gifts['first']; // 'partridge'
 ```
 
 Use the `containsKey` method to check whether a

--- a/src/guides/language/evolution.md
+++ b/src/guides/language/evolution.md
@@ -225,7 +225,7 @@ _Released 3 March 2021_
 
 Dart 2.12 added support for **[sound null safety][]**.
 When you opt into null safety, types in your code are non-nullable by default,
-meaning that variables can’t contain null unless you say they can.
+meaning that variables can't contain null unless you say they can.
 With null safety, your runtime null-dereference errors
 turn into edit-time analysis errors.
 
@@ -256,7 +256,7 @@ _Released 11 December 2019_
 
 Dart 2.7 added support for **[extension methods][]**,
 enabling you to add functionality to any type
-—-even types you don’t control—-
+—-even types you don't control—-
 with the brevity and auto-complete experience of regular method calls.
 
 The following example extends the `String` class from

--- a/src/guides/language/language-tour.md
+++ b/src/guides/language/language-tour.md
@@ -274,7 +274,7 @@ This content has moved to [Constructors](/language/constructors#initializing-for
 
 This content has moved to [Constructors](/language/constructors#default-constructors).
 
-#### Constructors aren’t inherited
+#### Constructors aren't inherited
 
 This content has moved to [Constructors](/language/constructors#constructors-arent-inherited).
 

--- a/src/guides/language/numbers.md
+++ b/src/guides/language/numbers.md
@@ -60,7 +60,7 @@ The following table shows how Dart numbers are usually implemented:
     </tr>
     <tr>
       <td><a href="https://en.wikipedia.org/wiki/Two%27s_complement">
-        64-bit signed two’s complement</a>
+        64-bit signed two's complement</a>
       </td>
       <td>✅</td>
       <td></td>
@@ -270,7 +270,7 @@ the identity expressions are usually different.
 ### Types and type checking
 
 On the web, the underlying `int` type is like a subtype of `double`:
-it’s a double-precision value without a fractional part.
+it's a double-precision value without a fractional part.
 In fact, a type check on the web of the form `x is int`
 returns true if `x` is a number (`double`) with
 a zero-valued fractional part.

--- a/src/guides/libraries/_dart-html-tour.md
+++ b/src/guides/libraries/_dart-html-tour.md
@@ -6,7 +6,7 @@ Other common uses of dart:html are manipulating styles (*CSS*), getting
 data using HTTP requests, and exchanging data using
 [WebSockets](#sending-and-receiving-real-time-data-with-websockets).
 HTML5 (and dart:html) has many
-additional APIs that this section doesn’t cover. Only web apps can use
+additional APIs that this section doesn't cover. Only web apps can use
 dart:html, not command-line apps.
 
 {{site.alert.note}}
@@ -103,8 +103,8 @@ Consider this example of specifying an anchor element in HTML:
 
 This `<a>` tag specifies an element with an `href` attribute and a text
 node (accessible via a `text` property) that contains the string
-“link text”. To change the URL that the link goes to, you can use
-AnchorElement’s `href` property:
+"link text". To change the URL that the link goes to, you can use
+AnchorElement's `href` property:
 
 <?code-excerpt "html/test/html_test.dart (href)" plaster="none"?>
 ```dart
@@ -114,7 +114,7 @@ anchor.href = 'https://dart.dev';
 
 Often you need to set properties on multiple elements. For example, the
 following code sets the `hidden` property of all elements that have a
-class of “mac”, “win”, or “linux”. Setting the `hidden` property to true
+class of "mac", "win", or "linux". Setting the `hidden` property to true
 has the same effect as adding `display: none` to the CSS.
 
 <?code-excerpt "html/test/html_test.dart (os-html)" replace="/.*? = '''|''';$//g"?>
@@ -148,12 +148,12 @@ for (final os in osList) {
 }
 ```
 
-When the right property isn’t available or convenient, you can use
-Element’s `attributes` property. This property is a
+When the right property isn't available or convenient, you can use
+Element's `attributes` property. This property is a
 `Map<String, String>`, where the keys are attribute names. For a list of
 attribute names and their meanings, see the [MDN Attributes
-page.](https://developer.mozilla.org/docs/Web/HTML/Attributes) Here’s an
-example of setting an attribute’s value:
+page.](https://developer.mozilla.org/docs/Web/HTML/Attributes) Here's an
+example of setting an attribute's value:
 
 <?code-excerpt "html/lib/html.dart (attributes)"?>
 ```dart
@@ -163,7 +163,7 @@ elem.attributes['someAttribute'] = 'someValue';
 #### Creating elements
 
 You can add to existing HTML pages by creating new elements and
-attaching them to the DOM. Here’s an example of creating a paragraph
+attaching them to the DOM. Here's an example of creating a paragraph
 (\<p\>) element:
 
 <?code-excerpt "html/lib/html.dart (creating-elements)"?>
@@ -185,7 +185,7 @@ var elem2 = Element.html(
 Note that `elem2` is a `ParagraphElement` in the preceding example.
 
 Attach the newly created element to the document by assigning a parent
-to the element. You can add an element to any existing element’s
+to the element. You can add an element to any existing element's
 children. In the following example, `body` is an element, and its child
 elements are accessible (as a `List<Element>`) from the `children` property.
 
@@ -241,7 +241,7 @@ var elem = querySelector('#message')!;
 elem.classes.add('warning');
 ```
 
-It’s often very efficient to find an element by ID. You can dynamically
+It's often very efficient to find an element by ID. You can dynamically
 set an element ID with the `id` property:
 
 <?code-excerpt "html/lib/html.dart (set-id)"?>
@@ -279,14 +279,14 @@ selections, add an event listener. You can add an event listener to any
 element on the page. Event dispatch and propagation is a complicated
 subject; [research the
 details](https://www.w3.org/TR/DOM-Level-3-Events/#dom-event-architecture)
-if you’re new to web programming.
+if you're new to web programming.
 
 Add an event handler using
 <code><em>element</em>.on<em>Event</em>.listen(<em>function</em>)</code>,
 where <code><em>Event</em></code> is the event
 name and <code><em>function</em></code> is the event handler.
 
-For example, here’s how you can handle clicks on a button:
+For example, here's how you can handle clicks on a button:
 
 <?code-excerpt "html/lib/html.dart (onClick)"?>
 ```dart
@@ -357,7 +357,7 @@ try {
 
 If you need access to the HttpRequest, not just the text data it
 retrieves, you can use the `request()` static method instead of
-`getString()`. Here’s an example of reading XML data:
+`getString()`. Here's an example of reading XML data:
 
 <?code-excerpt "html/test/html_test.dart (request)" replace="/Future<\w+\W/void/g; /await.*;/[!$&!]/g"?>
 ```dart
@@ -482,12 +482,12 @@ ws.onMessage.listen((MessageEvent e) {
 ```
 
 The message event handler receives a [MessageEvent][] object.
-This object’s `data` field has the data from the server.
+This object's `data` field has the data from the server.
 
 #### Handling WebSocket events
 
 Your app can handle the following WebSocket events: open, close, error,
-and (as shown earlier) message. Here’s an example of a method that
+and (as shown earlier) message. Here's an example of a method that
 creates a WebSocket object and registers handlers for open, close,
 error, and message events:
 

--- a/src/guides/libraries/_dart-io-tour.md
+++ b/src/guides/libraries/_dart-io-tour.md
@@ -63,7 +63,7 @@ void main() async {
 
 The following code reads an entire file as bytes into a list of ints.
 The call to `readAsBytes()` returns a Future, which provides the result
-when it’s available.
+when it's available.
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (readAsBytes)" replace="/\btest_data\///g"?>
 ```dart
@@ -240,7 +240,7 @@ server-side application. You can set headers, use HTTP methods, and read
 and write data. The HttpClient class does not work in browser-based
 apps. When programming in the browser, use the
 [dart:html HttpRequest class.][HttpRequest]
-Here’s an example of using HttpClient:
+Here's an example of using HttpClient:
 
 <?code-excerpt "misc/test/library_tour/io_test.dart (client)" replace="/Future<\w+\W/void/g"?>
 ```dart

--- a/src/guides/libraries/library-tour.md
+++ b/src/guides/libraries/library-tour.md
@@ -6,8 +6,8 @@ short-title: Library tour
 <?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g"?>
 <?code-excerpt plaster="none"?>
 
-This page shows you how to use the major features in Dart’s core libraries.
-It’s just an overview, and by no means comprehensive.
+This page shows you how to use the major features in Dart's core libraries.
+It's just an overview, and by no means comprehensive.
 Whenever you need more details about a class,
 consult the [Dart API reference.][Dart API]
 
@@ -251,8 +251,8 @@ assert('  '.isNotEmpty);
 #### Replacing part of a string
 
 Strings are immutable objects, which means you can create them but you
-can’t change them. If you look closely at the [String API reference,][String]
-you’ll notice that
+can't change them. If you look closely at the [String API reference,][String]
+you'll notice that
 none of the methods actually changes the state of a String. For example,
 the method `replaceAll()` returns a new String without changing the
 original String:
@@ -269,7 +269,7 @@ assert(greeting != greetingTemplate);
 #### Building a string
 
 To programmatically generate a string, you can use StringBuffer. A
-StringBuffer doesn’t generate a new String object until `toString()` is
+StringBuffer doesn't generate a new String object until `toString()` is
 called. The `writeAll()` method has an optional second parameter that
 lets you specify a separator—in this case, a space.
 
@@ -452,7 +452,7 @@ Refer to the [List API reference][List] for a full list of methods.
 #### Sets
 
 A set in Dart is an unordered collection of unique items. Because a set
-is unordered, you can’t get a set’s items by index (position).
+is unordered, you can't get a set's items by index (position).
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (Set)"?>
 ```dart
@@ -611,7 +611,7 @@ Some of this common functionality is defined by the Iterable class,
 which List and Set implement.
 
 {{site.alert.note}}
-  Although Map doesn’t implement Iterable, you can get Iterables from it using
+  Although Map doesn't implement Iterable, you can get Iterables from it using
   the Map `keys` and `values` properties.
 {{site.alert.end}}
 
@@ -659,8 +659,8 @@ loudTeas.forEach(print);
 ```
 
 {{site.alert.note}}
-  The object returned by `map()` is an Iterable that’s *lazily evaluated*: your
-  function isn’t called until you ask for an item from the returned object.
+  The object returned by `map()` is an Iterable that's *lazily evaluated*: your
+  function isn't called until you ask for an item from the returned object.
 {{site.alert.end}}
 
 To force your function to be called immediately on each item, use
@@ -671,8 +671,8 @@ To force your function to be called immediately on each item, use
 var loudTeas = teas.map((tea) => tea.toUpperCase()).toList();
 ```
 
-Use Iterable’s `where()` method to get all the items that match a
-condition. Use Iterable’s `any()` and `every()` methods to check whether
+Use Iterable's `where()` method to get all the items that match a
+condition. Use Iterable's `any()` and `every()` methods to check whether
 some or all items match a condition.
 {% comment %}
 PENDING: Change example as suggested by floitsch to have (maybe)
@@ -739,7 +739,7 @@ Notice how only the space between `some` and `message` was encoded.
 
 #### Encoding and decoding URI components
 
-To encode and decode all of a string’s characters that have special
+To encode and decode all of a string's characters that have special
 meaning in a URI, including (but not limited to) `/`, `&`, and `:`, use
 the `encodeComponent()` and `decodeComponent()` methods.
 
@@ -843,7 +843,7 @@ var sameTimeLastYear = now.copyWith(year: now.year - 1);
   `DateTime` operations might give unexpected results related to Daylight Savings Time and other non-standard time adjustments.  
 {{site.alert.end}}
 The `millisecondsSinceEpoch` property of a date returns the number of
-milliseconds since the “Unix epoch”—January 1, 1970, UTC:
+milliseconds since the "Unix epoch"—January 1, 1970, UTC:
 
 <?code-excerpt "misc/test/library_tour/core_test.dart (millisecondsSinceEpoch)"?>
 ```dart
@@ -923,7 +923,7 @@ Each object in Dart automatically provides an integer hash code, and
 thus can be used as a key in a map. However, you can override the
 `hashCode` getter to generate a custom hash code. If you do, you might
 also want to override the `==` operator. Objects that are equal (via
-`==`) must have identical hash codes. A hash code doesn’t have to be
+`==`) must have identical hash codes. A hash code doesn't have to be
 unique, but it should be well distributed.
 
 {{site.alert.tip}}
@@ -942,9 +942,9 @@ unique, but it should be well distributed.
 [`Object.hashAllUnordered()`]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/Object/hashAllUnordered.html
 
 {% comment %}
-Note: There’s disagreement over whether to include identical() in the ==
+Note: There's disagreement over whether to include identical() in the ==
 implementation. It might improve speed, at least when you need to
-compare many fields. They don’t do identical() automatically because, by
+compare many fields. They don't do identical() automatically because, by
 convention, NaN != NaN.
 {% endcomment %}
 
@@ -1023,7 +1023,7 @@ void main() {
 
 The Dart core library defines many common exceptions and errors.
 Exceptions are considered conditions that you can plan ahead for and
-catch. Errors are conditions that you don’t expect or plan for.
+catch. Errors are conditions that you don't expect or plan for.
 
 A couple of the most common errors are:
 
@@ -1786,7 +1786,7 @@ The dart:convert library also has converters for ASCII and ISO-8859-1
 ## Summary
 
 This page introduced you to the most commonly used functionality in
-Dart’s built-in libraries. It didn’t cover all the built-in
+Dart's built-in libraries. It didn't cover all the built-in
 libraries, however. Others that you might want to look into include
 [dart:collection][] and [dart:typed\_data,][dart:typed\_data]
 as well as platform-specific libraries like the

--- a/src/guides/libraries/writing-package-pages.md
+++ b/src/guides/libraries/writing-package-pages.md
@@ -262,7 +262,7 @@ If your package looks promising, users might want to test your package.
 Include a "Get started" or "Usage" section that has
 at least one code sample that users can easily understand—and, 
 ideally, that they can copy and paste into their project.
-It’s even better if you can provide more examples with more details
+It's even better if you can provide more examples with more details
 to help users to understand your package. 
 
 Remember that not all users speak English, but they all speak Dart!
@@ -376,7 +376,7 @@ that has information for potential contributors:
 
 ## Learn more about good README authoring
 
-We’ve suggested seven tips for good README in this documentation.
+We've suggested seven tips for good README in this documentation.
 You can learn more about common recommendations for developer documentation
 from the [Google Developer Documentation Style Guide][style-guide].
 Some additional tips include:  
@@ -405,9 +405,9 @@ with a template and suggestions for a good README.
 
 The suggestions in this page and others might not work for all packages.
 Be creative!
-Put yourself into users’ shoes and
+Put yourself into users' shoes and
 imagine what the reader might want to read and know.
-You’re the only person who can provide the information that the reader needs.
+You're the only person who can provide the information that the reader needs.
 
 [Awesome README]: https://github.com/matiassingers/awesome-readme
 [Badges]: https://github.com/badges/shields#readme

--- a/src/guides/whats-new.md
+++ b/src/guides/whats-new.md
@@ -1,6 +1,6 @@
 ---
-title: What’s new
-description: A list of what’s new on dart.dev and related sites.
+title: What's new
+description: A list of what's new on dart.dev and related sites.
 ---
 
 This page describes what's new on the Dart website and blog.
@@ -619,7 +619,7 @@ we made the following changes to this site:
 We published the following articles on the Dart blog:
 
 * [Experimenting with Dart and Wasm][blog-7-27-21]
-* [How Dart’s null safety helped me augment my projects][blog-6-23-21]
+* [How Dart's null safety helped me augment my projects][blog-6-23-21]
 * [Implementing structs by value in Dart FFI][blog-6/8-21]
 
 [blog-7-27-21]: https://medium.com/dartlang/experimenting-with-dart-and-wasm-ef7f1c065577
@@ -655,7 +655,7 @@ we made the following changes to this site:
     links to helpful documentation and samples.
   * The [command-line tutorial][] has been completely updated.
 * Published some other new pages:
-  * [Null safety codelab][] teaches you about Dart’s null-safe type system,
+  * [Null safety codelab][] teaches you about Dart's null-safe type system,
     which was introduced in Dart 2.12.
   * [Numbers in Dart][] has
     details about differences between native and web number implementations.
@@ -741,7 +741,7 @@ In addition to bug fixes and incremental improvements, we made the following cha
   and [`dart format`][].
 * Created a page documenting the quality and support of [Dart team packages][].
 * Replaced the Platforms page with a new [Overview page][].
-* Created this page ("What’s new").
+* Created this page ("What's new").
 
 We also switched from Travis CI to GitHub Actions, and we made multiple CSS changes to improve site legibility.
 
@@ -777,7 +777,7 @@ We published the following articles on the Dart blog:
   generate faster, smaller code.
 * [Why nullable types?][blog-12-7-20]
   expanded on a discussion on the /r/dart_lang subreddit,
-  answering the question “Why not get rid of null completely?”
+  answering the question "Why not get rid of null completely?"
 * [Announcing Dart null safety beta][blog-11-19-20]
   invited developers to start planning their migration to null safety.
 

--- a/src/language/built-in-types.md
+++ b/src/language/built-in-types.md
@@ -82,10 +82,10 @@ Dart numbers come in two flavors:
 
 Both `int` and `double` are subtypes of [`num`][].
 The num type includes basic operators such as +, -, /, and \*,
-and is also where you’ll find `abs()`,` ceil()`,
+and is also where you'll find `abs()`,` ceil()`,
 and `floor()`, among other methods.
 (Bitwise operators, such as \>\>, are defined in the `int` class.)
-If num and its subtypes don’t have what you’re looking for, the
+If num and its subtypes don't have what you're looking for, the
 [dart:math][] library might.
 
 Integers are numbers without a decimal point. Here are some examples of
@@ -122,7 +122,7 @@ Integer literals are automatically converted to doubles when necessary:
 double z = 1; // Equivalent to double z = 1.0.
 ```
 
-Here’s how you turn a string into a number, or vice versa:
+Here's how you turn a string into a number, or vice versa:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (number-conversion)"?>
 ```dart
@@ -190,7 +190,7 @@ var s4 = "It's even easier to use the other delimiter.";
 You can put the value of an expression inside a string by using
 `${`*`expression`*`}`. If the expression is an identifier, you can skip
 the {}. To get the string corresponding to an object, Dart calls the
-object’s `toString()` method.
+object's `toString()` method.
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (string-interpolation)"?>
 ```dart
@@ -241,7 +241,7 @@ var s2 = """This is also a
 multi-line string.""";
 ```
 
-You can create a “raw” string by prefixing it with `r`:
+You can create a "raw" string by prefixing it with `r`:
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (raw-strings)"?>
 ```dart

--- a/src/language/class-modifiers.md
+++ b/src/language/class-modifiers.md
@@ -295,7 +295,7 @@ String getVehicleSound(Vehicle vehicle) {
 }
 ```
 
-If you don’t want [exhaustive switching][exhaustive], 
+If you don't want [exhaustive switching][exhaustive], 
 or want to be able to add subtypes later without breaking the API, 
 use the [`final`](#final) modifier. For a more in depth comparison,
 read [`sealed` versus `final`](/language/class-modifiers-for-apis#sealed-versus-final).

--- a/src/language/classes.md
+++ b/src/language/classes.md
@@ -27,7 +27,7 @@ add functionality to a class without changing the class or creating a subclass.
 
 Objects have *members* consisting of functions and data (*methods* and
 *instance variables*, respectively). When you call a method, you *invoke*
-it on an object: the method has access to that object’s functions and
+it on an object: the method has access to that object's functions and
 data.
 
 Use a dot (`.`) to refer to an instance variable or method:
@@ -156,7 +156,7 @@ The rest of this section shows how to _implement_ classes.
 
 ## Instance variables
 
-Here’s how you declare instance variables:
+Here's how you declare instance variables:
 
 <?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class)"?>
 ```dart
@@ -224,7 +224,7 @@ after the constructor body starts, you can use one of the following:
 
 Every class implicitly defines an interface containing all the instance
 members of the class and of any interfaces it implements. If you want to
-create a class A that supports class B’s API without inheriting B’s
+create a class A that supports class B's API without inheriting B's
 implementation, class A should implement the B interface.
 
 A class implements one or more interfaces by declaring them in an
@@ -260,7 +260,7 @@ void main() {
 }
 ```
 
-Here’s an example of specifying that a class implements multiple
+Here's an example of specifying that a class implements multiple
 interfaces:
 
 <?code-excerpt "misc/lib/language_tour/classes/misc.dart (point_interfaces)"?>
@@ -290,7 +290,7 @@ void main() {
 }
 ```
 
-Static variables aren’t initialized until they’re used.
+Static variables aren't initialized until they're used.
 
 {{site.alert.note}}
   This page follows the [style guide

--- a/src/language/collections.md
+++ b/src/language/collections.md
@@ -51,7 +51,7 @@ var list = [
 
 Lists use zero-based indexing, where 0 is the index of the first value
 and `list.length - 1` is the index of the last value. 
-You can get a list’s length using the `.length` property
+You can get a list's length using the `.length` property
 and access a list's values using the subscript operator (`[]`):
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (list-indexing)"?>
@@ -220,7 +220,7 @@ var gifts = {'first': 'partridge'};
 assert(gifts['first'] == 'partridge');
 ```
 
-If you look for a key that isn’t in a map, you get `null` in return:
+If you look for a key that isn't in a map, you get `null` in return:
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (map-missing-key)"?>
 ```dart

--- a/src/language/concurrency/index.md
+++ b/src/language/concurrency/index.md
@@ -38,7 +38,7 @@ is an implementation detail that this page doesn't discuss.
 
 ## Asynchrony types and syntax
 
-If you’re already familiar with `Future`, `Stream`, and async-await,
+If you're already familiar with `Future`, `Stream`, and async-await,
 then you can skip ahead to the [isolates section][].
 
 [isolates section]: #how-isolates-work
@@ -98,7 +98,7 @@ The `async` and `await` keywords provide
 a declarative way to define asynchronous functions
 and use their results.
 
-Here’s an example of some synchronous code
+Here's an example of some synchronous code
 that blocks while waiting for file I/O:
 
 <?code-excerpt "lib/sync_number_of_keys.dart"?>
@@ -121,7 +121,7 @@ String _readFileSync() {
 }
 ```
 
-Here’s similar code, but with changes (highlighted) to make it asynchronous:
+Here's similar code, but with changes (highlighted) to make it asynchronous:
 
 <?code-excerpt "lib/async_number_of_keys.dart" replace="/async|await|readAsString\(\)/[!$&!]/g; /Future<\w+\W/[!$&!]/g;"?>
 {% prettify dart tag=pre+code %}
@@ -162,7 +162,7 @@ Once `readAsString()` returns a value, Dart code execution resumes.
 
 ![Flowchart-like figure showing app code executing from start to exit, waiting for native I/O in between](/language/concurrency/images/basics-await.png)
 
-If you’d like to learn more about using `async`, `await`, and futures,
+If you'd like to learn more about using `async`, `await`, and futures,
 visit the [asynchronous programming codelab][].
 
 [asynchronous programming codelab]: /codelabs/async-await
@@ -189,7 +189,7 @@ isolates don't prevent race conditions all together.
 
 
 Using isolates, your Dart code can perform multiple independent tasks at once,
-using additional processor cores if they’re available.
+using additional processor cores if they're available.
 Isolates are like threads or processes,
 but each isolate has its own memory and a single thread running an event loop.
 
@@ -204,7 +204,7 @@ but each isolate has its own memory and a single thread running an event loop.
 
 ### The main isolate
 
-You often don’t need to think about isolates at all.
+You often don't need to think about isolates at all.
 Dart programs run in the main isolate by default.
 It's the thread where a program starts to run and execute, 
 as shown in the following figure:
@@ -237,7 +237,7 @@ After handling the events, the isolate exits.
 
 ### Event handling
 
-In a client app, the main isolate’s event queue might contain
+In a client app, the main isolate's event queue might contain
 repaint requests and notifications of tap and other UI events.
 For example, the following figure shows a repaint event,
 followed by a tap event, followed by two repaint events.
@@ -271,7 +271,7 @@ Worse, the UI might become completely unresponsive.
 
 ### Background workers
 
-If your app’s UI becomes unresponsive due to 
+If your app's UI becomes unresponsive due to 
 a time-consuming computation—[parsing a large JSON file][json], 
 for example—consider offloading that computation to a worker isolate,
 often called a _background worker._
@@ -285,7 +285,7 @@ The worker isolate returns its result in a message when the worker exits.
 ![A figure showing a main isolate and a simple worker isolate](/language/concurrency/images/isolate-bg-worker.png)
 
 Each isolate message can deliver one object,
-which includes anything that’s transitively reachable from that object.
+which includes anything that's transitively reachable from that object.
 Not all object types are sendable, and
 the send fails if any transitively reachable object is unsendable.
 For example, you can send an object of type `List<Object>` only if
@@ -299,7 +299,7 @@ see the API reference documentation for the [`send()` method][].
 A worker isolate can perform I/O
 (reading and writing files, for example), set timers, and more.
 It has its own memory and
-doesn’t share any state with the main isolate.
+doesn't share any state with the main isolate.
 The worker isolate can block without affecting other isolates.
 
 [`send()` method]: {{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-isolate/SendPort/send.html
@@ -439,7 +439,7 @@ Closures are less limited than typical named functions,
 both in how they function and how they're written into the code.
 In this example, `Isolate.run()` executes what looks like local code, concurrently.
 In that sense, you can imagine `run()` to work like a control flow operator
-for “run in parallel”.
+for "run in parallel".
 
 [closure]: /language/functions#anonymous-functions
 

--- a/src/language/constructors.md
+++ b/src/language/constructors.md
@@ -69,14 +69,14 @@ are implicitly final and only in scope of the initializer list.
 
 ## Default constructors
 
-If you don’t declare a constructor, a default constructor is provided
+If you don't declare a constructor, a default constructor is provided
 for you. The default constructor has no arguments and invokes the
 no-argument constructor in the superclass.
 
 
-## Constructors aren’t inherited
+## Constructors aren't inherited
 
-Subclasses don’t inherit constructors from their superclass. A subclass
+Subclasses don't inherit constructors from their superclass. A subclass
 that declares no constructors has only the default (no argument, no
 name) constructor.
 
@@ -105,14 +105,14 @@ class Point {
 {% endprettify %}
 
 Remember that constructors are not inherited, which means that a
-superclass’s named constructor is not inherited by a subclass. If you
+superclass's named constructor is not inherited by a subclass. If you
 want a subclass to be created with a named constructor defined in the
 superclass, you must implement that constructor in the subclass.
 
 
 ## Invoking a non-default superclass constructor
 
-By default, a constructor in a subclass calls the superclass’s unnamed,
+By default, a constructor in a subclass calls the superclass's unnamed,
 no-argument constructor.
 The superclass's constructor is called at the beginning of the
 constructor body. If an [initializer list](#initializer-list)
@@ -123,7 +123,7 @@ In summary, the order of execution is as follows:
 1. superclass's no-arg constructor
 1. main class's no-arg constructor
 
-If the superclass doesn’t have an unnamed, no-argument constructor,
+If the superclass doesn't have an unnamed, no-argument constructor,
 then you must manually call one of the constructors in the
 superclass. Specify the superclass constructor after a colon (`:`), just
 before the constructor body (if any).
@@ -292,8 +292,8 @@ void main() {
 
 ## Redirecting constructors
 
-Sometimes a constructor’s only purpose is to redirect to another
-constructor in the same class. A redirecting constructor’s body is
+Sometimes a constructor's only purpose is to redirect to another
+constructor in the same class. A redirecting constructor's body is
 empty, with the constructor call
 (using `this` instead of the class name)
 appearing after a colon (:).
@@ -336,7 +336,7 @@ For details, see the section on
 
 ## Factory constructors
 
-Use the `factory` keyword when implementing a constructor that doesn’t
+Use the `factory` keyword when implementing a constructor that doesn't
 always create a new instance of its class. For example, a factory
 constructor might return an instance from a cache, or it might
 return an instance of a subtype.

--- a/src/language/error-handling.md
+++ b/src/language/error-handling.md
@@ -12,11 +12,11 @@ nextpage:
 ## Exceptions
 
 Your Dart code can throw and catch exceptions. Exceptions are errors
-indicating that something unexpected happened. If the exception isn’t
+indicating that something unexpected happened. If the exception isn't
 caught, the [isolate][] that raised the exception is suspended,
 and typically the isolate and its program are terminated.
 
-In contrast to Java, all of Dart’s exceptions are unchecked exceptions.
+In contrast to Java, all of Dart's exceptions are unchecked exceptions.
 Methods don't declare which exceptions they might throw, and you aren't
 required to catch any exceptions.
 
@@ -27,7 +27,7 @@ non-null object—not just Exception and Error objects—as an exception.
 
 ### Throw
 
-Here’s an example of throwing, or *raising*, an exception:
+Here's an example of throwing, or *raising*, an exception:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (throw-FormatException)"?>
 ```dart
@@ -72,7 +72,7 @@ try {
 
 To handle code that can throw more than one type of exception, you can
 specify multiple catch clauses. The first catch clause that matches the
-thrown object’s type handles the exception. If the catch clause does not
+thrown object's type handles the exception. If the catch clause does not
 specify a type, that clause can handle any type of thrown object:
 
 <?code-excerpt "misc/lib/language_tour/exceptions.dart (try-catch)"?>
@@ -199,7 +199,7 @@ assert(urlString.startsWith('https'),
 ```
 
 The first argument to `assert` can be any expression that
-resolves to a boolean value. If the expression’s value
+resolves to a boolean value. If the expression's value
 is true, the assertion succeeds and execution
 continues. If it's false, the assertion fails and an exception (an
 [`AssertionError`][]) is thrown.

--- a/src/language/functions.md
+++ b/src/language/functions.md
@@ -16,7 +16,7 @@ This means that functions can be assigned to variables or passed as arguments
 to other functions. You can also call an instance of a Dart class as if
 it were a function. For details, see [Callable objects][].
 
-Here’s an example of implementing a function:
+Here's an example of implementing a function:
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function)"?>
 ```dart
@@ -50,7 +50,7 @@ is sometimes referred to as _arrow_ syntax.
 
 {{site.alert.note}}
   Only an *expression*—not a *statement*—can appear between the arrow (=\>) and
-  the semicolon (;). For example, you can’t put an [if statement][]
+  the semicolon (;). For example, you can't put an [if statement][]
   there, but you can use a [conditional expression][].
 {{site.alert.end}}
 
@@ -168,7 +168,7 @@ String say(String from, String msg, [String? device]) {
 }
 ```
 
-Here’s an example of calling this function
+Here's an example of calling this function
 without the optional parameter:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (call-without-optional-param)"?>
@@ -176,7 +176,7 @@ without the optional parameter:
 assert(say('Bob', 'Howdy') == 'Bob says Howdy');
 ```
 
-And here’s an example of calling this function with the third parameter:
+And here's an example of calling this function with the third parameter:
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (call-with-optional-param)"?>
 ```dart
@@ -329,7 +329,7 @@ list
 
 Dart is a lexically scoped language, which means that the scope of
 variables is determined statically, simply by the layout of the code.
-You can “follow the curly braces outwards” to see if a variable is in
+You can "follow the curly braces outwards" to see if a variable is in
 scope.
 
 Here is an example of nested functions with variables at each scope

--- a/src/language/generics.md
+++ b/src/language/generics.md
@@ -12,7 +12,7 @@ nextpage:
 <?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; / *\/\/\s+ignore:[^\n]+//g; /([A-Z]\w*)\d\b/$1/g"?>
 
 If you look at the API documentation for the basic array type,
-[`List`][], you’ll see that the
+[`List`][], you'll see that the
 type is actually `List<E>`. The \<...\> notation marks List as a
 *generic* (or *parameterized*) type—a type that has formal type
 parameters. [By convention][], most type variables have single-letter names,
@@ -27,9 +27,9 @@ than just allowing your code to run:
 * You can use generics to reduce code duplication.
 
 If you intend for a list to contain only strings, you can
-declare it as `List<String>` (read that as “list of string”). That way
+declare it as `List<String>` (read that as "list of string"). That way
 you, your fellow programmers, and your tools can detect that assigning a non-string to
-the list is probably a mistake. Here’s an example:
+the list is probably a mistake. Here's an example:
 
 {:.fails-sa}
 ```dart
@@ -77,14 +77,14 @@ abstract class Cache<T> {
 }
 ```
 
-In this code, T is the stand-in type. It’s a placeholder that you can
+In this code, T is the stand-in type. It's a placeholder that you can
 think of as a type that a developer will define later.
 
 
 ## Using collection literals
 
 List, set, and map literals can be parameterized. Parameterized literals are
-just like the literals you’ve already seen, except that you add
+just like the literals you've already seen, except that you add
 <code>&lt;<em>type</em>></code> (for lists and sets) or
 <code>&lt;<em>keyType</em>, <em>valueType</em>></code> (for maps)
 before the opening bracket. Here is an example of using typed literals:
@@ -136,7 +136,7 @@ print(names is List<String>); // true
 {{site.alert.note}}
   In contrast, generics in Java use *erasure*, which means that generic
   type parameters are removed at runtime. In Java, you can test whether
-  an object is a List, but you can’t test whether it’s a `List<String>`.
+  an object is a List, but you can't test whether it's a `List<String>`.
 {{site.alert.end}}
 
 

--- a/src/language/index.md
+++ b/src/language/index.md
@@ -492,7 +492,7 @@ keep these facts and concepts in mind:
     is inferred to be of type `int`.
 
 -   If you enable [null safety][ns],
-    variables can’t contain `null` unless you say they can.
+    variables can't contain `null` unless you say they can.
     You can make a variable nullable by
     putting a question mark (`?`) at the end of its type.
     For example, a variable of type `int?` might be an integer,
@@ -521,8 +521,8 @@ keep these facts and concepts in mind:
     tied to a class or object (static and instance variables). Instance
     variables are sometimes known as *fields* or *properties*.
 
--   Unlike Java, Dart doesn’t have the keywords `public`, `protected`,
-    and `private`. If an identifier starts with an underscore (`_`), it’s
+-   Unlike Java, Dart doesn't have the keywords `public`, `protected`,
+    and `private`. If an identifier starts with an underscore (`_`), it's
     private to its library. For details, see
     [Libraries and imports][].
 
@@ -539,7 +539,7 @@ keep these facts and concepts in mind:
 
 -   Dart tools can report two kinds of problems: _warnings_ and _errors_.
     Warnings are just indications that your code might not work, but
-    they don’t prevent your program from executing. Errors can be either
+    they don't prevent your program from executing. Errors can be either
     compile-time or run-time. A compile-time error prevents the code
     from executing at all; a run-time error results in an
     [exception][] being raised while the code executes.

--- a/src/language/libraries.md
+++ b/src/language/libraries.md
@@ -14,7 +14,7 @@ The `import` and `library` directives can help you create a
 modular and shareable code base. Libraries not only provide APIs, but
 are a unit of privacy: identifiers that start with an underscore (`_`)
 are visible only inside the library. *Every Dart file (plus its parts) is a
-[library][]*, even if it doesn’t use a [`library`](#library-directive) directive.
+[library][]*, even if it doesn't use a [`library`](#library-directive) directive.
 
 Libraries can be distributed using [packages](/guides/packages).
 

--- a/src/language/loops.md
+++ b/src/language/loops.md
@@ -33,7 +33,7 @@ for (var i = 0; i < 5; i++) {
 }
 ```
 
-Closures inside of Dart’s `for` loops capture the _value_ of the index.
+Closures inside of Dart's `for` loops capture the _value_ of the index.
 This avoids a common pitfall found in JavaScript. For example, consider:
 
 <?code-excerpt "language/test/control_flow/loops_test.dart (for-and-closures)"?>
@@ -132,7 +132,7 @@ for (int i = 0; i < candidates.length; i++) {
 }
 ```
 
-If you’re using an [`Iterable`][] such as a list or set,
+If you're using an [`Iterable`][] such as a list or set,
 how you write the previous example might differ:
 
 <?code-excerpt "language/lib/control_flow/loops.dart (where)"?>

--- a/src/language/metadata.md
+++ b/src/language/metadata.md
@@ -20,7 +20,7 @@ Four annotations are available to all Dart code:
 [`@Deprecated`][], [`@deprecated`][], [`@override`][], and [`@pragma`][]. 
 For examples of using `@override`,
 see [Extending a class][].
-Here’s an example of using the `@Deprecated` annotation:
+Here's an example of using the `@Deprecated` annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/television.dart (deprecated)" replace="/@Deprecated.*/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
@@ -41,7 +41,7 @@ You can use `@deprecated` if you don't want to specify a message.
 However, we [recommend][dep-lint] always
 specifying a message with `@Deprecated`.
 
-You can define your own metadata annotations. Here’s an example of
+You can define your own metadata annotations. Here's an example of
 defining a `@Todo` annotation that takes two arguments:
 
 <?code-excerpt "misc/lib/language_tour/metadata/todo.dart"?>
@@ -54,7 +54,7 @@ class Todo {
 }
 ```
 
-And here’s an example of using that `@Todo` annotation:
+And here's an example of using that `@Todo` annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/misc.dart"?>
 ```dart

--- a/src/language/methods.md
+++ b/src/language/methods.md
@@ -94,7 +94,7 @@ void main() {
 ## Getters and setters
 
 Getters and setters are special methods that provide read and write
-access to an object’s properties. Recall that each instance variable has
+access to an object's properties. Recall that each instance variable has
 an implicit getter, plus a setter if appropriate. You can create
 additional properties by implementing getters and setters, using the
 `get` and `set` keywords:

--- a/src/language/operators.md
+++ b/src/language/operators.md
@@ -172,17 +172,17 @@ The following table lists the meanings of equality and relational operators.
 To test whether two objects x and y represent the same thing, use the
 `==` operator. (In the rare case where you need to know whether two
 objects are the exact same object, use the [identical()][]
-function instead.) Here’s how the `==` operator works:
+function instead.) Here's how the `==` operator works:
 
 1.  If *x* or *y* is null, return true if both are null, and false if only
     one is null.
 
 2.  Return the result of invoking the `==` method on *x* with the argument *y*.
-    (That’s right, operators such as `==` are methods that
+    (That's right, operators such as `==` are methods that
     are invoked on their first operand.
     For details, see [Operators][].)
 
-Here’s an example of using each of the equality and relational
+Here's an example of using each of the equality and relational
 operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (relational)"?>
@@ -231,13 +231,13 @@ if (employee is Person) {
 ```
 
 {{site.alert.note}}
-  The code isn’t equivalent. If `employee` is null or not a `Person`, the
+  The code isn't equivalent. If `employee` is null or not a `Person`, the
   first example throws an exception; the second does nothing.
 {{site.alert.end}}
 
 ## Assignment operators
 
-As you’ve already seen, you can assign values using the `=` operator.
+As you've already seen, you can assign values using the `=` operator.
 To assign only if the assigned-to variable is null,
 use the `??=` operator.
 
@@ -257,7 +257,7 @@ an operation with an assignment.
 | `-=` | `~/=` | `>>=`
 {:.table}
 
-Here’s how compound assignment operators work:
+Here's how compound assignment operators work:
 
 |-----------+----------------------+-----------------------|
 |           | Compound assignment  | Equivalent expression |
@@ -290,7 +290,7 @@ operators.
 | `&&`                        | logical AND
 {:.table .table-striped}
 
-Here’s an example of using the logical operators:
+Here's an example of using the logical operators:
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (op-logical)"?>
 ```dart
@@ -303,7 +303,7 @@ if (!done && (col == 0 || col == 3)) {
 ## Bitwise and shift operators
 
 You can manipulate the individual bits of numbers in Dart. Usually,
-you’d use these bitwise and shift operators with integers.
+you'd use these bitwise and shift operators with integers.
 
 |-----------------------------+-------------------------------------------|
 | Operator                    | Meaning                                   |
@@ -324,7 +324,7 @@ you’d use these bitwise and shift operators with integers.
   [Bitwise operations platform differences][].
 {{site.alert.end}}
 
-Here’s an example of using bitwise and shift operators:
+Here's an example of using bitwise and shift operators:
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (op-bitwise)"?>
 ```dart

--- a/src/language/pattern-types.md
+++ b/src/language/pattern-types.md
@@ -344,7 +344,7 @@ print('$a $b $rest $c $d');
 `{"key": subpattern1, someConst: subpattern2}`
 
 Map patterns match values that implement [`Map`][], and then recursively 
-match its subpatterns against the map’s keys to destructure them.
+match its subpatterns against the map's keys to destructure them.
 
 Map patterns don't require the pattern to match the entire map. A map pattern
 ignores any keys that the map contains that aren't matched by the pattern.

--- a/src/language/variables.md
+++ b/src/language/variables.md
@@ -11,7 +11,7 @@ nextpage:
 
 <?code-excerpt replace="/ *\/\/\s+ignore_for_file:[^\n]+\n//g; /(^|\n) *\/\/\s+ignore:[^\n]+\n/$1/g; /(\n[^\n]+) *\/\/\s+ignore:[^\n]+\n/$1\n/g; / *\/\/\s+ignore:[^\n]+//g; /([A-Z]\w*)\d\b/$1/g"?>
 
-Here’s an example of creating a variable and initializing it:
+Here's an example of creating a variable and initializing it:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (var-decl)"?>
 ```dart
@@ -19,7 +19,7 @@ var name = 'Bob';
 ```
 
 Variables store references. The variable called `name` contains a
-reference to a `String` object with a value of “Bob”.
+reference to a `String` object with a value of "Bob".
 
 The type of the `name` variable is inferred to be `String`,
 but you can change that type by specifying it.
@@ -251,7 +251,7 @@ const baz = []; // Equivalent to `const []`
 ```
 
 You can omit `const` from the initializing expression of a `const` declaration,
-like for `baz` above. For details, see [DON’T use const redundantly][].
+like for `baz` above. For details, see [DON'T use const redundantly][].
 
 You can change the value of a non-final, non-const variable,
 even if it used to have a `const` value:
@@ -295,7 +295,7 @@ For more information on using `const` to create constant values, see
 
 [Assert]: /language/error-handling#assert
 [Instance variables]: /language/classes#instance-variables
-[DON’T use const redundantly]: /effective-dart/usage#dont-use-const-redundantly
+[DON'T use const redundantly]: /effective-dart/usage#dont-use-const-redundantly
 [type checks and casts]: /language/operators#type-test-operators
 [collection `if`]: /language/collections#control-flow-operators
 [spread operators]: /language/collections#spread-operators

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -63,8 +63,8 @@ Dart supports null safety using the following three core design principles:
    can be null, it's considered non-nullable. This default was chosen
    after research found that non-null was by far the most common choice in APIs.
 
-* **Fully sound**. Dart’s null safety is sound, which enables compiler optimizations.
-  If the type system determines that something isn’t null, then that thing can _never_ be
+* **Fully sound**. Dart's null safety is sound, which enables compiler optimizations.
+  If the type system determines that something isn't null, then that thing can _never_ be
   null. Once you migrate your whole project
   and its dependencies to null safety, 
   you reap the full benefits of soundness—not only 

--- a/src/overview.md
+++ b/src/overview.md
@@ -33,7 +33,7 @@ formatting, analyzing, and testing code.
 
 The Dart language is type safe;
 it uses static type checking to ensure that
-a variable’s value _always_ matches the variable’s static type.
+a variable's value _always_ matches the variable's static type.
 Sometimes, this is referred to as sound typing.
 Although types are mandatory,
 type annotations are optional because of type inference.
@@ -43,7 +43,7 @@ which can be useful during experimentation or
 for code that needs to be especially dynamic.
 
 Dart has built-in [sound null safety](/null-safety).
-This means values can’t be null unless you say they can be.
+This means values can't be null unless you say they can be.
 With sound null safety, Dart can protect you from
 null exceptions at runtime through static code analysis.
 Unlike many other null-safe languages,

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -125,7 +125,7 @@ convenience by having covariant generics.
 The only other reasonable default variance would be invariance. While having
 only invariant generics would definitely prevent more errors, it would also
 prevent a lot of valid programs or require conversion every time you have a list
-of “apples”, and someone just wants “fruits”.
+of "apples", and someone just wants "fruits".
 
 We are familiar with a variety of ways that languages try to mark or infer
 variance. We feel that variance inference systems add too much complexity for
@@ -360,7 +360,7 @@ may like Dart's static type annotations.
 TypeScript and Dart have similar goals; they make building large-scale web
 apps easier. However, their approaches are fairly different. TypeScript
 maintains backwards compatability with JavaScript, whereas Dart purposely made a
-break from certain parts of JavaScript’s syntax and semantics in order to
+break from certain parts of JavaScript's syntax and semantics in order to
 eradicate large classes of bugs and to improve performance. The web has suffered
 from too little choice for too long, and we think that both Dart and TypeScript
 are pointing to a brighter future for web developers. You can read a
@@ -456,7 +456,7 @@ staying within smi range is still good practice.
 
 ### Q. How are typed lists handled when compiled to JavaScript?
 
-JavaScript offers typed arrays compatible with Dart’s typed lists.
+JavaScript offers typed arrays compatible with Dart's typed lists.
 The mapping is trivial: `Float32List` becomes a `Float32Array`.
 One exception exists: the production JavaScript compiler does not support
 64-bit integers: `Int64List` or `Uint64List`. Compiling Dart code with

--- a/src/resources/glossary.md
+++ b/src/resources/glossary.md
@@ -61,7 +61,7 @@ places where a variable that can only be assigned a value one time is being
 assigned after it might already have been assigned a value.
 
 For example, in the following code the variable `s` is definitely unassigned
-when it’s passed as an argument to `print`:
+when it's passed as an argument to `print`:
 
 ```dart
 void f() {
@@ -83,7 +83,7 @@ Definite assignment analysis can even tell whether a variable is definitely
 assigned (or unassigned) when there are multiple possible execution paths. In
 the following code the `print` function is called if execution goes through
 either the true or the false branch of the `if` statement, but because `s` is
-assigned no matter which branch is taken, it’s definitely assigned before it’s
+assigned no matter which branch is taken, it's definitely assigned before it's
 passed to `print`:
 
 ```dart
@@ -100,9 +100,9 @@ void f(String name, bool casual) {
 
 In flow analysis, the end of the `if` statement is referred to as a _join_—a
 place where two or more execution paths merge back together. Where there's a
-join, the analysis says that a variable is definitely assigned if it’s
+join, the analysis says that a variable is definitely assigned if it's
 definitely assigned along all of the paths that are merging, and definitely
-unassigned if it’s definitely unassigned along all of the paths.
+unassigned if it's definitely unassigned along all of the paths.
 
 Sometimes a variable is assigned a value on one path but not on another, in
 which case the variable might or might not have been assigned a value. In the
@@ -119,7 +119,7 @@ void f(String name, bool casual) {
 }
 ```
 
-The same is true if there is a false branch that doesn’t assign a value to `s`.
+The same is true if there is a false branch that doesn't assign a value to `s`.
 
 The analysis of loops is a little more complicated, but it follows the same
 basic reasoning. For example, the condition in a `while` loop is always

--- a/src/security.md
+++ b/src/security.md
@@ -35,7 +35,7 @@ The Google Security Team will respond within 5 working days of
 your report on g.co/vulnz.
 
 For more information about how Google handles security issues, see
-[Google’s security philosophy][].
+[Google's security philosophy][].
 
 ##  Flagging existing issues as security-related
 
@@ -75,7 +75,7 @@ mailing list.
   Check the [Dart changelog][]
   for security-related updates.
 
-* **Keep your application’s dependencies up to date.**
+* **Keep your application's dependencies up to date.**
   Make sure you [upgrade your package dependencies][]
   to keep the dependencies up to date.
   Avoid pinning to specific versions
@@ -85,7 +85,7 @@ mailing list.
 
 [Dart changelog]: https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md
 [GitHub security advisories]: https://docs.github.com/en/code-security/security-advisories
-[Google’s security philosophy]: https://www.google.com/about/appsecurity/
+[Google's security philosophy]: https://www.google.com/about/appsecurity/
 [https://g.co/vulnz]: https://g.co/vulnz
 [repos]: https://github.com/dart-lang/
 [upgrade your package dependencies]: /guides/packages#upgrading-a-dependency

--- a/src/tools/analysis.md
+++ b/src/tools/analysis.md
@@ -390,7 +390,7 @@ such as new diagnostics, quick fixes, and custom code completion.
 You can enable only one plugin per `analysis_options.yaml` file.
 Enabling an analyzer plugin increases how much memory the analyzer uses.
 
-Don’t use analyzer plugins if your situation meets
+Don't use analyzer plugins if your situation meets
 either of the following conditions:
 
 * You use a development machine with less than 16 GB of memory.

--- a/src/tools/dart-compile.md
+++ b/src/tools/dart-compile.md
@@ -287,7 +287,7 @@ improve JavaScript performance:
   you pass into each function or method.
 
 {{site.alert.tip}}
-  Don’t worry about the size of your app’s included libraries. 
+  Don't worry about the size of your app's included libraries. 
   The production compiler performs tree shaking to omit
   unused classes, functions, methods, and so on.
   Import the libraries you think you'll need, 

--- a/src/tools/dartpad/dartpad-best-practices.md
+++ b/src/tools/dartpad/dartpad-best-practices.md
@@ -105,7 +105,7 @@ Coding tutorials are sometimes referred to as _codelabs._
 </div>
 </div>
 
-This guide doesn’t provide general technical writing information,
+This guide doesn't provide general technical writing information,
 which you can find in the following resources:
 
 * [Google Developer Documentation Style Guide:][gddsg]
@@ -116,7 +116,7 @@ which you can find in the following resources:
 * [Other editorial resources][]
 
 The guidance provided in this page is based on
-Google’s internal research and
+Google's internal research and
 related academic research about instructional design.
 This document will evolve as we learn more about what works.
 
@@ -127,8 +127,8 @@ This document will evolve as we learn more about what works.
 DartPad enhances a traditional tutorial through its ability to
 support [guided discovery learning,][guided discovery learning]
 a recognized learning approach that calls for a balance between
-the student’s freedom of exploration and
-the teacher’s scaffolding of the learning process.
+the student's freedom of exploration and
+the teacher's scaffolding of the learning process.
 
 Past research ([Mayer, Richard E., 2004][]) suggested that
 guided discovery learning was more effective than
@@ -166,7 +166,7 @@ engage learners in actively writing code.
 #### **Give just-in-time and just-enough help, and feedback**
 
 Offer precise, contextualized, and immediate feedback on
-learners’ progress without taking away learning opportunities.
+learners' progress without taking away learning opportunities.
 
 </div>
 <div class="col-md-3" markdown="1">
@@ -178,7 +178,7 @@ learners’ progress without taking away learning opportunities.
 
 #### **Facilitate reflection**
 
-Encourage meta-cognitive learning, the learners’ ability to
+Encourage meta-cognitive learning, the learners' ability to
 predict the outcomes of their learning and monitor their understanding.
 
 </div>
@@ -291,7 +291,7 @@ This is useful to evaluate whether the [transfer of learning][] happened.
 
 
 
-What’s the difference between exercise and quiz?
+What's the difference between exercise and quiz?
 There are two main differences:
 
 1. **Exercises provide more scaffolds.**
@@ -310,8 +310,8 @@ There are two main differences:
   and requires a real understanding of how to complete a task,
   instead of just copying and pasting code snippets.
   Until now, we might not have explicitly claimed "this is a quiz" because
-  we didn’t know how users would perceive the word _quiz,_
-  and we didn’t want to add too much pressure.
+  we didn't know how users would perceive the word _quiz,_
+  and we didn't want to add too much pressure.
 
 
 ---
@@ -322,7 +322,7 @@ So far you've learned about the guiding principles and
 ways of using DartPad for creating interactive tutorials.
 But how do you apply these principles when you're
 developing a real-world tutorial?
-We’ll explain that through a detailed case study.
+We'll explain that through a detailed case study.
 In the case study we used DartPad in the instructional design of
 a tutorial titled _[Asynchronous programming: futures, async, await][],_
 or _the Dart Futures codelab_ for short.
@@ -450,8 +450,8 @@ there are a few things you need to pay attention to.
 
 Learners look for clear direction on what to expect next.
 When an exercise is first presented to the learner,
-provide a brief description of the exercise’s workflow.
-In this case, it’s important to point out that
+provide a brief description of the exercise's workflow.
+In this case, it's important to point out that
 the goal is to modify the snippet, to make the unit test pass.
 
 For example, the following exercise starts with an introduction:
@@ -459,7 +459,7 @@ _The following exercise is a failing unit test that
 contains partially completed code snippets.
 Your task is to complete the exercise by writing code to make the tests pass._
 In addition to explaining what the exercise is about,
-the author also clearly communicates that learners don’t need to
+the author also clearly communicates that learners don't need to
 implement the hidden code that was provided, such as `main()` and
 two asynchronous functions, `getRole()` and `getLoginAmount()`.
 
@@ -480,8 +480,8 @@ a clear, visual distinction between demos and exercises help
 users quickly recognize the expected actions.
 When we used the same UIs for both demos and exercises,
 one of our study participants said,
-“I wasn't sure whether I should just code something or
-I'm supposed to just run it to see it.”
+"I wasn't sure whether I should just code something or
+I'm supposed to just run it to see it."
 
 In the published Futures codelab,
 all embedded DartPads are labeled with clear headings,
@@ -507,18 +507,18 @@ Interactive tutorials provide hands-on practice so that
 learners can accumulate knowledge as they tackle
 more and more sophisticated problems.
 However, learners can get frustrated if the tutorial
-doesn’t prepare them for bigger challenges.
+doesn't prepare them for bigger challenges.
 We learned four lessons from developing the Futures codelab.
 
 First, including demos and exercises for each concept before the final quiz
 can provide a gradual progression that novices can follow.
 An earlier draft of this codelab had a demo for handling errors,
-but didn’t have a corresponding exercise to
+but didn't have a corresponding exercise to
 practice the try-catch concept before the final quiz.
 One of our study participants who tried that version said,
-“When you have to do something for the first time during the test,
+"When you have to do something for the first time during the test,
 it doesn't feel good.
-Because I'm not confident that I'll get this part right.” 
+Because I'm not confident that I'll get this part right." 
 
 Second, exercises need to provide necessary scaffolds.
 When an exercise has multiple tasks,
@@ -544,10 +544,10 @@ they check the code examples less frequently.
 In the Futures codelab,
 all code examples and exercises are put on the same page.
 One of our study participants said,
-“I liked how I could be typing here but then also
-refer back to the examples to see where I should put stuff.”
+"I liked how I could be typing here but then also
+refer back to the examples to see where I should put stuff."
 
-Last, demos and exercises (or quizzes) shouldn’t be too similar,
+Last, demos and exercises (or quizzes) shouldn't be too similar,
 to avoid feeling redundant.
 Providing almost identical examples and exercises may confuse learners.
 Ultimately, they just copy and paste the code
@@ -555,9 +555,9 @@ instead of practicing on their own.
 In our initial prototype, the demos and the first exercise used
 a similar context and function names, `getUserOrder()` and `reportChange()`.
 One of our study participants said,
-“This exercise is slightly odd that they’re looking for
+"This exercise is slightly odd that they're looking for
 basically the exact same code as the example.
-I’m not sure what they’re asking me to do.”
+I'm not sure what they're asking me to do."
 We then improved this by changing the context of exercise to
 access control instead of ordering coffee.
 
@@ -578,9 +578,9 @@ and how to handle errors.
 Even though this section is not explicitly labeled as a quiz,
 learners may still consider it as a final assessment.
 As one of our study participants said,
-“Whenever you do like a tutorial and it's the final part,
+"Whenever you do like a tutorial and it's the final part,
 it's usually to me that means it's like a test of
-every single thing that you've written out and combining them.“
+every single thing that you've written out and combining them."
 
 <div class="col-md-9" markdown="1">
 <img 
@@ -596,7 +596,7 @@ every single thing that you've written out and combining them.“
 
 The problem in a quiz is usually a bit harder than
 the problem in an exercise and less guidance is provided.
-Compared to the previous “Exercise: Practice using async and await,”
+Compared to the previous "Exercise: Practice using async and await,"
 the partially completed code in the starting point for this quiz is minimized.
 Also, this quiz has no **Hint** button.
 
@@ -618,14 +618,14 @@ lower the learning curves, are easy to use, and are more engaging.
 If you write tutorials for Dart or Flutter,
 we encourage you to consider using DartPad to enhance your tutorial.
 
-“*Exercises are an excellent learning tool!!! Thank you!*”
+"*Exercises are an excellent learning tool!!! Thank you!*"
 
-“*I learn coding concepts the best when I have to
-think through the entire process versus just being handed the solution.*”
+"*I learn coding concepts the best when I have to
+think through the entire process versus just being handed the solution.*"
 
-“*I like the live coding parts are free form.
+"*I like the live coding parts are free form.
 As long as you get the return correct,
-being able to write how you write it is nice.*”
+being able to write how you write it is nice.*"
 
 [DartPad]: {{site.dartpad}}
 [new dp issue]: https://github.com/dart-lang/dart-pad/issues/new/choose

--- a/src/tools/linter-rules/index.md
+++ b/src/tools/linter-rules/index.md
@@ -20,7 +20,7 @@ how you might fix your code.
 
 {{site.alert.tip}}
   Linter rules (sometimes called _lints_) can have false positives,
-  and they don’t all agree with each other.
+  and they don't all agree with each other.
   For example, some rules are more appropriate for regular Dart packages,
   and others are designed for Flutter apps.
 {{site.alert.end}}
@@ -41,7 +41,7 @@ which the following packages provide:
   Or, better yet, use the `recommended` rule set, 
   a superset of `core` that identifies additional issues
   and enforces style and format. 
-  If you’re writing Flutter code, 
+  If you're writing Flutter code, 
   use the rule set in the [`flutter_lints`](#flutter_lints) package,
   which builds on `lints`.
 

--- a/src/tools/pub/automated-publishing.md
+++ b/src/tools/pub/automated-publishing.md
@@ -119,7 +119,7 @@ jobs:
 ```
 
 Make sure to match the pattern in `on.push.tags` with the _tag pattern_
-specified on pub.dev. Otherwise, the GitHub Action workflow won’t work.
+specified on pub.dev. Otherwise, the GitHub Action workflow won't work.
 If publishing multiple packages from the same repository, 
 use a per-package _tag pattern_ like `my_package_name-v{{version}}`
 and create a separate workflow file for each package.

--- a/src/tools/pub/cmd/index.md
+++ b/src/tools/pub/cmd/index.md
@@ -104,7 +104,7 @@ or any modification of the pubspec.
 
 The [`global`](/tools/pub/cmd/pub-global) subcommand lets you 
 make a package globally available, 
-so you can run scripts from that package’s `bin` directory.
+so you can run scripts from that package's `bin` directory.
 To run globally available scripts, you must
 [add the system cache `bin` directory to your path][add-path].
 

--- a/src/tools/pub/dependencies.md
+++ b/src/tools/pub/dependencies.md
@@ -409,7 +409,7 @@ are ignored by all users of your package.
 
 ## Best practices
 
-It’s important to actively manage your dependencies and
+It's important to actively manage your dependencies and
 ensure that your packages use the freshest versions possible.
 If any dependency is stale,
 then you might have not only a stale version of that package,

--- a/src/tutorials/server/get-started.md
+++ b/src/tutorials/server/get-started.md
@@ -11,8 +11,8 @@ nextpage:
 ---
 
 Follow these steps to start using the Dart SDK to develop command-line and server apps.
-First you’ll play with the Dart language in your browser, no download required.
-Then you’ll install the Dart SDK, write a small program, and run that program using the Dart VM.
+First you'll play with the Dart language in your browser, no download required.
+Then you'll install the Dart SDK, write a small program, and run that program using the Dart VM.
 Finally, you'll use an AOT (_ahead of time_) compiler to compile your finished program to native machine code,
 which you'll execute using the Dart runtime.
 


### PR DESCRIPTION
According to the [style guide](https://developers.google.com/style/quotation-marks#straight-and-curly-quotation-marks), straight quotation marks are preferred. On the site, we are currently inconsistent, resulting in changes between pages, some unmatched marks, and even a few incorrect code snippet. This PR fixes this by changing them all into their straight equivalents.