### PR TITLE
 Updates dependabot and no-response pages with new GitHub labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,23 +8,23 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "infra.dependencies"
-      - "infra.bundler"
+      - "auto.dependencies"
+      - "auto.bundler"
       - "lang.ruby"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
-      - "infra.dependencies"
-      - "infra.docker"
+      - "auto.dependencies"
+      - "auto.docker"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
-      - "infra.dependencies"
-      - "infra.github-action"
+      - "auto.dependencies"
+      - "auto.github-action"
       - "lang.yaml"
   - package-ecosystem: "npm"
     directory: "/"
@@ -33,13 +33,13 @@ updates:
     allow:
       - dependency-type: "production"
     labels:
-      - "infra.dependencies"
-      - "infra.npm"
+      - "auto.dependencies"
+      - "auto.npm"
       - "lang.javascript"
   - package-ecosystem: 'gitsubmodule'
     directory: '/'
     schedule:
       interval: 'daily'
     labels:
-      - "infra.dependencies"
-      - "infra.submodules"
+      - "auto.dependencies"
+      - "auto.submodules"

--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -31,4 +31,4 @@ jobs:
           # Number of days of inactivity before an issue is closed for lack of response.
           daysUntilClose: 21
           # Label requiring a response.
-          responseRequiredLabel: "waiting for customer response"
+          responseRequiredLabel: "act.wait-for-customer"


### PR DESCRIPTION
 Updates dependabot and no-response pages with new GitHub labels. Fixes #5259
 
 | Old Label                     | New Label             |
|-------------------------------|-----------------------|
| infra.bundler                 | auto.bundler          |
| infra.dependencies            | auto.dependencies     |
| infra.docker                  | auto.docker           |
| infra.github-action           | auto.github-action    |
| infra.npm                     | auto.npm              |
| infra.submodules              | auto.submodules       |
| needs-info                    | act.wait-for-customer |
| waiting for customer response | act.wait-for-customer |