### PR TITLE
Verified publishers: add recommendation for several members

### DIFF
--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -128,10 +128,12 @@ To create a verified publisher, follow these steps:
    * When the verification flow is complete, return to step 4.
 
 
-{{site.alert.note}} We strongly recommend you invite other members of your
-  organization as members to the verified publisher. This ensures that your
-  organization retains access to the publisher when you are not available.
-  {{site.alert.end}}
+{{site.alert.tip}}
+  We strongly recommend you invite other members of your
+  organization to be members of the verified publisher.
+  This helps ensure that your organization retains access to
+  the publisher when you are not available.
+{{site.alert.end}}
 
 ## Publishing your package
 

--- a/src/tools/pub/publishing.md
+++ b/src/tools/pub/publishing.md
@@ -128,6 +128,11 @@ To create a verified publisher, follow these steps:
    * When the verification flow is complete, return to step 4.
 
 
+{{site.alert.note}} We strongly recommend you invite other members of your
+  organization as members to the verified publisher. This ensures that your
+  organization retains access to the publisher when you are not available.
+  {{site.alert.end}}
+
 ## Publishing your package
 
 Use the [`dart pub publish`][] command to publish your package for the first time,


### PR DESCRIPTION
We get many support emails asking for regaining access to a verified publisher after the original creator is not at the company anymore. 