### PR TITLE
Excerpt fix attempt

### DIFF
--- a/examples/type_system/test/strong_test.dart
+++ b/examples/type_system/test/strong_test.dart
@@ -37,7 +37,7 @@ void main() {
       }
       // #enddocregion runtime-checks
 
-      const msg = "type 'List<Animal>' is not a subtype of type 'List<Cat>'";
+      const msg = "type 'List<Dog>' is not a subtype of type 'List<Cat>'";
       expect(main, _throwsA<TypeError>(msg));
     });
 


### PR DESCRIPTION
Fixes all the broken PRs hopefully 🤞 

Check any open PR broken tests right now, outputs:

```
Testing code...
00:00 +0: loading test/strong_test.dart
00:00 +0: test/strong_test.dart: opening example
00:00 +1: test/strong_test.dart: runtime checks: introductory example
00:00 +1 -1: test/strong_test.dart: runtime checks: introductory example [E]
  Expected: throws (<Instance of 'TypeError'> and satisfies function)
    Actual: <Closure: () => void>
     Which: threw _TypeError:<type 'List<Dog>' is not a subtype of type 'List<Cat>' in type cast>
            stack test/strong_test.dart 36:34  main.<fn>.<fn>.main
                  package:matcher              expect
                  test/strong_test.dart 41:7   main.<fn>.<fn>
  
  package:matcher             expect
  test/strong_test.dart 41:7  main.<fn>.<fn>
  
00:00 +1 -1: test/strong_test.dart: runtime checks: downcast check fails
00:00 +2 -1: test/strong_test.dart: runtime checks: downcast check ok for <String>[]
00:00 +3 -1: test/strong_test.dart: runtime checks: downcast check ok for List<String>
00:00 +4 -1: test/strong_test.dart: runtime checks: downcast check ok: use cast()
00:00 +5 -1: test/strong_test.dart: runtime checks: instantiate-to-bound sanity
00:00 +6 -1: test/strong_test.dart: runtime checks: instantiate-to-bound fix: add type arg
00:00 +7 -1: Some tests failed.

Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
For example, 'dart test --chain-stack-traces'.
Error: Tests in examples/type_system failed:
Error: Process completed with exit code 1.
```

So I changed the error message to what the system expects to be thrown, hopefully that fixes it