### PR TITLE
Add go link redirect for `package:web`

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -175,6 +175,7 @@
       { "source": "/go/null-safety-migration", "destination": "/null-safety/migration-guide", "type": 301 },
       { "source": "/go/package-discontinue", "destination": "/tools/pub/publishing#discontinue", "type": 301 },
       { "source": "/go/package-retraction", "destination": "/tools/pub/publishing#retract", "type": 301 },
+      { "source": "/go/package-web", "destination": "https://pub.dev/packages/web", "type": 301 },
       { "source": "/go/pub-cache", "destination": "/tools/pub/cmd/pub-cache", "type": 301 },
       { "source": "/go/pubignore", "destination": "/tools/pub/publishing#what-files-are-published", "type": 301 },
       { "source": "/go/publishing-from-github", "destination": "/tools/pub/automated-publishing#publishing-packages-using-github-actions", "type": 301 },


### PR DESCRIPTION
Go link placeholder for migration `package:web` migration docs