### PR TITLE
[3.2] Update breaking changes page

### DIFF
--- a/src/resources/breaking-changes.md
+++ b/src/resources/breaking-changes.md
@@ -47,49 +47,21 @@ To be notified about future breaking changes, join the [Dart announce][] group.
 
 ## Not yet released to stable
 
-### Language
-{: .no_toc}
-
-* **Language versioned**: [Changed the split point for refutable patterns][53167]
-  to the top level pattern so type promotion in if-case statements is consistent
-  regardless of whether the scrutinee might throw an exception.
-
 ### Libraries
 {: .no_toc}
 
-#### `dart:convert`
+#### `dart:nativewrappers`
 
-* [Changed return types of `utf8.encode()` and `Utf8Codec.encode()`][52801]
- from `List<int>` to `Uint8List`.
+* [Marked classes belonging to `NativeWrapperClass` as `base`][51896] so that
+  none of their subtypes can be implemented.
 
-#### `dart:developer`
+#### `dart:typed_data`
 
-* **Deprecated**: The `Service.getIsolateID` method.
-
-#### `dart:io`
-
-* [Eliminated trailing whitespace from HTTP headers][53005].
-
-#### `dart:js_interop`
-
-* **Experimental** **Removed**: `JSNumber.toDart` in favor of `toDartDouble` and
-  `toDartInt`.
-* **Experimental** **Removed**: `Object.toJS` in favor of `Object.toJSBox.`
-
-### Tools
-{: .no_toc}
-
-#### Dart Dev Compiler (DDC) and Dart2js
-
-* [Added interceptors for JavaScript `Symbol` and `BigInt` types][53106];
-  they should no longer be used with `package:js` classes.
+* **Deprecated**: [Unmodifiable view classes for typed data][53218].
 
 
-[53167]: https://github.com/dart-lang/sdk/issues/53167
-[52801]: https://github.com/dart-lang/sdk/issues/52801
-[53005]: https://github.com/dart-lang/sdk/issues/53005
-[53106]: https://github.com/dart-lang/sdk/issues/53106
-
+[51896]: https://github.com/dart-lang/sdk/issues/51896
+[53218]: https://github.com/dart-lang/sdk/issues/53218
 
 {% comment %}
 Create new section from these headers for each release.
@@ -111,6 +83,70 @@ don't include the section header.
 
 #### (Dart VM, Pub, Linter, `dart2js`, etc)
 {% endcomment %}
+
+## Released in 3.2.0
+
+### Language
+{: .no_toc}
+
+* **Language versioned**: [Changed the split point for refutable patterns][53167]
+  to the top level pattern so type promotion in if-case statements is consistent
+  regardless of whether the scrutinee might throw an exception.
+
+### Libraries
+{: .no_toc}
+
+#### `dart:convert`
+
+* [Changed return types of `utf8.encode()` and `Utf8Codec.encode()`][52801]
+ from `List<int>` to `Uint8List`.
+
+#### `dart:developer`
+
+* **Deprecated**: The `Service.getIsolateID` method.
+
+#### `dart:ffi`
+
+* [Changed NativeCallable.nativeFunction so calls now throw an error if
+  the receiver is already closed][53311], instead of returning `nullptr`.
+
+#### `dart:io`
+
+* [Eliminated trailing whitespace from HTTP headers][53005].
+* [Inserted a space at the fold point of folded header values][53227]
+  that `HttpClientResponse.headers` and `HttpRequest.headers` return.
+
+#### `dart:js_interop`
+
+* **Experimental** **Removed**: `JSNumber.toDart` in favor of `toDartDouble` and
+  `toDartInt`.
+* **Experimental** **Removed**: `Object.toJS` in favor of `Object.toJSBox.`
+* **Experimental**: Restricted external JS interop APIs using `dart:js_interop`
+  to a set of allowed types.
+* **Experimental**: Prohibited use of `isNull` and `isUndefined` on dart2wasm.
+* **Experimental**: Changed `typeofEquals` and `instanceof` APIs to both return
+  bool instead of `JSBoolean`.
+  Also, `typeofEquals` now takes `String` instead of `JSString`.
+* **Experimental**: Changed `JSAny` and `JSObject` types to only implementable,
+  not extendable, by user `@staticInterop` types.
+* **Experimental**: Changed `JSArray.withLength` to take `int` instead of `JSNumber`.
+
+### Tools
+{: .no_toc}
+
+#### Dart Dev Compiler (DDC) and Dart2js
+
+* [Added interceptors for JavaScript `Symbol` and `BigInt` types][53106];
+  they should no longer be used with `package:js` classes.
+
+
+[53167]: https://github.com/dart-lang/sdk/issues/53167
+[52801]: https://github.com/dart-lang/sdk/issues/52801
+[53311]: https://github.com/dart-lang/sdk/issues/53311
+[53005]: https://github.com/dart-lang/sdk/issues/53005
+[53227]: https://github.com/dart-lang/sdk/issues/53227
+[53106]: https://github.com/dart-lang/sdk/issues/53106
+
 
 ## Released in 3.1.0
 

--- a/src/resources/breaking-changes.md
+++ b/src/resources/breaking-changes.md
@@ -148,6 +148,31 @@ don't include the section header.
 * [Added interceptors for JavaScript `Symbol` and `BigInt` types][53106];
   they should no longer be used with `package:js` classes.
 
+#### Analyzer
+
+* **Language versioned**: [Private final field promotion][2020] might cause the following
+  analyzer warnings to trigger on existing code that previously passed analysis:
+  
+  * [`unnecessary_non_null_assertion`](/tools/diagnostic-messages#unnecessary_non_null_assertion)
+  * [`invalid_null_aware_operator`](/tools/diagnostic-messages#invalid_null_aware_operator)
+  * [`unnecessary_cast`](/tools/diagnostic-messages#unnecessary_cast)
+
+  ```dart
+  class C {
+    final num? _x = null;
+
+    void test() {
+      if (_x != null) {
+        print(_x! * 2); // unnecessary_non_null_assertion
+        print(_x?.abs()); // invalid_null_aware_operator
+      }
+      if (_x is int) {
+        print((_x as int).bitLength); // unnecessary_cast
+      }
+    }
+  }
+  ```
+
 [53167]: https://github.com/dart-lang/sdk/issues/53167
 [52121]: https://github.com/dart-lang/sdk/issues/52121
 [52801]: https://github.com/dart-lang/sdk/issues/52801
@@ -155,6 +180,7 @@ don't include the section header.
 [53005]: https://github.com/dart-lang/sdk/issues/53005
 [53227]: https://github.com/dart-lang/sdk/issues/53227
 [53106]: https://github.com/dart-lang/sdk/issues/53106
+[2020]: https://github.com/dart-lang/language/issues/2020
 
 
 ## Released in 3.1.0

--- a/src/resources/breaking-changes.md
+++ b/src/resources/breaking-changes.md
@@ -96,6 +96,10 @@ don't include the section header.
 ### Libraries
 {: .no_toc}
 
+#### `dart:cli`
+
+* **Experimental** **Deprecated**: [The `waitFor` function.][52121]
+
 #### `dart:convert`
 
 * [Changed return types of `utf8.encode()` and `Utf8Codec.encode()`][52801]
@@ -134,13 +138,18 @@ don't include the section header.
 ### Tools
 {: .no_toc}
 
-#### Dart Dev Compiler (DDC) and Dart2js
+#### Development JavaScript compiler (DDC)
 
 * [Added interceptors for JavaScript `Symbol` and `BigInt` types][53106];
   they should no longer be used with `package:js` classes.
 
+#### Production JavaScript compiler (dart2js)
+
+* [Added interceptors for JavaScript `Symbol` and `BigInt` types][53106];
+  they should no longer be used with `package:js` classes.
 
 [53167]: https://github.com/dart-lang/sdk/issues/53167
+[52121]: https://github.com/dart-lang/sdk/issues/52121
 [52801]: https://github.com/dart-lang/sdk/issues/52801
 [53311]: https://github.com/dart-lang/sdk/issues/53311
 [53005]: https://github.com/dart-lang/sdk/issues/53005

--- a/src/resources/breaking-changes.md
+++ b/src/resources/breaking-changes.md
@@ -107,7 +107,7 @@ don't include the section header.
 
 #### `dart:ffi`
 
-* [Changed NativeCallable.nativeFunction so calls now throw an error if
+* [Changed `NativeCallable.nativeFunction` so calls now throw an error if
   the receiver is already closed][53311], instead of returning `nullptr`.
 
 #### `dart:io`


### PR DESCRIPTION
### Do not merge until 3.2

---

- Moved "not yet released to stable" contents to "released in 3.2" section, and added newer entries from the changelog. 
- Added 3.3.0 changelog contents to "not yet released in stable"

fyi @leafpetersen 