### PR TITLE
Migrate iterables codelab away from multi-file

### DIFF
--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -353,9 +353,6 @@ void main() {
     print('Tried calling singleWhere, but received an exception: $e');
   }
 }
-
-// ignore: non_constant_identifier_names
-// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -581,9 +578,6 @@ void main() {
 
   print('Success. All tests passed!');
 }
-
-// ignore: non_constant_identifier_names
-// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -822,9 +816,6 @@ void main() {
 
   print('Success. All tests passed!');
 }
-
-// ignore: non_constant_identifier_names
-// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -969,9 +960,6 @@ bool _listEquals<T>(List<T>? a, List<T>? b) {
   }
   return true;
 }
-
-// ignore: non_constant_identifier_names
-// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -1192,9 +1180,6 @@ void main() {
 bool isValidEmailAddress(EmailAddress email) {
   return email.address.contains('@');
 }
-
-// ignore: non_constant_identifier_names
-// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>

--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -311,8 +311,51 @@ you can check the class documentation for help.
 // * The element contains the character `'a'`
 // * The element starts with the character `'M'`
 String singleWhere(Iterable<String> items) {
-  return items.singleWhere(TODO('Implement predicate'));
+  return items.singleWhere(TODO('Implement the outlined predicate.'));
 }
+
+// The following code is used to provide feedback on your solution.
+// Try your best first and do not modify.
+void main() {
+  const items = [
+    'Salad',
+    'Popcorn',
+    'Milk',
+    'Toast',
+    'Sugar',
+    'Mozzarella',
+    'Tomato',
+    'Egg',
+    'Water',
+  ];
+
+  try {
+    final str = singleWhere(items);
+    if (str == 'Mozzarella') {
+      print('Success. All tests passed!');
+    } else {
+      print(
+        'Tried calling singleWhere, but received $str instead of '
+        'the expected value \'Mozzarella\'',
+      );
+    }
+  } on StateError catch (stateError) {
+    print(
+      'Tried calling singleWhere, but received a StateError: ${stateError.message}. '
+      'singleWhere will fail if 0 or many elements match the predicate.',
+    );
+  } on UnimplementedError {
+    print(
+      'Tried running `singleWhere`, but received an error. '
+      'Did you implement the function?',
+    );
+  } catch (e) {
+    print('Tried calling singleWhere, but received an exception: $e');
+  }
+}
+
+// ignore: non_constant_identifier_names
+Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -424,22 +467,123 @@ Use `any()` and `every()` to implement two functions:
 
 ```dart:run-dartpad:theme-dark:height-395px:ga_id-verify_iterable
 bool anyUserUnder18(Iterable<User> users) {
-  TODO('Implement this method');
+  TODO('Implement the anyUserUnder18 function.');
 }
 
 bool everyUserOver13(Iterable<User> users) {
-  TODO('Implement this method');
+  TODO('Implement the everyUserOver13 function.');
 }
 
 class User {
-  String name;
-  int age;
+  final String name;
+  final int age;
 
   User(
     this.name,
     this.age,
   );
 }
+
+// The following code is used to provide feedback on your solution.
+// Try your best first and do not modify.
+void main() {
+  final users = [
+    User('Alice', 21),
+    User('Bob', 17),
+    User('Claire', 52),
+    User('David', 14),
+  ];
+
+  try {
+    final out = anyUserUnder18(users);
+    if (!out) {
+      print('Looks like `anyUserUnder18` is wrong. Keep trying!');
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `anyUserUnder18`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print('Tried running `anyUserUnder18`, but received an exception: $e');
+    return;
+  }
+
+  try {
+    // with only one user older than 18, should be false
+    final out = anyUserUnder18([User('Alice', 21)]);
+    if (out) {
+      print(
+          'Looks like `anyUserUnder18` is wrong. What if all users are over 18?');
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `anyUserUnder18`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `anyUserUnder18([User("Alice", 21)])`, '
+      'but received an exception: $e',
+    );
+    return;
+  }
+
+  try {
+    final out = everyUserOver13(users);
+    if (!out) {
+      print(
+        'Looks like `everyUserOver13` is wrong. '
+        'There are no users under 13!',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `everyUserOver13`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `everyUserOver13`, '
+      'but received an exception: $e',
+    );
+    return;
+  }
+
+  try {
+    final out = everyUserOver13([User('Dan', 12)]);
+    if (out) {
+      print(
+        'Looks like `everyUserOver13` is wrong. '
+        'There is at least one user under 13!',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `everyUserOver13`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `everyUserOver13([User(\'Dan\', 12)])`, '
+      'but received an exception: $e',
+    );
+    return;
+  }
+
+  print('Success. All tests passed!');
+}
+
+// ignore: non_constant_identifier_names
+Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -603,22 +747,84 @@ Use `where()` to implement two functions:
 
 ```dart:run-dartpad:theme-dark:height-380px:ga_id-filtering_elements_from_a_list
 Iterable<User> filterOutUnder21(Iterable<User> users) {
-  TODO('Implement this method');
+  TODO('Implement the filterOutUnder21 function.');
 }
 
 Iterable<User> findShortNamed(Iterable<User> users) {
-  TODO('Implement this method');
+  TODO('Implement the findShortNamed function.');
 }
 
 class User {
-  String name;
-  int age;
+  final String name;
+  final int age;
 
   User(
     this.name,
     this.age,
   );
 }
+
+// The following code is used to provide feedback on your solution.
+// Try your best first and do not modify.
+void main() {
+  final users = [
+    User('Alice', 21),
+    User('Bob', 17),
+    User('Claire', 52),
+    User('Dan', 12),
+  ];
+
+  try {
+    final out = filterOutUnder21(users);
+    if (out.any((user) => user.age < 21) || out.length != 2) {
+      print(
+        'Looks like `filterOutUnder21` is wrong, there are '
+        'exactly two users with age under 21. Keep trying!',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `filterOutUnder21`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `filterOutUnder21`, '
+      'but received an exception: ${e.runtimeType}',
+    );
+    return;
+  }
+
+  try {
+    final out = findShortNamed(users);
+    if (out.any((user) => user.name.length > 3) || out.length != 2) {
+      print(
+        'Looks like `findShortNamed` is wrong, there are '
+        'exactly two users with a three letter name. Keep trying!',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `findShortNamed`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `findShortNamed`, '
+      'but received an exception: ${e.runtimeType}',
+    );
+    return;
+  }
+
+  print('Success. All tests passed!');
+}
+
+// ignore: non_constant_identifier_names
+Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -710,18 +916,62 @@ Each string in the `Iterable` must follow this format:
 
 ```dart:run-dartpad:theme-dark:height-310px:ga_id-mapping_to_a_different_type
 Iterable<String> getNameAndAges(Iterable<User> users) {
-  TODO('Implement this method');
+  TODO('Implement the getNameAndAges function.');
 }
 
 class User {
-  String name;
-  int age;
+  final String name;
+  final int age;
 
   User(
     this.name,
     this.age,
   );
 }
+
+// The following code is used to provide feedback on your solution.
+// Try your best first and do not modify.
+void main() {
+  final users = [
+    User('Alice', 21),
+    User('Bob', 17),
+    User('Claire', 52),
+  ];
+
+  try {
+    final out = getNameAndAges(users).toList();
+    if (!_listEquals(out, ['Alice is 21', 'Bob is 17', 'Claire is 52'])) {
+      print(
+        'Looks like `getNameAndAges` is wrong. Keep trying! '
+        'The output was: $out',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `getNameAndAges`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print('Tried running the function, but received an exception: $e');
+    return;
+  }
+
+  print('Success. All tests passed!');
+}
+
+bool _listEquals<T>(List<T>? a, List<T>? b) {
+  if (a == null) return b == null;
+  if (b == null || a.length != b.length) return false;
+  for (var index = 0; index < a.length; index += 1) {
+    if (a[index] != b[index]) return false;
+  }
+  return true;
+}
+
+// ignore: non_constant_identifier_names
+Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -799,15 +1049,15 @@ Part 3: Implement `validEmailAddresses()`.
 
 ```dart:run-dartpad:theme-dark:height-600px:ga_id-putting_it_all_together
 Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {
-  TODO('Implement this method');
+  TODO('Implement the parseEmailAddresses function.');
 }
 
 bool anyInvalidEmailAddress(Iterable<EmailAddress> emails) {
-  TODO('Implement this method');
+  TODO('Implement the anyInvalidEmailAddress function.');
 }
 
 Iterable<EmailAddress> validEmailAddresses(Iterable<EmailAddress> emails) {
-  TODO('Implement this method');
+  TODO('Implement the validEmailAddresses function.');
 }
 
 class EmailAddress {
@@ -818,17 +1068,133 @@ class EmailAddress {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is EmailAddress &&
-              address == other.address;
+      other is EmailAddress && address == other.address;
 
   @override
   int get hashCode => address.hashCode;
 
   @override
-  String toString() {
-    return 'EmailAddress{address: $address}';
-  }
+  String toString() => 'EmailAddress{address: $address}';
 }
+
+// The following code is used to provide feedback on your solution.
+// Try your best first and do not modify.
+void main() {
+  const input = [
+    'ali@gmail.com',
+    'bobgmail.com',
+    'cal@gmail.com',
+  ];
+
+  const correctInput = ['dash@gmail.com', 'sparky@gmail.com'];
+
+  bool _listEquals<T>(List<T>? a, List<T>? b) {
+    if (a == null) return b == null;
+    if (b == null || a.length != b.length) return false;
+    for (var index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) return false;
+    }
+    return true;
+  }
+
+  final Iterable<EmailAddress> emails;
+  final Iterable<EmailAddress> correctEmails;
+  try {
+    emails = parseEmailAddresses(input);
+    correctEmails = parseEmailAddresses(correctInput);
+    if (emails.isEmpty) {
+      print(
+        'Tried running `parseEmailAddresses`, but received an empty list.',
+      );
+      return;
+    }
+    if (!_listEquals(emails.toList(), [
+      EmailAddress('ali@gmail.com'),
+      EmailAddress('bobgmail.com'),
+      EmailAddress('cal@gmail.com'),
+    ])) {
+      print('Looks like `parseEmailAddresses` is wrong. Keep trying!');
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `parseEmailAddresses`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running `parseEmailAddresses`, '
+      'but received an exception: $e',
+    );
+    return;
+  }
+
+  try {
+    final out = anyInvalidEmailAddress(emails);
+    if (!out) {
+      print(
+        'Looks like `anyInvalidEmailAddress` is wrong. Keep trying! '
+        'The result should be false with at least one invalid address.',
+      );
+      return;
+    }
+    final falseOut = anyInvalidEmailAddress(correctEmails);
+    if (falseOut) {
+      print(
+        'Looks like `anyInvalidEmailAddress` is wrong. Keep trying! '
+        'The result should be false with all valid addresses.',
+      );
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `anyInvalidEmailAddress`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+        'Tried running `anyInvalidEmailAddress`, but received an exception: $e');
+    return;
+  }
+
+  try {
+    final valid = validEmailAddresses(emails);
+    if (emails.isEmpty) {
+      print('Tried running `validEmailAddresses`, but received an empty list.');
+      return;
+    }
+    if (!_listEquals(valid.toList(), [
+      EmailAddress('ali@gmail.com'),
+      EmailAddress('cal@gmail.com'),
+    ])) {
+      print('Looks like `validEmailAddresses` is wrong. Keep trying!');
+      return;
+    }
+  } on UnimplementedError {
+    print(
+      'Tried running `validEmailAddresses`, but received an error. '
+      'Did you implement the function?',
+    );
+    return;
+  } catch (e) {
+    print(
+      'Tried running the `validEmailAddresses`, '
+      'but received an exception: $e',
+    );
+    return;
+  }
+
+  print('Success. All tests passed!');
+}
+
+bool isValidEmailAddress(EmailAddress email) {
+  return email.address.contains('@');
+}
+
+// ignore: non_constant_identifier_names
+Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>

--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -355,7 +355,7 @@ void main() {
 }
 
 // ignore: non_constant_identifier_names
-Never TODO([String? message]) => throw UnimplementedError('$message');
+// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -583,7 +583,7 @@ void main() {
 }
 
 // ignore: non_constant_identifier_names
-Never TODO([String? message]) => throw UnimplementedError('$message');
+// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -824,7 +824,7 @@ void main() {
 }
 
 // ignore: non_constant_identifier_names
-Never TODO([String? message]) => throw UnimplementedError('$message');
+// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -971,7 +971,7 @@ bool _listEquals<T>(List<T>? a, List<T>? b) {
 }
 
 // ignore: non_constant_identifier_names
-Never TODO([String? message]) => throw UnimplementedError('$message');
+// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>
@@ -1194,7 +1194,7 @@ bool isValidEmailAddress(EmailAddress email) {
 }
 
 // ignore: non_constant_identifier_names
-Never TODO([String? message]) => throw UnimplementedError('$message');
+// Never TODO([String? message]) => throw UnimplementedError('$message');
 ```
 
 <details>

--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -316,7 +316,7 @@ String singleWhere(Iterable<String> items) {
 ```
 
 <details>
-  <summary>Hint</summary>
+  <summary title="Expand for a hint on the predicate exercise.">Hint</summary>
 
   Your solution might make use of the `contains` and `startsWith`
   methods from the `String` class.
@@ -324,7 +324,7 @@ String singleWhere(Iterable<String> items) {
 </details>
 
 <details>
-  <summary>Solution</summary>
+  <summary title="Expand for the solution of the predicate exercise.">Solution</summary>
 
   ```dart
   String singleWhere(Iterable<String> items) {
@@ -443,7 +443,7 @@ class User {
 ```
 
 <details>
-  <summary>Hint</summary>
+  <summary title="Expand for a hint on the conditional filtering exercise.">Hint</summary>
 
   Remember to use the `any` and `every` methods from the `Iterable` class.
   For help and examples using these methods, refer to
@@ -452,7 +452,7 @@ class User {
 </details>
 
 <details>
-  <summary>Solution</summary>
+  <summary title="Expand for the solution of the conditional filtering exercise.">Solution</summary>
 
   ```dart
   bool anyUserUnder18(Iterable<User> users) {
@@ -622,7 +622,7 @@ class User {
 ```
 
 <details>
-  <summary>Hint</summary>
+  <summary title="Expand for a hint on the filtering elements exercise.">Hint</summary>
 
   Remember to take advantage of the `where` method from the `Iterable` class.
   For help and examples using `where`, refer to
@@ -631,7 +631,7 @@ class User {
 </details>
 
 <details>
-  <summary>Solution</summary>
+  <summary title="Expand for the solution of the filtering elements exercise.">Solution</summary>
 
   ```dart
   Iterable<User> filterOutUnder21(Iterable<User> users) {
@@ -725,7 +725,7 @@ class User {
 ```
 
 <details>
-  <summary>Hint</summary>
+  <summary title="Expand for a hint on the mapping elements exercise.">Hint</summary>
 
   Remember to take advantage of the `map` method from the `Iterable` class.
   For help and examples using `map`, refer to
@@ -737,7 +737,7 @@ class User {
 </details>
 
 <details>
-  <summary>Solution</summary>
+  <summary title="Expand for the solution of the mapping elements exercise.">Solution</summary>
 
   ```dart
   Iterable<String> getNameAndAges(Iterable<User> users) {
@@ -832,7 +832,7 @@ class EmailAddress {
 ```
 
 <details>
-  <summary>Solution</summary>
+  <summary title="Expand for the solution of the 'Putting it all together' exercise.">Solution</summary>
 
   ```dart
   Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {

--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -315,6 +315,26 @@ String singleWhere(Iterable<String> items) {
 }
 ```
 
+<details>
+  <summary>Hint</summary>
+
+  Your solution might make use of the `contains` and `startsWith`
+  methods from the `String` class.
+
+</details>
+
+<details>
+  <summary>Solution</summary>
+
+  ```dart
+  String singleWhere(Iterable<String> items) {
+    return items.singleWhere(
+            (element) => element.startsWith('M') && element.contains('a'));
+  }
+  ```
+
+</details>
+
 ## Checking conditions
 
 When working with `Iterable`, sometimes you need to verify that
@@ -421,6 +441,30 @@ class User {
   );
 }
 ```
+
+<details>
+  <summary>Hint</summary>
+
+  Remember to use the `any` and `every` methods from the `Iterable` class.
+  For help and examples using these methods, refer to
+  the [earlier discussion of them](#example-using-any-and-every).
+
+</details>
+
+<details>
+  <summary>Solution</summary>
+
+  ```dart
+  bool anyUserUnder18(Iterable<User> users) {
+    return users.any((user) => user.age < 18);
+  }
+  
+  bool everyUserOver13(Iterable<User> users) {
+    return users.every((user) => user.age > 13);
+  }
+  ```
+
+</details>
 
 :::secondary Quick review
 * Although you can use `for-in` loops to check conditions,
@@ -577,6 +621,30 @@ class User {
 }
 ```
 
+<details>
+  <summary>Hint</summary>
+
+  Remember to take advantage of the `where` method from the `Iterable` class.
+  For help and examples using `where`, refer to
+  the [earlier discussion of it](#example-using-where).
+
+</details>
+
+<details>
+  <summary>Solution</summary>
+
+  ```dart
+  Iterable<User> filterOutUnder21(Iterable<User> users) {
+    return users.where((user) => user.age >= 21);
+  }
+  
+  Iterable<User> findShortNamed(Iterable<User> users) {
+    return users.where((user) => user.name.length <= 3);
+  }
+  ```
+
+</details>
+
 :::secondary Quick review
 * Filter the elements of an `Iterable` with `where()`.
 * The output of `where()` is another `Iterable`.
@@ -655,6 +723,29 @@ class User {
   );
 }
 ```
+
+<details>
+  <summary>Hint</summary>
+
+  Remember to take advantage of the `map` method from the `Iterable` class.
+  For help and examples using `map`, refer to
+  the [earlier discussion of it](#example-using-map-to-change-elements).
+
+  To concatenate multiple values into a single string, consider
+  using [string interpolation](/language/built-in-types#string-interpolation).
+
+</details>
+
+<details>
+  <summary>Solution</summary>
+
+  ```dart
+  Iterable<String> getNameAndAges(Iterable<User> users) {
+    return users.map((user) => '${user.name} is ${user.age}');
+  }
+  ```
+
+</details>
 
 :::secondary Quick review
 * `map()` applies a function to all the elements of an `Iterable`.
@@ -739,6 +830,25 @@ class EmailAddress {
   }
 }
 ```
+
+<details>
+  <summary>Solution</summary>
+
+  ```dart
+  Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {
+    return strings.map((s) => EmailAddress(s));
+  }
+  
+  bool anyInvalidEmailAddress(Iterable<EmailAddress> emails) {
+    return emails.any((email) => !isValidEmailAddress(email));
+  }
+  
+  Iterable<EmailAddress> validEmailAddresses(Iterable<EmailAddress> emails) {
+    return emails.where((email) => isValidEmailAddress(email));
+  }
+  ```
+
+</details>
 
 ## What's next
 

--- a/src/content/codelabs/iterables.md
+++ b/src/content/codelabs/iterables.md
@@ -306,7 +306,6 @@ All the elements in the test data are [strings][String class];
 you can check the class documentation for help.
 
 ```dart:run-dartpad:theme-dark:ga_id-practice_writing_a_test_predicate
-{$ begin main.dart $}
 // Implement the predicate of singleWhere
 // with the following conditions
 // * The element contains the character `'a'`
@@ -314,58 +313,6 @@ you can check the class documentation for help.
 String singleWhere(Iterable<String> items) {
   return items.singleWhere(TODO('Implement predicate'));
 }
-{$ end main.dart $}
-{$ begin solution.dart $}
-String singleWhere(Iterable<String> items) {
-  return items.singleWhere(
-      (element) => element.startsWith('M') && element.contains('a'));
-}
-{$ end solution.dart $}
-{$ begin test.dart $}
-const items = [
-  'Salad',
-  'Popcorn',
-  'Milk',
-  'Toast',
-  'Sugar',
-  'Mozzarella',
-  'Tomato',
-  'Egg',
-  'Water',
-];
-
-void main() {
-  try {
-    final str = singleWhere(items);
-    if (str == 'Mozzarella') {
-      _result(true);
-    } else {
-      _result(false, [
-        'Tried calling singleWhere, but received $str instead of the expected '
-            'value \'Mozzarella\''
-      ]);
-    }
-  } on StateError catch (stateError) {
-    _result(false, [
-      'Tried calling singleWhere, but received a StateError: ${stateError.message}. '
-          'singleWhere will fail if 0 or many elements match the '
-          'predicate'
-    ]);
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `singleWhere`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried calling singleWhere, but received an exception: $e'
-    ]);
-  }
-}
-{$ end test.dart $}
-{$ begin hint.txt $}
-Use the methods `contains()` and `startsWith()` from the `String` class.
-{$ end hint.txt $}
 ```
 
 ## Checking conditions
@@ -456,7 +403,6 @@ Use `any()` and `every()` to implement two functions:
   * Return `true` if all users are 14 or older.
 
 ```dart:run-dartpad:theme-dark:height-395px:ga_id-verify_iterable
-{$ begin main.dart $}
 bool anyUserUnder18(Iterable<User> users) {
   TODO('Implement this method');
 }
@@ -474,119 +420,6 @@ class User {
     this.age,
   );
 }
-{$ end main.dart $}
-{$ begin solution.dart $}
-bool anyUserUnder18(Iterable<User> users) {
-  return users.any((user) => user.age < 18);
-}
-
-bool everyUserOver13(Iterable<User> users) {
-  return users.every((user) => user.age > 13);
-}
-
-class User {
-  String name;
-  int age;
-
-  User(
-    this.name,
-    this.age,
-  );
-}
-{$ end solution.dart $}
-{$ begin test.dart $}
-var users = [
-  User('Alice', 21),
-  User('Bob', 17),
-  User('Claire', 52),
-  User('David', 14),
-];
-
-void main() {
-  try {
-    var out = anyUserUnder18(users);
-    if (!out) {
-      _result(false, ['Looks like `anyUserUnder18` is wrong. Keep trying!']);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `anyUserUnder18`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false,
-        ['Tried running `anyUserUnder18`, but received an exception: $e']);
-    return;
-  }
-
-  try {
-    // with only one user older than 18, should be false
-    var out = anyUserUnder18([User('Alice', 21)]);
-    if (out) {
-      _result(false, [
-        'Looks like `anyUserUnder18` is wrong. What if all users are over 18?'
-      ]);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `anyUserUnder18`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `anyUserUnder18([User("Alice", 21)])`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  try {
-    var out = everyUserOver13(users);
-    if (!out) {
-      _result(false, [
-        'Looks like `everyUserOver13` is wrong. There are no users under 13!'
-      ]);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `everyUserOver13`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `everyUserOver13`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  try {
-    var out = everyUserOver13([User('Dan', 12)]);
-    if (out) {
-      _result(false, [
-        'Looks like `everyUserOver13` is wrong. There is at least one user under 13!'
-      ]);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `everyUserOver13`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `everyUserOver13([User(\'Dan\', 12)])`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  _result(true);
-}
-{$ end test.dart $}
-{$ begin hint.txt $}
-Use the methods `any()` and `every()` to compare the user age.
-{$ end hint.txt $}
 ```
 
 :::secondary Quick review
@@ -725,7 +558,6 @@ Use `where()` to implement two functions:
     names of length 3 or less.
 
 ```dart:run-dartpad:theme-dark:height-380px:ga_id-filtering_elements_from_a_list
-{$ begin main.dart $}
 Iterable<User> filterOutUnder21(Iterable<User> users) {
   TODO('Implement this method');
 }
@@ -743,77 +575,6 @@ class User {
     this.age,
   );
 }
-{$ end main.dart $}
-{$ begin solution.dart $}
-Iterable<User> filterOutUnder21(Iterable<User> users) {
-  return users.where((user) => user.age >= 21);
-}
-
-Iterable<User> findShortNamed(Iterable<User> users) {
-  return users.where((user) => user.name.length <= 3);
-}
-
-class User {
-  String name;
-  int age;
-
-  User(
-    this.name,
-    this.age,
-  );
-}
-{$ end solution.dart $}
-{$ begin test.dart $}
-var users = [
-  User('Alice', 21),
-  User('Bob', 17),
-  User('Claire', 52),
-  User('Dan', 12),
-];
-
-void main() {
-  try {
-    var out = filterOutUnder21(users);
-    if (out.any((user) => user.age < 21) || out.length != 2) {
-      _result(false, ['Looks like `filterOutUnder21` is wrong, there are exactly two users with age under 21. Keep trying!']);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `filterOutUnder21`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `filterOutUnder21`, but received an exception: ${e.runtimeType}'
-    ]);
-    return;
-  }
-
-  try {
-    var out = findShortNamed(users);
-    if (out.any((user) => user.name.length > 3) || out.length != 2) {
-      _result(false, ['Looks like `findShortNamed` is wrong, there are exactly two users with a three letter name. Keep trying!']);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `findShortNamed`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `findShortNamed`, but received an exception: ${e.runtimeType}'
-    ]);
-    return;
-  }
-  
-  _result(true);
-}
-{$ end test.dart $}
-{$ begin hint.txt $}
-Use the `where()` method to implement the filters.
-{$ end hint.txt $}
 ```
 
 :::secondary Quick review
@@ -880,7 +641,6 @@ Each string in the `Iterable` must follow this format:
 `'{name} is {age}'`—for example `'Alice is 21'`.
 
 ```dart:run-dartpad:theme-dark:height-310px:ga_id-mapping_to_a_different_type
-{$ begin main.dart $}
 Iterable<String> getNameAndAges(Iterable<User> users) {
   TODO('Implement this method');
 }
@@ -894,59 +654,6 @@ class User {
     this.age,
   );
 }
-{$ end main.dart $}
-{$ begin solution.dart $}
-Iterable<String> getNameAndAges(Iterable<User> users) {
-  return users.map((user) => '${user.name} is ${user.age}');
-}
-
-class User {
-  String name;
-  int age;
-
-  User(
-    this.name,
-    this.age,
-  );
-}
-{$ end solution.dart $}
-{$ begin test.dart $}
-var users = [
-  User('Alice', 21),
-  User('Bob', 17),
-  User('Claire', 52),
-];
-
-void main() {
-  try {
-    final out = getNameAndAges(users).toList();
-    if (!_listEquals(out, ['Alice is 21', 'Bob is 17', 'Claire is 52'])) {
-      _result(false, ['Looks like `getNameAndAges` is wrong. Keep trying! The output was $out']);
-      return;
-    }
-    _result(true);
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `getNameAndAges`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, ['Tried running the method, but received an exception: $e']);
-  }
-}
-
-bool _listEquals<T>(List<T>? a, List<T>? b) {
-  if (a == null) return b == null;
-  if (b == null || a.length != b.length) return false;
-  for (int index = 0; index < a.length; index += 1) {
-    if (a[index] != b[index]) return false;
-  }
-  return true;
-}
-{$ end test.dart $}
-{$ begin hint.txt $}
-Use `map()` to create a String with the values of `user.name` and `user.age`.
-{$ end hint.txt $}
 ```
 
 :::secondary Quick review
@@ -1000,7 +707,6 @@ Part 3: Implement `validEmailAddresses()`.
   an `EmailAddress` is valid.
 
 ```dart:run-dartpad:theme-dark:height-600px:ga_id-putting_it_all_together
-{$ begin main.dart $}
 Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {
   TODO('Implement this method');
 }
@@ -1032,155 +738,6 @@ class EmailAddress {
     return 'EmailAddress{address: $address}';
   }
 }
-{$ end main.dart $}
-{$ begin solution.dart $}
-Iterable<EmailAddress> parseEmailAddresses(Iterable<String> strings) {
-  return strings.map((s) => EmailAddress(s));
-}
-
-bool anyInvalidEmailAddress(Iterable<EmailAddress> emails) {
-  return emails.any((email) => !isValidEmailAddress(email));
-}
-
-Iterable<EmailAddress> validEmailAddresses(Iterable<EmailAddress> emails) {
-  return emails.where((email) => isValidEmailAddress(email));
-}
-
-class EmailAddress {
-  final String address;
-
-  EmailAddress(this.address);
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-          other is EmailAddress &&
-              runtimeType == other.runtimeType &&
-              address == other.address;
-
-  @override
-  int get hashCode => address.hashCode;
-
-  @override
-  String toString() {
-    return 'EmailAddress{address: $address}';
-  }
-}
-{$ end solution.dart $}
-{$ begin test.dart $}
-const input = [
-  'ali@gmail.com',
-  'bobgmail.com',
-  'cal@gmail.com',
-];
-
-const correctInput = ['dash@gmail.com', 'sparky@gmail.com'];
-
-bool isValidEmailAddress(EmailAddress email) {
-  return email.address.contains('@');
-}
-
-void main() {
-  Iterable<EmailAddress> emails;
-  Iterable<EmailAddress> correctEmails;
-  try {
-    emails = parseEmailAddresses(input);
-    correctEmails = parseEmailAddresses(correctInput);
-    if (emails.isEmpty) {
-      _result(false, [
-        'Tried running `parseEmailAddresses`, but received an empty list.'
-      ]);
-      return;
-    }
-    if (!_listEquals(emails.toList(), [
-      EmailAddress('ali@gmail.com'),
-      EmailAddress('bobgmail.com'),
-      EmailAddress('cal@gmail.com'),
-    ])) {
-      _result(false, ['Looks like `parseEmailAddresses` is wrong. Keep trying!']);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `parseEmailAddresses`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `parseEmailAddresses`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  try {
-    final out = anyInvalidEmailAddress(emails);
-    if (!out) {
-      _result(false, [
-        'Looks like `anyInvalidEmailAddress` is wrong. Keep trying! The result should be false with at least one invalid address.'
-      ]);
-      return;
-    }
-    final falseOut = anyInvalidEmailAddress(correctEmails);
-    if (falseOut) {
-      _result(false, [
-        'Looks like `anyInvalidEmailAddress` is wrong. Keep trying! The result should be false with all valid addresses.'
-      ]);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `anyInvalidEmailAddress`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running `anyInvalidEmailAddress`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  try {
-    final valid = validEmailAddresses(emails);
-    if (emails.isEmpty) {
-      _result(false, [
-        'Tried running `validEmailAddresses`, but received an empty list.'
-      ]);
-      return;
-    }
-    if (!_listEquals(valid.toList(), [
-      EmailAddress('ali@gmail.com'),
-      EmailAddress('cal@gmail.com'),
-    ])) {
-      _result(false, ['Looks like `validEmailAddresses` is wrong. Keep trying!']);
-      return;
-    }
-  } on UnimplementedError {
-    _result(false, [
-      'Tried running `validEmailAddresses`, but received an error. Did you implement the method?'
-    ]);
-    return;
-  } catch (e) {
-    _result(false, [
-      'Tried running the `validEmailAddresses`, but received an exception: $e'
-    ]);
-    return;
-  }
-
-  _result(true);
-}
-
-bool _listEquals<T>(List<T>? a, List<T>? b) {
-  if (a == null) return b == null;
-  if (b == null || a.length != b.length) return false;
-  for (int index = 0; index < a.length; index += 1) {
-    if (a[index] != b[index]) return false;
-  }
-  return true;
-}
-{$ end test.dart $}
-{$ begin hint.txt $}
-Use the methods `map()`, `any()`, and `where()` to solve the exercise.
-{$ end hint.txt $}
 ```
 
 ## What's next

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -187,9 +187,11 @@ var s3 = 'It\'s easy to escape the string delimiter.';
 var s4 = "It's even easier to use the other delimiter.";
 ```
 
+<a id="string-interpolation"></a>
+
 You can put the value of an expression inside a string by using
 `${`*`expression`*`}`. If the expression is an identifier, you can skip
-the {}. To get the string corresponding to an object, Dart calls the
+the `{}`. To get the string corresponding to an object, Dart calls the
 object's `toString()` method.
 
 <?code-excerpt "misc/test/language_tour/built_in_types_test.dart (string-interpolation)"?>


### PR DESCRIPTION
- Removes usage of multi-file DartPad support (tests, hints, solutions)
- Introduces new separate **Hint** and **Solution** details-based dropdowns

Contributes to https://github.com/dart-lang/site-www/issues/5382

**Staged:** https://dart-dev--pr5542-fix-migrate-iterables-codelab-4glpkbdh.web.app/codelabs/iterables