### PR TITLE
Fix broken DartPad link in "The Dart type system" section

### DIFF
--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -73,7 +73,7 @@ void main() {
 }
 ```
 
-[Try it in DartPad]({{site.dartpad}}/25074a51a00c71b4b000f33b688dedd0).
+[Try it in DartPad]({{site.dartpad}}/?id=25074a51a00c71b4b000f33b688dedd0).
 
 ## What is soundness?
 


### PR DESCRIPTION
This PR fixes the DartPad link in "The Dart type system" section so that it opens up the correct DartPad link instead of a "Page Not Found" error page.

Screen recording:


https://github.com/dart-lang/site-www/assets/19398044/d0f3b6a6-9a42-4047-a926-dbe062f52746





Fixes #5585 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
