### PR TITLE
Mark dev channel as experimental to fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - sdk: dev
-            experimental: false
+            experimental: true
           - sdk: beta
             experimental: false
           - sdk: stable


### PR DESCRIPTION
This is temporary as I expect the diagnostic change causing the failure to be fixed in the SDK. 