### PR TITLE
Specify hook directory

### DIFF
--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -501,10 +501,12 @@ enchilada/
 Packages can define hooks to be invoked by the Dart and Flutter SDK.
 These hooks have a predefined CLI, and will be invoked by the SDK tools if present.
 
-:::note
 Because these hooks are invoked by the SDKs on runs and builds, the dependencies
 of these hooks must be normal dependencies and not dev dependencies.
-:::
+
+Hooks are currently an experimental feature.
+For more information see the
+[build.dart hook documentation](https://github.com/dart-lang/native/blob/main/pkgs/native_assets_cli/README.md).
 
 ## Project-specific caching for tools
 

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -505,9 +505,15 @@ Because these hooks are invoked by the
 `dart` and `flutter` tools on runs and builds, the dependencies
 of these hooks must be normal dependencies and not `dev_dependencies`.
 
-Hooks are currently an experimental feature.
-For more information see the
-[build.dart hook documentation](https://github.com/dart-lang/native/blob/main/pkgs/native_assets_cli/README.md).
+:::note
+Hook support is **experimental** and in active development.
+
+To learn more about how to define hooks and their current status,
+refer to the [`build.dart` hook documentation][].
+:::
+
+
+[`build.dart` hook documentation]: https://github.com/dart-lang/native/blob/main/pkgs/native_assets_cli/README.md
 
 ## Project-specific caching for tools
 

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -502,7 +502,7 @@ Packages can define hooks to be invoked by the Dart and Flutter SDK.
 These hooks have a predefined CLI, and will be invoked by the SDK tools if present.
 
 Because these hooks are invoked by the SDKs on runs and builds, the dependencies
-of these hooks must be normal dependencies and not dev dependencies.
+of these hooks must be normal dependencies and not `dev_dependencies`.
 
 Hooks are currently an experimental feature.
 For more information see the

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -38,6 +38,8 @@ enchilada/
     getting_started.md
   example/
     main.dart
+  hook/
+    build.dart
   integration_test/
     app_test.dart
   lib/
@@ -487,6 +489,22 @@ documentation generators, or other bits of automation.
 
 Unlike the scripts in `bin`, these are *not* for external users of the package.
 If you have any of these, place them in a directory called `tool`.
+
+## Hooks
+
+```plaintext
+enchilada/
+  hook/
+    build.dart
+```
+
+Packages can define hooks to be invoked by the Dart and Flutter SDK.
+These hooks have a predefined CLI, and will be invoked by the SDK tools if present.
+
+:::note
+Because these hooks are invoked by the SDKs on runs and builds, the dependencies
+of these hooks must be normal dependencies and not dev dependencies.
+:::
 
 ## Project-specific caching for tools
 

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -501,7 +501,8 @@ enchilada/
 Packages can define hooks to be invoked by the Dart and Flutter SDK.
 These hooks have a predefined CLI, and will be invoked by the SDK tools if present.
 
-Because these hooks are invoked by the SDKs on runs and builds, the dependencies
+Because these hooks are invoked by the
+`dart` and `flutter` tools on runs and builds, the dependencies
 of these hooks must be normal dependencies and not `dev_dependencies`.
 
 Hooks are currently an experimental feature.


### PR DESCRIPTION
Specify the `hook/` directory in the package layout.

* https://github.com/dart-lang/sdk/issues/54334

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
