### PR TITLE
Fix and remove duplicated `toc` ID

### DIFF
--- a/src/_includes/navigation-toc.html
+++ b/src/_includes/navigation-toc.html
@@ -12,6 +12,7 @@
 {% endif %}
 {% if include.extendToc -%}
   {% assign toc = toc | underscore_breaker: true %}
+  {% assign toc = toc | replace: 'id="toc" ', '' %}
   {% assign toc = toc | replace: '<ul>', '<ul class="nav">' %}
   {% assign toc = toc | replace: '<ul class="section-nav">', '<ul class="section-nav nav">' %}
   {% assign toc = toc | replace: 'class="toc-entry', 'class="toc-entry nav-item' %}

--- a/src/_sass/_overwrites.scss
+++ b/src/_sass/_overwrites.scss
@@ -39,7 +39,7 @@ a {
 @media print {
   /* Don't display navigation aids when printing */
   #page-header, #sidenav, #subnav, #page-footer, .banner,
-  #toc, #site-toc--inline, #site-toc--side, #page-github-links {
+  #site-toc--inline, #site-toc--side, #page-github-links {
     display: none !important;
   }
 


### PR DESCRIPTION
We use a TOC generated from a plugin, so we need to do the replacement manually.

Fixes https://github.com/dart-lang/site-www/issues/5296
Fixes [#5302](https://github.com/dart-lang/site-www/issues/5302)