### PR TITLE
Add go/security-advisories redirection

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -181,7 +181,7 @@
       { "source": "/go/publishing-with-service-account", "destination": "/tools/pub/automated-publishing#publishing-from-google-cloud-build", "type": 301 },
       { "source": "/go/sdk-constraint", "destination": "/tools/pub/pubspec#sdk-constraints", "type": 301 },
       { "source": "/go/sdk-version-pinning", "destination": "https://github.com/dart-lang/sdk/wiki/Flutter-Pinned-Packages", "type": 301 },
-      { "source": "/go/security-advisories", "destination": "https://github.com/dart-lang/site-www/issues/5458", "type": 301 },
+      { "source": "/go/pub-security-advisories", "destination": "https://github.com/dart-lang/site-www/issues/5458", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
 

--- a/firebase.json
+++ b/firebase.json
@@ -181,6 +181,7 @@
       { "source": "/go/publishing-with-service-account", "destination": "/tools/pub/automated-publishing#publishing-from-google-cloud-build", "type": 301 },
       { "source": "/go/sdk-constraint", "destination": "/tools/pub/pubspec#sdk-constraints", "type": 301 },
       { "source": "/go/sdk-version-pinning", "destination": "https://github.com/dart-lang/sdk/wiki/Flutter-Pinned-Packages", "type": 301 },
+      { "source": "/go/security-advisories", "destination": "https://github.com/dart-lang/site-www/issues/5458", "type": 301 },
       { "source": "/go/test-docs/:page*", "destination": "https://github.com/dart-lang/test/blob/master/pkgs/test/doc/:page*", "type": 301 },
       { "source": "/go/unsound-null-safety", "destination": "/null-safety/unsound-null-safety", "type": 301 },
 


### PR DESCRIPTION
For now this points at the issue tracking the documentation. The go link is to be used in the dart sdk changelog.