### PR TITLE
Update more uses of prettify to Markdown code blocks

### DIFF
--- a/src/effective-dart/documentation.md
+++ b/src/effective-dart/documentation.md
@@ -347,14 +347,14 @@ class Chunk { ... }
 
 {:.good}
 <?code-excerpt "docs_good.dart (code-sample)"?>
-{% prettify dart tag=pre+code %}
+````dart
 /// Returns the lesser of two numbers.
 ///
 /// ```dart
 /// min(5, 3) == 3
 /// ```
 num min(num a, num b) => ...
-{% endprettify %}
+````
 
 Humans are great at generalizing from examples, so even a single code sample
 makes an API easier to learn.
@@ -456,7 +456,7 @@ universal popularity is why we chose it. Here's just a quick example to give you
 a flavor of what's supported:
 
 <?code-excerpt "docs_good.dart (markdown)"?>
-{% prettify dart tag=pre+code %}
+````dart
 /// This is a paragraph of regular text.
 ///
 /// This sentence has *two* _emphasized_ words (italics) and **two**
@@ -507,7 +507,7 @@ a flavor of what's supported:
 /// ### A subsubheader
 ///
 /// #### If you need this many levels of headers, you're doing it wrong
-{% endprettify %}
+````
 
 ### AVOID using markdown excessively
 


### PR DESCRIPTION
Now that https://github.com/dart-lang/site-shared/pull/195 has landed, fixing https://github.com/dart-lang/site-www/issues/5288, we can use normal Markdown code blocks for these entries (that have other code blocks inside of them).