### PR TITLE
Remove guideline on named parameter default value syntax

### DIFF
--- a/src/effective-dart/_toc.md
+++ b/src/effective-dart/_toc.md
@@ -127,7 +127,6 @@ $ dart run tool/effective_dart_rules/bin/main.dart
 
 * <a href='/effective-dart/usage#do-use-a-function-declaration-to-bind-a-function-to-a-name'>DO use a function declaration to bind a function to a name.</a>
 * <a href='/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do'>DON'T create a lambda when a tear-off will do.</a>
-* <a href='/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value'>DO use <code>=</code> to separate a named parameter from its default value.</a>
 
 **Variables**
 
@@ -205,8 +204,7 @@ $ dart run tool/effective_dart_rules/bin/main.dart
 * <a href='/effective-dart/design#do-document-if-your-class-supports-being-extended'>DO document if your class supports being extended.</a>
 * <a href='/effective-dart/design#avoid-implementing-a-class-that-isnt-intended-to-be-an-interface'>AVOID implementing a class that isn't intended to be an interface.</a>
 * <a href='/effective-dart/design#do-document-if-your-class-supports-being-used-as-an-interface'>DO document if your class supports being used as an interface.</a>
-* <a href='/effective-dart/design#do-use-mixin-to-define-a-mixin-type'>DO use <code>mixin</code> to define a mixin type.</a>
-* <a href='/effective-dart/design#avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin'>AVOID mixing in a type that isn't intended to be a mixin.</a>
+* <a href='/effective-dart/design#prefer-defining-a-pure-mixin-or-pure-class-to-a-mixin-class'>PREFER defining a pure <code>mixin</code> or pure <code>class</code> to a <code>mixin class</code>.</a>
 
 **Constructors**
 

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -947,26 +947,6 @@ var buffers = charCodes.map((code) => StringBuffer(code));
 ```
 
 
-### DO use `=` to separate a named parameter from its default value
-
-{% include linter-rule-mention.md rule="prefer_equal_for_default_values" %}
-
-Before Dart 3, Dart allowed both `:` and `=` 
-as the default value separator for named parameters. 
-For consistency with optional positional parameters, use `=`.
-
-{:.good}
-<?code-excerpt "usage_good.dart (default-separator)"?>
-```dart
-void insert(Object item, {int at = 0}) { ... }
-```
-
-{:.bad}
-```dart
-void insert(Object item, {int at: 0}) { ... }
-```
-
-
 ## Variables
 
 The following best practices describe how to best use variables in Dart.


### PR DESCRIPTION
It's time. The old syntax was deprecated and linted for many years, then had a warning in the analyzer for a while, and now has been removed from the language for a few releases. 

🫡

Closes https://github.com/dart-lang/site-www/issues/4787