### PR TITLE
Fix incorrect link in 'dart doc' page

### DIFF
--- a/src/tools/dart-doc.md
+++ b/src/tools/dart-doc.md
@@ -46,7 +46,7 @@ $ dart help doc
 ```
 
 [documentation comments]: /language/comments#documentation-comments
-[effective doc]: /effective-dart/usage#do-use-strings-in-part-of-directives
+[effective doc]: /effective-dart/documentation#doc-comments
 [Markdown]: {{site.pub-pkg}}/markdown
 
 {% comment %}


### PR DESCRIPTION
Fixes #5426.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
