### PR TITLE
Remove mention of PWA package

### DIFF
--- a/src/web/deployment.md
+++ b/src/web/deployment.md
@@ -31,17 +31,9 @@ with `webdev build`.
 The following steps are optional. They can help make your app more
 reliable and responsive.
 
-* [Use the pwa package to make your app work offline](#use-the-pwa-package-to-make-your-app-work-offline)
 * [Use deferred loading to reduce your app's initial size](#use-deferred-loading-to-reduce-your-apps-initial-size)
 * [Follow best practices for web apps](#follow-best-practices-for-web-apps)
 * [Remove unneeded build files](#remove-unneeded-build-files)
-
-#### Use the pwa package to make your app work offline
-
-The [pwa package]({{site.pub-pkg}}/pwa) simplifies the task of
-making your app work with limited or no connectivity.
-To learn more about using this package, see
-[Making a Dart web app offline-capable: 3 lines of code.](https://medium.com/dartlang/making-a-dart-web-app-offline-capable-3-lines-of-code-e980010a7815)
 
 #### Use deferred loading to reduce your app's initial size
 


### PR DESCRIPTION
PWA package hasn't been updated in 2 years, and I think is fully integrated into Flutter Web. This seems like old advice https://pub.dev/packages/pwa

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
