### PR TITLE
Update docs: Correct 'argument' to 'parameter', fix whitespace & EOF.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ More info:
 
 ## Updating code samples
 
-If your PR changes Dart code within a page, 
+If your PR changes Dart code within a page,
 you'll probably need to change the code in two places:
 
 1. In a `.md` file for the page.

--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -2,11 +2,11 @@
 
 This directory contains sources for generating images used across the website.
 
-These come in various forms, such as 
-`.graffle` used by the [OmniGraffle][] tool 
+These come in various forms, such as
+`.graffle` used by the [OmniGraffle][] tool
 as well as PNGs and SVGs generated with [diagrams.net][].
 
-Do **NOT** optimize any images or vectors that are in this directory. 
+Do **NOT** optimize any images or vectors that are in this directory.
 They contain metadata used by editors to enable editing the image.
 
 [OmniGraffle]: https://www.omnigroup.com/omnigraffle/

--- a/src/language/extend.md
+++ b/src/language/extend.md
@@ -77,10 +77,10 @@ This violates the normal rules, and
 it's similar to a downcast in that it can cause a type error at runtime.
 Still, narrowing the type is possible
 if the code can guarantee that a type error won't occur.
-In this case, you can use the 
+In this case, you can use the
 [`covariant` keyword](/guides/language/sound-problems#the-covariant-keyword)
 in a parameter declaration.
-For details, see the 
+For details, see the
 [Dart language specification][].
 
 {{site.alert.warning}}

--- a/src/language/extend.md
+++ b/src/language/extend.md
@@ -63,9 +63,9 @@ the method (or methods) that it overrides in several ways:
 * The return type must be the same type as (or a subtype of)
   the overridden method's return type.
 * Parameter types must be the same type as (or a supertype of)
-  the overridden method's argument types.
+  the overridden method's parameter types.
   In the preceding example, the `contrast` setter of `SmartTelevision`
-  changes the argument type from `int` to a supertype, `num`.
+  changes the parameter type from `int` to a supertype, `num`.
 * If the overridden method accepts _n_ positional parameters,
   then the overriding method must also accept _n_ positional parameters.
 * A [generic method][] can't override a non-generic one,

--- a/src/language/extend.md
+++ b/src/language/extend.md
@@ -62,7 +62,7 @@ the method (or methods) that it overrides in several ways:
 
 * The return type must be the same type as (or a subtype of)
   the overridden method's return type.
-* Argument types must be the same type as (or a supertype of)
+* Parameter types must be the same type as (or a supertype of)
   the overridden method's argument types.
   In the preceding example, the `contrast` setter of `SmartTelevision`
   changes the argument type from `int` to a supertype, `num`.

--- a/src/tools/pub/cmd/pub-get.md
+++ b/src/tools/pub/cmd/pub-get.md
@@ -26,7 +26,7 @@ doesn't already contain the dependencies, `dart pub get`
 updates the cache,
 downloading dependencies if necessary.
 To map packages back to the system cache,
-this command creates a `package_config.json` file 
+this command creates a `package_config.json` file
 in the `.dart_tool/` directory.
 
 Once the dependencies are acquired, they may be referenced in Dart code.
@@ -63,7 +63,7 @@ in the `.dart_tool/` directory that maps from package names to location URIs.
 {{site.alert.note}}
   Don't check the generated `.dart_tool/` directory into your repo;
   add it to your repo's `.gitignore` file.
-  For more information, 
+  For more information,
   see [What not to commit](/guides/libraries/private-files).
 {{site.alert.end}}
 

--- a/src/tools/pub/cmd/pub-global.md
+++ b/src/tools/pub/cmd/pub-global.md
@@ -74,7 +74,7 @@ $ dart pub global activate -sgit https://github.com/dart-lang/async_await.git
 ```
 
 Pub expects to find the package in the root of the Git repository.
-To specify a different location, 
+To specify a different location,
 use the `--git-path` option with
 a path relative to the repository root:
 
@@ -229,8 +229,8 @@ For options that apply to all pub commands, see
 
 ### `[version-constraint]`
 
-Use `dart pub global activate <package> [version-constraint]` 
-to specify a specific version of the package. 
+Use `dart pub global activate <package> [version-constraint]`
+to specify a specific version of the package.
 For example, the following command pulls
 the 0.6.0 version of the `markdown` package:
 
@@ -259,7 +259,7 @@ to add the specified executable to your PATH.
 You can pass more than one of these flags.
 
 For example, the following command adds `bar` and `baz`,
-(but not any other executables that `foo` might define) 
+(but not any other executables that `foo` might define)
 to your PATH.
 
 ```terminal

--- a/src/tools/pub/cmd/pub-outdated.md
+++ b/src/tools/pub/cmd/pub-outdated.md
@@ -81,7 +81,7 @@ you just need to run `dart pub upgrade`:
 
 ```terminal
 $ dart pub upgrade
-Resolving dependencies... 
+Resolving dependencies...
 > args 1.6.0 (was 1.4.4)
   ...
 Changed 1 dependency!
@@ -111,15 +111,15 @@ due to constraints determined by other dependencies:
 $ dart pub upgrade
 ...
 $ dart pub outdated
-Package Name  Current  Upgradable  Resolvable  Latest 
+Package Name  Current  Upgradable  Resolvable  Latest
 
 direct dependencies:
-path          1.6.2    1.6.2       1.6.2       1.7.0   
+path          1.6.2    1.6.2       1.6.2       1.7.0
 
 dev_dependencies: all up-to-date
 
 transitive dependencies:
-meta          1.1.6    1.1.6       1.1.6       1.1.8   
+meta          1.1.6    1.1.6       1.1.6       1.1.8
 
 transitive dev_dependencies: all up-to-date
 

--- a/src/tools/pub/cmd/pub-remove.md
+++ b/src/tools/pub/cmd/pub-remove.md
@@ -30,7 +30,7 @@ For options that apply to all pub commands, see
 
 ### `-n, --dry-run`
 
-Reports which dependencies would change, 
+Reports which dependencies would change,
 but doesn't change any.
 
 ### `--[no-]precompile`


### PR DESCRIPTION
In some places “argument type” was used and this has been corrected into “parameter type”.
Some trailing whitespaces where removed.
One file didn’t end in a newline and this has been fixed.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
