### PR TITLE
Use fenced code blocks instead of prettify blocks in Effective Dart

### DIFF
--- a/src/_sass/core/_mixins.scss
+++ b/src/_sass/core/_mixins.scss
@@ -51,7 +51,9 @@
 
 @mixin dart-style-for($kind, $bg-color, $fg-color, $msg) {
   .#{$kind} {
-    background-color: $bg-color !important;
+    @if $bg-color != 'inherit' {
+      background-color: $bg-color !important;
+    }
     position: relative;
 
     &:after {
@@ -63,6 +65,12 @@
       top: 6px;
       left: 8px;
       color: $fg-color;
+    }
+  }
+
+  @if $bg-color != 'inherit' {
+    .#{$kind} pre {
+      background-color: $bg-color;
     }
   }
 }

--- a/src/effective-dart/design.md
+++ b/src/effective-dart/design.md
@@ -23,21 +23,21 @@ already exists outside your API that users are likely to know, follow that
 precedent.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 pageCount         // A field.
 updatePageCount() // Consistent with pageCount.
 toSomething()     // Consistent with Iterable's toList().
 asSomething()     // Consistent with List's asMap().
 Point             // A familiar concept.
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 renumberPages()      // Confusingly different from pageCount.
 convertToSomething() // Inconsistent with toX() precedent.
 wrappedAsSomething() // Inconsistent with asX() precedent.
 Cartesian            // Unfamiliar to most users.
-{% endprettify %}
+```
 
 The goal is to take advantage of what the user already knows. This includes
 their knowledge of the problem domain itself, the conventions of the core
@@ -54,20 +54,20 @@ abbreviate. If you do abbreviate, [capitalize it correctly][caps].
 [caps]: /effective-dart/style#identifiers
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 pageCount
 buildRectangles
 IOStream
 HttpRequest
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 numPages    // "Num" is an abbreviation of "number (of)".
 buildRects
 InputOutputStream
 HypertextTransferProtocolRequest
-{% endprettify %}
+```
 
 
 ### PREFER putting the most descriptive noun last
@@ -76,19 +76,19 @@ The last word should be the most descriptive of what the thing is. You can
 prefix it with other words, such as adjectives, to further describe the thing.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 pageCount             // A count (of pages).
 ConversionSink        // A sink for doing conversions.
 ChunkedConversionSink // A ConversionSink that's chunked.
 CssFontFaceRule       // A rule for font faces in CSS.
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 numPages                  // Not a collection of pages.
 CanvasRenderingContext2D  // Not a "2D".
 RuleFontFaceCss           // Not a CSS.
-{% endprettify %}
+```
 
 
 ### CONSIDER making the code read like a sentence
@@ -98,7 +98,7 @@ it like a sentence.
 
 {:.good}
 <?code-excerpt "design_good.dart (code-like-prose)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // "If errors is empty..."
 if (errors.isEmpty) ...
 
@@ -107,11 +107,11 @@ subscription.cancel();
 
 // "Get the monsters where the monster has claws."
 monsters.where((monster) => monster.hasClaws);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (code-like-prose)" replace="/ as bool//g"?>
-{% prettify dart tag=pre+code %}
+```dart
 // Telling errors to empty itself, or asking if it is?
 if (errors.empty) ...
 
@@ -120,7 +120,7 @@ subscription.toggle();
 
 // Filter the monsters with claws *out* or include *only* those?
 monsters.filter((monster) => monster.hasClaws);
-{% endprettify %}
+```
 
 It's helpful to try out your API and see how it "reads" when used in code, but
 you can go too far. It's not helpful to add articles and other parts of speech
@@ -128,11 +128,11 @@ to force your names to *literally* read like a grammatically correct sentence.
 
 {:.bad}
 <?code-excerpt "design_bad.dart (code-like-prose-overdone)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (theCollectionOfErrors.isEmpty) ...
 
 monsters.producesANewSequenceWhereEach((monster) => monster.hasClaws);
-{% endprettify %}
+```
 
 
 ### PREFER a noun phrase for a non-boolean property or variable
@@ -142,16 +142,16 @@ The reader's focus is on *what* the property is. If the user cares more about
 verb phrase name.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 list.length
 context.lineWidth
 quest.rampagingSwampBeast
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 list.deleteItems
-{% endprettify %}
+```
 
 
 ### PREFER a non-imperative verb phrase for a boolean property or variable
@@ -159,10 +159,10 @@ list.deleteItems
 Boolean names are often used as conditions in control flow, so you want a name
 that reads well there. Compare:
 
-{% prettify dart tag=pre+code %}
+```dart
 if (window.closeable) ...  // Adjective.
 if (window.canClose) ...   // Verb.
-{% endprettify %}
+```
 
 Good names tend to start with one of a few kinds of verbs:
 
@@ -188,24 +188,24 @@ object to do something, because accessing a property doesn't change the object.
 method.)
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 isEmpty
 hasElements
 canClose
 closesWindow
 canShowPopup
 hasShownPopup
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 empty         // Adjective or verb?
 withElements  // Sounds like it might hold elements.
 closeable     // Sounds like an interface.
               // "canClose" reads better as a sentence.
 closingWindow // Returns a bool or a window?
 showPopup     // Sounds like it shows the popup.
-{% endprettify %}
+```
 
 
 ### CONSIDER omitting the verb for a named boolean *parameter*
@@ -216,11 +216,11 @@ site.
 
 {:.good}
 <?code-excerpt "design_good.dart (omit-verb-for-bool-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Isolate.spawn(entryPoint, message, paused: false);
 var copy = List.from(elements, growable: true);
 var regExp = RegExp(pattern, caseSensitive: false);
-{% endprettify %}
+```
 
 
 ### PREFER the "positive" name for a boolean property or variable
@@ -240,19 +240,19 @@ understand what the code means.
 
 {:.good}
 <?code-excerpt "design_good.dart (positive)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (socket.isConnected && database.hasData) {
   socket.write(database.read());
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (positive)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (!socket.isDisconnected && !database.isEmpty) {
   socket.write(database.read());
 }
-{% endprettify %}
+```
 
 For some properties, there is no obvious positive form. Is a document that has
 been flushed to disk "saved" or "*un*-changed"? Is a document that *hasn't* been
@@ -277,11 +277,11 @@ clarifies the work the member performs.
 
 {:.good}
 <?code-excerpt "design_good.dart (verb-for-func-with-side-effect)"?>
-{% prettify dart tag=pre+code %}
+```dart
 list.add('element');
 queue.removeFirst();
 window.refresh();
-{% endprettify %}
+```
 
 This way, an invocation reads like a command to do that work.
 
@@ -300,11 +300,11 @@ member returns.
 
 {:.good}
 <?code-excerpt "design_good.dart (noun-for-func-returning-value)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var element = list.elementAt(3);
 var first = list.firstWhere(test);
 var char = string.codeUnitAt(4);
-{% endprettify %}
+```
 
 This guideline is deliberately softer than the previous one. Sometimes a method
 has no side effects but is still simpler to name with a verb phrase like
@@ -323,10 +323,10 @@ work.
 
 {:.good}
 <?code-excerpt "design_good.dart (verb-for-func-with-work)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var table = database.downloadData();
 var packageVersions = packageGraph.solveConstraints();
-{% endprettify %}
+```
 
 Note, though, that this guideline is softer than the previous two. The work an
 operation performs is often an implementation detail that isn't relevant to the
@@ -370,11 +370,11 @@ If you define a conversion method, it's helpful to follow that convention.
 
 {:.good}
 <?code-excerpt "design_good.dart (to___)"?>
-{% prettify dart tag=pre+code %}
+```dart
 list.toSet();
 stackTrace.toString();
 dateTime.toLocal();
-{% endprettify %}
+```
 
 
 ### PREFER naming a method `as___()` if it returns a different representation backed by the original object
@@ -390,11 +390,11 @@ The core library convention for you to follow is `as___()`.
 
 {:.good}
 <?code-excerpt "design_good.dart (as___)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var map = table.asMap();
 var list = bytes.asFloat32List();
 var future = subscription.asFuture();
-{% endprettify %}
+```
 
 
 ### AVOID describing the parameters in the function's or method's name
@@ -404,26 +404,26 @@ readability to also refer to it in the name itself.
 
 {:.good}
 <?code-excerpt "design_good.dart (avoid-desc-param-in-func)"?>
-{% prettify dart tag=pre+code %}
+```dart
 list.add(element);
 map.remove(key);
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 list.addElement(element)
 map.removeKey(key)
-{% endprettify %}
+```
 
 However, it can be useful to mention a parameter to disambiguate it from other
 similarly-named methods that take different types:
 
 {:.good}
 <?code-excerpt "design_good.dart (desc-param-in-func-ok)"?>
-{% prettify dart tag=pre+code %}
+```dart
 map.containsKey(key);
 map.containsValue(value);
-{% endprettify %}
+```
 
 
 ### DO follow existing mnemonic conventions when naming type parameters
@@ -436,23 +436,23 @@ The conventions are:
 
     {:.good}
     <?code-excerpt "design_good.dart (type-parameter-e)" replace="/\n\n/\n/g"?>
-    {% prettify dart tag=pre+code %}
+    ```dart
     class IterableBase<E> {}
     class List<E> {}
     class HashSet<E> {}
     class RedBlackTree<E> {}
-    {% endprettify %}
+    ```
 
 *   `K` and `V` for the **key** and **value** types in an associative
     collection:
 
     {:.good}
     <?code-excerpt "design_good.dart (type-parameter-k-v)" replace="/\n\n/\n/g"?>
-    {% prettify dart tag=pre+code %}
+    ```dart
     class Map<K, V> {}
     class Multimap<K, V> {}
     class MapEntry<K, V> {}
-    {% endprettify %}
+    ```
 
 *   `R` for a type used as the **return** type of a function or a class's
     methods. This isn't common, but appears in typedefs sometimes and in classes
@@ -460,13 +460,13 @@ The conventions are:
 
     {:.good}
     <?code-excerpt "design_good.dart (type-parameter-r)"?>
-    {% prettify dart tag=pre+code %}
+    ```dart
     abstract class ExpressionVisitor<R> {
       R visitBinary(BinaryExpression node);
       R visitLiteral(LiteralExpression node);
       R visitUnary(UnaryExpression node);
     }
-    {% endprettify %}
+    ```
 
 *   Otherwise, use `T`, `S`, and `U` for generics that have a single type
     parameter and where the surrounding type makes its meaning obvious. There
@@ -475,11 +475,11 @@ The conventions are:
 
     {:.good}
     <?code-excerpt "design_good.dart (type-parameter-t)"?>
-    {% prettify dart tag=pre+code %}
+    ```dart
     class Future<T> {
       Future<S> then<S>(FutureOr<S> onValue(T value)) => ...
     }
-    {% endprettify %}
+    ```
 
     Here, the generic method `then<S>()` uses `S` to avoid shadowing the `T`
     on `Future<T>`.
@@ -489,7 +489,7 @@ mnemonic name or a descriptive name is fine:
 
 {:.good}
 <?code-excerpt "design_good.dart (type-parameter-graph)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Graph<N, E> {
   final List<N> nodes = [];
   final List<E> edges = [];
@@ -499,7 +499,7 @@ class Graph<Node, Edge> {
   final List<Node> nodes = [];
   final List<Edge> edges = [];
 }
-{% endprettify %}
+```
 
 In practice, the existing conventions cover most type parameters.
 
@@ -560,17 +560,17 @@ just want a function.
 
 {:.good}
 <?code-excerpt "design_good.dart (one-member-abstract-class)"?>
-{% prettify dart tag=pre+code %}
+```dart
 typedef Predicate<E> = bool Function(E element);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (one-member-abstract-class)"?>
-{% prettify dart tag=pre+code %}
+```dart
 abstract class Predicate<E> {
   bool test(E element);
 }
-{% endprettify %}
+```
 
 
 ### AVOID defining a class that contains only static members
@@ -594,17 +594,17 @@ move it to a separate library that can be imported with a prefix.
 
 {:.good}
 <?code-excerpt "design_good.dart (class-only-static)"?>
-{% prettify dart tag=pre+code %}
+```dart
 DateTime mostRecent(List<DateTime> dates) {
   return dates.reduce((a, b) => a.isAfter(b) ? a : b);
 }
 
 const _favoriteMammal = 'weasel';
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (class-only-static)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class DateUtils {
   static DateTime mostRecent(List<DateTime> dates) {
     return dates.reduce((a, b) => a.isAfter(b) ? a : b);
@@ -614,7 +614,7 @@ class DateUtils {
 class _Favorites {
   static const mammal = 'weasel';
 }
-{% endprettify %}
+```
 
 In idiomatic Dart, classes define *kinds of objects*. A type that is never
 instantiated is a code smell.
@@ -624,7 +624,7 @@ natural to group them in a class.
 
 {:.good}
 <?code-excerpt "design_bad.dart (class-only-static-exception)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Color {
   static const red = '#f00';
   static const green = '#0f0';
@@ -632,7 +632,7 @@ class Color {
   static const black = '#000';
   static const white = '#fff';
 }
-{% endprettify %}
+```
 
 
 ### AVOID extending a class that isn't intended to be subclassed
@@ -704,7 +704,7 @@ intend to be used as a mixin, use this syntax.
 
 {:.good}
 <?code-excerpt "design_good.dart (mixin)"?>
-{% prettify dart tag=pre+code %}
+```dart
 mixin ClickableMixin implements Control {
   bool _isDown = false;
 
@@ -719,7 +719,7 @@ mixin ClickableMixin implements Control {
     _isDown = false;
   }
 }
-{% endprettify %}
+```
 
 You might still encounter older code using `class` to define mixins, but the new
 syntax is preferred.
@@ -820,10 +820,10 @@ as the caller knows. That implies:
     whose name is a verb describing what it does.
 
     {:.bad}
-    {% prettify dart tag=pre+code %}
+    ```dart
     connection.nextIncomingMessage; // Does network I/O.
     expression.normalForm; // Could be exponential to calculate.
-    {% endprettify %}
+    ```
 
 *   **The operation does not have user-visible side effects.** Accessing a real
     field does not alter the object or any other state in the program. It
@@ -836,10 +836,10 @@ as the caller knows. That implies:
     doesn't *care* about the side effect, it's probably fine.
 
     {:.bad}
-    {% prettify dart tag=pre+code %}
+    ```dart
     stdout.newline; // Produces output.
     list.clear; // Modifies object.
-    {% endprettify %}
+    ```
 
 *   **The operation is *idempotent*.** "Idempotent" is an odd word that, in this
     context, basically means that calling the operation multiple times produces
@@ -858,9 +858,9 @@ as the caller knows. That implies:
     caller cares about.*
 
     {:.bad}
-    {% prettify dart tag=pre+code %}
+    ```dart
     DateTime.now; // New result each time.
-    {% endprettify %}
+    ```
 
 *   **The resulting object doesn't expose all of the original object's state.**
     A field exposes only a piece of an object. If your operation returns a
@@ -876,12 +876,12 @@ operations just do some computation on some state and most of those can and
 should be getters.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 rectangle.area;
 collection.isEmpty;
 button.canShow;
 dataSet.minimumValue;
-{% endprettify %}
+```
 
 
 ### DO use setters for operations that conceptually change properties
@@ -905,10 +905,10 @@ For a setter, "field-like" means:
     call does nothing.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 rectangle.width = 3;
 button.visible = false;
-{% endprettify %}
+```
 
 
 ### DON'T define a setter without a corresponding getter
@@ -997,21 +997,21 @@ Method cascades are a better solution for chaining method calls.
 
 {:.good}
 <?code-excerpt "design_good.dart (cascades)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var buffer = StringBuffer()
   ..write('one')
   ..write('two')
   ..write('three');
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (cascades)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var buffer = StringBuffer()
     .write('one')
     .write('two')
     .write('three');
-{% endprettify %}
+```
 
 
 ## Types
@@ -1027,12 +1027,12 @@ the following example, `bool` and `String` are type annotations. They hang off
 the static declarative structure of the code and aren't "executed" at runtime.
 
 <?code-excerpt "design_good.dart (annotate-declaration)"?>
-{% prettify dart tag=pre+code %}
+```dart
 bool isEmpty(String parameter) {
   bool result = parameter.isEmpty;
   return result;
 }
-{% endprettify %}
+```
 
 A generic invocation is a collection literal, a call to a generic class's
 constructor, or an invocation of a generic method. In the next example, `num`
@@ -1041,19 +1041,19 @@ they are first-class entities that get reified and passed to the invocation at
 runtime.
 
 <?code-excerpt "design_good.dart (annotate-invocation)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var lists = <num>[1, 2];
 lists.addAll(List<num>.filled(3, 4));
 lists.cast<int>();
-{% endprettify %}
+```
 
 We stress the "generic invocation" part here, because type arguments can *also*
 appear in type annotations:
 
 <?code-excerpt "design_good.dart (annotate-type-arg)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<int> ints = [1, 2];
-{% endprettify %}
+```
 
 Here, `int` is a type argument, but it appears inside a type annotation, not a
 generic invocation. You usually don't need to worry about this distinction, but
@@ -1125,25 +1125,25 @@ initializer, inference fails.
 
 {:.good}
 <?code-excerpt "design_good.dart (uninitialized-local)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<AstNode> parameters;
 if (node is Constructor) {
   parameters = node.signature;
 } else if (node is Method) {
   parameters = node.parameters;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (uninitialized-local)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var parameters;
 if (node is Constructor) {
   parameters = node.signature;
 } else if (node is Method) {
   parameters = node.parameters;
 }
-{% endprettify %}
+```
 
 
 ### DO type annotate fields and top-level variables if the type isn't obvious
@@ -1156,26 +1156,26 @@ type error. Consider:
 
 {:.bad}
 <?code-excerpt "design_bad.dart (type_annotate_public_apis)"?>
-{% prettify dart tag=pre+code %}
+```dart
 install(id, destination) => ...
-{% endprettify %}
+```
 
 Here, it's unclear what `id` is. A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous? This is clearer:
 
 {:.good}
 <?code-excerpt "design_good.dart (type_annotate_public_apis)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<bool> install(PackageId id, String destination) => ...
-{% endprettify %}
+```
 
 In some cases, though, the type is so obvious that writing it is pointless:
 
 {:.good}
 <?code-excerpt "design_good.dart (inferred)"?>
-{% prettify dart tag=pre+code %}
+```dart
 const screenWidth = 640; // Inferred as int.
-{% endprettify %}
+```
 
 "Obvious" isn't precisely defined, but these are all good candidates:
 
@@ -1211,7 +1211,7 @@ more important *name* of the variable and its initialized value.
 
 {:.good}
 <?code-excerpt "design_good.dart (omit-types-on-locals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
   var desserts = <List<Ingredient>>[];
   for (final recipe in cookbook) {
@@ -1222,11 +1222,11 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 
   return desserts;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (omit-types-on-locals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
   List<List<Ingredient>> desserts = <List<Ingredient>>[];
   for (final List<Ingredient> recipe in cookbook) {
@@ -1237,7 +1237,7 @@ List<List<Ingredient>> possibleDesserts(Set<Ingredient> pantry) {
 
   return desserts;
 }
-{% endprettify %}
+```
 
 Sometimes the inferred type is not the type you want the variable to have. For
 example, you may intend to assign values of other types later. In that case,
@@ -1245,7 +1245,7 @@ annotate the variable with the type you want.
 
 {:.good}
 <?code-excerpt "design_good.dart (upcast-local)" replace="/Widget result/[!Widget!] result/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 Widget build(BuildContext context) {
   [!Widget!] result = Text('You won!');
   if (applyPadding) {
@@ -1253,7 +1253,7 @@ Widget build(BuildContext context) {
   }
   return result;
 }
-{% endprettify %}
+```
 
 
 ### DO annotate return types on function declarations
@@ -1264,19 +1264,19 @@ the return type yourself.
 
 {:.good}
 <?code-excerpt "design_good.dart (annotate-return-types)"?>
-{% prettify dart tag=pre+code %}
+```dart
 String makeGreeting(String who) {
   return 'Hello, $who!';
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (annotate-return-types)"?>
-{% prettify dart tag=pre+code %}
+```dart
 makeGreeting(String who) {
   return 'Hello, $who!';
 }
-{% endprettify %}
+```
 
 Note that this guideline only applies to *named* function declarations:
 top-level functions, methods, and local functions. Anonymous function
@@ -1293,23 +1293,23 @@ Dart doesn't infer an optional parameter's type from its default value.
 
 {:.good}
 <?code-excerpt "design_good.dart (annotate-parameters)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void sayRepeatedly(String message, {int count = 2}) {
   for (var i = 0; i < count; i++) {
     print(message);
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (annotate-parameters)" replace="/\(count as num\)/count/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 void sayRepeatedly(message, {count = 2}) {
   for (var i = 0; i < count; i++) {
     print(message);
   }
 }
-{% endprettify %}
+```
 
 **Exception:** Function expressions and initializing formals have
 different type annotation conventions, as described in the next two guidelines.
@@ -1329,15 +1329,15 @@ expects:
 
 {:.good}
 <?code-excerpt "design_good.dart (func-expr-no-param-type)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var names = people.map((person) => person.name);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (func-expr-no-param-type)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var names = people.map((Person person) => person.name);
-{% endprettify %}
+```
 
 If the language is able to infer the type you want for a parameter in a function
 expression, then don't annotate. In rare cases, the surrounding
@@ -1360,7 +1360,7 @@ the field or super-constructor parameter respectively.
 
 {:.good}
 <?code-excerpt "design_good.dart (dont-type-init-formals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(this.x, this.y);
@@ -1369,11 +1369,11 @@ class Point {
 class MyWidget extends StatelessWidget {
   MyWidget({super.key});
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (dont-type-init-formals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(double this.x, double this.y);
@@ -1382,7 +1382,7 @@ class Point {
 class MyWidget extends StatelessWidget {
   MyWidget({Key? super.key});
 }
-{% endprettify %}
+```
 
 
 ### DO write type arguments on generic invocations that aren't inferred
@@ -1395,17 +1395,17 @@ list explicitly.
 
 {:.good}
 <?code-excerpt "design_good.dart (non-inferred-type-args)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var playerScores = <String, int>{};
 final events = StreamController<Event>();
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (non-inferred-type-args)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var playerScores = {};
 final events = StreamController();
-{% endprettify %}
+```
 
 Sometimes the invocation occurs as the initializer to a variable declaration. If
 the variable is *not* local, then instead of writing the type argument list on the
@@ -1413,19 +1413,19 @@ invocation itself, you may put a type annotation on the declaration:
 
 {:.good}
 <?code-excerpt "design_good.dart (inferred-type-args)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Downloader {
   final Completer<String> response = Completer();
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (inferred-type-args)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Downloader {
   final response = Completer();
 }
-{% endprettify %}
+```
 
 Annotating the variable also addresses this guideline because now the type
 arguments *are* inferred.
@@ -1439,34 +1439,34 @@ Dart do the work for you.
 
 {:.good}
 <?code-excerpt "design_good.dart (redundant)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Downloader {
   final Completer<String> response = Completer();
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (redundant)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Downloader {
   final Completer<String> response = Completer<String>();
 }
-{% endprettify %}
+```
 
 Here, the type annotation on the field provides a surrounding context to infer
 the type argument of constructor call in the initializer.
 
 {:.good}
 <?code-excerpt "design_good.dart (explicit)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var items = Future.value([1, 2, 3]);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (explicit)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var items = Future<List<int>>.value(<int>[1, 2, 3]);
-{% endprettify %}
+```
 
 Here, the types of the collection and instance can be inferred bottom-up from
 their elements and arguments.
@@ -1481,10 +1481,10 @@ types". For example:
 
 {:.bad}
 <?code-excerpt "design_bad.dart (incomplete-generic)" replace="/List|Map/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 [!List!] numbers = [1, 2, 3];
 var completer = Completer<[!Map!]>();
-{% endprettify %}
+```
 
 Here, `numbers` has a type annotation, but the annotation doesn't provide a type
 argument to the generic `List`. Likewise, the `Map` type argument to `Completer`
@@ -1498,10 +1498,10 @@ argument inside some invocation, make sure to write a complete type:
 
 {:.good}
 <?code-excerpt "design_good.dart (incomplete-generic)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<num> numbers = [1, 2, 3];
 var completer = Completer<Map<String, int>>();
-{% endprettify %}
+```
 
 
 ### DO annotate with `dynamic` instead of letting inference fail
@@ -1518,21 +1518,21 @@ clear and highlight that this code has less static safety.
 
 {:.good}
 <?code-excerpt "design_good.dart (prefer-dynamic)"?>
-{% prettify dart tag=pre+code %}
+```dart
 dynamic mergeJson(dynamic original, dynamic changes) => ...
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (prefer-dynamic)"?>
-{% prettify dart tag=pre+code %}
+```dart
 mergeJson(original, changes) => ...
-{% endprettify %}
+```
 
 Note that it's OK to omit the type when Dart *successfully* infers `dynamic`.
 
 {:.good}
 <?code-excerpt "design_good.dart (infer-dynamic)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Map<String, dynamic> readJson() => ...
 
 void printUsers() {
@@ -1540,7 +1540,7 @@ void printUsers() {
   var users = json['users'];
   print(users);
 }
-{% endprettify %}
+```
 
 Here, Dart infers `Map<String, dynamic>` for `json` and then from that infers
 `dynamic` for `users`. It's fine to leave `users` without a type annotation. The
@@ -1574,15 +1574,15 @@ function.
 
 {:.good}
 <?code-excerpt "design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 bool isValid(String value, [!bool Function(String)!] test) => ...
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 bool isValid(String value, [!Function!] test) => ...
-{% endprettify %}
+```
 
 [fn syntax]: #prefer-inline-function-types-over-typedefs
 
@@ -1594,7 +1594,7 @@ no way to precisely type that and you'd normally have to use `dynamic`.
 
 {:.good}
 <?code-excerpt "design_good.dart (function-arity)" replace="/(void )?Function(\(.*?\))?/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 void handleError([!void Function()!] operation, [!Function!] errorHandler) {
   try {
     operation();
@@ -1608,7 +1608,7 @@ void handleError([!void Function()!] operation, [!Function!] errorHandler) {
     }
   }
 }
-{% endprettify %}
+```
 
 
 ### DON'T specify a return type for a setter
@@ -1619,15 +1619,15 @@ Setters always return `void` in Dart. Writing the word is pointless.
 
 {:.bad}
 <?code-excerpt "design_bad.dart (avoid_return_types_on_setters)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void set foo(Foo value) { ... }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "design_good.dart (avoid_return_types_on_setters)"?>
-{% prettify dart tag=pre+code %}
+```dart
 set foo(Foo value) { ... }
-{% endprettify %}
+```
 
 
 ### DON'T use the legacy typedef syntax
@@ -1639,9 +1639,9 @@ original syntax looks like:
 
 {:.bad}
 <?code-excerpt "design_bad.dart (old-typedef)"?>
-{% prettify dart tag=pre+code %}
+```dart
 typedef int Comparison<T>(T a, T b);
-{% endprettify %}
+```
 
 That syntax has a couple of problems:
 
@@ -1656,9 +1656,9 @@ That syntax has a couple of problems:
 
     {:.bad}
     <?code-excerpt "design_bad.dart (typedef-param)"?>
-    {% prettify dart tag=pre+code %}
+    ```dart
     typedef bool TestNumber(num);
-    {% endprettify %}
+    ```
 
     Most users expect this to be a function type that takes a `num` and returns
     `bool`. It is actually a function type that takes *any* object (`dynamic`)
@@ -1670,17 +1670,17 @@ The new syntax looks like this:
 
 {:.good}
 <?code-excerpt "design_good.dart (new-typedef)"?>
-{% prettify dart tag=pre+code %}
+```dart
 typedef Comparison<T> = int Function(T, T);
-{% endprettify %}
+```
 
 If you want to include a parameter's name, you can do that too:
 
 {:.good}
 <?code-excerpt "design_good.dart (new-typedef-param-name)"?>
-{% prettify dart tag=pre+code %}
+```dart
 typedef Comparison<T> = int Function(T a, T b);
-{% endprettify %}
+```
 
 The new syntax can express anything the old syntax could express and more, and
 lacks the error-prone misfeature where a single identifier is treated as the
@@ -1702,7 +1702,7 @@ a function type syntax that can be used anywhere a type annotation is allowed:
 
 {:.good}
 <?code-excerpt "design_good.dart (function-type)"  replace="/(bool|void) Function\(Event\)/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 class FilteredObservable {
   final [!bool Function(Event)!] _predicate;
   final List<[!void Function(Event)!]> _observers;
@@ -1721,7 +1721,7 @@ class FilteredObservable {
     return last;
   }
 }
-{% endprettify %}
+```
 
 It may still be worth defining a typedef if the function type is particularly
 long or frequently used. But in most cases, users want to see what the function
@@ -1738,9 +1738,9 @@ Sort of like in C, you surround the parameter's name with the function's return
 type and parameter signature:
 
 <?code-excerpt "design_bad.dart (function-type-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Iterable<T> where(bool predicate(T element)) => ...
-{% endprettify %}
+```
 
 Before Dart 2 added function type syntax, this was the only way to give a
 parameter a function type without defining a typedef. Now that Dart has a
@@ -1749,9 +1749,9 @@ parameters as well:
 
 {:.good}
 <?code-excerpt "design_good.dart (function-type-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Iterable<T> where(bool Function(T) predicate) => ...
-{% endprettify %}
+```
 
 The new syntax is a little more verbose, but is consistent with other locations
 where you must use the new syntax.
@@ -1778,7 +1778,7 @@ before you access it.
 
 {:.good}
 <?code-excerpt "design_good.dart (Object-vs-dynamic)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Returns a Boolean representation for [arg], which must
 /// be a String or bool.
 bool convertToBool(Object arg) {
@@ -1786,7 +1786,7 @@ bool convertToBool(Object arg) {
   if (arg is String) return arg.toLowerCase() == 'true';
   throw ArgumentError('Cannot convert $arg to a bool.');
 }
-{% endprettify %}
+```
 
 The main exception to this rule is when working with existing APIs that use
 `dynamic`, especially inside a generic type. For example, JSON objects have type
@@ -1830,18 +1830,18 @@ either is hard to use correctly.
 
 {:.good}
 <?code-excerpt "design_good.dart (future-or)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<int> triple(FutureOr<int> value) async => (await value) * 3;
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (future-or)"?>
-{% prettify dart tag=pre+code %}
+```dart
 FutureOr<int> triple(FutureOr<int> value) {
   if (value is int) return value * 3;
   return value.then((v) => v * 3);
 }
-{% endprettify %}
+```
 
 The more precise formulation of this guideline is to *only use `FutureOr<T>` in
 [contravariant][] positions.* Parameters are contravariant and return types are
@@ -1854,14 +1854,14 @@ means it's OK for a *callback's* type to return `FutureOr<T>`:
 
 {:.good}
 <?code-excerpt "design_good.dart (future-or-contra)" replace="/FutureOr.S./[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 Stream<S> asyncMap<T, S>(
     Iterable<T> iterable, [!FutureOr<S>!] Function(T) callback) async* {
   for (final element in iterable) {
     yield await callback(element);
   }
 }
-{% endprettify %}
+```
 
 
 ## Parameters
@@ -1879,33 +1879,33 @@ numbers are usually wrapped in named constants, but we typically pass around
 clear what the boolean represents:
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 new Task(true);
 new Task(false);
 new ListBox(false, true, true);
 new Button(false);
-{% endprettify %}
+```
 
 Instead, prefer using named arguments, named constructors, or named constants
 to clarify what the call is doing.
 
 {:.good}
 <?code-excerpt "design_good.dart (avoid-positional-bool-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Task.oneShot();
 Task.repeating();
 ListBox(scroll: true, showScrollbars: true);
 Button(ButtonState.enabled);
-{% endprettify %}
+```
 
 Note that this doesn't apply to setters, where the name makes it clear what the
 value represents:
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 listBox.canScroll = true;
 button.isEnabled = false;
-{% endprettify %}
+```
 
 
 ### AVOID optional positional parameters if the user may want to omit earlier parameters
@@ -1917,7 +1917,7 @@ pass later one. You're better off using named arguments for that.
 
 {:.good}
 <?code-excerpt "design_good.dart (omit-optional-positional)"?>
-{% prettify dart tag=pre+code %}
+```dart
 String.fromCharCodes(Iterable<int> charCodes, [int start = 0, int? end]);
 
 DateTime(int year,
@@ -1936,7 +1936,7 @@ Duration(
     int seconds = 0,
     int milliseconds = 0,
     int microseconds = 0});
-{% endprettify %}
+```
 
 
 ### AVOID mandatory parameters that accept a special "no argument" value
@@ -1951,15 +1951,15 @@ providing a real value.
 
 {:.good}
 <?code-excerpt "design_good.dart (avoid-mandatory-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var rest = string.substring(start);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (avoid-mandatory-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var rest = string.substring(start, null);
-{% endprettify %}
+```
 
 
 ### DO use inclusive start and exclusive end parameters to accept a range
@@ -1973,10 +1973,10 @@ This is consistent with core libraries that do the same thing.
 
 {:.good}
 <?code-excerpt "../../test/effective_dart_test.dart (param-range)" replace="/expect\(//g; /, \/\*\*\// \/\//g; /\);//g"?>
-{% prettify dart tag=pre+code %}
+```dart
 [0, 1, 2, 3].sublist(1, 3) // [1, 2]
 'abcd'.substring(1, 3) // 'bc'
-{% endprettify %}
+```
 
 It's particularly important to be consistent here because these parameters are
 usually unnamed. If your API takes a length instead of an end point, the
@@ -2039,18 +2039,18 @@ method is called only if the right-hand side is not `null`.
 
 {:.good}
 <?code-excerpt "design_good.dart (eq-dont-check-for-null)" plaster?>
-{% prettify dart tag=pre+code %}
+```dart
 class Person {
   final String name;
   // ···
 
   bool operator ==(Object other) => other is Person && name == other.name;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "design_bad.dart (eq-dont-check-for-null)" replace="/Object\?/[!$&!]/g" plaster?>
-{% prettify dart tag=pre+code %}
+```dart
 class Person {
   final String name;
   // ···
@@ -2058,5 +2058,5 @@ class Person {
   bool operator ==([!Object?!] other) =>
       other != null && other is Person && name == other.name;
 }
-{% endprettify %}
+```
 

--- a/src/effective-dart/documentation.md
+++ b/src/effective-dart/documentation.md
@@ -31,10 +31,10 @@ generated documentation.
 
 {:.good}
 <?code-excerpt "docs_good.dart (comments-like-sentences)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // Not if anything comes before it.
 if (_chunks.isNotEmpty) return false;
-{% endprettify %}
+```
 
 Capitalize the first word unless it's a case-sensitive identifier. End it with a
 period (or "!" or "?", I suppose). This is true for all comments: doc comments,
@@ -44,21 +44,21 @@ inline stuff, even TODOs. Even if it's a sentence fragment.
 
 {:.good}
 <?code-excerpt "docs_good.dart (block-comments)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void greet(String name) {
   // Assume we have a valid name.
   print('Hi, $name!');
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (block-comments)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void greet(String name) {
   /* Assume we have a valid name. */
   print('Hi, $name!');
 }
-{% endprettify %}
+```
 
 You can use a block comment (`/* ... */`) to temporarily comment out a section
 of code, but all other comments should use `//`.
@@ -83,17 +83,17 @@ and generate documentation for it.
 
 {:.good}
 <?code-excerpt "docs_good.dart (use-doc-comments)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// The number of characters in this chunk when unsplit.
 int get length => ...
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_good.dart (use-doc-comments)" replace="/^\///g"?>
-{% prettify dart tag=pre+code %}
+```dart
 // The number of characters in this chunk when unsplit.
 int get length => ...
-{% endprettify %}
+```
 
 For historical reasons, `dart doc` supports two syntaxes of doc comments: `///`
 ("C# style") and `/** ... */` ("JavaDoc style"). We prefer `///` because it's
@@ -131,11 +131,11 @@ at the start of the file.
 
 {:.good}
 <?code-excerpt "docs_good.dart (library-doc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// A really great test library.
 @TestOn('browser')
 library;
-{% endprettify %}
+```
 
 ### CONSIDER writing doc comments for private APIs
 
@@ -152,16 +152,16 @@ elsewhere for the solution to their problem.
 
 {:.good}
 <?code-excerpt "docs_good.dart (first-sentence)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Deletes the file at [path] from the file system.
 void delete(String path) {
   ...
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (first-sentence)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Depending on the state of the file system and the user's permissions,
 /// certain operations may or may not be possible. If there is no file at
 /// [path] or it can't be accessed, this function throws either [IOError]
@@ -169,7 +169,7 @@ void delete(String path) {
 void delete(String path) {
   ...
 }
-{% endprettify %}
+```
 
 ### DO separate the first sentence of a doc comment into its own paragraph
 
@@ -183,7 +183,7 @@ like lists of classes and members.
 
 {:.good}
 <?code-excerpt "docs_good.dart (first-sentence-a-paragraph)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Deletes the file at [path].
 ///
 /// Throws an [IOError] if the file could not be found. Throws a
@@ -191,18 +191,18 @@ like lists of classes and members.
 void delete(String path) {
   ...
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (first-sentence-a-paragraph)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Deletes the file at [path]. Throws an [IOError] if the file could not
 /// be found. Throws a [PermissionError] if the file is present but could
 /// not be deleted.
 void delete(String path) {
   ...
 }
-{% endprettify %}
+```
 
 ### AVOID redundancy with the surrounding context
 
@@ -214,7 +214,7 @@ spelled out in the doc comment. Instead, focus on explaining what the reader
 
 {:.good}
 <?code-excerpt "docs_good.dart (redundant)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class RadioButtonWidget extends Widget {
   /// Sets the tooltip to [lines], which should have been word wrapped using
   /// the current font.
@@ -222,11 +222,11 @@ class RadioButtonWidget extends Widget {
     ...
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (redundant)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class RadioButtonWidget extends Widget {
   /// Sets the tooltip for this radio button widget to the list of strings in
   /// [lines].
@@ -234,7 +234,7 @@ class RadioButtonWidget extends Widget {
     ...
   }
 }
-{% endprettify %}
+```
 
 If you really don't have anything interesting to say
 that can't be inferred from the declaration itself,
@@ -249,7 +249,7 @@ The doc comment should focus on what the code *does*.
 
 {:.good}
 <?code-excerpt "docs_good.dart (third-person)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Returns `true` if every element satisfies the [predicate].
 bool all(bool predicate(T element)) => ...
 
@@ -257,7 +257,7 @@ bool all(bool predicate(T element)) => ...
 void start() {
   ...
 }
-{% endprettify %}
+```
 
 ### PREFER starting a non-boolean variable or property comment with a noun phrase
 
@@ -267,13 +267,13 @@ the *result* of that work, not the work itself.
 
 {:.good}
 <?code-excerpt "docs_good.dart (noun-phrases-for-non-boolean-var-etc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// The current day of the week, where `0` is Sunday.
 int weekday;
 
 /// The number of checked buttons on the page.
 int get checkedCount => ...
-{% endprettify %}
+```
 
 ### PREFER starting a boolean variable or property comment with "Whether" followed by a noun or gerund phrase
 
@@ -283,7 +283,7 @@ What the caller cares about is the *result* of that work, not the work itself.
 
 {:.good}
 <?code-excerpt "docs_good.dart (noun-phrases-for-boolean-var-etc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Whether the modal is currently displayed to the user.
 bool isVisible;
 
@@ -292,7 +292,7 @@ bool get shouldConfirm => ...
 
 /// Whether resizing the current browser window will also resize the modal.
 bool get canResize => ...
-{% endprettify %}
+```
 
 {{site.alert.note}}
   This guideline intentionally doesn't include using "Whether or not". In many
@@ -309,23 +309,23 @@ and if both the getter and the setter have doc comments, then
 
 {:.good}
 <?code-excerpt "docs_good.dart (getter-and-setter)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// The pH level of the water in the pool.
 ///
 /// Ranges from 0-14, representing acidic to basic, with 7 being neutral.
 int get phLevel => ...
 set phLevel(int level) => ...
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (getter-and-setter)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// The depth of the water in the pool, in meters.
 int get waterDepth => ...
 
 /// Updates the water depth to a total of [meters] in height.
 set waterDepth(int meters) => ...
-{% endprettify %}
+```
 
 ### PREFER starting library or type comments with noun phrases
 
@@ -336,25 +336,25 @@ extra effort here can make all of the other members simpler to document.
 
 {:.good}
 <?code-excerpt "docs_good.dart (noun-phrases-for-type-or-lib)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// A chunk of non-breaking output text terminated by a hard or soft newline.
 ///
 /// ...
 class Chunk { ... }
-{% endprettify %}
+```
 
 ### CONSIDER including code samples in doc comments
 
 {:.good}
 <?code-excerpt "docs_good.dart (code-sample)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Returns the lesser of two numbers.
 ///
 /// ```dart
 /// min(5, 3) == 3
 /// ```
 num min(num a, num b) => ...
-{% endprettify %}
+```
 
 Humans are great at generalizing from examples, so even a single code sample
 makes an API easier to learn.
@@ -370,28 +370,28 @@ but can make it clearer when you're referring to a method or constructor.
 
 {:.good}
 <?code-excerpt "docs_good.dart (identifiers)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Throws a [StateError] if ...
 /// similar to [anotherMethod()], but ...
-{% endprettify %}
+```
 
 To link to a member of a specific class, use the class name and member name,
 separated by a dot:
 
 {:.good}
 <?code-excerpt "docs_good.dart (member)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Similar to [Duration.inDays], but handles fractional days.
-{% endprettify %}
+```
 
 The dot syntax can also be used to refer to named constructors. For the unnamed
 constructor, use `.new` after the class name:
 
 {:.good}
 <?code-excerpt "docs_good.dart (ctor)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// To create a point, call [Point.new] or use [Point.polar] to ...
-{% endprettify %}
+```
 
 ### DO use prose to explain parameters, return values, and exceptions
 
@@ -400,7 +400,7 @@ and returns of a method are.
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (no-annotations)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Defines a flag with the given name and abbreviation.
 ///
 /// @param name The name of the flag.
@@ -409,38 +409,38 @@ and returns of a method are.
 /// @throws ArgumentError If there is already an option with
 ///     the given name or abbreviation.
 Flag addFlag(String name, String abbr) => ...
-{% endprettify %}
+```
 
 The convention in Dart is to integrate that into the description of the method
 and highlight parameters using square brackets.
 
 {:.good}
 <?code-excerpt "docs_good.dart (no-annotations)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// Defines a flag.
 ///
 /// Throws an [ArgumentError] if there is already an option named [name] or
 /// there is already an option using abbreviation [abbr]. Returns the new flag.
 Flag addFlag(String name, String abbr) => ...
-{% endprettify %}
+```
 
 ### DO put doc comments before metadata annotations
 
 {:.good}
 <?code-excerpt "docs_good.dart (doc-before-meta)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// A button that can be flipped on and off.
 @Component(selector: 'toggle')
 class ToggleComponent {}
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "docs_bad.dart (doc-before-meta)" replace="/\n\n/\n/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 @Component(selector: 'toggle')
 /// A button that can be flipped on and off.
 class ToggleComponent {}
-{% endprettify %}
+```
 
 
 ## Markdown
@@ -456,7 +456,7 @@ universal popularity is why we chose it. Here's just a quick example to give you
 a flavor of what's supported:
 
 <?code-excerpt "docs_good.dart (markdown)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// This is a paragraph of regular text.
 ///
 /// This sentence has *two* _emphasized_ words (italics) and **two**
@@ -507,7 +507,7 @@ a flavor of what's supported:
 /// ### A subsubheader
 ///
 /// #### If you need this many levels of headers, you're doing it wrong
-{% endprettify %}
+```
 
 ### AVOID using markdown excessively
 
@@ -532,22 +532,22 @@ The backtick syntax avoids those indentation woes, lets you indicate the code's
 language, and is consistent with using backticks for inline code.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 /// You can use [CodeBlockExample] like this:
 ///
 /// ```dart
 /// var example = CodeBlockExample();
 /// print(example.isItGreat); // "Yes."
 /// ```
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 /// You can use [CodeBlockExample] like this:
 ///
 ///     var example = CodeBlockExample();
 ///     print(example.isItGreat); // "Yes."
-{% endprettify %}
+```
 
 ## Writing
 
@@ -577,7 +577,7 @@ object the member is being called on. Using "the" can be ambiguous.
 
 {:.good}
 <?code-excerpt "docs_good.dart (this)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   /// The value this wraps.
   Object? _value;
@@ -585,4 +585,4 @@ class Box {
   /// True if this box contains a value.
   bool get hasValue => _value != null;
 }
-{% endprettify %}
+```

--- a/src/effective-dart/documentation.md
+++ b/src/effective-dart/documentation.md
@@ -347,14 +347,14 @@ class Chunk { ... }
 
 {:.good}
 <?code-excerpt "docs_good.dart (code-sample)"?>
-```dart
+{% prettify dart tag=pre+code %}
 /// Returns the lesser of two numbers.
 ///
 /// ```dart
 /// min(5, 3) == 3
 /// ```
 num min(num a, num b) => ...
-```
+{% endprettify %}
 
 Humans are great at generalizing from examples, so even a single code sample
 makes an API easier to learn.
@@ -456,7 +456,7 @@ universal popularity is why we chose it. Here's just a quick example to give you
 a flavor of what's supported:
 
 <?code-excerpt "docs_good.dart (markdown)"?>
-```dart
+{% prettify dart tag=pre+code %}
 /// This is a paragraph of regular text.
 ///
 /// This sentence has *two* _emphasized_ words (italics) and **two**
@@ -507,7 +507,7 @@ a flavor of what's supported:
 /// ### A subsubheader
 ///
 /// #### If you need this many levels of headers, you're doing it wrong
-```
+{% endprettify %}
 
 ### AVOID using markdown excessively
 

--- a/src/effective-dart/style.md
+++ b/src/effective-dart/style.md
@@ -42,19 +42,19 @@ letter of each word (including the first word), and use no separators.
 
 {:.good}
 <?code-excerpt "style_good.dart (type-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class SliderMenu { ... }
 
 class HttpRequest { ... }
 
 typedef Predicate<T> = bool Function(T value);
-{% endprettify %}
+```
 
 This even includes classes intended to be used in metadata annotations.
 
 {:.good}
 <?code-excerpt "style_good.dart (annotation-type-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Foo {
   const Foo([Object? arg]);
 }
@@ -64,19 +64,19 @@ class A { ... }
 
 @Foo()
 class B { ... }
-{% endprettify %}
+```
 
 If the annotation class's constructor takes no parameters, you might want to
 create a separate `lowerCamelCase` constant for it.
 
 {:.good}
 <?code-excerpt "style_good.dart (annotation-const)"?>
-{% prettify dart tag=pre+code %}
+```dart
 const foo = Foo();
 
 @foo
 class C { ... }
-{% endprettify %}
+```
 
 ### DO name extensions using `UpperCamelCase`
 
@@ -88,11 +88,11 @@ and use no separators.
 
 {:.good}
 <?code-excerpt "style_good.dart (extension-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 extension MyFancyList<T> on List<T> { ... }
 
 extension SmartIterable<T> on Iterable<T> { ... }
-{% endprettify %}
+```
 
 [extensions]: /language/extension-methods
 
@@ -132,19 +132,19 @@ mypackage
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (import-as)" replace="/(package):examples\/effective_dart\/foo.dart[^']*/$1:angular_components\/angular_components.dart/g; /(package):examples\/effective_dart\/bar.dart[^']*/$1:js\/js.dart/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'dart:math' as math;
 import 'package:angular_components/angular_components.dart' as angular_components;
 import 'package:js/js.dart' as js;
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "style_lib_good.dart (import-as)" replace="/(package):examples\/effective_dart\/foo.dart[^']*/$1:angular_components\/angular_components.dart/g; /as angular_components/as angularComponents/g; /(package):examples\/effective_dart\/bar.dart[^']*/$1:js\/js.dart/g; / math/ Math/g;/as js/as JS/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'dart:math' as Math;
 import 'package:angular_components/angular_components.dart' as angularComponents;
 import 'package:js/js.dart' as JS;
-{% endprettify %}
+```
 
 
 ### DO name other identifiers using `lowerCamelCase`
@@ -157,7 +157,7 @@ word, and use no separators.
 
 {:.good}
 <?code-excerpt "style_good.dart (misc-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var count = 3;
 
 HttpRequest httpRequest;
@@ -165,7 +165,7 @@ HttpRequest httpRequest;
 void align(bool clearItems) {
   // ...
 }
-{% endprettify %}
+```
 
 
 ### PREFER using `lowerCamelCase` for constant names
@@ -176,7 +176,7 @@ In new code, use `lowerCamelCase` for constant variables, including enum values.
 
 {:.good}
 <?code-excerpt "style_good.dart (const-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 const pi = 3.14;
 const defaultTimeout = 1000;
 final urlScheme = RegExp('^([a-z]+):');
@@ -184,11 +184,11 @@ final urlScheme = RegExp('^([a-z]+):');
 class Dice {
   static final numberGenerator = Random();
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "style_bad.dart (const-names)"?>
-{% prettify dart tag=pre+code %}
+```dart
 const PI = 3.14;
 const DefaultTimeout = 1000;
 final URL_SCHEME = RegExp('^([a-z]+):');
@@ -196,7 +196,7 @@ final URL_SCHEME = RegExp('^([a-z]+):');
 class Dice {
   static final NUMBER_GENERATOR = Random();
 }
-{% endprettify %}
+```
 
 You may use `SCREAMING_CAPS` for consistency with existing code,
 as in the following cases:
@@ -234,7 +234,7 @@ capitalized: `IO`. On the other hand, two-letter *abbreviations* like
 ID (identification) are still capitalized like regular words: `Id`.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 class HttpConnection {}
 class DBIOPort {}
 class TVVcr {}
@@ -244,10 +244,10 @@ var httpRequest = ...
 var uiHandler = ...
 var userId = ...
 Id id;
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 class HTTPConnection {}
 class DbIoPort {}
 class TvVcr {}
@@ -257,7 +257,7 @@ var hTTPRequest = ...
 var uIHandler = ...
 var userID = ...
 ID iD;
-{% endprettify %}
+```
 
 
 ### PREFER using `_`, `__`, etc. for unused callback parameters
@@ -270,11 +270,11 @@ underscores to avoid name collisions: `__`, `___`, etc.
 
 {:.good}
 <?code-excerpt "style_good.dart (unused-callback-params)"?>
-{% prettify dart tag=pre+code %}
+```dart
 futureOfVoid.then((_) {
   print('Operation complete.');
 });
-{% endprettify %}
+```
 
 This guideline is only for functions that are both *anonymous and local*.
 These functions are usually used immediately in a context where it's
@@ -305,14 +305,14 @@ mutability, and other properties of your declarations, there's no reason to
 encode those properties in identifier names.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 defaultTimeout
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 kDefaultTimeout
-{% endprettify %}
+```
 
 ### DON'T explicitly name libraries
 
@@ -327,18 +327,18 @@ the main library file in question.
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (library-dir)"?>
-{% prettify dart tag=pre+code %}
+```dart
 
 library my_library;
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "docs_good.dart (library-doc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 /// A really great test library.
 @TestOn('browser')
 library;
-{% endprettify %}
+```
 
 ## Ordering
 
@@ -355,13 +355,13 @@ A single linter rule handles all the ordering guidelines:
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (dart-import-first)" replace="/\w+\/effective_dart\///g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'dart:async';
 import 'dart:html';
 
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
-{% endprettify %}
+```
 
 
 ### DO place `package:` imports before relative imports
@@ -370,12 +370,12 @@ import 'package:foo/foo.dart';
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (pkg-import-before-local)" replace="/\w+\/effective_dart\///g;/'foo/'util/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
 
 import 'util.dart';
-{% endprettify %}
+```
 
 
 ### DO specify exports in a separate section after all imports
@@ -384,20 +384,20 @@ import 'util.dart';
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (export)"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'src/error.dart';
 import 'src/foo_bar.dart';
 
 export 'src/error.dart';
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "style_lib_bad.dart (export)"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'src/error.dart';
 export 'src/error.dart';
 import 'src/foo_bar.dart';
-{% endprettify %}
+```
 
 
 ### DO sort sections alphabetically
@@ -406,23 +406,23 @@ import 'src/foo_bar.dart';
 
 {:.good}
 <?code-excerpt "style_lib_good.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
 
 import 'foo.dart';
 import 'foo/foo.dart';
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "style_lib_bad.dart (sorted)" replace="/\w+\/effective_dart\///g"?>
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:foo/foo.dart';
 import 'package:bar/bar.dart';
 
 import 'foo/foo.dart';
 import 'foo.dart';
-{% endprettify %}
+```
 
 
 ## Formatting
@@ -497,36 +497,36 @@ Doing so avoids the [dangling else][] problem.
 
 {:.good}
 <?code-excerpt "style_good.dart (curly-braces)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (isWeekDay) {
   print('Bike to work!');
 } else {
   print('Go dancing or read a book!');
 }
-{% endprettify %}
+```
 
 **Exception:** When you have an `if` statement with no `else` clause and the
 whole `if` statement fits on one line, you can omit the braces if you prefer:
 
 {:.good}
 <?code-excerpt "style_good.dart (one-line-if)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (arg == null) return defaultValue;
-{% endprettify %}
+```
 
 If the body wraps to the next line, though, use braces:
 
 {:.good}
 <?code-excerpt "style_good.dart (one-line-if-wrap)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (overflowChars != other.overflowChars) {
   return overflowChars < other.overflowChars;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "style_bad.dart (one-line-if-wrap)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (overflowChars != other.overflowChars)
   return overflowChars < other.overflowChars;
-{% endprettify %}
+```

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -42,27 +42,27 @@ directly to the library file.
 If you have some library, `my_library.dart`, that contains:
 
 <?code-excerpt "my_library.dart"?>
-{% prettify dart tag=pre+code %}
+```dart
 library my_library;
 
 part 'some/other/file.dart';
-{% endprettify %}
+```
 
 Then the part file should use the library file's URI string:
 
 {:.good}
 <?code-excerpt "some/other/file.dart"?>
-{% prettify dart tag=pre+code %}
+```dart
 part of '../../my_library.dart';
-{% endprettify %}
+```
 
 Not the library name:
 
 {:.bad}
 <?code-excerpt "some/other/file_2.dart"?>
-{% prettify dart tag=pre+code %}
+```dart
 part of my_library;
-{% endprettify %}
+```
 
 ### DON'T import libraries that are inside the `src` directory of another package
 
@@ -108,10 +108,10 @@ my_package
 And say `api_test.dart` imports `api.dart` in two ways:
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:my_package/api.dart';
 import '../lib/api.dart';
-{% endprettify %}
+```
 
 Dart thinks those are imports of two completely unrelated libraries.
 To avoid confusing Dart and yourself, follow these two rules:
@@ -125,9 +125,9 @@ or any other top-level directory),
 use a `package:` import.
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:my_package/api.dart';
-{% endprettify %}
+```
 
 A package should never reach *out* of its `lib` directory and
 import libraries from other places in the package.
@@ -159,27 +159,27 @@ Here is how the various libraries should import each other:
 **lib/api.dart:**
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 import 'src/stuff.dart';
 import 'src/utils.dart';
-{% endprettify %}
+```
 
 **lib/src/utils.dart:**
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 import '../api.dart';
 import 'stuff.dart';
-{% endprettify %}
+```
 
 **test/api_test.dart:**
 
 {:.good}
-{% prettify dart tag=pre+code %}
+```dart
 import 'package:my_package/api.dart'; // Don't reach into 'lib'.
 
 import 'test_utils.dart'; // Relative within 'test' is fine.
-{% endprettify %}
+```
 
 
 ## Null
@@ -197,7 +197,7 @@ variable to `null` to be "safe".
 
 {:.good}
 <?code-excerpt "usage_good.dart (no-null-init)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Item? bestDeal(List<Item> cart) {
   Item? bestItem;
 
@@ -209,11 +209,11 @@ Item? bestDeal(List<Item> cart) {
 
   return bestItem;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (no-null-init)" replace="/ = null/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 Item? bestDeal(List<Item> cart) {
   Item? bestItem[! = null!];
 
@@ -225,7 +225,7 @@ Item? bestDeal(List<Item> cart) {
 
   return bestItem;
 }
-{% endprettify %}
+```
 
 
 ### DON'T use an explicit default value of `null`
@@ -237,19 +237,19 @@ language implicitly uses `null` as the default, so there's no need to write it.
 
 {:.good}
 <?code-excerpt "usage_good.dart (default-value-null)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void error([String? message]) {
   stderr.write(message ?? '\n');
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (default-value-null)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void error([String? message = null]) {
   stderr.write(message ?? '\n');
 }
-{% endprettify %}
+```
 
 <a id="prefer-using--to-convert-null-to-a-boolean-value"></a>
 ### DON'T use `true` or `false` in equality operations
@@ -261,43 +261,43 @@ and use the unary negation operator `!` if necessary:
 
 {:.good}
 <?code-excerpt "usage_good.dart (non-null-boolean-expression)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (nonNullableBool) { ... }
 
 if (!nonNullableBool) { ... }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (non-null-boolean-expression)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (nonNullableBool == true) { ... }
 
 if (nonNullableBool == false) { ... }
-{% endprettify %}
+```
 
 To evaluate a boolean expression that *is nullable*, you should use `??`
 or an explicit `!= null` check.
 
 {:.good}
 <?code-excerpt "usage_good.dart (nullable-boolean-expression)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // If you want null to result in false:
 if (nullableBool ?? false) { ... }
 
 // If you want null to result in false
 // and you want the variable to type promote:
 if (nullableBool != null && nullableBool) { ... }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (nullable-boolean-expression)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // Static error if null:
 if (nullableBool) { ... }
 
 // If you want null to be false:
 if (nullableBool == true) { ... }
-{% endprettify %}
+```
 
 `nullableBool == true` is a viable expression, 
 but shouldn't be used for several reasons:
@@ -360,7 +360,7 @@ it as non-nullable.
 
 {:.good}
 <?code-excerpt "usage_good.dart (shadow-nullable-field)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class UploadException {
   final Response? response;
 
@@ -377,14 +377,14 @@ class UploadException {
     return 'Could not upload (no response).';
   }
 }
-{% endprettify %}
+```
 
 Assigning to a local variable can be cleaner and safer than using `!` every
 place the field or top-level variable is used:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>
-{% prettify dart tag=pre+code %}
+```dart
 class UploadException {
   final Response? response;
 
@@ -400,7 +400,7 @@ class UploadException {
     return 'Could not upload (no response).';
   }
 }
-{% endprettify %}
+```
 
 Be careful when using a local variable. If you need to write back to the field,
 make sure that you don't write back to the local variable instead. (Making the
@@ -424,17 +424,17 @@ a single long string that doesn't fit on one line.
 
 {:.good}
 <?code-excerpt "usage_good.dart (adjacent-strings-literals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 raiseAlarm('ERROR: Parts of the spaceship are on fire. Other '
     'parts are overrun by martians. Unclear which are which.');
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (adjacent-strings-literals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 raiseAlarm('ERROR: Parts of the spaceship are on fire. Other ' +
     'parts are overrun by martians. Unclear which are which.');
-{% endprettify %}
+```
 
 ### PREFER using interpolation to compose strings and values
 
@@ -446,15 +446,15 @@ it's almost always cleaner and shorter to use interpolation:
 
 {:.good}
 <?code-excerpt "usage_good.dart (string-interpolation)"?>
-{% prettify dart tag=pre+code %}
+```dart
 'Hello, $name! You are ${year - birth} years old.';
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (string-interpolation)"?>
-{% prettify dart tag=pre+code %}
+```dart
 'Hello, ' + name + '! You are ' + (year - birth).toString() + ' y...';
-{% endprettify %}
+```
 
 Note that this guideline applies to combining *multiple* literals and values.
 It's fine to use `.toString()` when converting only a single object to a string.
@@ -468,15 +468,15 @@ alphanumeric text, the `{}` should be omitted.
 
 {:.good}
 <?code-excerpt "usage_good.dart (string-interpolation-avoid-curly)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var greeting = 'Hi, $name! I love your ${decade}s costume.';
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (string-interpolation-avoid-curly)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var greeting = 'Hi, ${name}! I love your ${decade}s costume.';
-{% endprettify %}
+```
 
 ## Collections
 
@@ -494,18 +494,18 @@ them:
 
 {:.good}
 <?code-excerpt "usage_good.dart (collection-literals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var points = <Point>[];
 var addresses = <String, Address>{};
 var counts = <int>{};
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (collection-literals)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var addresses = Map<String, Address>();
 var counts = Set<int>();
-{% endprettify %}
+```
 
 Note that this guideline doesn't apply to the *named* constructors for those
 classes. `List.from()`, `Map.fromIterable()`, and friends all have their uses.
@@ -523,7 +523,7 @@ building the contents:
 
 {:.good}
 <?code-excerpt "usage_good.dart (spread-etc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var arguments = [
   ...options,
   command,
@@ -531,11 +531,11 @@ var arguments = [
   for (var path in filePaths)
     if (path.endsWith('.dart')) path.replaceAll('.dart', '.js')
 ];
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (spread-etc)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var arguments = <String>[];
 arguments.addAll(options);
 arguments.add(command);
@@ -543,7 +543,7 @@ if (modeFlags != null) arguments.addAll(modeFlags);
 arguments.addAll(filePaths
     .where((path) => path.endsWith('.dart'))
     .map((path) => path.replaceAll('.dart', '.js')));
-{% endprettify %}
+```
 
 
 ### DON'T use `.length` to see if a collection is empty
@@ -561,17 +561,17 @@ Instead, there are faster and more readable getters: `.isEmpty` and
 
 {:.good}
 <?code-excerpt "usage_good.dart (dont-use-length)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (lunchBox.isEmpty) return 'so hungry...';
 if (words.isNotEmpty) return words.join(' ');
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (dont-use-length)"?>
-{% prettify dart tag=pre+code %}
+```dart
 if (lunchBox.length == 0) return 'so hungry...';
 if (!words.isEmpty) return words.join(' ');
-{% endprettify %}
+```
 
 
 ### AVOID using `Iterable.forEach()` with a function literal
@@ -584,28 +584,28 @@ over a sequence, the idiomatic way to do that is using a loop.
 
 {:.good}
 <?code-excerpt "usage_good.dart (avoid-forEach)"?>
-{% prettify dart tag=pre+code %}
+```dart
 for (final person in people) {
   ...
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (avoid-forEach)"?>
-{% prettify dart tag=pre+code %}
+```dart
 people.forEach((person) {
   ...
 });
-{% endprettify %}
+```
 
 Note that this guideline specifically says "function *literal*". If you want to
 invoke some *already existing* function on each element, `forEach()` is fine.
 
 {:.good}
 <?code-excerpt "usage_good.dart (forEach-over-func)"?>
-{% prettify dart tag=pre+code %}
+```dart
 people.forEach(print);
-{% endprettify %}
+```
 
 Also note that it's always OK to use `Map.forEach()`. Maps aren't iterable, so
 this guideline doesn't apply.
@@ -616,10 +616,10 @@ Given an Iterable, there are two obvious ways to produce a new List that
 contains the same elements:
 
 <?code-excerpt "../../test/effective_dart_test.dart (list-from-1)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var copy1 = iterable.toList();
 var copy2 = List.from(iterable);
-{% endprettify %}
+```
 
 The obvious difference is that the first one is shorter. The *important*
 difference is that the first one preserves the type argument of the original
@@ -627,33 +627,33 @@ object:
 
 {:.good}
 <?code-excerpt "../../test/effective_dart_test.dart (list-from-good)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // Creates a List<int>:
 var iterable = [1, 2, 3];
 
 // Prints "List<int>":
 print(iterable.toList().runtimeType);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "../../test/effective_dart_test.dart (list-from-bad)"?>
-{% prettify dart tag=pre+code %}
+```dart
 // Creates a List<int>:
 var iterable = [1, 2, 3];
 
 // Prints "List<dynamic>":
 print(List.from(iterable).runtimeType);
-{% endprettify %}
+```
 
 If you *want* to change the type, then calling `List.from()` is useful:
 
 {:.good}
 <?code-excerpt "../../test/effective_dart_test.dart (list-from-3)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var numbers = [1, 2.3, 4]; // List<num>.
 numbers.removeAt(1); // Now it only contains integers.
 var ints = List<int>.from(numbers);
-{% endprettify %}
+```
 
 But if your goal is just to copy the iterable and preserve its original type, or
 you don't care about the type, then use `toList()`.
@@ -668,10 +668,10 @@ just the integers out of it. You could use `where()` like this:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (where-type)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var objects = [1, 'a', 2, 'b', 3];
 var ints = objects.where((e) => e is int);
-{% endprettify %}
+```
 
 This is verbose, but, worse, it returns an iterable whose type probably isn't
 what you want. In the example here, it returns an `Iterable<Object>` even though
@@ -681,10 +681,10 @@ Sometimes you see code that "corrects" the above error by adding `cast()`:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (where-type-2)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var objects = [1, 'a', 2, 'b', 3];
 var ints = objects.where((e) => e is int).cast<int>();
-{% endprettify %}
+```
 
 That's verbose and causes two wrappers to be created, with two layers of
 indirection and redundant runtime checking. Fortunately, the core library has
@@ -694,10 +694,10 @@ the [`whereType()`][where-type] method for this exact use case:
 
 {:.good}
 <?code-excerpt "../../test/effective_dart_test.dart (whereType)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var objects = [1, 'a', 2, 'b', 3];
 var ints = objects.whereType<int>();
-{% endprettify %}
+```
 
 Using `whereType()` is concise, produces an [Iterable][] of the desired type,
 and has no unnecessary levels of wrapping.
@@ -717,17 +717,17 @@ If you're already calling `toList()`, replace that with a call to
 
 {:.good}
 <?code-excerpt "usage_good.dart (cast-list)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var stuff = <dynamic>[1, 2];
 var ints = List<int>.from(stuff);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (cast-list)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var stuff = <dynamic>[1, 2];
 var ints = stuff.toList().cast<int>();
-{% endprettify %}
+```
 
 If you are calling `map()`, give it an explicit type argument so that it
 produces an iterable of the desired type. Type inference often picks the correct
@@ -736,17 +736,17 @@ to be explicit.
 
 {:.good}
 <?code-excerpt "usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 var stuff = <dynamic>[1, 2];
 var reciprocals = stuff.map<double>((n) => 1 / n);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 var stuff = <dynamic>[1, 2];
 var reciprocals = stuff.map((n) => 1 / n).cast<double>();
-{% endprettify %}
+```
 
 
 ### AVOID using `cast()`
@@ -776,71 +776,71 @@ Here is an example of **creating it with the right type:**
 
 {:.good}
 <?code-excerpt "usage_good.dart (cast-at-create)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<int> singletonList(int value) {
   var list = <int>[];
   list.add(value);
   return list;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (cast-at-create)"?>
-{% prettify dart tag=pre+code %}
+```dart
 List<int> singletonList(int value) {
   var list = []; // List<dynamic>.
   list.add(value);
   return list.cast<int>();
 }
-{% endprettify %}
+```
 
 Here is **casting each element on access:**
 
 {:.good}
 <?code-excerpt "usage_good.dart (cast-iterate)" replace="/\(n as int\)/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 void printEvens(List<Object> objects) {
   // We happen to know the list only contains ints.
   for (final n in objects) {
     if ([!(n as int)!].isEven) print(n);
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (cast-iterate)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void printEvens(List<Object> objects) {
   // We happen to know the list only contains ints.
   for (final n in objects.cast<int>()) {
     if (n.isEven) print(n);
   }
 }
-{% endprettify %}
+```
 
 Here is **casting eagerly using `List.from()`:**
 
 {:.good}
 <?code-excerpt "usage_good.dart (cast-from)"?>
-{% prettify dart tag=pre+code %}
+```dart
 int median(List<Object> objects) {
   // We happen to know the list only contains ints.
   var ints = List<int>.from(objects);
   ints.sort();
   return ints[ints.length ~/ 2];
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (cast-from)"?>
-{% prettify dart tag=pre+code %}
+```dart
 int median(List<Object> objects) {
   // We happen to know the list only contains ints.
   var ints = objects.cast<int>();
   ints.sort();
   return ints[ints.length ~/ 2];
 }
-{% endprettify %}
+```
 
 These alternatives don't always work, of course, and sometimes `cast()` is the
 right answer. But consider that method a little risky and undesirable—it
@@ -867,23 +867,23 @@ instead of binding a lambda to a variable.
 
 {:.good}
 <?code-excerpt "usage_good.dart (func-decl)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void main() {
   void localFunction() {
     ...
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (func-decl)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void main() {
   var localFunction = () {
     ...
   };
 }
-{% endprettify %}
+```
 
 ### DON'T create a lambda when a tear-off will do
 
@@ -897,7 +897,7 @@ parameters as the closure accepts, don't manually wrap the call in a lambda.
 
 {:.good}
 <?code-excerpt "usage_good.dart (use-tear-off)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var charCodes = [68, 97, 114, 116];
 var buffer = StringBuffer();
 
@@ -912,11 +912,11 @@ var strings = charCodes.map(String.fromCharCode);
 
 // Unnamed constructor:
 var buffers = charCodes.map(StringBuffer.new);
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (use-tear-off)"?>
-{% prettify dart tag=pre+code %}
+```dart
 var charCodes = [68, 97, 114, 116];
 var buffer = StringBuffer();
 
@@ -935,7 +935,7 @@ var strings = charCodes.map((code) => String.fromCharCode(code));
 
 // Unnamed constructor:
 var buffers = charCodes.map((code) => StringBuffer(code));
-{% endprettify %}
+```
 
 
 ### DO use `=` to separate a named parameter from its default value
@@ -948,14 +948,14 @@ For consistency with optional positional parameters, use `=`.
 
 {:.good}
 <?code-excerpt "usage_good.dart (default-separator)"?>
-{% prettify dart tag=pre+code %}
+```dart
 void insert(Object item, {int at = 0}) { ... }
-{% endprettify %}
+```
 
 {:.bad}
-{% prettify dart tag=pre+code %}
+```dart
 void insert(Object item, {int at: 0}) { ... }
-{% endprettify %}
+```
 
 
 ## Variables
@@ -988,7 +988,7 @@ constructor and then stores them:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (calc-vs-store1)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Circle {
   double radius;
   double area;
@@ -999,7 +999,7 @@ class Circle {
         area = pi * radius * radius,
         circumference = pi * 2.0 * radius;
 }
-{% endprettify %}
+```
 
 This code has two things wrong with it. First, it's likely wasting memory. The
 area and circumference, strictly speaking, are *caches*. They are stored
@@ -1016,7 +1016,7 @@ To correctly handle cache invalidation, we would need to do this:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (calc-vs-store2)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Circle {
   double _radius;
   double get radius => _radius;
@@ -1040,14 +1040,14 @@ class Circle {
     _circumference = pi * 2.0 * _radius;
   }
 }
-{% endprettify %}
+```
 
 That's an awful lot of code to write, maintain, debug, and read. Instead, your
 first implementation should be:
 
 {:.good}
 <?code-excerpt "usage_good.dart (calc-vs-store)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Circle {
   double radius;
 
@@ -1056,7 +1056,7 @@ class Circle {
   double get area => pi * radius * radius;
   double get circumference => pi * 2.0 * radius;
 }
-{% endprettify %}
+```
 
 This code is shorter, uses less memory, and is less error-prone. It stores the
 minimal amount of data needed to represent the circle. There are no fields to
@@ -1089,15 +1089,15 @@ getter and setter without having to touch any code that uses that field.
 
 {:.good}
 <?code-excerpt "usage_good.dart (dont-wrap-field)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   Object? contents;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (dont-wrap-field)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   Object? _contents;
   Object? get contents => _contents;
@@ -1105,7 +1105,7 @@ class Box {
     _contents = value;
   }
 }
-{% endprettify %}
+```
 
 
 ### PREFER using a `final` field to make a read-only property
@@ -1115,20 +1115,20 @@ simple solution that works in many cases is to simply mark it `final`.
 
 {:.good}
 <?code-excerpt "usage_good.dart (final)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   final contents = [];
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (final)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   Object? _contents;
   Object? get contents => _contents;
 }
-{% endprettify %}
+```
 
 Of course, if you need to internally assign to the field outside of the
 constructor, you may need to do the "private field, public getter" pattern, but
@@ -1145,12 +1145,12 @@ and return a value.
 
 {:.good}
 <?code-excerpt "usage_good.dart (use-arrow)"?>
-{% prettify dart tag=pre+code %}
+```dart
 double get area => (right - left) * (bottom - top);
 
 String capitalize(String name) =>
     '${name[0].toUpperCase()}${name.substring(1)}';
-{% endprettify %}
+```
 
 People *writing* code seem to love `=>`, but it's very easy to abuse it and end
 up with code that's hard to *read*. If your declaration is more than a couple of
@@ -1160,7 +1160,7 @@ your code a favor and use a block body and some statements.
 
 {:.good}
 <?code-excerpt "usage_good.dart (arrow-long)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Treasure? openChest(Chest chest, Point where) {
   if (_opened.containsKey(chest)) return null;
 
@@ -1169,25 +1169,25 @@ Treasure? openChest(Chest chest, Point where) {
   _opened[chest] = treasure;
   return treasure;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (arrow-long)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Treasure? openChest(Chest chest, Point where) => _opened.containsKey(chest)
     ? null
     : _opened[chest] = (Treasure(where)..addAll(chest.contents));
-{% endprettify %}
+```
 
 You can also use `=>` on members that don't return a value. This is idiomatic
 when a setter is small and has a corresponding getter that uses `=>`.
 
 {:.good}
 <?code-excerpt "usage_good.dart (arrow-setter)"?>
-{% prettify dart tag=pre+code %}
+```dart
 num get x => center.x;
 set x(num value) => center = Point(value, center.y);
-{% endprettify %}
+```
 
 
 ### DON'T use `this.` except to redirect to a named constructor or to avoid shadowing {#dont-use-this-when-not-needed-to-avoid-shadowing}
@@ -1203,7 +1203,7 @@ with the same name shadows the member you want to access:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (this-dot)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   Object? value;
 
@@ -1215,11 +1215,11 @@ class Box {
     this.value = value;
   }
 }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "usage_good.dart (this-dot)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box {
   Object? value;
 
@@ -1231,13 +1231,13 @@ class Box {
     this.value = value;
   }
 }
-{% endprettify %}
+```
 
 The other time to use `this.` is when redirecting to a named constructor:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (this-dot-constructor)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class ShadeOfGray {
   final int brightness;
 
@@ -1248,11 +1248,11 @@ class ShadeOfGray {
   // This won't parse or compile!
   // ShadeOfGray.alsoBlack() : black();
 }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "usage_good.dart (this-dot-constructor)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class ShadeOfGray {
   final int brightness;
 
@@ -1263,14 +1263,14 @@ class ShadeOfGray {
   // But now it will!
   ShadeOfGray.alsoBlack() : this.black();
 }
-{% endprettify %}
+```
 
 Note that constructor parameters never shadow fields in constructor initializer
 lists:
 
 {:.good}
 <?code-excerpt "usage_good.dart (param-dont-shadow-field-ctr-init)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Box extends BaseBox {
   Object? value;
 
@@ -1278,7 +1278,7 @@ class Box extends BaseBox {
       : value = value,
         super(value);
 }
-{% endprettify %}
+```
 
 This looks surprising, but works like you want. Fortunately, code like this is
 relatively rare thanks to initializing formals and super initializers.
@@ -1292,7 +1292,7 @@ the class has multiple constructors.
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (field-init-at-decl)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class ProfileMark {
   final String name;
   final DateTime start;
@@ -1302,11 +1302,11 @@ class ProfileMark {
       : name = '',
         start = DateTime.now();
 }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "usage_good.dart (field-init-at-decl)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class ProfileMark {
   final String name;
   final DateTime start = DateTime.now();
@@ -1314,7 +1314,7 @@ class ProfileMark {
   ProfileMark(this.name);
   ProfileMark.unnamed() : name = '';
 }
-{% endprettify %}
+```
 
 Some fields can't be initialized at their declarations because they need to reference
 `this`—to use other fields or call methods, for example. However, if the
@@ -1336,25 +1336,25 @@ Many fields are initialized directly from a constructor parameter, like:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (field-init-as-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(double x, double y)
       : x = x,
         y = y;
 }
-{% endprettify %}
+```
 
 We've got to type `x` _four_ times here to define a field. We can do better:
 
 {:.good}
 <?code-excerpt "usage_good.dart (field-init-as-param)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(this.x, this.y);
 }
-{% endprettify %}
+```
 
 This `this.` syntax before a constructor parameter is called an "initializing
 formal". You can't always take advantage of it. Sometimes you want to have a
@@ -1376,18 +1376,18 @@ initialize the field in the constructor initializer list:
 
 {:.good}
 <?code-excerpt "usage_good.dart (late-init-list)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point.polar(double theta, double radius)
       : x = cos(theta) * radius,
         y = sin(theta) * radius;
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (late-init-list)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   late double x, y;
   Point.polar(double theta, double radius) {
@@ -1395,7 +1395,7 @@ class Point {
     y = sin(theta) * radius;
   }
 }
-{% endprettify %}
+```
 
 
 The initializer list gives you access to constructor parameters and lets you
@@ -1413,21 +1413,21 @@ semicolon. (In fact, it's required for const constructors.)
 
 {:.good}
 <?code-excerpt "usage_good.dart (semicolon-for-empty-body)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(this.x, this.y);
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (semicolon-for-empty-body)"?>
-{% prettify dart tag=pre+code %}
+```dart
 class Point {
   double x, y;
   Point(this.x, this.y) {}
 }
-{% endprettify %}
+```
 
 ### DON'T use `new`
 
@@ -1442,7 +1442,7 @@ consider it deprecated and remove it from your code.
 
 {:.good}
 <?code-excerpt "usage_good.dart (no-new)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Widget build(BuildContext context) {
   return Row(
     children: [
@@ -1453,11 +1453,11 @@ Widget build(BuildContext context) {
     ],
   );
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (no-new)" replace="/new/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 Widget build(BuildContext context) {
   return [!new!] Row(
     children: [
@@ -1468,7 +1468,7 @@ Widget build(BuildContext context) {
     ],
   );
 }
-{% endprettify %}
+```
 
 
 ### DON'T use `const` redundantly
@@ -1494,23 +1494,23 @@ Basically, any place where it would be an error to write `new` instead of
 
 {:.good}
 <?code-excerpt "usage_good.dart (no-const)"?>
-{% prettify dart tag=pre+code %}
+```dart
 const primaryColors = [
   Color('red', [255, 0, 0]),
   Color('green', [0, 255, 0]),
   Color('blue', [0, 0, 255]),
 ];
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (no-const)" replace="/ (const)/ [!$1!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 const primaryColors = [!const!] [
   [!const!] Color('red', [!const!] [255, 0, 0]),
   [!const!] Color('green', [!const!] [0, 255, 0]),
   [!const!] Color('blue', [!const!] [0, 0, 255]),
 ];
-{% endprettify %}
+```
 
 ## Error handling
 
@@ -1584,25 +1584,25 @@ other hand resets the stack trace to the last thrown position.
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (rethrow)"?>
-{% prettify dart tag=pre+code %}
+```dart
 try {
   somethingRisky();
 } catch (e) {
   if (!canHandle(e)) throw e;
   handle(e);
 }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "usage_good.dart (rethrow)" replace="/rethrow/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 try {
   somethingRisky();
 } catch (e) {
   if (!canHandle(e)) [!rethrow!];
   handle(e);
 }
-{% endprettify %}
+```
 
 
 ## Asynchrony
@@ -1618,7 +1618,7 @@ lets you use all of the Dart control flow structures within your async code.
 
 {:.good}
 <?code-excerpt "usage_good.dart (async-await)" replace="/async|await/[!$&!]/g"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<int> countActivePlayers(String teamName) [!async!] {
   try {
     var team = [!await!] downloadTeam(teamName);
@@ -1631,11 +1631,11 @@ Future<int> countActivePlayers(String teamName) [!async!] {
     return 0;
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (async-await)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<int> countActivePlayers(String teamName) {
   return downloadTeam(teamName).then((team) {
     if (team == null) return Future.value(0);
@@ -1648,7 +1648,7 @@ Future<int> countActivePlayers(String teamName) {
     return 0;
   });
 }
-{% endprettify %}
+```
 
 ### DON'T use `async` when it has no useful effect
 
@@ -1658,19 +1658,19 @@ omit the `async` without changing the behavior of the function, do so.
 
 {:.good}
 <?code-excerpt "usage_good.dart (unnecessary-async)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<int> fastestBranch(Future<int> left, Future<int> right) {
   return Future.any([left, right]);
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (unnecessary-async)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<int> fastestBranch(Future<int> left, Future<int> right) async {
   return Future.any([left, right]);
 }
-{% endprettify %}
+```
 
 Cases where `async` *is* useful include:
 
@@ -1684,7 +1684,7 @@ Cases where `async` *is* useful include:
 
 {:.good}
 <?code-excerpt "usage_good.dart (async)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<void> usesAwait(Future<String> later) async {
   print(await later);
 }
@@ -1694,7 +1694,7 @@ Future<void> asyncError() async {
 }
 
 Future<String> asyncValue() async => 'value';
-{% endprettify %}
+```
 
 ### CONSIDER using higher-order methods to transform a stream
 
@@ -1710,7 +1710,7 @@ eventually find the Completer class and use that.
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (avoid-completer)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<bool> fileContainsBear(String path) {
   var completer = Completer<bool>();
 
@@ -1720,7 +1720,7 @@ Future<bool> fileContainsBear(String path) {
 
   return completer.future;
 }
-{% endprettify %}
+```
 
 Completer is needed for two kinds of low-level code: new asynchronous
 primitives, and interfacing with asynchronous code that doesn't use futures.
@@ -1731,22 +1731,22 @@ they're clearer and make error handling easier.
 
 {:.good}
 <?code-excerpt "usage_good.dart (avoid-completer)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<bool> fileContainsBear(String path) {
   return File(path).readAsString().then((contents) {
     return contents.contains('bear');
   });
 }
-{% endprettify %}
+```
 
 {:.good}
 <?code-excerpt "usage_good.dart (avoid-completer-alt)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<bool> fileContainsBear(String path) async {
   var contents = await File(path).readAsString();
   return contents.contains('bear');
 }
-{% endprettify %}
+```
 
 
 ### DO test for `Future<T>` when disambiguating a `FutureOr<T>` whose type argument could be `Object`
@@ -1765,7 +1765,7 @@ object is a future. Instead, explicitly test for the `Future` case:
 
 {:.good}
 <?code-excerpt "usage_good.dart (test-future-or)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<T> logValue<T>(FutureOr<T> value) async {
   if (value is Future<T>) {
     var result = await value;
@@ -1776,11 +1776,11 @@ Future<T> logValue<T>(FutureOr<T> value) async {
     return value;
   }
 }
-{% endprettify %}
+```
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (test-future-or)"?>
-{% prettify dart tag=pre+code %}
+```dart
 Future<T> logValue<T>(FutureOr<T> value) async {
   if (value is T) {
     print(value);
@@ -1791,7 +1791,7 @@ Future<T> logValue<T>(FutureOr<T> value) async {
     return result;
   }
 }
-{% endprettify %}
+```
 
 In the bad example, if you pass it a `Future<Object>`, it incorrectly treats it
 like a bare, synchronous value.


### PR DESCRIPTION
This makes css changes so the colored `.good` and `.bad` backgrounds apply successfully to the Effective Dart code blocks. Since all code blocks using highlighting (`[! !]`) are already code excerpts, highlighting continues to work.

Contributes to https://github.com/dart-lang/site-www/issues/3846 and https://github.com/dart-lang/site-www/issues/5177
