### PR TITLE
Update mention to sdk constraint on type promotion page

### DIFF
--- a/src/tools/non-promotion-reasons.md
+++ b/src/tools/non-promotion-reasons.md
@@ -54,10 +54,11 @@ because field promotion is only available in Dart 3.2 and above.
 
 **Solution:**
 
-Ensure your code isn't targeting
-a previous [language version][] of Dart. 
-Check the top of your file for a `//@dart=version` comment,
-or the `version` field of your `pubspec.yaml`.
+Ensure your library isn't using a [language version][] earlier than 3.2.
+Check the top of your file for an outdated `//@dart=version` comment
+or your `pubspec.yaml` for a [SDK constraint lower-bound][] that's too low.
+
+[SDK constraint lower-bound]: /tools/pub/pubspec#sdk-constraints
 
 ## Only local variables can be promoted (before Dart 3.2) {#property}
 


### PR DESCRIPTION
I'm not sure about the writing of this, so please feel free to make adjustments, but you're right, there is no `version` field. The package-wide default language version comes from the lower bound of the [SDK constraint](https://dart.dev/tools/pub/pubspec#sdk-constraints) you declare in your `pubspec.yaml` file.

Fixes https://github.com/dart-lang/site-www/issues/5360