### PR TITLE
Replace typo "wih" with "with"

### DIFF
--- a/examples/language/lib/patterns/pattern_types.dart
+++ b/examples/language/lib/patterns/pattern_types.dart
@@ -187,13 +187,13 @@ void miscDeclAnalyzedButNotTested() {
       case (:var untyped, :int typed): // ...
     }
 
-    // Record pattern wih null-check and null-assert subpatterns:
+    // Record pattern with null-check and null-assert subpatterns:
     switch (record) {
       case (checked: var checked?, asserted: var asserted!): // ...
       case (:var checked?, :var asserted!): // ...
     }
 
-    // Record pattern wih cast subpattern:
+    // Record pattern with cast subpattern:
     var (untyped: untyped as int, typed: typed as String) = record;
     var (:untyped as int, :typed as String) = record;
     // #enddocregion record-getter

--- a/src/language/pattern-types.md
+++ b/src/language/pattern-types.md
@@ -383,13 +383,13 @@ switch (record) {
   case (:var untyped, :int typed): // ...
 }
 
-// Record pattern wih null-check and null-assert subpatterns:
+// Record pattern with null-check and null-assert subpatterns:
 switch (record) {
   case (checked: var checked?, asserted: var asserted!): // ...
   case (:var checked?, :var asserted!): // ...
 }
 
-// Record pattern wih cast subpattern:
+// Record pattern with cast subpattern:
 var (untyped: untyped as int, typed: typed as String) = record;
 var (:untyped as int, :typed as String) = record;
 ```


### PR DESCRIPTION
Replaces the typo "wih" with "with".

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
