### PR TITLE
[3.2] Update effective dart mention of "only local variables can be promoted"

### DIFF
--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -353,10 +353,8 @@ to a non-nullable type. That lets you access members on the variable and pass it
 to functions expecting a non-nullable type.
 
 Type promotion is only supported, however, for local variables, parameters, and
-private final fields. Values that are open to manipulation, whether
-directly, like top-level variables, or indirectly, like fields with a concrete
-getter of the same name in the same library, can't be type promoted.
-Read [Fixing type promotion failures][] for a full list of non-promotion reasons.
+private final fields. Values that are open to manipulation
+[can't be type promoted][].
 
 Declaring members [private][] and [final][], as we generally recommend, is often
 enough to bypass these limitations. But, that's not always an option.
@@ -414,7 +412,7 @@ local variable [`final`][] can prevent such mistakes.) Also, if the field might
 change while the local is still in scope, then the local might have a stale
 value. Sometimes it's best to simply [use `!`][] on the field.
 
-[Fixing type promotion failures]: /tools/non-promotion-reasons
+[can't be type promoted]: /tools/non-promotion-reasons
 [private]: /effective-dart/design#prefer-making-declarations-private
 [final]: /effective-dart/design#prefer-making-fields-and-top-level-variables-final
 [`final`]: /effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -352,16 +352,17 @@ Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
 to functions expecting a non-nullable type.
 
-Type promotion is only sound, however, for local variables, parameters, and
-private final fields. Instances that are open to manipulation, whether
-explicitly, like top-level variables, or implicitly, like fields with a concrete
+Type promotion is only supported, however, for local variables, parameters, and
+private final fields. Values that are open to manipulation, whether
+directly, like top-level variables, or indirectly, like fields with a concrete
 getter of the same name in the same library, cannot be type promoted.
 Read [Fixing type promotion failures][] for a full list of non-promotion reasons.
 
-Declaring members [private] and [final], as we generally recommend, bypasses
-these limitations, but that's not always an option. One pattern to work around
-this is to assign the field's value to a local variable. Null checks on that
-variable will promote, so you can safely treat it as non-nullable.
+Declaring members [private] and [final], as we generally recommend, is often
+enough to bypass these limitations. But, that's not always an option.
+One pattern to work around this is to assign the field's value
+to a local variable. Null checks on that variable will promote,
+so you can safely treat it as non-nullable.
 
 {:.good}
 <?code-excerpt "usage_good.dart (shadow-nullable-field)"?>
@@ -385,7 +386,7 @@ class UploadException {
 ```
 
 Assigning to a local variable can be cleaner and safer than using `!` every
-place the instance is used:
+place the value is used:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -350,13 +350,18 @@ then it probably does make sense to have a separate boolean field.
 
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
-to functions expecting a non-nullable type. Unfortunately, promotion is only
-sound for local variables and parameters, so fields and top-level variables
-aren't promoted.
+to functions expecting a non-nullable type.
 
-One pattern to work around this is to assign the field's value to a local
-variable. Null checks on that variable do promote, so you can safely treat
-it as non-nullable.
+Type promotion is only sound, however, for local variables, parameters, and
+private final fields. Instances that are open to manipulation, whether
+explicitly, like top-level variables, or implicitly, like fields with a concrete
+getter of the same name in the same library, cannot be type promoted.
+Read [Fixing type promotion failures][] for a full list of non-promotion reasons.
+
+Declaring members [private] and [final], as we generally recommend, bypasses
+these limitations, but that's not always an option. One pattern to work around
+this is to assign the field's value to a local variable. Null checks on that
+variable will promote, so you can safely treat it as non-nullable.
 
 {:.good}
 <?code-excerpt "usage_good.dart (shadow-nullable-field)"?>
@@ -380,7 +385,7 @@ class UploadException {
 ```
 
 Assigning to a local variable can be cleaner and safer than using `!` every
-place the field or top-level variable is used:
+place the instance is used:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>
@@ -404,10 +409,15 @@ class UploadException {
 
 Be careful when using a local variable. If you need to write back to the field,
 make sure that you don't write back to the local variable instead. (Making the
-local variable `final` can prevent such mistakes.) Also, if the field might
+local variable [`final`] can prevent such mistakes.) Also, if the field might
 change while the local is still in scope, then the local might have a stale
-value. Sometimes it's best to simply use `!` on the field.
+value. Sometimes it's best to simply [use `!`] on the field.
 
+[Fixing type promotion failures]: /tools/non-promotion-reasons
+[private]: design#prefer-making-declarations-private
+[final]: design#prefer-making-fields-and-top-level-variables-final
+[`final`]: /effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables
+[use `!`]: /null-safety/understanding-null-safety#null-assertion-operator
 
 ## Strings
 

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -355,10 +355,10 @@ to functions expecting a non-nullable type.
 Type promotion is only supported, however, for local variables, parameters, and
 private final fields. Values that are open to manipulation, whether
 directly, like top-level variables, or indirectly, like fields with a concrete
-getter of the same name in the same library, cannot be type promoted.
+getter of the same name in the same library, can't be type promoted.
 Read [Fixing type promotion failures][] for a full list of non-promotion reasons.
 
-Declaring members [private] and [final], as we generally recommend, is often
+Declaring members [private][] and [final][], as we generally recommend, is often
 enough to bypass these limitations. But, that's not always an option.
 One pattern to work around this is to assign the field's value
 to a local variable. Null checks on that variable will promote,
@@ -386,7 +386,7 @@ class UploadException {
 ```
 
 Assigning to a local variable can be cleaner and safer than using `!` every
-place the value is used:
+time you need to treat the value as non-null:
 
 {:.bad}
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>
@@ -410,13 +410,13 @@ class UploadException {
 
 Be careful when using a local variable. If you need to write back to the field,
 make sure that you don't write back to the local variable instead. (Making the
-local variable [`final`] can prevent such mistakes.) Also, if the field might
+local variable [`final`][] can prevent such mistakes.) Also, if the field might
 change while the local is still in scope, then the local might have a stale
-value. Sometimes it's best to simply [use `!`] on the field.
+value. Sometimes it's best to simply [use `!`][] on the field.
 
 [Fixing type promotion failures]: /tools/non-promotion-reasons
-[private]: design#prefer-making-declarations-private
-[final]: design#prefer-making-fields-and-top-level-variables-final
+[private]: /effective-dart/design#prefer-making-declarations-private
+[final]: /effective-dart/design#prefer-making-fields-and-top-level-variables-final
 [`final`]: /effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables
 [use `!`]: /null-safety/understanding-null-safety#null-assertion-operator
 


### PR DESCRIPTION
This is the same as #4272 but that was stale (not requesting Bob's review again since he approved that one), plus added more links to more info. 