### PR TITLE
Add next-gen JS interop short link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -170,7 +170,8 @@
       { "source": "/go/non-promo-public-field", "destination": "/tools/non-promotion-reasons#private", "type": 301 },
       { "source": "/go/non-promo-this", "destination": "/tools/non-promotion-reasons#this", "type": 301 },
       { "source": "/go/non-promo-write", "destination": "/tools/non-promotion-reasons#write", "type": 301 },
-    
+
+      { "source": "/go/next-gen-js-interop", "destination": "/interop/js-interop#next-generation-js-interop-preview", "type": 301 },
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },
       { "source": "/go/package-discontinue", "destination": "/tools/pub/publishing#discontinue", "type": 301 },
       { "source": "/go/package-retraction", "destination": "/tools/pub/publishing#retract", "type": 301 },


### PR DESCRIPTION
I'd like to add this to link to from DartPad and the Flutter site. Perhaps elsewhere as well (such as tools or docs in the SDK).

That way we can adjust the destination of the redirect in the future as we add more documentation.