### PR TITLE
Adjust error message text to match implementation.

### DIFF
--- a/src/tools/non-promotion-reasons.md
+++ b/src/tools/non-promotion-reasons.md
@@ -235,7 +235,7 @@ test(C c) {
 **Message:**
 
 ```nocode
-'n' refers to a public field so it couldn’t be promoted.
+'n' refers to a public property so it couldn’t be promoted.
 ```
 
 **Solution:**


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/337609 made a small change in the context message that the analyzer and CFE generate when field promotion fails due to the member in question being public. Previously the message referred to the non-promoting members as a `public field`. Now it refers to it as a `public property` (because in certain circumstances, private properties *are* promotable).

This small change in the context message text doesn't really have any impact on the advice we want to give to users about field promotability, but it's nice for the documentation to match the implementation's output as closely as possible.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
