### PR TITLE
Cleanup generated human readable index

### DIFF
--- a/src/map.html
+++ b/src/map.html
@@ -6,15 +6,7 @@ toc: false
 
 <ul>
 {% for document in site.pages %}
-  {% if document.url and document.url != '/404' %}
-  <li>
-    <a href="{{document.url}}">{{ document.title | xml_escape }}</a><br>
-    <small>{{document.url}}</small>
-  </li>
-  {% endif %}
-{% endfor %}
-{% for document in site.documents %}
-  {% if document.url %}
+  {% if document.url and document.url contains '.html' and document.url != '/404.html' %}
   <li>
     <a href="{{document.url}}">{{ document.title | xml_escape }}</a><br>
     <small>{{document.url}}</small>


### PR DESCRIPTION
- Prevents the 404 page being included on the generated page
- Prevents non-HTML files (like CSS) being included
- Stops looping through `site.documents` since we don't use it (therefore it's empty)

Contributes to https://github.com/dart-lang/site-www/issues/5177 which won't support `site.documents` anyway

**Staged:** https://dart-dev--pr5213-misc-cleanup-human-r-kij4d07f.web.app/map