### PR TITLE
Fix broken image links on front page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -267,7 +267,7 @@ js:
                                 </div>
                             </div>
                         </li>
-                        <li tabindex="0" data-banner="assets/dash/svg/1-2 language optimized.svg">
+                        <li tabindex="0" data-banner="assets/dash/svg/1-2-language-optimized.svg">
                             <div>
                                 <div class="bullet-container">
                                     <div class="animated-bullet"></div>
@@ -279,7 +279,7 @@ js:
                                 </div>
                             </div>
                         </li>
-                        <li tabindex="0" data-banner="assets/dash/svg/1-3 familiar syntax.svg">
+                        <li tabindex="0" data-banner="assets/dash/svg/1-3-familiar-syntax.svg">
                             <div>
                                 <div class="bullet-container">
                                     <div class="animated-bullet"></div>


### PR DESCRIPTION
Fixes broken image links on front page:

<img width="735" alt="Screenshot 2024-02-02 at 16 07 53" src="https://github.com/dart-lang/site-www/assets/13644170/f13166a4-5033-456e-9226-8f28857ee653">


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn’t contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
