### PR TITLE
Reorder constructors in ‘Effective Dart: Usage’ and ’Constructors’ examples

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -272,14 +272,14 @@ void miscDeclAnalyzedButNotTested() {
 
 // #docregion this-dot-constructor
 class ShadeOfGray {
-  final int brightness;
-
   ShadeOfGray(int val) : brightness = val;
 
   ShadeOfGray.black() : this(0);
 
   // This won't parse or compile!
   // ShadeOfGray.alsoBlack() : black();
+
+  final int brightness;
 }
 // #enddocregion this-dot-constructor
 
@@ -330,9 +330,9 @@ Item? bestDeal(List<Item> cart) {
 
 // #docregion shadow-nullable-field
 class UploadException {
-  final Response? response;
-
   UploadException([this.response]);
+
+  final Response? response;
 
   @override
   String toString() {
@@ -350,14 +350,14 @@ class UploadException {
 
 // #docregion calc-vs-store1
 class Circle1 {
-  double radius;
-  double area;
-  double circumference;
-
   Circle1(double radius)
       : radius = radius,
         area = pi * radius * radius,
         circumference = pi * 2.0 * radius;
+
+  double radius;
+  double area;
+  double circumference;
 }
 // #enddocregion calc-vs-store1
 
@@ -365,6 +365,10 @@ class Circle1 {
 
 // #docregion calc-vs-store2
 class Circle2 {
+  Circle2(this._radius) {
+    _recalculate();
+  }
+
   double _radius;
   double get radius => _radius;
   set radius(double value) {
@@ -377,10 +381,6 @@ class Circle2 {
 
   double _circumference = 0.0;
   double get circumference => _circumference;
-
-  Circle2(this._radius) {
-    _recalculate();
-  }
 
   void _recalculate() {
     _area = pi * _radius * _radius;
@@ -430,13 +430,13 @@ class Box2 {
 
 // #docregion field-init-at-decl
 class ProfileMark {
-  final String name;
-  final DateTime start;
-
   ProfileMark(this.name) : start = DateTime.now();
   ProfileMark.unnamed()
       : name = '',
         start = DateTime.now();
+
+  final String name;
+  final DateTime start;
 }
 // #enddocregion field-init-at-decl
 
@@ -444,10 +444,11 @@ class ProfileMark {
 
 // #docregion field-init-as-param
 class Point0 {
-  double x, y;
   Point0(double x, double y)
       : x = x,
         y = y;
+
+  double x, y;
 }
 // #enddocregion field-init-as-param
 
@@ -455,11 +456,12 @@ class Point0 {
 
 // #docregion late-init-list
 class Point1 {
-  late double x, y;
   Point1.polar(double theta, double radius) {
     x = cos(theta) * radius;
     y = sin(theta) * radius;
   }
+
+  late double x, y;
 }
 // #enddocregion late-init-list
 

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -359,9 +359,9 @@ class Response {
 
 // #docregion shadow-nullable-field
 class UploadException {
-  final Response? response;
-
   UploadException([this.response]);
+
+  final Response? response;
 
   @override
   String toString() {
@@ -380,9 +380,9 @@ class UploadException {
 
 // #docregion calc-vs-store
 class Circle {
-  double radius;
-
   Circle(this.radius);
+
+  double radius;
 
   double get area => pi * radius * radius;
   double get circumference => pi * 2.0 * radius;
@@ -466,14 +466,14 @@ class Box2 {
 
 // #docregion this-dot-constructor
 class ShadeOfGray {
-  final int brightness;
-
   ShadeOfGray(int val) : brightness = val;
 
   ShadeOfGray.black() : this(0);
 
   // But now it will!
   ShadeOfGray.alsoBlack() : this.black();
+
+  final int brightness;
 }
 // #enddocregion this-dot-constructor
 
@@ -485,11 +485,11 @@ class BaseBox {
 
 // #docregion param-dont-shadow-field-ctr-init
 class Box3 extends BaseBox {
-  Object? value;
-
   Box3(Object? value)
       : value = value,
         super(value);
+
+  Object? value;
 }
 // #enddocregion param-dont-shadow-field-ctr-init
 
@@ -499,11 +499,11 @@ class Document {}
 
 // #docregion field-init-at-decl
 class ProfileMark {
-  final String name;
-  final DateTime start = DateTime.now();
-
   ProfileMark(this.name);
   ProfileMark.unnamed() : name = '';
+
+  final String name;
+  final DateTime start = DateTime.now();
 }
 // #enddocregion field-init-at-decl
 
@@ -511,8 +511,9 @@ class ProfileMark {
 
 // #docregion field-init-as-param
 class Point0 {
-  double x, y;
   Point0(this.x, this.y);
+
+  double x, y;
 }
 // #enddocregion field-init-as-param
 
@@ -520,10 +521,11 @@ class Point0 {
 
 // #docregion late-init-list
 class Point1 {
-  double x, y;
   Point1.polar(double theta, double radius)
       : x = cos(theta) * radius,
         y = sin(theta) * radius;
+
+  double x, y;
 }
 // #enddocregion late-init-list
 
@@ -531,8 +533,8 @@ class Point1 {
 
 // #docregion semicolon-for-empty-body
 class Point2 {
-  double x, y;
   Point2(this.x, this.y);
+  double x, y;
 }
 // #enddocregion semicolon-for-empty-body
 

--- a/examples/misc/lib/language_tour/classes/employee.dart
+++ b/examples/misc/lib/language_tour/classes/employee.dart
@@ -4,11 +4,11 @@ Map fetchDefaultData() => {}; // stub
 
 // #docregion super
 class Person {
-  String? firstName;
-
   Person.fromJson(Map data) {
     print('in Person');
   }
+
+  String? firstName;
 }
 
 // #docregion method-then-constructor

--- a/examples/misc/lib/language_tour/classes/immutable_point.dart
+++ b/examples/misc/lib/language_tour/classes/immutable_point.dart
@@ -1,7 +1,7 @@
 class ImmutablePoint {
+  const ImmutablePoint(this.x, this.y);
+
   static const ImmutablePoint origin = ImmutablePoint(0, 0);
 
   final double x, y;
-
-  const ImmutablePoint(this.x, this.y);
 }

--- a/examples/misc/lib/language_tour/classes/logger.dart
+++ b/examples/misc/lib/language_tour/classes/logger.dart
@@ -1,12 +1,5 @@
 // #docregion
 class Logger {
-  final String name;
-  bool mute = false;
-
-  // _cache is library-private, thanks to
-  // the _ in front of its name.
-  static final Map<String, Logger> _cache = <String, Logger>{};
-
   factory Logger(String name) {
     return _cache.putIfAbsent(name, () => Logger._internal(name));
   }
@@ -16,6 +9,13 @@ class Logger {
   }
 
   Logger._internal(this.name);
+
+  final String name;
+  bool mute = false;
+
+  // _cache is library-private, thanks to
+  // the _ in front of its name.
+  static final Map<String, Logger> _cache = <String, Logger>{};
 
   void log(String msg) {
     if (!mute) print(msg);

--- a/examples/misc/lib/language_tour/classes/point.dart
+++ b/examples/misc/lib/language_tour/classes/point.dart
@@ -8,9 +8,6 @@ const double yOrigin = 0;
 
 // #docregion class-with-distanceTo, constructor-initializer
 class Point {
-  final double x;
-  final double y;
-
   // #docregion class-with-distanceTo, named-constructor
   Point(this.x, this.y);
   // #enddocregion class-with-distanceTo, named-constructor
@@ -39,4 +36,7 @@ class Point {
     return sqrt(dx * dx + dy * dy);
   }
   // #docregion constructor-initializer, named-constructor
+
+  final double x;
+  final double y;
 }

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -6,9 +6,6 @@
 ///
 // #docregion idiomatic-constructor
 class Point {
-  double x = 0;
-  double y = 0;
-
   // Generative constructor with initializing formal parameters:
   Point(this.x, this.y);
   // #enddocregion idiomatic-constructor
@@ -32,4 +29,7 @@ class Point {
   // #enddocregion initializer-list-with-assert
 
 // #docregion idiomatic-constructor
+
+  double x = 0;
+  double y = 0;
 }

--- a/examples/misc/lib/language_tour/classes/point_redirecting.dart
+++ b/examples/misc/lib/language_tour/classes/point_redirecting.dart
@@ -1,9 +1,9 @@
 class Point {
-  double x, y;
-
   // The main constructor for this class.
   Point(this.x, this.y);
 
   // Delegates to the main constructor.
   Point.alongXAxis(double x) : this(x, 0);
+
+  double x, y;
 }

--- a/examples/misc/lib/language_tour/classes/point_with_distance_field.dart
+++ b/examples/misc/lib/language_tour/classes/point_with_distance_field.dart
@@ -2,14 +2,14 @@
 import 'dart:math';
 
 class Point {
-  final double x;
-  final double y;
-  final double distanceFromOrigin;
-
   Point(double x, double y)
       : x = x,
         y = y,
         distanceFromOrigin = sqrt(x * x + y * y);
+
+  final double x;
+  final double y;
+  final double distanceFromOrigin;
 }
 
 void main() {

--- a/examples/misc/lib/language_tour/classes/super_initializer_parameters.dart
+++ b/examples/misc/lib/language_tour/classes/super_initializer_parameters.dart
@@ -1,5 +1,14 @@
 // #docregion positional, named
 class Vector2d {
+  // #docregion positional
+  Vector2d(this.x, this.y);
+  // #enddocregion positional
+
+  // #docregion named
+  Vector2d.named({required this.x, required this.y});
+  // #enddocregion named
+
+  // #docregion positional, named
   // #enddocregion positional
   // ...
 
@@ -7,23 +16,11 @@ class Vector2d {
   // #docregion positional
   final double x;
   final double y;
-
-  Vector2d(this.x, this.y);
-  // #enddocregion positional
-
-  // #docregion named
-  Vector2d.named({required this.x, required this.y});
 // #docregion positional
 }
 
 class Vector3d extends Vector2d {
-  // #enddocregion positional
-  // ...
-
-  // #enddocregion named
   // #docregion positional
-  final double z;
-
   // Forward the x and y parameters to the default super constructor like:
   // Vector3d(final double x, final double y, this.z) : super(x, y);
   Vector3d(super.x, super.y, this.z);
@@ -34,6 +31,14 @@ class Vector3d extends Vector2d {
   // Vector3d.yzPlane({required double y, required this.z})
   //       : super.named(x: 0, y: y);
   Vector3d.yzPlane({required super.y, required this.z}) : super.named(x: 0);
+  // #enddocregion named
+
+  // #enddocregion positional
+  // ...
+
+  // #enddocregion named
+  // #docregion positional
+  final double z;
 // #docregion positional
 }
 // #enddocregion positional, named

--- a/src/effective-dart/usage.md
+++ b/src/effective-dart/usage.md
@@ -366,9 +366,9 @@ so you can safely treat it as non-nullable.
 <?code-excerpt "usage_good.dart (shadow-nullable-field)"?>
 ```dart
 class UploadException {
-  final Response? response;
-
   UploadException([this.response]);
+
+  final Response? response;
 
   @override
   String toString() {
@@ -390,9 +390,9 @@ time you need to treat the value as non-null:
 <?code-excerpt "usage_bad.dart (shadow-nullable-field)" replace="/!\./[!!!]./g"?>
 ```dart
 class UploadException {
-  final Response? response;
-
   UploadException([this.response]);
+
+  final Response? response;
 
   @override
   String toString() {
@@ -979,14 +979,14 @@ constructor and then stores them:
 <?code-excerpt "usage_bad.dart (calc-vs-store1)"?>
 ```dart
 class Circle {
-  double radius;
-  double area;
-  double circumference;
-
   Circle(double radius)
       : radius = radius,
         area = pi * radius * radius,
         circumference = pi * 2.0 * radius;
+
+  double radius;
+  double area;
+  double circumference;
 }
 ```
 
@@ -1007,6 +1007,10 @@ To correctly handle cache invalidation, we would need to do this:
 <?code-excerpt "usage_bad.dart (calc-vs-store2)"?>
 ```dart
 class Circle {
+  Circle(this._radius) {
+    _recalculate();
+  }
+
   double _radius;
   double get radius => _radius;
   set radius(double value) {
@@ -1019,10 +1023,6 @@ class Circle {
 
   double _circumference = 0.0;
   double get circumference => _circumference;
-
-  Circle(this._radius) {
-    _recalculate();
-  }
 
   void _recalculate() {
     _area = pi * _radius * _radius;
@@ -1038,9 +1038,9 @@ first implementation should be:
 <?code-excerpt "usage_good.dart (calc-vs-store)"?>
 ```dart
 class Circle {
-  double radius;
-
   Circle(this.radius);
+
+  double radius;
 
   double get area => pi * radius * radius;
   double get circumference => pi * 2.0 * radius;
@@ -1228,14 +1228,14 @@ The other time to use `this.` is when redirecting to a named constructor:
 <?code-excerpt "usage_bad.dart (this-dot-constructor)"?>
 ```dart
 class ShadeOfGray {
-  final int brightness;
-
   ShadeOfGray(int val) : brightness = val;
 
   ShadeOfGray.black() : this(0);
 
   // This won't parse or compile!
   // ShadeOfGray.alsoBlack() : black();
+
+  final int brightness;
 }
 ```
 
@@ -1243,14 +1243,14 @@ class ShadeOfGray {
 <?code-excerpt "usage_good.dart (this-dot-constructor)"?>
 ```dart
 class ShadeOfGray {
-  final int brightness;
-
   ShadeOfGray(int val) : brightness = val;
 
   ShadeOfGray.black() : this(0);
 
   // But now it will!
   ShadeOfGray.alsoBlack() : this.black();
+
+  final int brightness;
 }
 ```
 
@@ -1261,11 +1261,11 @@ lists:
 <?code-excerpt "usage_good.dart (param-dont-shadow-field-ctr-init)"?>
 ```dart
 class Box extends BaseBox {
-  Object? value;
-
   Box(Object? value)
       : value = value,
         super(value);
+
+  Object? value;
 }
 ```
 
@@ -1283,13 +1283,13 @@ the class has multiple constructors.
 <?code-excerpt "usage_bad.dart (field-init-at-decl)"?>
 ```dart
 class ProfileMark {
-  final String name;
-  final DateTime start;
-
   ProfileMark(this.name) : start = DateTime.now();
   ProfileMark.unnamed()
       : name = '',
         start = DateTime.now();
+
+  final String name;
+  final DateTime start;
 }
 ```
 
@@ -1297,11 +1297,11 @@ class ProfileMark {
 <?code-excerpt "usage_good.dart (field-init-at-decl)"?>
 ```dart
 class ProfileMark {
-  final String name;
-  final DateTime start = DateTime.now();
-
   ProfileMark(this.name);
   ProfileMark.unnamed() : name = '';
+
+  final String name;
+  final DateTime start = DateTime.now();
 }
 ```
 
@@ -1327,10 +1327,11 @@ Many fields are initialized directly from a constructor parameter, like:
 <?code-excerpt "usage_bad.dart (field-init-as-param)"?>
 ```dart
 class Point {
-  double x, y;
   Point(double x, double y)
       : x = x,
         y = y;
+
+  double x, y;
 }
 ```
 
@@ -1340,8 +1341,9 @@ We've got to type `x` _four_ times here to define a field. We can do better:
 <?code-excerpt "usage_good.dart (field-init-as-param)"?>
 ```dart
 class Point {
-  double x, y;
   Point(this.x, this.y);
+
+  double x, y;
 }
 ```
 
@@ -1367,10 +1369,11 @@ initialize the field in the constructor initializer list:
 <?code-excerpt "usage_good.dart (late-init-list)"?>
 ```dart
 class Point {
-  double x, y;
   Point.polar(double theta, double radius)
       : x = cos(theta) * radius,
         y = sin(theta) * radius;
+
+  double x, y;
 }
 ```
 
@@ -1378,11 +1381,12 @@ class Point {
 <?code-excerpt "usage_bad.dart (late-init-list)"?>
 ```dart
 class Point {
-  late double x, y;
   Point.polar(double theta, double radius) {
     x = cos(theta) * radius;
     y = sin(theta) * radius;
   }
+
+  late double x, y;
 }
 ```
 
@@ -1404,8 +1408,8 @@ semicolon. (In fact, it's required for const constructors.)
 <?code-excerpt "usage_good.dart (semicolon-for-empty-body)"?>
 ```dart
 class Point {
-  double x, y;
   Point(this.x, this.y);
+  double x, y;
 }
 ```
 
@@ -1413,8 +1417,8 @@ class Point {
 <?code-excerpt "usage_bad.dart (semicolon-for-empty-body)"?>
 ```dart
 class Point {
-  double x, y;
   Point(this.x, this.y) {}
+  double x, y;
 }
 ```
 

--- a/src/language/constructors.md
+++ b/src/language/constructors.md
@@ -23,11 +23,11 @@ to instantiate any instance variables, if necessary:
 <?code-excerpt "misc/lib/language_tour/classes/point_alt.dart (idiomatic-constructor)" plaster="none"?>
 ```dart
 class Point {
-  double x = 0;
-  double y = 0;
-
   // Generative constructor with initializing formal parameters:
   Point(this.x, this.y);
+  
+  double x = 0;
+  double y = 0;
 }
 ```
 
@@ -53,12 +53,12 @@ which both must be initialized or provided a default value:
 <?code-excerpt "misc/lib/language_tour/classes/point.dart (constructor-initializer)" plaster="none"?>
 ```dart
 class Point {
-  final double x;
-  final double y;
-
   Point(this.x, this.y);
   // Sets the x and y instance variables
   // before the constructor body runs.
+
+  final double x;
+  final double y;
 }
 ```
 
@@ -97,15 +97,15 @@ const double xOrigin = 0;
 const double yOrigin = 0;
 
 class Point {
-  final double x;
-  final double y;
-
   Point(this.x, this.y);
 
   // Named constructor
   [!Point.origin()!]
       : x = xOrigin,
         y = yOrigin;
+
+  final double x;
+  final double y;
 }
 {% endprettify %}
 
@@ -139,11 +139,11 @@ constructor for its superclass, Person. Click **Run** to execute the code.
 <?code-excerpt "misc/lib/language_tour/classes/employee.dart (super)" plaster="none"?>
 ```dart:run-dartpad:height-450px:ga_id-non_default_superclass_constructor
 class Person {
-  String? firstName;
-
   Person.fromJson(Map data) {
     print('in Person');
   }
+  
+  String? firstName;
 }
 
 class Employee extends Person {
@@ -194,18 +194,18 @@ Super-initializer parameters have similar syntax and semantics to
 <?code-excerpt "misc/lib/language_tour/classes/super_initializer_parameters.dart (positional)" plaster="none"?>
 ```dart
 class Vector2d {
+  Vector2d(this.x, this.y);
+  
   final double x;
   final double y;
-
-  Vector2d(this.x, this.y);
 }
 
 class Vector3d extends Vector2d {
-  final double z;
-
   // Forward the x and y parameters to the default super constructor like:
   // Vector3d(final double x, final double y, this.z) : super(x, y);
   Vector3d(super.x, super.y, this.z);
+  
+  final double z;
 }
 ```
 
@@ -278,14 +278,14 @@ the code.
 import 'dart:math';
 
 class Point {
-  final double x;
-  final double y;
-  final double distanceFromOrigin;
-
   Point(double x, double y)
       : x = x,
         y = y,
         distanceFromOrigin = sqrt(x * x + y * y);
+        
+  final double x;
+  final double y;
+  final double distanceFromOrigin;
 }
 
 void main() {
@@ -306,13 +306,13 @@ appearing after a colon (:).
 <?code-excerpt "misc/lib/language_tour/classes/point_redirecting.dart"?>
 ```dart
 class Point {
-  double x, y;
-
   // The main constructor for this class.
   Point(this.x, this.y);
 
   // Delegates to the main constructor.
   Point.alongXAxis(double x) : this(x, 0);
+  
+  double x, y;
 }
 ```
 
@@ -326,11 +326,11 @@ and make sure that all instance variables are `final`.
 <?code-excerpt "misc/lib/language_tour/classes/immutable_point.dart"?>
 ```dart
 class ImmutablePoint {
+  const ImmutablePoint(this.x, this.y);
+  
   static const ImmutablePoint origin = ImmutablePoint(0, 0);
 
   final double x, y;
-
-  const ImmutablePoint(this.x, this.y);
 }
 ```
 
@@ -362,13 +362,6 @@ initializes a final variable from a JSON object.
 <?code-excerpt "misc/lib/language_tour/classes/logger.dart"?>
 ```dart
 class Logger {
-  final String name;
-  bool mute = false;
-
-  // _cache is library-private, thanks to
-  // the _ in front of its name.
-  static final Map<String, Logger> _cache = <String, Logger>{};
-
   factory Logger(String name) {
     return _cache.putIfAbsent(name, () => Logger._internal(name));
   }
@@ -378,6 +371,13 @@ class Logger {
   }
 
   Logger._internal(this.name);
+
+  final String name;
+  bool mute = false;
+
+  // _cache is library-private, thanks to
+  // the _ in front of its name.
+  static final Map<String, Logger> _cache = <String, Logger>{};
 
   void log(String msg) {
     if (!mute) print(msg);


### PR DESCRIPTION
In this commit, I have reordered the constructors in all examples on the ‘Effective Dart: Usage’ (https://dart.dev/effective-dart/usage) and ‘Constructors‘ (https://dart.dev/language/constructors) pages to align with the Dart and Flutter style guides.  

Specifically, I followed the guidelines from ‘sort_constructors_first’ (https://dart.dev/tools/linter-rules/sort_constructors_first), ‘sort_unnamed_constructors_first’ (https://dart.dev/tools/linter-rules/sort_unnamed_constructors_first), ‘Constructors come first in a class’ (https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#constructors-come-first-in-a-class) and ‘Order other class members in a way that makes sense‘ (https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#order-other-class-members-in-a-way-that-makes-sense).  

By placing constructors before other class members, these examples now adhere to the recommended style and provide clearer, more consistent code for Dart and Flutter developers.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
