### PR TITLE
Correct word usage in `extend.md`.

### DIFF
--- a/src/language/extend.md
+++ b/src/language/extend.md
@@ -62,7 +62,7 @@ the method (or methods) that it overrides in several ways:
 
 * The return type must be the same type as (or a subtype of)
   the overridden method's return type.
-* Argument types must be the same type as (or a supertype of)
+* Parameter types must be the same type as (or a supertype of)
   the overridden method's argument types.
   In the preceding example, the `contrast` setter of `SmartTelevision`
   changes the argument type from `int` to a supertype, `num`.


### PR DESCRIPTION
At this place we talk about the method parameters, not the arguments at the call site. I verified that both, ChatGPT and Bard, agree with this assessment.

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
