### PR TITLE
Avoid duplicated search box IDs

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -13,7 +13,7 @@ sitemap: false
       <input type="hidden" name="cx" value="011220921317074318178:i4mscbaxtru">
       <input type="hidden" name="ie" value="UTF-8">
       <input type="hidden" name="hl" value="en">
-      <input class="search-field" type="search" name="q" id="q" autocomplete="off" placeholder="Enter keywords">
+      <input class="search-field" type="search" name="q" id="search-main" autocomplete="off" placeholder="Enter keywords">
     </form>
   </div>
 

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -36,7 +36,7 @@
         <input type="hidden" name="ie" value="UTF-8">
         <input type="hidden" name="hl" value="en">
         <input class="site-header__searchfield form-control search-field" type="search" name="q"
-          id="q" autocomplete="off" placeholder="Search" aria-label="Search">
+          id="search-main" autocomplete="off" placeholder="Search" aria-label="Search">
       </form>
     </li>
   </ul>

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -1,7 +1,7 @@
 <div id="sidenav" class="">
   <form action="/search/" class="site-header__search form-inline">
     <input class="site-header__searchfield form-control search-field" type="search" name="q"
-           id="q" autocomplete="off" placeholder="Search" aria-label="Search">
+           id="search-side" autocomplete="off" placeholder="Search" aria-label="Search">
   </form>
 
   <div class="site-sidebar">


### PR DESCRIPTION
The `name` field on an input is used for submitting the search, so it's okay for the IDs to be different, but the names to remain the same.

Fixes https://github.com/dart-lang/site-www/issues/5295