### PR TITLE
Fix site build on ARM devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim-bookworm@sha256:540e94266a7509bba7b50d5194eb63f51197ffbe5c203c5c81aa956c377ec4e8 as base
+FROM ruby:3.2.3-slim-bookworm@sha256:97fccffe954d1e0c7fa6634020379417d67435a7f9a7c10b6ef3f49e498307e6 as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=US/Pacific

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.6)
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -29,6 +29,8 @@ GEM
     ffi (1.16.3)
     forwardable-extended (2.6.0)
     google-protobuf (3.25.2)
+    google-protobuf (3.25.2-aarch64-linux)
+    google-protobuf (3.25.2-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -68,7 +70,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.5)
-    minitest (5.21.1)
+    minitest (5.21.2)
     mutex_m (0.2.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
@@ -89,12 +91,12 @@ GEM
     rouge (4.2.0)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.7)
+    sass-embedded (1.70.0)
       google-protobuf (~> 3.25)
       rake (>= 13.0.0)
-    sass-embedded (1.69.7-aarch64-linux-gnu)
+    sass-embedded (1.70.0-aarch64-linux-gnu)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-x86_64-linux-gnu)
+    sass-embedded (1.70.0-x86_64-linux-gnu)
       google-protobuf (~> 3.25)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -118,4 +120,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.4
+   2.5.5


### PR DESCRIPTION
Mirrors https://github.com/flutter/website/commit/b2dbf1a76ed23486a668e6641a3d838be57ce3d3 to downgrade to Ruby 3.2.2 as https://bugs.ruby-lang.org/issues/20085
(affecting 3.3.0) breaks a dependency of ours when running on ARM64
devices (such as Apple Silicon).
