### PR TITLE
Remove incorrect/outdated Dart 3 mention on JS interop page

### DIFF
--- a/src/web/js-interop.md
+++ b/src/web/js-interop.md
@@ -39,7 +39,7 @@ For a glimpse into the next generation of JS interop,
 you can refactor your code to conform to
 the new syntax and semantics now. 
 Doing so will likely not prevent the need to refactor again
-once [Dart 3][] lands, as the features are still in development. 
+once these features stabilize, as the features are still in development. 
 However, the features available for preview are much closer
 to future JS interop than any pattern supported today.
 So, there are a few reasons to try them out now:


### PR DESCRIPTION
This doesn't resolve the entire https://github.com/dart-lang/site-www/issues/5285 issue, but it at least fixes the out of date Dart 3 mention.

Either way, it's maybe time for a new watch @domesticmouse 👀 