### PR TITLE
fix typos in language/patterns.md

### DIFF
--- a/src/language/patterns.md
+++ b/src/language/patterns.md
@@ -264,11 +264,11 @@ for (var MapEntry(:key, value: count) in hist.entries) {
 }
 ```
 
-## Uses cases for patterns
+## Use cases for patterns
 
 The [previous section](#places-patterns-can-appear)
 describes _how_ patterns fit into other Dart code constructs. 
-You saw some interesting uses cases as examples, like [swapping](#variable-assignment)
+You saw some interesting use cases as examples, like [swapping](#variable-assignment)
 the values of two variables, or
 [destructuring key-value pairs](#for-and-for-in-loops)
 in a map. This section describes even more use cases, answering:


### PR DESCRIPTION
s/uses cases/use cases

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.