### PR TITLE
Fix accidental replacement on type system page

### DIFF
--- a/src/language/type-system.md
+++ b/src/language/type-system.md
@@ -163,9 +163,9 @@ class HoneyBadger extends Animal {
 ```
 
 {:.fails-sa}
-<?code-excerpt "lib/animal.dart (HoneyBadger)" replace="/HoneyBadger/[!Root!]/g"?>
+<?code-excerpt "lib/animal.dart (HoneyBadger)" replace="/HoneyBadger get/[!Root!] get/g"?>
 ```dart
-class [!Root!] extends Animal {
+class HoneyBadger extends Animal {
   @override
   void chase(Animal a) { ... }
 


### PR DESCRIPTION
In https://github.com/dart-lang/site-www/pull/5217, when adding code excerpts to these samples, I accidentally didn't make the replace specific enough and replaced too much.