### PR TITLE
Adds an entry for 'function' to the glossary

### DIFF
--- a/src/content/resources/glossary.md
+++ b/src/content/resources/glossary.md
@@ -134,7 +134,7 @@ For additional details, see the
 
 ## Function
 
-"Function" refers to top-level functions, local functions, static
+Unless noted otherwise, the term *function* refers to top-level functions, local functions, static
 methods, and instance methods.
 
 For additional details, see the documentation on [Functions][_functions_].

--- a/src/content/resources/glossary.md
+++ b/src/content/resources/glossary.md
@@ -132,6 +132,15 @@ For additional details, see the
 
 [definiteAssignmentSpec]: https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md
 
+## Function
+
+"Function" refers to top-level functions, local functions, static
+methods, and instance methods.
+
+For additional details, see the documentation on [Functions][_functions_].
+
+[_functions_]: /language/functions
+
 ## Irrefutable pattern
 
 _Irrefutable patterns_ are patterns that always match. 


### PR DESCRIPTION
Adds a new entry to the site glossary for the word "function." Text is taken pretty much verbatim from a comment made by @munificent in #3602. 😄 

I'm assigning this to @MaryaBelanger, since she literally watched me make the change over GVC as I was testing the new 11ty infra. 

Fixes #3602

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.