### PR TITLE
Don't run tests on the dev channel for now to fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sdk: dev
-            experimental: false
+#          - sdk: dev
+#            experimental: false
           - sdk: beta
             experimental: false
           - sdk: stable


### PR DESCRIPTION
This is temporary until either the next release or the whitespace change causing the failure is reverted from the underlying diagnostic in the SDK.

We don't rely on the `dev` testing much anyway, with most of our focus on `stable` and `beta`.