### PR TITLE
Reduce home page load time by lazy loading DartPad iframe

### DIFF
--- a/src/assets/dash/js/dartpad_picker_main.dart.js
+++ b/src/assets/dash/js/dartpad_picker_main.dart.js
@@ -61,7 +61,102 @@ return r}function updateHolder(a,b){copyProperties(b,a)
 return a}var hunkHelpers=function(){var s=function(a,b,c,d,e){return function(f,g,h,i){return installInstanceTearOff(f,g,a,b,c,d,[h],i,e,false)}},r=function(a,b,c,d){return function(e,f,g,h){return installStaticTearOff(e,f,a,b,c,[g],h,d)}}
 return{inherit:inherit,inheritMany:inheritMany,mixin:mixinEasy,mixinHard:mixinHard,installStaticTearOff:installStaticTearOff,installInstanceTearOff:installInstanceTearOff,_instance_0u:s(0,0,null,["$0"],0),_instance_1u:s(0,1,null,["$1"],0),_instance_2u:s(0,2,null,["$2"],0),_instance_0i:s(1,0,null,["$0"],0),_instance_1i:s(1,1,null,["$1"],0),_instance_2i:s(1,2,null,["$2"],0),_static_0:r(0,null,["$0"],0),_static_1:r(1,null,["$1"],0),_static_2:r(2,null,["$2"],0),makeConstList:makeConstList,lazy:lazy,lazyFinal:lazyFinal,lazyOld:lazyOld,updateHolder:updateHolder,convertToFastObject:convertToFastObject,updateTypes:updateTypes,setOrUpdateInterceptorsByTag:setOrUpdateInterceptorsByTag,setOrUpdateLeafTags:setOrUpdateLeafTags}}()
 function initializeDeferredHunk(a){x=v.types.length
-a(hunkHelpers,v,w,$)}var A={FK:function FK(){},
+a(hunkHelpers,v,w,$)}var J={
+Qu(a,b,c,d){return{i:a,p:b,e:c,x:d}},
+ks(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
+if(n==null)if($.Bv==null){A.XD()
+n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
+if(!1===s)return n.i
+if(!0===s)return a
+r=Object.getPrototypeOf(a)
+if(s===r)return n.i
+if(n.e===r)throw A.Og(A.SY("Return interceptor for "+A.d(s(a,n))))}q=a.constructor
+if(q==null)p=null
+else{o=$.zm
+if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
+p=q[o]}if(p!=null)return p
+p=A.w3(a)
+if(p!=null)return p
+if(typeof a=="function")return B.DG
+s=Object.getPrototypeOf(a)
+if(s==null)return B.ZQ
+if(s===Object.prototype)return B.ZQ
+if(typeof q=="function"){o=$.zm
+if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
+Object.defineProperty(q,o,{value:B.vB,enumerable:false,writable:true,configurable:true})
+return B.vB}return B.vB},
+Kh(a){if(a<0)throw A.Og(A.xY("Length must be a non-negative integer: "+a,null))
+return new Array(a)},
+Ep(a){a.fixed$length=Array
+return a},
+RE(a){if(a==null)return a
+if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
+if(typeof a=="symbol")return J.Dw.prototype
+if(typeof a=="bigint")return J.yP.prototype
+return a}if(a instanceof A.a)return a
+return J.ks(a)},
+U6(a){if(typeof a=="string")return J.Dr.prototype
+if(a==null)return a
+if(Array.isArray(a))return J.jd.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
+if(typeof a=="symbol")return J.Dw.prototype
+if(typeof a=="bigint")return J.yP.prototype
+return a}if(a instanceof A.a)return a
+return J.ks(a)},
+ia(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.bU.prototype
+return J.kD.prototype}if(typeof a=="string")return J.Dr.prototype
+if(a==null)return J.PE.prototype
+if(typeof a=="boolean")return J.yE.prototype
+if(Array.isArray(a))return J.jd.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
+if(typeof a=="symbol")return J.Dw.prototype
+if(typeof a=="bigint")return J.yP.prototype
+return a}if(a instanceof A.a)return a
+return J.ks(a)},
+w1(a){if(a==null)return a
+if(Array.isArray(a))return J.jd.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
+if(typeof a=="symbol")return J.Dw.prototype
+if(typeof a=="bigint")return J.yP.prototype
+return a}if(a instanceof A.a)return a
+return J.ks(a)},
+C(a){return J.ia(a)["["](a)},
+CR(a){return J.ia(a).gbx(a)},
+Hm(a){return J.U6(a).gB(a)},
+IT(a){return J.w1(a).gk(a)},
+RM(a,b){if(a==null)return b==null
+if(typeof a!="object")return b!=null&&a===b
+return J.ia(a).DN(a,b)},
+dZ(a,b,c,d){return J.RE(a).On(a,b,c,d)},
+ep(a,b,c){return J.RE(a).AS(a,b,c)},
+fF(a,b){return J.RE(a).Tk(a,b)},
+h(a,b){return J.w1(a).U(a,b)},
+iU(a){return J.RE(a).gwd(a)},
+ld(a,b,c){return J.RE(a).X6(a,b,c)},
+u(a){return J.ia(a).gi(a)},
+zY(a,b){if(typeof b==="number")if(Array.isArray(a)||A.wV(a,a[v.dispatchPropertyName]))if(b>>>0===b&&b<a.length)return a[b]
+return J.w1(a).W(a,b)},
+vB:function vB(){},
+yE:function yE(){},
+PE:function PE(){},
+MF:function MF(){},
+zh:function zh(){},
+iC:function iC(){},
+kd:function kd(){},
+c5:function c5(){},
+yP:function yP(){},
+Dw:function Dw(){},
+jd:function jd(){},
+Po:function Po(){},
+m1:function m1(a,b){var _=this
+_.a=a
+_.b=b
+_.c=0
+_.d=null},
+qI:function qI(){},
+bU:function bU(){},
+kD:function kD(){},
+Dr:function Dr(){}},A={FK:function FK(){},
 q(a,b){a=a+b&536870911
 a=a+((a&524287)<<10)&536870911
 return a^a>>>6},
@@ -450,6 +545,9 @@ cz(a,b){var s=b.c
 return s==null?b.c=A.Bc(a,b.y,!0):s},
 xZ(a,b){var s=b.c
 return s==null?b.c=A.Q2(a,"b8",[b.y]):s},
+MR(a){var s=a.d
+if(s!=null)return s
+return a.d=new Map()},
 Q1(a){var s=a.x
 if(s===6||s===7||s===8)return A.Q1(a.y)
 return s===12||s===13},
@@ -602,7 +700,7 @@ else s=!0
 return s},
 YO(a){var s=this
 if(a==null)return A.Qj(s)
-return A.We(v.typeUniverse,A.Ue(a,s),null,s,null)},
+return A.t1(v.typeUniverse,A.Ue(a,s),s)},
 AQ(a){if(a==null)return!0
 return this.y.b(a)},
 t4(a){var s,r=this
@@ -1077,6 +1175,11 @@ if(q!==9)throw A.Og(A.hV("Indexed base must be an interface type"))
 s=b.z
 if(c<=s.length)return s[c-1]
 throw A.Og(A.hV("Bad index "+c+" for "+b["["](0)))},
+t1(a,b,c){var s,r=A.MR(b),q=r.get(c)
+if(q!=null)return q
+s=A.We(a,b,null,c,null)
+r.set(c,s)
+return s},
 We(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
 if(b===d)return!0
 if(!A.A8(d))if(!(d===t._))s=!1
@@ -1199,7 +1302,7 @@ vU(a){return a>0?new Array(a):v.typeUniverse.sEA},
 Jc:function Jc(a,b){var _=this
 _.a=a
 _.b=b
-_.w=_.r=_.c=null
+_.w=_.r=_.e=_.d=_.c=null
 _.x=0
 _.at=_.as=_.Q=_.z=_.y=null},
 ET:function ET(){this.c=this.b=this.a=null},
@@ -1770,102 +1873,7 @@ r=q.querySelector("#dartpad-select")
 if(s==null||!t.M.b(r))return
 q=new A.K(s,r,B.qO,"try-dart-pad")
 q.R()
-q.u()}},J={
-Qu(a,b,c,d){return{i:a,p:b,e:c,x:d}},
-ks(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
-if(n==null)if($.Bv==null){A.XD()
-n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
-if(!1===s)return n.i
-if(!0===s)return a
-r=Object.getPrototypeOf(a)
-if(s===r)return n.i
-if(n.e===r)throw A.Og(A.SY("Return interceptor for "+A.d(s(a,n))))}q=a.constructor
-if(q==null)p=null
-else{o=$.zm
-if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
-p=q[o]}if(p!=null)return p
-p=A.w3(a)
-if(p!=null)return p
-if(typeof a=="function")return B.DG
-s=Object.getPrototypeOf(a)
-if(s==null)return B.ZQ
-if(s===Object.prototype)return B.ZQ
-if(typeof q=="function"){o=$.zm
-if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
-Object.defineProperty(q,o,{value:B.vB,enumerable:false,writable:true,configurable:true})
-return B.vB}return B.vB},
-Kh(a){if(a<0)throw A.Og(A.xY("Length must be a non-negative integer: "+a,null))
-return new Array(a)},
-Ep(a){a.fixed$length=Array
-return a},
-RE(a){if(a==null)return a
-if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
-if(typeof a=="symbol")return J.Dw.prototype
-if(typeof a=="bigint")return J.yP.prototype
-return a}if(a instanceof A.a)return a
-return J.ks(a)},
-U6(a){if(typeof a=="string")return J.Dr.prototype
-if(a==null)return a
-if(Array.isArray(a))return J.jd.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
-if(typeof a=="symbol")return J.Dw.prototype
-if(typeof a=="bigint")return J.yP.prototype
-return a}if(a instanceof A.a)return a
-return J.ks(a)},
-ia(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.bU.prototype
-return J.kD.prototype}if(typeof a=="string")return J.Dr.prototype
-if(a==null)return J.PE.prototype
-if(typeof a=="boolean")return J.yE.prototype
-if(Array.isArray(a))return J.jd.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
-if(typeof a=="symbol")return J.Dw.prototype
-if(typeof a=="bigint")return J.yP.prototype
-return a}if(a instanceof A.a)return a
-return J.ks(a)},
-w1(a){if(a==null)return a
-if(Array.isArray(a))return J.jd.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
-if(typeof a=="symbol")return J.Dw.prototype
-if(typeof a=="bigint")return J.yP.prototype
-return a}if(a instanceof A.a)return a
-return J.ks(a)},
-C(a){return J.ia(a)["["](a)},
-CR(a){return J.ia(a).gbx(a)},
-Hm(a){return J.U6(a).gB(a)},
-IT(a){return J.w1(a).gk(a)},
-RM(a,b){if(a==null)return b==null
-if(typeof a!="object")return b!=null&&a===b
-return J.ia(a).DN(a,b)},
-dZ(a,b,c,d){return J.RE(a).On(a,b,c,d)},
-ep(a,b,c){return J.RE(a).AS(a,b,c)},
-fF(a,b){return J.RE(a).Tk(a,b)},
-h(a,b){return J.w1(a).U(a,b)},
-iU(a){return J.RE(a).gwd(a)},
-ld(a,b,c){return J.RE(a).X6(a,b,c)},
-u(a){return J.ia(a).gi(a)},
-zY(a,b){if(typeof b==="number")if(Array.isArray(a)||A.wV(a,a[v.dispatchPropertyName]))if(b>>>0===b&&b<a.length)return a[b]
-return J.w1(a).W(a,b)},
-vB:function vB(){},
-yE:function yE(){},
-PE:function PE(){},
-MF:function MF(){},
-zh:function zh(){},
-iC:function iC(){},
-kd:function kd(){},
-c5:function c5(){},
-yP:function yP(){},
-Dw:function Dw(){},
-jd:function jd(){},
-Po:function Po(){},
-m1:function m1(a,b){var _=this
-_.a=a
-_.b=b
-_.c=0
-_.d=null},
-qI:function qI(){},
-bU:function bU(){},
-kD:function kD(){},
-Dr:function Dr(){}},B={}
+q.u()}},B={}
 var w=[A,J,B]
 var $={}
 A.FK.prototype={}
@@ -3189,6 +3197,7 @@ o.textContent=p.a
 r.appendChild(o)}A.JE(r,"change",new A.XV(this),!1)},
 u(){var s=this,r=document.createElement("iframe")
 r.src="https://dartpad.dev/embed-dart.html?theme=dark"
+r.setAttribute("loading","lazy")
 s.f!==$&&A.SQ()
 s.f=r
 r.id=s.e
@@ -3358,7 +3367,7 @@ s(A.qG,A.ar)
 s(A.CH,A.Pb)
 s(A.pS,A.il)})()
 var v={typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{KN:"int",CP:"double",lf:"num",qU:"String",Yo:"bool",c8:"Null",zM:"List"},mangledNames:{},types:["~()","~(qU,@)","~(~())","c8(@)","c8()","~(ea)","~(@)","@(@)","@(@,qU)","@(qU)","c8(~())","c8(a,Gz)","vs<@>(@)","~(a?,a?)","~(qU,qU)","~(@,@)","c8(@,@)","@(@,@)","Yo(KV)","cv(KV)","c8(ea)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti")}
-A.xb(v.typeUniverse,JSON.parse('{"iC":"zh","kd":"zh","c5":"zh","iX":"MF","y0":"MF","ZZ":"MF","rx":"ea","e5":"ea","DX":"V7","c0":"D0","fy":"D0","cg":"D0","Y0":"d5","tp":"d5","Mr":"qE","El":"qE","Vb":"KV","QF":"KV","j6":"MN","n6":"nx","kJ":"nx","Bs":"cv","QH":"xn","CM":"lw","yJ":"Uv","zC":"WW","eu":"Bw","w8":"Bw","ql":"Bw","yE":{"y5":[]},"PE":{"c8":[],"y5":[]},"MF":{"vm":[]},"zh":{"vm":[]},"jd":{"zM":["1"],"vm":[]},"Po":{"zM":["1"],"vm":[]},"qI":{"CP":[],"lf":[]},"bU":{"CP":[],"KN":[],"lf":[],"y5":[]},"kD":{"CP":[],"lf":[],"y5":[]},"Dr":{"qU":[],"y5":[]},"n":{"Ge":[]},"W0":{"E":[],"Ge":[]},"az":{"Ge":[]},"vV":{"Ge":[]},"XO":{"Gz":[]},"GK":{"Ge":[]},"Eq":{"Ge":[]},"N5":{"Z0":["1","2"],"il.V":"2"},"WZ":{"vm":[],"y5":[]},"eH":{"vm":[]},"df":{"eH":[],"vm":[],"y5":[]},"b0":{"eH":[],"Xj":["1"],"vm":[]},"Dg":{"eH":[],"Xj":["CP"],"zM":["CP"],"vm":[]},"DV":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[]},"zU":{"eH":[],"Xj":["CP"],"zM":["CP"],"vm":[],"y5":[]},"K8":{"eH":[],"Xj":["CP"],"zM":["CP"],"vm":[],"y5":[]},"xj":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"dE":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"ZA":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"wf":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"Pq":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"eE":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"V6":{"eH":[],"Xj":["KN"],"zM":["KN"],"vm":[],"y5":[]},"u9":{"Ge":[]},"iM":{"E":[],"Ge":[]},"vs":{"b8":["1"]},"OH":{"Ge":[]},"Zf":{"Pf":["1"]},"ar":{"zM":["1"]},"il":{"Z0":["1","2"]},"CP":{"lf":[]},"KN":{"lf":[]},"C6":{"Ge":[]},"E":{"Ge":[]},"AT":{"Ge":[]},"bJ":{"Ge":[]},"eY":{"Ge":[]},"ub":{"Ge":[]},"ds":{"Ge":[]},"lj":{"Ge":[]},"UV":{"Ge":[]},"VS":{"Ge":[]},"Zd":{"Gz":[]},"lw":{"vm":[]},"cv":{"KV":[],"vm":[]},"ea":{"vm":[]},"dU":{"Az":[],"vm":[]},"GO":{"vm":[]},"AW":{"vm":[]},"KV":{"vm":[]},"kT":{"vm":[]},"SV":{"vm":[]},"Y4":{"vm":[]},"l8":{"vm":[]},"WW":{"vm":[]},"A1":{"vm":[]},"MN":{"vm":[]},"a3":{"vm":[]},"qE":{"cv":[],"KV":[],"vm":[]},"PI":{"vm":[]},"Gh":{"cv":[],"KV":[],"vm":[]},"fY":{"cv":[],"KV":[],"vm":[]},"Az":{"vm":[]},"nx":{"KV":[],"vm":[]},"Tf":{"vm":[]},"oJ":{"vm":[]},"Bw":{"vm":[]},"Uv":{"vm":[]},"HS":{"vm":[]},"n1":{"vm":[]},"Sb":{"vm":[]},"Nh":{"vm":[]},"Fv":{"zM":["tn<lf>"],"Xj":["tn<lf>"],"vm":[]},"IB":{"tn":["lf"],"vm":[]},"Yl":{"zM":["qU"],"Xj":["qU"],"vm":[]},"zX":{"vm":[]},"VG":{"zM":["cv"]},"D0":{"vm":[]},"Dy":{"zM":["dU"],"Xj":["dU"],"vm":[]},"wJ":{"vm":[]},"Yu":{"cv":[],"KV":[],"vm":[]},"br":{"vm":[]},"xn":{"zM":["KV"],"Xj":["KV"],"vm":[]},"Sg":{"vm":[]},"u8":{"vm":[]},"tL":{"vm":[]},"av":{"ea":[],"vm":[]},"Cf":{"vm":[]},"S0":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"z2":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"bw":{"zM":["AW"],"Xj":["AW"],"vm":[]},"e7":{"zM":["KV"]},"BH":{"zM":["KV"],"Xj":["KV"],"vm":[]},"AM":{"zM":["kT"],"Xj":["kT"],"vm":[]},"p8":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"lp":{"cv":[],"KV":[],"vm":[]},"Jr":{"vm":[]},"Mk":{"zM":["SV"],"Xj":["SV"],"vm":[]},"Nn":{"zM":["Y4"],"Xj":["Y4"],"vm":[]},"As":{"vm":[],"Z0":["qU","qU"],"il.V":"qU"},"X0":{"zM":["MN"],"Xj":["MN"],"vm":[]},"nJ":{"zM":["A1"],"Xj":["A1"],"vm":[]},"M0":{"vm":[]},"o4":{"zM":["a3"],"Xj":["a3"],"vm":[]},"cn":{"vm":[]},"Fj":{"vm":[]},"vX":{"vm":[]},"Oi":{"vm":[]},"PR":{"zM":["lw"],"Xj":["lw"],"vm":[]},"w4":{"tn":["lf"],"vm":[]},"Ij":{"zM":["GO?"],"Xj":["GO?"],"vm":[]},"rh":{"zM":["KV"],"Xj":["KV"],"vm":[]},"LO":{"zM":["l8"],"Xj":["l8"],"vm":[]},"i9":{"zM":["WW"],"Xj":["WW"],"vm":[]},"dW":{"vm":[]},"D7":{"zM":["cv"]},"x0":{"vm":[]},"uP":{"vm":[]},"dq":{"vm":[]},"jK":{"zM":["x0"],"vm":[]},"LZ":{"zM":["uP"],"vm":[]},"ED":{"vm":[]},"Kq":{"zM":["qU"],"vm":[]},"d5":{"cv":[],"KV":[],"vm":[]},"DT":{"zM":["dq"],"vm":[]},"r2":{"vm":[]},"VK":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"fo":{"vm":[]},"V7":{"vm":[]},"Gn":{"vm":[]},"ZX":{"zM":["KN"]},"F0":{"zM":["KN"]},"zt":{"zM":["KN"]},"rF":{"zM":["KN"]},"yc":{"zM":["KN"]},"X6":{"zM":["KN"]},"Pz":{"zM":["KN"]},"oI":{"zM":["CP"]},"mJ":{"zM":["CP"]}}'))
+A.xb(v.typeUniverse,JSON.parse('{"iC":"zh","kd":"zh","c5":"zh","iX":"MF","y0":"MF","ZZ":"MF","rx":"ea","e5":"ea","DX":"V7","c0":"D0","fy":"D0","cg":"D0","Y0":"d5","tp":"d5","Mr":"qE","El":"qE","Vb":"KV","QF":"KV","j6":"MN","n6":"nx","kJ":"nx","Bs":"cv","QH":"xn","CM":"lw","yJ":"Uv","zC":"WW","eu":"Bw","w8":"Bw","ql":"Bw","yE":{"y5":[]},"PE":{"c8":[],"y5":[]},"MF":{"vm":[]},"zh":{"vm":[]},"jd":{"zM":["1"],"vm":[]},"Po":{"zM":["1"],"vm":[]},"qI":{"CP":[],"lf":[]},"bU":{"CP":[],"KN":[],"lf":[],"y5":[]},"kD":{"CP":[],"lf":[],"y5":[]},"Dr":{"qU":[],"y5":[]},"n":{"Ge":[]},"W0":{"E":[],"Ge":[]},"az":{"Ge":[]},"vV":{"Ge":[]},"XO":{"Gz":[]},"GK":{"Ge":[]},"Eq":{"Ge":[]},"N5":{"Z0":["1","2"],"il.V":"2"},"WZ":{"vm":[],"y5":[]},"eH":{"vm":[]},"df":{"eH":[],"vm":[],"y5":[]},"b0":{"eH":[],"Xj":["1"],"vm":[]},"Dg":{"zM":["CP"],"eH":[],"Xj":["CP"],"vm":[]},"DV":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[]},"zU":{"zM":["CP"],"eH":[],"Xj":["CP"],"vm":[],"y5":[]},"K8":{"zM":["CP"],"eH":[],"Xj":["CP"],"vm":[],"y5":[]},"xj":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"dE":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"ZA":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"wf":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"Pq":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"eE":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"V6":{"zM":["KN"],"eH":[],"Xj":["KN"],"vm":[],"y5":[]},"u9":{"Ge":[]},"iM":{"E":[],"Ge":[]},"vs":{"b8":["1"]},"OH":{"Ge":[]},"Zf":{"Pf":["1"]},"ar":{"zM":["1"]},"il":{"Z0":["1","2"]},"CP":{"lf":[]},"KN":{"lf":[]},"C6":{"Ge":[]},"E":{"Ge":[]},"AT":{"Ge":[]},"bJ":{"Ge":[]},"eY":{"Ge":[]},"ub":{"Ge":[]},"ds":{"Ge":[]},"lj":{"Ge":[]},"UV":{"Ge":[]},"VS":{"Ge":[]},"Zd":{"Gz":[]},"lw":{"vm":[]},"cv":{"KV":[],"vm":[]},"ea":{"vm":[]},"dU":{"Az":[],"vm":[]},"GO":{"vm":[]},"AW":{"vm":[]},"KV":{"vm":[]},"kT":{"vm":[]},"SV":{"vm":[]},"Y4":{"vm":[]},"l8":{"vm":[]},"WW":{"vm":[]},"A1":{"vm":[]},"MN":{"vm":[]},"a3":{"vm":[]},"qE":{"cv":[],"KV":[],"vm":[]},"PI":{"vm":[]},"Gh":{"cv":[],"KV":[],"vm":[]},"fY":{"cv":[],"KV":[],"vm":[]},"Az":{"vm":[]},"nx":{"KV":[],"vm":[]},"Tf":{"vm":[]},"oJ":{"vm":[]},"Bw":{"vm":[]},"Uv":{"vm":[]},"HS":{"vm":[]},"n1":{"vm":[]},"Sb":{"vm":[]},"Nh":{"vm":[]},"Fv":{"zM":["tn<lf>"],"Xj":["tn<lf>"],"vm":[]},"IB":{"tn":["lf"],"vm":[]},"Yl":{"zM":["qU"],"Xj":["qU"],"vm":[]},"zX":{"vm":[]},"VG":{"zM":["cv"]},"D0":{"vm":[]},"Dy":{"zM":["dU"],"Xj":["dU"],"vm":[]},"wJ":{"vm":[]},"Yu":{"cv":[],"KV":[],"vm":[]},"br":{"vm":[]},"xn":{"zM":["KV"],"Xj":["KV"],"vm":[]},"Sg":{"vm":[]},"u8":{"vm":[]},"tL":{"vm":[]},"av":{"ea":[],"vm":[]},"Cf":{"vm":[]},"S0":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"z2":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"bw":{"zM":["AW"],"Xj":["AW"],"vm":[]},"e7":{"zM":["KV"]},"BH":{"zM":["KV"],"Xj":["KV"],"vm":[]},"AM":{"zM":["kT"],"Xj":["kT"],"vm":[]},"p8":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"lp":{"cv":[],"KV":[],"vm":[]},"Jr":{"vm":[]},"Mk":{"zM":["SV"],"Xj":["SV"],"vm":[]},"Nn":{"zM":["Y4"],"Xj":["Y4"],"vm":[]},"As":{"vm":[],"Z0":["qU","qU"],"il.V":"qU"},"X0":{"zM":["MN"],"Xj":["MN"],"vm":[]},"nJ":{"zM":["A1"],"Xj":["A1"],"vm":[]},"M0":{"vm":[]},"o4":{"zM":["a3"],"Xj":["a3"],"vm":[]},"cn":{"vm":[]},"Fj":{"vm":[]},"vX":{"vm":[]},"Oi":{"vm":[]},"PR":{"zM":["lw"],"Xj":["lw"],"vm":[]},"w4":{"tn":["lf"],"vm":[]},"Ij":{"zM":["GO?"],"Xj":["GO?"],"vm":[]},"rh":{"zM":["KV"],"Xj":["KV"],"vm":[]},"LO":{"zM":["l8"],"Xj":["l8"],"vm":[]},"i9":{"zM":["WW"],"Xj":["WW"],"vm":[]},"dW":{"vm":[]},"D7":{"zM":["cv"]},"x0":{"vm":[]},"uP":{"vm":[]},"dq":{"vm":[]},"jK":{"zM":["x0"],"vm":[]},"LZ":{"zM":["uP"],"vm":[]},"ED":{"vm":[]},"Kq":{"zM":["qU"],"vm":[]},"d5":{"cv":[],"KV":[],"vm":[]},"DT":{"zM":["dq"],"vm":[]},"r2":{"vm":[]},"VK":{"vm":[],"Z0":["qU","@"],"il.V":"@"},"fo":{"vm":[]},"V7":{"vm":[]},"Gn":{"vm":[]},"ZX":{"zM":["KN"]},"F0":{"zM":["KN"]},"zt":{"zM":["KN"]},"rF":{"zM":["KN"]},"yc":{"zM":["KN"]},"X6":{"zM":["KN"]},"Pz":{"zM":["KN"]},"oI":{"zM":["CP"]},"mJ":{"zM":["CP"]}}'))
 A.FF(v.typeUniverse,JSON.parse('{"jd":1,"Po":1,"m1":1,"bQ":1,"a7":1,"i1":2,"MH":2,"U5":1,"vG":1,"SU":1,"N5":2,"i5":1,"N6":1,"b0":1,"ar":1,"il":2,"Ly":1,"xC":1,"Pb":1,"W9":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
 var t=(function rtii(){var s=A.N0

--- a/src/index.html
+++ b/src/index.html
@@ -429,7 +429,7 @@ js:
             <div class="modal-body">
                 <div class="embedded-video-wrapper">
                     <div id="video-player"></div>
-<!--                    <iframe id="video-player-iframe" class="embedded-video-wrapper__frame" width="auto" height="auto" src="https://youtube.com/embed/5F-6n_2XWR8?cc_lang_pref=en&cc_load_policy=1&enablejsapi=1" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>-->
+<!--                    <iframe id="video-player-iframe" class="embedded-video-wrapper__frame" width="auto" height="auto" src="https://youtube.com/embed/5F-6n_2XWR8?cc_lang_pref=en&cc_load_policy=1&enablejsapi=1" loading="lazy" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>-->
                 </div>
             </div>
         </div>

--- a/tool/dartpad_picker/lib/dartpad_picker.dart
+++ b/tool/dartpad_picker/lib/dartpad_picker.dart
@@ -54,7 +54,9 @@ class DartPadPicker {
 
   void _initDartPad() {
     _iFrameElement = IFrameElement()
-      ..src = iFrameSrc(theme: 'dark', mode: 'dart');
+      ..src = iFrameSrc(theme: 'dark', mode: 'dart')
+      ..attributes['loading'] = 'lazy';
+
     final id = frameId;
     if (id != null) {
       _iFrameElement.id = id;

--- a/tool/dartpad_picker/pubspec.yaml
+++ b/tool/dartpad_picker/pubspec.yaml
@@ -8,4 +8,4 @@ dev_dependencies:
   analysis_defaults:
     path: ../../site-shared/packages/analysis_defaults
   build_runner: ^2.4.6
-  build_web_compilers: ^4.0.5
+  build_web_compilers: ^4.0.6


### PR DESCRIPTION
[Lazy loads](https://web.dev/articles/iframe-lazy-loading) the DartPad iframe on the (bottom of the homepage) since it is almost always offscreen on first load and does not need to delay other parts of site loading. The browsers that respect this can choose to load it based on certain heuristics, so it may not make a difference, but across a few runs I saw the largest contentful paint time in lighthouse reduce by 1-5%.

