### PR TITLE
Reduce padding at top of content

### DIFF
--- a/src/_sass/core/_variables.scss
+++ b/src/_sass/core/_variables.scss
@@ -68,7 +68,7 @@ $font-size-small:         14px;
 // Spacing
 $live-content-width:      1280px;
 $content-padding:         32px;
-$top-content-padding:     55px;
+$top-content-padding:     40px;
 
 // Fonts
 $site-font-family-gsans: 'Google Sans', 'Roboto', sans-serif;


### PR DESCRIPTION
This PR reduces the space at the top of an article, matching docs.flutter.dev's padding of 40px.

There's just a lot of empty space when first opening an article, especially on mobile. This finds a good balance without having too much crowding.

Old example: https://dart.dev/community
New example: https://dart-dev--pr5240-fix-reduce-content-t-dw82pczn.web.app/community