### PR TITLE
Update pubspec.md

### DIFF
--- a/src/tools/pub/pubspec.md
+++ b/src/tools/pub/pubspec.md
@@ -252,7 +252,7 @@ executables:
   fvm:
 ```
 
-Once the package is activated using `pub global activate`,
+Once the package is activated using `dart pub global activate`,
 typing `slidy` executes `bin/main.dart`.
 Typing `fvm` executes `bin/fvm.dart`.
 If you don't specify the value, it is inferred from the key.


### PR DESCRIPTION
The command `pub` is no longer in path for most people. We use `dart pub` now.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
