### PR TITLE
Removed the latest keyword from the docs, fix issue #5233

### DIFF
--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -80,7 +80,7 @@ so that you can easily undo any changes.
 ### Switch to the Dart 2.19.6 release
 
 Switch to the **2.19.6 release** of the Dart SDK. 
-This is included in the Flutter 3.7 SDK.
+This is included in the Flutter 3.7.12 SDK.
 
 Check that you have Dart 2.19:
 

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -7,7 +7,7 @@ description: How to move your existing Dart code to the world of null safety
   Dart 2.19 is the final release that supports null-safety migration,
   including the `dart migrate` tool.
   To migrate your package to null safety,
-  use the   Dart 2.19 SDK.
+  use the Dart 2.19.6 SDK.
   To learn more,
   see [Dart 3 and null safety](/null-safety#dart-3-and-null-safety).
 {{site.alert.end}}

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -82,7 +82,7 @@ so that you can easily undo any changes.
 Switch to the **2.19.6 release** of the Dart SDK. 
 This is included in the Flutter 3.7.12 SDK.
 
-Check that you have Dart 2.19:
+Check that you have Dart 2.19.6:
 
 ```terminal
 $ dart --version 

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -137,7 +137,7 @@ update its dependencies to null-safe versions:
    latest versions supporting null safety.
    **Note:** This command changes your `pubspec.yaml` file.
 
-3. Run `dart pub get`.
+2. Run `dart pub get`.
 
 
 ## 2. Migrate {#step2-migrate}

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -85,7 +85,7 @@ This is included in the Flutter 3.7.12 SDK.
 Check that you have Dart 2.19.6:
 
 ```terminal
-$ dart --version 
+$ dart --version
 Dart SDK version: 2.19.6
 ```
 
@@ -133,11 +133,11 @@ You can find contact details on the package page on [pub.dev][].
 Before migrating your package's code,
 update its dependencies to null-safe versions:
 
-1. Run `dart pub upgrade --null-safety` to upgrade to the versions
-   supporting null safety.
+1. Run `dart pub upgrade --null-safety` to upgrade to the
+   latest versions supporting null safety.
    **Note:** This command changes your `pubspec.yaml` file.
 
-2. Run `dart pub get`.
+3. Run `dart pub get`.
 
 
 ## 2. Migrate {#step2-migrate}

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -7,7 +7,7 @@ description: How to move your existing Dart code to the world of null safety
   Dart 2.19 is the final release that supports null-safety migration,
   including the `dart migrate` tool.
   To migrate your package to null safety,
-  use the latest Dart 2.19 SDK.
+  use the   Dart 2.19 SDK.
   To learn more,
   see [Dart 3 and null safety](/null-safety#dart-3-and-null-safety).
 {{site.alert.end}}
@@ -76,16 +76,16 @@ with the help of the `dart pub outdated` command in null-safety mode.
 The instructions assume your code is under **source control**,
 so that you can easily undo any changes.
 
-<a id="switch-to-the-latest-stable-dart-release"></a>
-### Switch to the latest Dart 2.19 release
+<a id="switch-to-the- -stable-dart-release"></a>
+### Switch to the   Dart 2.19 release
 
-Switch to the latest **Dart 2.19 release** of the Dart SDK. 
+Switch to the   **Dart 2.19 release** of the Dart SDK. 
 This is included in the Flutter 3.7 SDK.
 
 Check that you have Dart 2.19:
 
 ```terminal
-$ dart --version
+$ dart --version 
 Dart SDK version: 2.19.6
 ```
 
@@ -133,7 +133,7 @@ You can find contact details on the package page on [pub.dev][].
 Before migrating your package's code,
 update its dependencies to null-safe versions:
 
-1. Run `dart pub upgrade --null-safety` to upgrade to the latest versions
+1. Run `dart pub upgrade --null-safety` to upgrade to the   versions
    supporting null safety.
    **Note:** This command changes your `pubspec.yaml` file.
 
@@ -179,7 +179,7 @@ adding [hint markers][] to your Dart code.
 
 Before starting the tool, make sure you're ready:
 
-* Use the latest 2.19 release of the Dart SDK.
+* Use the   2.19 release of the Dart SDK.
 * Use `dart pub outdated --mode=null-safety` to make sure that
   all dependencies are null safe and up-to-date.
   

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -179,7 +179,7 @@ adding [hint markers][] to your Dart code.
 
 Before starting the tool, make sure you're ready:
 
-* Use the   2.19 release of the Dart SDK.
+* Use the 2.19.6 release of the Dart SDK.
 * Use `dart pub outdated --mode=null-safety` to make sure that
   all dependencies are null safe and up-to-date.
   

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -133,7 +133,7 @@ You can find contact details on the package page on [pub.dev][].
 Before migrating your package's code,
 update its dependencies to null-safe versions:
 
-1. Run `dart pub upgrade --null-safety` to upgrade to the   versions
+1. Run `dart pub upgrade --null-safety` to upgrade to the versions
    supporting null safety.
    **Note:** This command changes your `pubspec.yaml` file.
 

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -77,7 +77,7 @@ The instructions assume your code is under **source control**,
 so that you can easily undo any changes.
 
 <a id="switch-to-the-latest-stable-dart-release"></a>
-### Switch to the   Dart 2.19 release
+### Switch to the Dart 2.19.6 release
 
 Switch to the   **Dart 2.19 release** of the Dart SDK. 
 This is included in the Flutter 3.7 SDK.

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -79,7 +79,7 @@ so that you can easily undo any changes.
 <a id="switch-to-the-latest-stable-dart-release"></a>
 ### Switch to the Dart 2.19.6 release
 
-Switch to the   **Dart 2.19 release** of the Dart SDK. 
+Switch to the **2.19.6 release** of the Dart SDK. 
 This is included in the Flutter 3.7 SDK.
 
 Check that you have Dart 2.19:

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -76,7 +76,7 @@ with the help of the `dart pub outdated` command in null-safety mode.
 The instructions assume your code is under **source control**,
 so that you can easily undo any changes.
 
-<a id="switch-to-the- -stable-dart-release"></a>
+<a id="switch-to-the-latest-stable-dart-release"></a>
 ### Switch to the   Dart 2.19 release
 
 Switch to the   **Dart 2.19 release** of the Dart SDK. 


### PR DESCRIPTION
Removed the "latest" keyword from the showing int the dart version, which currently shows 2.19.6 and it is not the latest one.

Fixes  #5233

--- 

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
