### PR TITLE
Fix sealed exhaustiveness example.

### DIFF
--- a/examples/language/lib/class_modifiers/sealed_exhaustiveness.dart
+++ b/examples/language/lib/class_modifiers/sealed_exhaustiveness.dart
@@ -1,0 +1,14 @@
+// amigos.dart
+sealed class Amigo {}
+
+class Lucky extends Amigo {}
+
+class Dusty extends Amigo {}
+
+class Ned extends Amigo {}
+
+String lastName(Amigo amigo) => switch (amigo) {
+      Lucky _ => 'Day',
+      Dusty _ => 'Bottoms',
+      Ned _ => 'Nederlander',
+    };

--- a/src/language/class-modifiers-for-apis.md
+++ b/src/language/class-modifiers-for-apis.md
@@ -232,6 +232,7 @@ In return, you have the fewest restrictions as the class maintainer.
 You can add new methods, turn constructors into factory constructors, etc.
 without worrying about breaking any downstream users.
 
+<a id="the-sealed-modifer"></a>
 ## The `sealed` modifier
 
 The last modifier, [`sealed`](/language/class-modifiers#sealed), is special.

--- a/src/language/class-modifiers-for-apis.md
+++ b/src/language/class-modifiers-for-apis.md
@@ -232,7 +232,7 @@ In return, you have the fewest restrictions as the class maintainer.
 You can add new methods, turn constructors into factory constructors, etc.
 without worrying about breaking any downstream users.
 
-## The `sealed` modifer
+## The `sealed` modifier
 
 The last modifier, [`sealed`](/language/class-modifiers#sealed), is special.
 It exists primarily to enable [exhaustiveness checking][] in pattern matching.
@@ -241,19 +241,22 @@ then the compiler knows the switch is exhaustive.
 
 [exhaustiveness checking]: /language/branches#exhaustiveness-checking
 
+<?code-excerpt "language/lib/class_modifiers/sealed_exhaustiveness.dart"?>
 ```dart
 // amigos.dart
 sealed class Amigo {}
+
 class Lucky extends Amigo {}
+
 class Dusty extends Amigo {}
+
 class Ned extends Amigo {}
 
-String lastName(Amigo amigo) =>
-    switch (amigo) {
-      case Lucky _ => 'Day';
-      case Dusty _ => 'Bottoms';
-      case Ned _   => 'Nederlander';
-    }
+String lastName(Amigo amigo) => switch (amigo) {
+      Lucky _ => 'Day',
+      Dusty _ => 'Bottoms',
+      Ned _ => 'Nederlander',
+    };
 ```
 
 This switch has a case for each of the subtypes of `Amigo`.


### PR DESCRIPTION
This PR fixes `sealed` exhaustiveness code example: https://dart.dev/language/class-modifiers-for-apis#the-sealed-modifer

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.