### PR TITLE
Change deploy project to dart-dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,6 @@
+# This GitHub workflow has been disabled and is no longer used. 
+# Website deploys are now done through Cloud Build. 
+# See https://github.com/dart-lang/site-www/pull/5447
 name: deploy
 
 on:

--- a/cloud_build/deploy.yaml
+++ b/cloud_build/deploy.yaml
@@ -14,6 +14,6 @@ steps:
     args:
       - '-c'
       - |-
-        firebase deploy --project=flutter-website-staging-349021 --only=hosting
+        firebase deploy --project=dart-dev --only=hosting
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloud_build/deploy.yaml
+++ b/cloud_build/deploy.yaml
@@ -9,6 +9,7 @@ steps:
         set -e
         echo "Building the website using a makefile..."
         make build
+        make write-prod-robots
   - name: gcr.io/flutter-dev-230821/firebase-ghcli
     entrypoint: '/bin/bash'
     args:


### PR DESCRIPTION
Addresses remaining AI's from #5447.

- [x] Swapped out deploy project to `dart-dev`
- [x] I've manually disabled the [deploy.yaml GitHub action](https://github.com/dart-lang/site-www/blob/main/.github/workflows/deploy.yml) workflow from the "Actions" menu. 
- [x] Updated the Cloud Build trigger to go off on push to `main` branch