### PR TITLE
Fix a getter name in a comment from an extension types usage example

### DIFF
--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -380,7 +380,7 @@ void testE() {
   
   List<NumberE> numbers = [
     NumberE(1), 
-    num1.next, // OK: 'i' getter returns type 'NumberE'.
+    num1.next, // OK: 'next' getter returns type 'NumberE'.
     1, // Error: Can't assign 'int' element to list type 'NumberE'.
   ];
 }


### PR DESCRIPTION
This PR just fixes a typo in the NumberE usage example :  a comment refers to a 'i' getter when it should be the 'next' getter
