### PR TITLE
Fixes to the command line tutorial

### DIFF
--- a/src/tutorials/server/cmdline.md
+++ b/src/tutorials/server/cmdline.md
@@ -47,9 +47,9 @@ The `dart` commands are included with the [Dart SDK](/tools/sdk).
 
 {{site.alert.important}}
   The location of the SDK installation directory
-  (we'll call it _&lt;sdk-install-dir&gt;_) depends on your platform
+  (we'll call it `<sdk-install-dir>`) depends on your platform
   and how you installed the SDK.
-  You can find `dart` in `_&lt;sdk-install-dir&gt;_/bin`.
+  You can find `dart` in `<sdk-install-dir>/bin`.
   By putting this directory in your PATH
   you can refer to the `dart` command by name.
 {{site.alert.end}}
@@ -626,7 +626,7 @@ that help with parsing and using command-line arguments:
 [`ArgResults`]({{argsAPI}}/ArgResults-class.html).
 
 For more classes, functions, and properties,
-consult to the API docs for
+consult the API docs for
 [`dart:io`]({{ioAPI}}/dart-io-library.html),
 [`dart:convert`]({{site.dart-api}}/{{site.data.pkg-vers.SDK.channel}}/dart-convert/dart-convert-library.html),
 and [`package:args`]({{argsAPI}}/args-library.html).  


### PR DESCRIPTION
- Fix formatting of the `<sdk-install-dir>` variable.
- Fix copy of "consult the docs ..."

Fixed formatting:
<img width="914" alt="Showcases the variable correctly formatted" src="https://github.com/dart-lang/site-www/assets/18372958/07e5bc14-0501-44da-8632-9fc26fc4ee77">
