### PR TITLE
Remove and replace some explicit version mentions in Effective Dart

### DIFF
--- a/src/effective-dart/design.md
+++ b/src/effective-dart/design.md
@@ -1696,9 +1696,10 @@ it's deprecated.
 
 {% include linter-rule-mention.md rule="avoid_private_typedef_functions" %}
 
-In Dart 1, if you wanted to use a function type for a field, variable, or
-generic type argument, you had to first define a typedef for it. Dart 2 supports
-a function type syntax that can be used anywhere a type annotation is allowed:
+In Dart, if you want to use a function type for a field, variable, or
+generic type argument, you can define a typedef for the function type.
+However, Dart supports an inline function type syntax that
+can be used anywhere a type annotation is allowed:
 
 {:.good}
 <?code-excerpt "design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
@@ -1742,7 +1743,7 @@ type and parameter signature:
 Iterable<T> where(bool predicate(T element)) => ...
 {% endprettify %}
 
-Before Dart 2 added function type syntax, this was the only way to give a
+Before Dart added function type syntax, this was the only way to give a
 parameter a function type without defining a typedef. Now that Dart has a
 general notation for function types, you can use it for function-typed
 parameters as well:

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -1433,12 +1433,12 @@ class Point {
 
 {% include linter-rule-mention.md rule="unnecessary_new" %}
 
-Dart 2 makes the `new` keyword optional. Even in Dart 1, its meaning was never
-clear because factory constructors mean a `new` invocation may still not
-actually return a new object.
+The `new` keyword is optional when calling a constructor.
+Its meaning is not clear because factory constructors mean a
+`new` invocation may not actually return a new object.
 
-The language still permits `new` in order to make migration less painful, but
-consider it deprecated and remove it from your code.
+The language still permits `new`, but consider
+it deprecated and avoid using it in your code.
 
 {:.good}
 <?code-excerpt "usage_good.dart (no-new)"?>
@@ -1490,7 +1490,7 @@ expression inside:
 may support non-const default values.)
 
 Basically, any place where it would be an error to write `new` instead of
-`const`, Dart 2 allows you to omit the `const`.
+`const`, Dart allows you to omit the `const`.
 
 {:.good}
 <?code-excerpt "usage_good.dart (no-const)"?>


### PR DESCRIPTION
Now that we're in a Dart 3 world, the historical context or version isn't relevant for new developers reading these entries.

These guidelines could potentially be adjusted further, but this PR focuses on mostly avoiding the unnecessary version mentions.