### PR TITLE
Update site for release of Dart 3.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ RUN set -eu; \
     case "$(dpkg --print-architecture)_${DART_CHANNEL}" in \
       # BEGIN dart-sha
       amd64_stable) \
-        DART_SHA256="280fcd1edba1b59af8a2d4b578904d25428ccff6e865c44bbfb5434d5cc02ddb"; \
+        DART_SHA256="4342ba274a4e9f8057079cf9de43b1c7bdb002016ad538313e8ebe942b61bba8"; \
         SDK_ARCH="x64";; \
       arm64_stable) \
-        DART_SHA256="7e65aa7084bd87f1d752b3070bb8c22fb85080fef12432db11eed8ed0cb0c99c"; \
+        DART_SHA256="0f0e19c276c99fa3efd6428ea4bef1502f742f2a1f9772959637eec775c10ba0"; \
         SDK_ARCH="arm64";; \
       amd64_beta) \
         DART_SHA256="b3aa85b15bd13d619ba924524d5c7f082dc256a062ad34fe12ec824c9f05c2b3"; \
@@ -47,10 +47,10 @@ RUN set -eu; \
         DART_SHA256="b7644435c8acf1e73da3f1ce16889b7222fbab37a75111aff225422a1cc61cab"; \
         SDK_ARCH="arm64";; \
       amd64_dev) \
-        DART_SHA256="942d507e3aca412f8b54910f9e34c4f76e3ca61c1fffa46ff30bb6b926354fdc"; \
+        DART_SHA256="ae283eec0aa6e044064a79fc524af3dffec0543c48488538fc1a01a1fae7567b"; \
         SDK_ARCH="x64";; \
       arm64_dev) \
-        DART_SHA256="93352d1ed979b864fa53fd67768cd4ab8ae0dd86b05d773f7e3f9fcfc0f70a2e"; \
+        DART_SHA256="99153759fe1edbc5c1c6a8c5e5164fad11671eed8a8899bf127a17412b701172"; \
         SDK_ARCH="arm64";; \
       # END dart-sha
     esac; \

--- a/src/_data/pkg-vers.json
+++ b/src/_data/pkg-vers.json
@@ -3,6 +3,6 @@
     "doc-path": "install",
     "channel": "stable",
     "prev-vers": "2.19.6",
-    "vers": "3.1.4"
+    "vers": "3.1.5"
   }
 }


### PR DESCRIPTION
Other failure will be fixed by https://github.com/dart-lang/site-www/pull/5282.