### PR TITLE
Standardize and clean up code excerpt regions

### DIFF
--- a/examples/async_await/bin/futures_intro.dart
+++ b/examples/async_await/bin/futures_intro.dart
@@ -7,9 +7,11 @@ Future<void> fetchUserOrder() {
 
 // #docregion error
 Future<void> fetchUserOrderError() {
-// Imagine that this function is fetching user info but encounters a bug
-  return Future.delayed(const Duration(seconds: 2),
-      () => throw Exception('Logout failed: user ID is invalid'));
+  // Imagine that this function is fetching user info but encounters a bug.
+  return Future.delayed(
+    const Duration(seconds: 2),
+    () => throw Exception('Logout failed: user ID is invalid'),
+  );
 }
 // #docregion ''
 
@@ -17,3 +19,4 @@ void main() {
   fetchUserOrder();
   print('Fetching user order...');
 }
+// #enddocregion error

--- a/examples/async_await/bin/get_order_sync_bad.dart
+++ b/examples/async_await/bin/get_order_sync_bad.dart
@@ -19,3 +19,4 @@ void main() {
   print('Fetching user order...');
   print(createOrderMessage());
 }
+// #enddocregion no-warning

--- a/examples/cli/bin/dcat.dart
+++ b/examples/cli/bin/dcat.dart
@@ -43,12 +43,12 @@ Future<void> dcat(List<String> paths, {bool showLineNumbers = false}) async {
           .transform(const LineSplitter());
       try {
         await for (final line in lines) {
-          // #docregion showLineNumbers
+          // #docregion show-line-numbers
           if (showLineNumbers) {
             stdout.write('${lineNumber++} ');
           }
           stdout.writeln(line);
-          // #enddocregion showLineNumbers
+          // #enddocregion show-line-numbers
         }
       } catch (_) {
         await _handleError(path);

--- a/examples/concurrency/lib/basic_ports_example/complete.dart
+++ b/examples/concurrency/lib/basic_ports_example/complete.dart
@@ -8,21 +8,19 @@ void main() async {
   await worker.parseJson('{"key":"value"}');
 }
 
-// #docregion handleResponses parseJson
 class Worker {
   late SendPort _sendPort;
   final Completer<void> _isolateReady = Completer.sync();
-// #enddocregion handleResponses parseJson
 
-// #docregion spawn
+  // #docregion spawn
   Future<void> spawn() async {
     final receivePort = ReceivePort();
     receivePort.listen(_handleResponsesFromIsolate);
     await Isolate.spawn(_startRemoteIsolate, receivePort.sendPort);
   }
-// #enddocregion spawn
+  // #enddocregion spawn
 
-// #docregion handleResponses
+  // #docregion handle-responses
   void _handleResponsesFromIsolate(dynamic message) {
     if (message is SendPort) {
       _sendPort = message;
@@ -31,9 +29,9 @@ class Worker {
       print(message);
     }
   }
-// #enddocregion handleResponses
+  // #enddocregion handle-responses
 
-// #docregion startRemoteIsolate
+  // #docregion start-remote-isolate
   static void _startRemoteIsolate(SendPort port) {
     final receivePort = ReceivePort();
     port.send(receivePort.sendPort);
@@ -45,12 +43,12 @@ class Worker {
       }
     });
   }
-// #enddocregion startRemoteIsolate
+  // #enddocregion start-remote-isolate
 
-// #docregion parseJson
+  // #docregion parse-json
   Future<void> parseJson(String message) async {
     await _isolateReady.future;
     _sendPort.send(message);
   }
-// #enddocregion parseJson
+  // #enddocregion parse-json
 }

--- a/examples/create_libraries/lib/hw_mp.dart
+++ b/examples/create_libraries/lib/hw_mp.dart
@@ -5,3 +5,4 @@ library hw_mp;
 export 'src/hw_none.dart' // Stub implementation
     if (dart.library.io) 'src/hw_io.dart' // dart:io implementation
     if (dart.library.js_interop) 'src/hw_web.dart'; // package:web implementation
+// #enddocregion export

--- a/examples/html/lib/html.dart
+++ b/examples/html/lib/html.dart
@@ -5,7 +5,7 @@ import 'dart:html';
 
 void miscDeclAnalyzedButNotTested() {
   {
-    // #docregion querySelector
+    // #docregion query-selector
     // Find an element by id (an-id).
     Element idElement = querySelector('#an-id')!;
 
@@ -24,7 +24,7 @@ void miscDeclAnalyzedButNotTested() {
     // inside of a <p> that is inside an element with
     // the ID 'id'.
     List<Element> specialParagraphElements = querySelectorAll('#id p.class');
-    // #enddocregion querySelector
+    // #enddocregion query-selector
   }
 
   {
@@ -54,9 +54,9 @@ void miscDeclAnalyzedButNotTested() {
     querySelector('#inputs')!.nodes.add(elem);
     // #enddocregion nodes-add
 
-    // #docregion replaceWith
+    // #docregion replace-with
     querySelector('#status')!.replaceWith(elem);
-    // #enddocregion replaceWith
+    // #enddocregion replace-with
 
     // #docregion remove
     // Find a node by ID, and remove it from the DOM if it is found.
@@ -91,13 +91,13 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion set-style
 
     void submitData() {}
-    // #docregion onClick
+    // #docregion on-click
     // Find a button by ID and add an event handler.
     querySelector('#submitInfo')!.onClick.listen((e) {
       // When the button is clicked, it runs this code.
       submitData();
     });
-    // #enddocregion onClick
+    // #enddocregion on-click
 
     // #docregion target
     document.body!.onClick.listen((e) {
@@ -109,14 +109,14 @@ void miscDeclAnalyzedButNotTested() {
 
   Future<void> tryGetString() async {
     String jsonUri = 'data.json';
-    // #docregion try-getString
+    // #docregion try-get-string
     try {
       var data = await HttpRequest.getString(jsonUri);
       // Process data...
     } catch (e) {
       // Handle exception...
     }
-    // #enddocregion try-getString
+    // #enddocregion try-get-string
   }
 
   {

--- a/examples/html/test/html_test.dart
+++ b/examples/html/test/html_test.dart
@@ -63,18 +63,18 @@ void main() {
 
   test('getString', skip: 'httpbin timing out', () async {
     final url = 'https://httpbin.org';
-    // #docregion getString
+    // #docregion get-string
     Future<void> main() async {
       String pageHtml = await HttpRequest.getString(url);
       // Do something with pageHtml...
-      // #enddocregion getString
+      // #enddocregion get-string
       expect(
         pageHtml.substring(0, 250),
         contains('<title>httpbin'),
       );
-      // #docregion getString
+      // #docregion get-string
     }
-    // #enddocregion getString
+    // #enddocregion get-string
 
     await main();
   });

--- a/examples/language/lib/patterns/algebraic_datatypes.dart
+++ b/examples/language/lib/patterns/algebraic_datatypes.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-// #docregion algebraic_datatypes
+// #docregion algebraic-datatypes
 sealed class Shape {}
 
 class Square implements Shape {
@@ -17,4 +17,4 @@ double calculateArea(Shape shape) => switch (shape) {
       Square(length: var l) => l * l,
       Circle(radius: var r) => math.pi * r * r
     };
-// #enddocregion algebraic_datatypes
+// #enddocregion algebraic-datatypes

--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -138,9 +138,9 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion prefer-dynamic
   }
 
-  // #docregion avoid-Function
+  // #docregion avoid-function
   bool isValid(String value, Function test) => ellipsis();
-  // #enddocregion avoid-Function
+  // #enddocregion avoid-function
 
   // #docregion future-or
   FutureOr<int> triple(FutureOr<int> value) {

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -88,20 +88,20 @@ void miscDeclAnalyzedButNotTested() {
   };
 
   (stackTrace) {
-    // #docregion to___
+    // #docregion to-misc
     list.toSet();
     stackTrace.toString();
     dateTime.toLocal();
-    // #enddocregion to___
+    // #enddocregion to-misc
   };
 
   () {
     dynamic table;
-    // #docregion as___
+    // #docregion as-misc
     var map = table.asMap();
     var list = bytes.asFloat32List();
     var future = subscription.asFuture();
-    // #enddocregion as___
+    // #enddocregion as-misc
   };
 
   () {
@@ -288,9 +288,9 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion infer-dynamic
   }
 
-  // #docregion avoid-Function
+  // #docregion avoid-function
   bool isValid(String value, bool Function(String) test) => ellipsis();
-  // #enddocregion avoid-Function
+  // #enddocregion avoid-function
 
   // #docregion function-arity
   void handleError(void Function() operation, Function errorHandler) {
@@ -309,7 +309,7 @@ void miscDeclAnalyzedButNotTested() {
   // #enddocregion function-arity
 
   () {
-    // #docregion Object-vs-dynamic
+    // #docregion object-vs-dynamic
     /// Returns a Boolean representation for [arg], which must
     /// be a String or bool.
     bool convertToBool(Object arg) {
@@ -317,7 +317,7 @@ void miscDeclAnalyzedButNotTested() {
       if (arg is String) return arg.toLowerCase() == 'true';
       throw ArgumentError('Cannot convert $arg to a bool.');
     }
-    // #enddocregion Object-vs-dynamic
+    // #enddocregion object-vs-dynamic
   };
 
   // #docregion future-or

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -96,12 +96,12 @@ void miscDeclAnalyzedButNotTested() {
   };
 
   (Iterable people) {
-    // #docregion avoid-forEach
+    // #docregion avoid-for-each
     people.forEach((person) {
       /*...*/
     });
 
-    // #enddocregion avoid-forEach
+    // #enddocregion avoid-for-each
   };
 
   {

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -134,19 +134,12 @@ void miscDeclAnalyzedButNotTested() {
   }
   // #enddocregion cast-from
 
-  (Iterable<Animal> animals) {
-    // #docregion use-higher-order-func
-    var aquaticNames = animals
-        .where((animal) => animal.isAquatic)
-        .map((animal) => animal.name);
-  };
-
   (Iterable people) {
-    // #docregion avoid-forEach
+    // #docregion avoid-for-each
     for (final person in people) {
       /*...*/
     }
-    // #enddocregion avoid-forEach
+    // #enddocregion avoid-for-each
     // #docregion forEach-over-func
     people.forEach(print);
     // #enddocregion forEach-over-func

--- a/examples/misc/lib/language_tour/async.dart
+++ b/examples/misc/lib/language_tour/async.dart
@@ -1,14 +1,14 @@
 // ignore_for_file: unused_element, unused_local_variable, unawaited_futures
 
 Future<void> miscDeclAnalyzedButNotTested() async {
-  // #docregion async-lookUpVersion
+  // #docregion async-look-up-version
   Future<String> lookUpVersion() async => '1.0.0';
-  // #enddocregion async-lookUpVersion
+  // #enddocregion async-look-up-version
 
   {
-    // #docregion await-lookUpVersion
+    // #docregion await-look-up-version
     await lookUpVersion();
-    // #enddocregion await-lookUpVersion
+    // #enddocregion await-look-up-version
   }
 
   {
@@ -32,9 +32,9 @@ Future<void> miscDeclAnalyzedButNotTested() async {
   }
 
   {
-    // #docregion sync-lookUpVersion
+    // #docregion sync-look-up-version
     String lookUpVersion() => '1.0.0';
-    // #enddocregion sync-lookUpVersion
+    // #enddocregion sync-look-up-version
   }
 
   {
@@ -62,7 +62,7 @@ Future<void> miscDeclAnalyzedButNotTested() async {
   {
     Stream<dynamic> requestServer = Stream.empty();
     Future<dynamic> handleRequest(_) async => Never;
-    // #docregion number_thinker
+    // #docregion number-thinker
     void main() async {
       // ...
       await for (final request in requestServer) {
@@ -70,7 +70,7 @@ Future<void> miscDeclAnalyzedButNotTested() async {
       }
       // ...
     }
-    // #enddocregion number_thinker
+    // #enddocregion number-thinker
   }
 
   <varOrType>(Stream<varOrType> expression) async {

--- a/examples/misc/lib/language_tour/classes/employee.dart
+++ b/examples/misc/lib/language_tour/classes/employee.dart
@@ -34,16 +34,16 @@ void main() {
   // in Employee
   // Instance of 'Employee'
   // #enddocregion super
-  // #docregion emp-is-Person
+  // #docregion emp-is-person
   // ignore: unnecessary_type_check
   if (employee is Person) {
     // Type check
     employee.firstName = 'Bob';
   }
-  // #enddocregion emp-is-Person
-  // #docregion emp-as-Person
+  // #enddocregion emp-is-person
+  // #docregion emp-as-person
   (employee as Person).firstName = 'Bob';
-  // #enddocregion emp-as-Person
+  // #enddocregion emp-as-person
 // #docregion super
 }
 // #enddocregion super

--- a/examples/misc/lib/language_tour/classes/misc.dart
+++ b/examples/misc/lib/language_tour/classes/misc.dart
@@ -13,9 +13,9 @@ class Comparable {}
 
 class Location {}
 
-// #docregion point_interfaces
+// #docregion point-interfaces
 class Point implements Comparable, Location {/*...*/}
-// #enddocregion point_interfaces
+// #enddocregion point-interfaces
 
 // #docregion static-field
 class Queue {

--- a/examples/misc/lib/language_tour/classes/orchestra.dart
+++ b/examples/misc/lib/language_tour/classes/orchestra.dart
@@ -1,4 +1,4 @@
-// #docregion Musical
+// #docregion musical
 mixin Musical {
   bool canPlayPiano = false;
   bool canCompose = false;
@@ -14,7 +14,7 @@ mixin Musical {
     }
   }
 }
-// #enddocregion Musical
+// #enddocregion musical
 
 mixin Aggressive {
   bool passive = false;
@@ -35,11 +35,11 @@ abstract class Performer {
   String? name;
 }
 
-// #docregion Musician-and-Maestro
+// #docregion musician-and-maestro
 class Musician extends Performer with Musical {
-  // #enddocregion Musician-and-Maestro
+  // #enddocregion musician-and-maestro
   Musician(super.name);
-  // #docregion Musician-and-Maestro
+  // #docregion musician-and-maestro
 }
 
 class Maestro extends Person with Musical, Aggressive, Demented {
@@ -48,7 +48,7 @@ class Maestro extends Person with Musical, Aggressive, Demented {
     canConduct = true;
   }
 }
-// #enddocregion Musician-and-Maestro
+// #enddocregion musician-and-maestro
 
 // Musician2 was a workaround for https://github.com/dart-lang/sdk/issues/35011,
 // which has been marked as fixed.

--- a/examples/misc/lib/language_tour/classes/point.dart
+++ b/examples/misc/lib/language_tour/classes/point.dart
@@ -1,25 +1,23 @@
-// #docregion class-with-distanceTo
+// #docregion class-with-distance-to
 import 'dart:math';
 
-// #enddocregion class-with-distanceTo
+// #enddocregion class-with-distance-to
 // #docregion named-constructor
 const double xOrigin = 0;
 const double yOrigin = 0;
 
-// #docregion class-with-distanceTo, constructor-initializer
+// #docregion class-with-distance-to, constructor-initializer
 class Point {
   final double x;
   final double y;
 
-  // #docregion class-with-distanceTo, named-constructor
-  Point(this.x, this.y);
-  // #enddocregion class-with-distanceTo, named-constructor
   // Sets the x and y instance variables
   // before the constructor body runs.
-  // #enddocregion class-with-distanceTo, constructor-initializer
+  // #docregion class-with-distance-to, named-constructor
+  Point(this.x, this.y);
+  // #enddocregion class-with-distance-to, constructor-initializer
 
   // #docregion named-constructor
-
   // Named constructor
   Point.origin()
       : x = xOrigin,
@@ -31,7 +29,7 @@ class Point {
   Point.fromJson(Map<String, double> json)
       : x = json['x']!,
         y = json['y']!;
-  // #docregion class-with-distanceTo
+  // #docregion class-with-distance-to
 
   double distanceTo(Point other) {
     var dx = x - other.x;
@@ -40,3 +38,4 @@ class Point {
   }
   // #docregion constructor-initializer, named-constructor
 }
+// #enddocregion class-with-distance-to, constructor-initializer, named-constructor

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -33,3 +33,4 @@ class Point {
 
 // #docregion idiomatic-constructor
 }
+// #enddocregion idiomatic-constructor

--- a/examples/misc/lib/language_tour/classes/point_with_main.dart
+++ b/examples/misc/lib/language_tour/classes/point_with_main.dart
@@ -14,3 +14,4 @@ void main() {
   assert(point.x == 4); // Use the getter method for x.
   assert(point.y == null); // Values default to null.
 }
+// #enddocregion class-main

--- a/examples/misc/lib/language_tour/comments.dart
+++ b/examples/misc/lib/language_tour/comments.dart
@@ -54,3 +54,5 @@ class Llama {
     // ...
   }
 }
+
+// #enddocregion doc-comments

--- a/examples/misc/lib/language_tour/generics/cache.dart
+++ b/examples/misc/lib/language_tour/generics/cache.dart
@@ -1,20 +1,20 @@
-// #docregion ObjectCache
+// #docregion object-cache
 abstract class ObjectCache {
   Object getByKey(String key);
   void setByKey(String key, Object value);
 }
-// #enddocregion ObjectCache
+// #enddocregion object-cache
 
-// #docregion StringCache
+// #docregion string-cache
 abstract class StringCache {
   String getByKey(String key);
   void setByKey(String key, String value);
 }
-// #enddocregion StringCache
+// #enddocregion string-cache
 
-// #docregion Cache
+// #docregion cache
 abstract class Cache<T> {
   T getByKey(String key);
   void setByKey(String key, T value);
 }
-// #enddocregion Cache
+// #enddocregion cache

--- a/examples/misc/lib/language_tour/libraries/greeter.dart
+++ b/examples/misc/lib/language_tour/libraries/greeter.dart
@@ -2,8 +2,9 @@
 import 'hello.dart' deferred as hello;
 // #enddocregion import
 
-// #docregion loadLibrary
+// #docregion load-library
 Future<void> greet() async {
   await hello.loadLibrary();
   hello.printGreeting();
 }
+// #enddocregion load-library

--- a/examples/misc/lib/language_tour/typedefs/misc.dart
+++ b/examples/misc/lib/language_tour/typedefs/misc.dart
@@ -18,3 +18,4 @@ void main() {
   // ignore: unnecessary_type_check
   assert(sort is Compare<int>); // True!
 }
+// #enddocregion compare

--- a/examples/misc/lib/library_tour/async/basic.dart
+++ b/examples/misc/lib/library_tour/async/basic.dart
@@ -13,12 +13,12 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion catchError
+    // #docregion catch-error
     httpClient.read(url).then((String result) {
       print(result);
     }).catchError((e) {
       // Handle or ignore the error.
     });
-    // #enddocregion catchError
+    // #enddocregion catch-error
   }
 }

--- a/examples/misc/lib/library_tour/async/future.dart
+++ b/examples/misc/lib/library_tour/async/future.dart
@@ -10,25 +10,25 @@ void miscDeclAnalyzedButNotTested() {
   Future<int> flushThenExit(int exitCode) async => 0;
 
   {
-    // #docregion runUsingFuture
+    // #docregion run-using-future
     void runUsingFuture() {
       // ...
       findEntryPoint().then((entryPoint) {
         return runExecutable(entryPoint, args);
       }).then(flushThenExit);
     }
-    // #enddocregion runUsingFuture
+    // #enddocregion run-using-future
   }
 
   {
-    // #docregion runUsingAsyncAwait
+    // #docregion run-using-async-await
     Future<void> runUsingAsyncAwait() async {
       // ...
       var entryPoint = await findEntryPoint();
       var exitCode = await runExecutable(entryPoint, args);
       await flushThenExit(exitCode);
     }
-    // #enddocregion runUsingAsyncAwait
+    // #enddocregion run-using-async-await
   }
 
   {

--- a/examples/misc/lib/library_tour/async/stream.dart
+++ b/examples/misc/lib/library_tour/async/stream.dart
@@ -47,7 +47,7 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion readFileAwaitFor
+    // #docregion read-file-await-for
     Future<void> readFileAwaitFor() async {
       var config = File('config.txt');
       Stream<List<int>> inputStream = config.openRead();
@@ -65,11 +65,11 @@ void miscDeclAnalyzedButNotTested() {
         print(e);
       }
     }
-    // #enddocregion readFileAwaitFor
+    // #enddocregion read-file-await-for
   }
 
   {
-    // #docregion onDone
+    // #docregion on-done
     var config = File('config.txt');
     Stream<List<int>> inputStream = config.openRead();
 
@@ -81,6 +81,6 @@ void miscDeclAnalyzedButNotTested() {
     }, onError: (e) {
       print(e);
     });
-    // #enddocregion onDone
+    // #enddocregion on-done
   }
 }

--- a/examples/misc/lib/library_tour/core/collections.dart
+++ b/examples/misc/lib/library_tour/core/collections.dart
@@ -1,7 +1,7 @@
 void miscDeclAnalyzedButNotTested() {
   var fruits = <String>[];
-  // #docregion List-of-String
+  // #docregion list-of-string
   // ignore: argument_type_not_assignable, unused_local_variable
   fruits.add(5); // Error: 'int' can't be assigned to 'String'
-  // #enddocregion List-of-String
+  // #enddocregion list-of-string
 }

--- a/examples/misc/lib/tutorial/misc.dart
+++ b/examples/misc/lib/tutorial/misc.dart
@@ -21,27 +21,17 @@ void futuresTutorial() {
       .then((bValue) => expensiveC())
       .then((cValue) => doSomethingWith(cValue));
   // #enddocregion chaining
-
-  void handleError(dynamic) {}
-  void chooseBestResponse(List responses, bool anotherArg) => responses[0];
-  bool moreInfo = true;
-
-  // #docregion Future-wait
-  Future.wait([expensiveA(), expensiveB(), expensiveC()])
-      .then((List responses) => chooseBestResponse(responses, moreInfo))
-      .catchError(handleError);
-  // #enddocregion Future-wait
 }
 
 void streamsTutorial() {
-  // #docregion lastPositive
+  // #docregion last-positive
   Future<int> lastPositive(Stream<int> stream) =>
       stream.lastWhere((x) => x >= 0);
-  // #enddocregion lastPositive
+  // #enddocregion last-positive
 
   void log(e) {}
 
-  // #docregion mapLogErrors
+  // #docregion map-log-errors
   Stream<S> mapLogErrors<S, T>(
     Stream<T> stream,
     S Function(T event) convert,
@@ -51,7 +41,7 @@ void streamsTutorial() {
       yield convert(event);
     }
   }
-  // #enddocregion mapLogErrors
+  // #enddocregion map-log-errors
 }
 
 abstract class MyStream<T> extends Stream<T> {

--- a/examples/misc/lib/tutorial/sum_stream.dart
+++ b/examples/misc/lib/tutorial/sum_stream.dart
@@ -1,5 +1,5 @@
 // #docregion
-// #docregion sumStream
+// #docregion sum-stream
 Future<int> sumStream(Stream<int> stream) async {
   var sum = 0;
   await for (final value in stream) {
@@ -7,7 +7,7 @@ Future<int> sumStream(Stream<int> stream) async {
   }
   return sum;
 }
-// #enddocregion sumStream
+// #enddocregion sum-stream
 
 Stream<int> countStream(int to) async* {
   for (int i = 1; i <= to; i++) {

--- a/examples/misc/test/effective_dart_test.dart
+++ b/examples/misc/test/effective_dart_test.dart
@@ -58,10 +58,10 @@ void main() {
   });
 
   test('whereType usage_good', () {
-    // #docregion whereType
+    // #docregion where-type
     var objects = [1, 'a', 2, 'b', 3];
     var ints = objects.whereType<int>();
-    // #enddocregion whereType
+    // #enddocregion where-type
     expect(ints, TypeMatcher<Iterable<int>>());
     expect(ints, [1, 2, 3]);
   });

--- a/examples/misc/test/language_tour/classes_test.dart
+++ b/examples/misc/test/language_tour/classes_test.dart
@@ -78,9 +78,9 @@ void main() {
       assert(identical(a, b)); // They are the same instance!
       // #enddocregion identical
 
-      // #docregion runtimeType
+      // #docregion runtime-type
       print('The type of a is ${a.runtimeType}');
-      // #enddocregion runtimeType
+      // #enddocregion runtime-type
     }
 
     expect(checkIdentical, m.prints('The type of a is ImmutablePoint'));

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -52,7 +52,7 @@ void main() {
     });
 
     test('toString()', () {
-      // #docregion toString-
+      // #docregion to-string
       // Convert an int to a string.
       assert(42.toString() == '42');
 
@@ -65,7 +65,7 @@ void main() {
       // Specify the number of significant figures.
       assert(123.456.toStringAsPrecision(2) == '1.2e+2');
       assert(double.parse('1.2e+2') == 120.0);
-      // #enddocregion toString-
+      // #enddocregion to-string
     });
   });
 
@@ -117,13 +117,13 @@ void main() {
     });
 
     test('change case', () {
-      // #docregion toUpperCase-toLowerCase
+      // #docregion case-conversions
       // Convert to uppercase.
       assert('web apps'.toUpperCase() == 'WEB APPS');
 
       // Convert to lowercase.
       assert('WEB APPS'.toLowerCase() == 'web apps');
-      // #enddocregion toUpperCase-toLowerCase
+      // #enddocregion case-conversions
     });
 
     test('trim-etc', () {
@@ -150,7 +150,7 @@ void main() {
     });
 
     test('StringBuffer', () {
-      // #docregion StringBuffer
+      // #docregion string-buffer
       var sb = StringBuffer();
       sb
         ..write('Use a StringBuffer for ')
@@ -160,11 +160,11 @@ void main() {
       var fullString = sb.toString();
 
       assert(fullString == 'Use a StringBuffer for efficient string creation.');
-      // #enddocregion StringBuffer
+      // #enddocregion string-buffer
     });
 
     test('RegExp', () {
-      // #docregion RegExp
+      // #docregion regexp
       // Here's a regular expression for one or more digits.
       var numbers = RegExp(r'\d+');
 
@@ -178,7 +178,7 @@ void main() {
       // Replace every match with another string.
       var exedOut = someDigits.replaceAll(numbers, 'XX');
       assert(exedOut == 'llamas live XX to XX years');
-      // #enddocregion RegExp
+      // #enddocregion regexp
     });
 
     test('match', () {
@@ -203,7 +203,7 @@ void main() {
 
   group('Collections: List:', () {
     test('constructor', () {
-      // #docregion List
+      // #docregion list
       // Create an empty list of strings.
       var grains = <String>[];
       assert(grains.isEmpty);
@@ -232,11 +232,11 @@ void main() {
       // You can also create a List using one of the constructors.
       var vegetables = List.filled(99, 'broccoli');
       assert(vegetables.every((v) => v == 'broccoli'));
-      // #enddocregion List
+      // #enddocregion list
     });
 
     test('indexOf', () {
-      // #docregion indexOf
+      // #docregion index-of
       var fruits = ['apples', 'oranges'];
 
       // Access a list item by index.
@@ -244,21 +244,21 @@ void main() {
 
       // Find an item in a list.
       assert(fruits.indexOf('apples') == 0);
-      // #enddocregion indexOf
+      // #enddocregion index-of
     });
 
     test('compareTo', () {
-      // #docregion compareTo
+      // #docregion compare-to
       var fruits = ['bananas', 'apples', 'oranges'];
 
       // Sort a list.
       fruits.sort((a, b) => a.compareTo(b));
       assert(fruits[0] == 'apples');
-      // #enddocregion compareTo
+      // #enddocregion compare-to
     });
 
     test('List-of-String', () {
-      // #docregion List-of-String
+      // #docregion list-of-string
       // This list should contain only strings.
       var fruits = <String>[];
 
@@ -266,13 +266,13 @@ void main() {
       var fruit = fruits[0];
       // ignore: unnecessary_type_check
       assert(fruit is String);
-      // #enddocregion List-of-String
+      // #enddocregion list-of-string
     });
   });
 
   group('Collections: Set', () {
     test('constructor', () {
-      // #docregion Set
+      // #docregion set
       // Create an empty set of strings.
       var ingredients = <String>{};
 
@@ -291,7 +291,7 @@ void main() {
       // You can also create sets using
       // one of the constructors.
       var atomicNumbers = Set.from([79, 22, 54]);
-      // #enddocregion Set
+      // #enddocregion set
       expect(ingredients, isNot(contains('gold')));
       expect(atomicNumbers, isNotEmpty);
     });
@@ -325,7 +325,7 @@ void main() {
 
   group('Collections: Map', () {
     test('constructor', () {
-      // #docregion Map
+      // #docregion map
       // Maps often use strings as keys.
       var hawaiianBeaches = {
         'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
@@ -339,7 +339,7 @@ void main() {
       // Maps are parameterized types; you can specify what
       // types the key and value should be.
       var nobleGases = Map<int, String>();
-      // #enddocregion Map
+      // #enddocregion map
       assert(hawaiianBeaches.isNotEmpty);
       assert(searchTerms.isEmpty);
       assert(nobleGases.isEmpty);
@@ -385,7 +385,7 @@ void main() {
     });
 
     test('containsKey', () {
-      // #docregion containsKey
+      // #docregion contains-key
       var hawaiianBeaches = {
         'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
         'Big Island': ['Wailea Bay', 'Pololu Beach'],
@@ -394,16 +394,16 @@ void main() {
 
       assert(hawaiianBeaches.containsKey('Oahu'));
       assert(!hawaiianBeaches.containsKey('Florida'));
-      // #enddocregion containsKey
+      // #enddocregion contains-key
     });
 
     test('putIfAbsent', () {
       String pickToughestKid() => 'Rock';
-      // #docregion putIfAbsent
+      // #docregion put-if-absent
       var teamAssignments = <String, String>{};
       teamAssignments.putIfAbsent('Catcher', () => pickToughestKid());
       assert(teamAssignments['Catcher'] != null);
-      // #enddocregion putIfAbsent
+      // #enddocregion put-if-absent
     });
   });
 
@@ -415,22 +415,22 @@ void main() {
     final teasCheck = ['green', 'black', 'chamomile', 'earl grey'];
 
     test('isEmpty', () {
-      // #docregion isEmpty
+      // #docregion is-empty
       var coffees = <String>[];
       var teas = ['green', 'black', 'chamomile', 'earl grey'];
       assert(coffees.isEmpty);
       assert(teas.isNotEmpty);
-      // #enddocregion isEmpty
+      // #enddocregion is-empty
       expect(teas, teasCheck);
     });
 
     test('List.forEach()', () {
       void testForEach() {
-        // #docregion List-forEach
+        // #docregion list-for-each
         var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
         teas.forEach((tea) => print('I drink $tea'));
-        // #enddocregion List-forEach
+        // #enddocregion list-for-each
         expect(teas, teasCheck);
       }
 
@@ -440,13 +440,13 @@ void main() {
     test('Map.forEach()', () {
       void testForEach() {
         final hawaiianBeaches = {'Honolulu': 'Hanauma Bay'};
-        // #docregion Map-forEach
+        // #docregion map-for-each
         hawaiianBeaches.forEach((k, v) {
           print('I want to visit $k and swim at $v');
           // I want to visit Oahu and swim at
           // [Waikiki, Kailua, Waimanalo], etc.
         });
-        // #enddocregion Map-forEach
+        // #enddocregion map-for-each
       }
 
       expect(testForEach,
@@ -455,12 +455,12 @@ void main() {
 
     test('List.map()', () {
       void testListMap() {
-        // #docregion List-map
+        // #docregion list-map
         var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
         var loudTeas = teas.map((tea) => tea.toUpperCase());
         loudTeas.forEach(print);
-        // #enddocregion List-map
+        // #enddocregion list-map
         expect(teas, teasCheck);
       }
 
@@ -469,9 +469,9 @@ void main() {
 
     test('toList()', () {
       var teas = <String>[];
-      // #docregion toList
+      // #docregion to-list
       var loudTeas = teas.map((tea) => tea.toUpperCase()).toList();
-      // #enddocregion toList
+      // #enddocregion to-list
       // ignore: unnecessary_type_check
       expect(loudTeas is List, isTrue);
     });
@@ -502,7 +502,7 @@ void main() {
 
   group('URIs', () {
     test('encodeFull', () {
-      // #docregion encodeFull
+      // #docregion encode-full
       var uri = 'https://example.org/api?foo=some message';
 
       var encoded = Uri.encodeFull(uri);
@@ -510,11 +510,11 @@ void main() {
 
       var decoded = Uri.decodeFull(encoded);
       assert(uri == decoded);
-      // #enddocregion encodeFull
+      // #enddocregion encode-full
     });
 
     test('encodeComponent', () {
-      // #docregion encodeComponent
+      // #docregion encode-component
       var uri = 'https://example.org/api?foo=some message';
 
       var encoded = Uri.encodeComponent(uri);
@@ -523,11 +523,11 @@ void main() {
 
       var decoded = Uri.decodeComponent(encoded);
       assert(uri == decoded);
-      // #enddocregion encodeComponent
+      // #enddocregion encode-component
     });
 
     test('Uri.parse', () {
-      // #docregion Uri-parse
+      // #docregion uri-parse
       var uri = Uri.parse('https://example.org:8080/foo/bar#frag');
 
       assert(uri.scheme == 'https');
@@ -535,11 +535,11 @@ void main() {
       assert(uri.path == '/foo/bar');
       assert(uri.fragment == 'frag');
       assert(uri.origin == 'https://example.org:8080');
-      // #enddocregion Uri-parse
+      // #enddocregion uri-parse
     });
 
     test('constructor', () {
-      // #docregion Uri
+      // #docregion uri
       var uri = Uri(
           scheme: 'https',
           host: 'example.org',
@@ -547,23 +547,23 @@ void main() {
           fragment: 'frag',
           queryParameters: {'lang': 'dart'});
       assert(uri.toString() == 'https://example.org/foo/bar?lang=dart#frag');
-      // #enddocregion Uri
+      // #enddocregion uri
     });
 
     test('http constructors', () {
-      // #docregion Uri-http
+      // #docregion uri-http
       var httpUri = Uri.http('example.org', '/foo/bar', {'lang': 'dart'});
       var httpsUri = Uri.https('example.org', '/foo/bar', {'lang': 'dart'});
 
       assert(httpUri.toString() == 'http://example.org/foo/bar?lang=dart');
       assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
-      // #enddocregion Uri-http
+      // #enddocregion uri-http
     });
   });
 
   group('DateTime:', () {
     test('DateTime', () {
-      // #docregion DateTime
+      // #docregion date-time
       // Get the current date and time.
       var now = DateTime.now();
 
@@ -584,14 +584,14 @@ void main() {
 
       // Create a new DateTime from an existing one, adjusting just some properties:
       var sameTimeLastYear = now.copyWith(year: now.year - 1);
-      // #enddocregion DateTime
+      // #enddocregion date-time
       assert(2016 < now.year, 'Time travel is verboten!');
       expect(y2k.year, 2000);
       expect(sameTimeLastYear.year, now.year - 1);
     });
 
     test('millisecondsSinceEpoch', () {
-      // #docregion millisecondsSinceEpoch
+      // #docregion milliseconds-since-epoch
       // 1/1/2000, UTC
       var y2k = DateTime.utc(2000);
       assert(y2k.millisecondsSinceEpoch == 946684800000);
@@ -599,11 +599,11 @@ void main() {
       // 1/1/1970, UTC
       var unixEpoch = DateTime.utc(1970);
       assert(unixEpoch.millisecondsSinceEpoch == 0);
-      // #enddocregion millisecondsSinceEpoch
+      // #enddocregion milliseconds-since-epoch
     });
 
     test('Duration', () {
-      // #docregion Duration
+      // #docregion duration
       var y2k = DateTime.utc(2000);
 
       // Add one year.
@@ -619,7 +619,7 @@ void main() {
       // Returns a Duration object.
       var duration = y2001.difference(y2k);
       assert(duration.inDays == 366); // y2k was a leap year.
-      // #enddocregion Duration
+      // #enddocregion duration
     });
   });
 

--- a/examples/misc/test/library_tour/io_test.dart
+++ b/examples/misc/test/library_tour/io_test.dart
@@ -12,7 +12,7 @@ import 'package:examples_util/print_matcher.dart' as m;
 
 void main() {
   test('readAsString, readAsLines', () async {
-    // #docregion readAsString
+    // #docregion read-as-string
     void main() async {
       var config = File('test_data/config.txt');
 
@@ -24,7 +24,7 @@ void main() {
       var lines = await config.readAsLines();
       print('The file is ${lines.length} lines long.');
     }
-    // #enddocregion readAsString
+    // #enddocregion read-as-string
 
     expect(
         main,
@@ -33,14 +33,14 @@ void main() {
   });
 
   test('readAsBytes', () {
-    // #docregion readAsBytes
+    // #docregion read-as-bytes
     void main() async {
       var config = File('test_data/config.txt');
 
       var contents = await config.readAsBytes();
       print('The file is ${contents.length} bytes long.');
     }
-    // #enddocregion readAsBytes
+    // #enddocregion read-as-bytes
 
     expect(main, m.prints('The file is 58 bytes long.'));
   });

--- a/examples/misc/test/library_tour/math_test.dart
+++ b/examples/misc/test/library_tour/math_test.dart
@@ -39,17 +39,17 @@ void main() {
   });
 
   test('Random', () {
-    // #docregion Random
+    // #docregion random
     var random = Random();
     random.nextDouble(); // Between 0.0 and 1.0: [0, 1)
     random.nextInt(10); // Between 0 and 9.
-    // #enddocregion Random
+    // #enddocregion random
   });
 
   test('Random-bool', () {
-    // #docregion Random-bool
+    // #docregion random-bool
     var random = Random();
     random.nextBool(); // true or false
-    // #enddocregion Random-bool
+    // #enddocregion random-bool
   });
 }

--- a/examples/misc/test/samples_test.dart
+++ b/examples/misc/test/samples_test.dart
@@ -190,14 +190,14 @@ void main() {
   });
 
   test('Future.then', () {
-    // #docregion Future-then
+    // #docregion future-then
     Future<void> printWithDelay(String message) {
       return Future.delayed(oneSecond).then((_) {
         print(message);
       });
     }
 
-    // #enddocregion Future-then
+    // #enddocregion future-then
     expect(() => printWithDelay('Hi'), prints('Hi\n'));
   });
 
@@ -251,14 +251,14 @@ void main() {
     var voyager = Spacecraft('Voyager I', DateTime(1977, 9, 5));
     var flybyObjects = ['Jupiter', 'Saturn', 'Uranus', 'Neptune'];
 
-    // #docregion async-
+    // #docregion async-star
     Stream<String> report(Spacecraft craft, Iterable<String> objects) async* {
       for (final object in objects) {
         await Future.delayed(oneSecond);
         yield '${craft.name} flies by $object';
       }
     }
-    // #enddocregion async-
+    // #enddocregion async-star
 
     final messages = flybyObjects.map((o) => 'Voyager I flies by $o');
     expect(await report(voyager, flybyObjects).toList(), messages);

--- a/examples/non_promotion/lib/non_promotion.dart
+++ b/examples/non_promotion/lib/non_promotion.dart
@@ -6,13 +6,13 @@ class C1 {
   int? i;
   void f() {
     if (i == null) return;
-    // #docregion property_bang
+    // #docregion property-bang
     print(i!.isEven);
-    // #enddocregion property_bang
+    // #enddocregion property-bang
   }
 }
 
-// #docregion property_copy
+// #docregion property-copy
 class C {
   int? i;
   void f() {
@@ -21,7 +21,7 @@ class C {
     print(i.isEven);
   }
 }
-// #enddocregion property_copy
+// #enddocregion property-copy
 
 class Link {
   final value = 0;
@@ -30,7 +30,7 @@ class Link {
 
 void miscDeclAnalyzedButNotTested() {
   {
-    // #docregion write_combine_ifs
+    // #docregion write-combine-ifs
     void f(bool b, int? i, int? j) {
       if (i == null) return;
       if (b) {
@@ -39,11 +39,11 @@ void miscDeclAnalyzedButNotTested() {
         print(i.isEven);
       }
     }
-    // #enddocregion write_combine_ifs
+    // #enddocregion write-combine-ifs
   }
 
   {
-    // #docregion write_change_type
+    // #docregion write-change-type
     void f(bool b, int? i, int j) {
       if (i == null) return;
       if (b) {
@@ -53,7 +53,7 @@ void miscDeclAnalyzedButNotTested() {
         print(i.isEven);
       }
     }
-    // #enddocregion write_change_type
+    // #enddocregion write-change-type
   }
 
   {
@@ -149,7 +149,7 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion subtype-String
+    // #docregion subtype-string
     void f(Object o) {
       if (o is Comparable /* (1) */) {
         if (o is String /* (2) */) {
@@ -157,7 +157,7 @@ void miscDeclAnalyzedButNotTested() {
         }
       }
     }
-    // #enddocregion subtype-String
+    // #enddocregion subtype-string
   }
 
   {

--- a/examples/type_system/lib/bounded/instantiate_to_bound.dart
+++ b/examples/type_system/lib/bounded/instantiate_to_bound.dart
@@ -1,9 +1,9 @@
 import 'my_collection.dart';
 
 void cannotRunThis() {
-  // #docregion undefined_method
+  // #docregion undefined-method
   var c = C(Iterable.empty()).collection;
   // ignore: stable, beta, dev, undefined_method
   c.add(2); //!analysis-issue
-  // #enddocregion undefined_method
+  // #enddocregion undefined-method
 }

--- a/src/content/articles/libraries/creating-streams.md
+++ b/src/content/articles/libraries/creating-streams.md
@@ -49,7 +49,7 @@ The most general approach is to create a new stream that
 waits for events on the original stream and then
 outputs new events. Example:
 
-<?code-excerpt "misc/lib/articles/creating-streams/line_stream_generator.dart (split into lines)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/line_stream_generator.dart (split-into-lines)"?>
 ```dart
 /// Splits a stream of consecutive strings into lines.
 ///
@@ -80,7 +80,7 @@ For example, assume you have a stream, `counterStream`,
 that emits an increasing counter every second.
 Here's how it might be implemented:
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (basic usage)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (basic-usage)"?>
 ```dart
 var counterStream =
     Stream<int>.periodic(const Duration(seconds: 1), (x) => x).take(15);
@@ -88,7 +88,7 @@ var counterStream =
 
 To quickly see the events, you can use code like this:
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (basic for each)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (basic-for-each)"?>
 ```dart
 counterStream.forEach(print); // Print an integer every second, 15 times.
 ```
@@ -234,7 +234,7 @@ which are neither futures nor stream events.
 
 [stream_controller_bad.dart]: https://github.com/dart-lang/site-www/blob/main/examples/misc/lib/articles/creating-streams/stream_controller_bad.dart
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (flawed stream)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (flawed-stream)"?>
 ```dart tag=bad
 // NOTE: This implementation is FLAWED!
 // It starts before it has subscribers, and it doesn't implement pause.
@@ -260,7 +260,7 @@ As before, you can use the stream returned by `timedCounter()` like this:
 **[PENDING: Did we show this before?]**
 {% endcomment %}
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (using stream)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (using-stream)"?>
 ```dart
 var counterStream = timedCounter(const Duration(seconds: 1), 15);
 counterStream.listen(print); // Print an integer every second, 15 times.
@@ -291,7 +291,7 @@ if the stream never gets a subscriber.
 
 Try changing the code that uses the stream to the following:
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (pre-subscribe problem)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (pre-subscribe-problem)"?>
 ```dart
 void listenAfterDelay() async {
   var counterStream = timedCounter(const Duration(seconds: 1), 15);
@@ -337,7 +337,7 @@ then the work spent creating the buffer is wasted.
 To see what happens without pause support,
 try changing the code that uses the stream to the following:
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (pause problem)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller_bad.dart (pause-problem)"?>
 ```dart
 void listenWithPause() {
   var counterStream = timedCounter(const Duration(seconds: 1), 15);
@@ -368,7 +368,7 @@ on the `StreamController`.
 
 [stream_controller.dart]: https://github.com/dart-lang/site-www/blob/main/examples/misc/lib/articles/creating-streams/stream_controller.dart
 
-<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (better stream)"?>
+<?code-excerpt "misc/lib/articles/creating-streams/stream_controller.dart (better-stream)"?>
 ```dart
 Stream<int> timedCounter(Duration interval, [int? maxCount]) {
   late StreamController<int> controller;

--- a/src/content/codelabs/async-await.md
+++ b/src/content/codelabs/async-await.md
@@ -196,9 +196,11 @@ A bit later you'll learn how to handle the error.
 <?code-excerpt "async_await/bin/futures_intro.dart (error)" replace="/Error//g"?>
 ```dart:run-dartpad:height-300px:ga_id-completing_with_error
 Future<void> fetchUserOrder() {
-// Imagine that this function is fetching user info but encounters a bug
-  return Future.delayed(const Duration(seconds: 2),
-      () => throw Exception('Logout failed: user ID is invalid'));
+  // Imagine that this function is fetching user info but encounters a bug.
+  return Future.delayed(
+    const Duration(seconds: 2),
+    () => throw Exception('Logout failed: user ID is invalid'),
+  );
 }
 
 void main() {

--- a/src/content/effective-dart/design.md
+++ b/src/content/effective-dart/design.md
@@ -349,7 +349,7 @@ named starting with `to` followed by the kind of result.
 
 If you define a conversion method, it's helpful to follow that convention.
 
-<?code-excerpt "design_good.dart (to___)"?>
+<?code-excerpt "design_good.dart (to-misc)"?>
 ```dart tag=good
 list.toSet();
 stackTrace.toString();
@@ -367,7 +367,7 @@ original. Later changes to the original object are reflected in the view.
 
 The core library convention for you to follow is `as___()`.
 
-<?code-excerpt "design_good.dart (as___)"?>
+<?code-excerpt "design_good.dart (as-misc)"?>
 ```dart tag=good
 var map = table.asMap();
 var list = bytes.asFloat32List();
@@ -1473,12 +1473,12 @@ function.
 
 [Function]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Function-class.html
 
-<?code-excerpt "design_good.dart (avoid-Function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
+<?code-excerpt "design_good.dart (avoid-function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
 ```dart tag=good
 bool isValid(String value, [!bool Function(String)!] test) => ...
 ```
 
-<?code-excerpt "design_bad.dart (avoid-Function)" replace="/Function/[!$&!]/g"?>
+<?code-excerpt "design_bad.dart (avoid-function)" replace="/Function/[!$&!]/g"?>
 ```dart tag=bad
 bool isValid(String value, [!Function!] test) => ...
 ```
@@ -1667,7 +1667,7 @@ promotion to
 ensure that the value's runtime type supports the member you want to access
 before you access it.
 
-<?code-excerpt "design_good.dart (Object-vs-dynamic)"?>
+<?code-excerpt "design_good.dart (object-vs-dynamic)"?>
 ```dart tag=good
 /// Returns a Boolean representation for [arg], which must
 /// be a String or bool.

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -556,14 +556,14 @@ if (!words.isEmpty) return words.join(' ');
 `for-in` loop doesn't do what you usually want. In Dart, if you want to iterate
 over a sequence, the idiomatic way to do that is using a loop.
 
-<?code-excerpt "usage_good.dart (avoid-forEach)"?>
+<?code-excerpt "usage_good.dart (avoid-for-each)"?>
 ```dart tag=good
 for (final person in people) {
   ...
 }
 ```
 
-<?code-excerpt "usage_bad.dart (avoid-forEach)"?>
+<?code-excerpt "usage_bad.dart (avoid-for-each)"?>
 ```dart tag=bad
 people.forEach((person) {
   ...
@@ -658,7 +658,7 @@ the [`whereType()`][where-type] method for this exact use case:
 
 [where-type]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable/whereType.html
 
-<?code-excerpt "../../test/effective_dart_test.dart (whereType)"?>
+<?code-excerpt "../../test/effective_dart_test.dart (where-type)"?>
 ```dart tag=good
 var objects = [1, 'a', 2, 'b', 3];
 var ints = objects.whereType<int>();

--- a/src/content/guides/language/sound-problems.md
+++ b/src/content/guides/language/sound-problems.md
@@ -149,7 +149,7 @@ class C<T extends Iterable> {
 The following code creates a new instance of this class 
 (omitting the type argument) and accesses its `collection` member:
 
-<?code-excerpt "lib/bounded/instantiate_to_bound.dart (undefined_method)" replace="/c\.add\(2\)/[!$&!]/g"?>
+<?code-excerpt "lib/bounded/instantiate_to_bound.dart (undefined-method)" replace="/c\.add\(2\)/[!$&!]/g"?>
 ```dart tag=fails-sa
 var c = C(Iterable.empty()).collection;
 [!c.add(2)!];
@@ -485,7 +485,7 @@ var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
 
 #### Fix: Supply appropriate type as explicit type argument
 
-<?code-excerpt "lib/common_fixes_analysis.dart  (type-inf-fix)"?>
+<?code-excerpt "lib/common_fixes_analysis.dart (type-inf-fix)"?>
 ```dart tag=passes-sa
 var ints = [1, 2, 3];
 var maximumOrNull =

--- a/src/content/language/async.md
+++ b/src/content/language/async.md
@@ -40,7 +40,7 @@ but it looks a lot like synchronous code.
 For example, here's some code that uses `await`
 to wait for the result of an asynchronous function:
 
-<?code-excerpt "misc/lib/language_tour/async.dart (await-lookUpVersion)"?>
+<?code-excerpt "misc/lib/language_tour/async.dart (await-look-up-version)"?>
 ```dart
 await lookUpVersion();
 ```
@@ -129,7 +129,7 @@ Adding the `async` keyword to a function makes it return a Future.
 For example, consider this synchronous function,
 which returns a String:
 
-<?code-excerpt "misc/lib/language_tour/async.dart (sync-lookUpVersion)"?>
+<?code-excerpt "misc/lib/language_tour/async.dart (sync-look-up-version)"?>
 ```dart
 String lookUpVersion() => '1.0.0';
 ```
@@ -138,7 +138,7 @@ If you change it to be an `async` function—for example,
 because a future implementation will be time consuming—the
 returned value is a Future:
 
-<?code-excerpt "misc/lib/language_tour/async.dart (async-lookUpVersion)"?>
+<?code-excerpt "misc/lib/language_tour/async.dart (async-look-up-version)"?>
 ```dart
 Future<String> lookUpVersion() async => '1.0.0';
 ```
@@ -199,7 +199,7 @@ make sure the `await for` is in an `async` function.**
 For example, to use an asynchronous for loop in your app's `main()` function,
 the body of `main()` must be marked as `async`:
 
-<?code-excerpt "misc/lib/language_tour/async.dart (number_thinker)" replace="/async|await for/[!$&!]/g"?>
+<?code-excerpt "misc/lib/language_tour/async.dart (number-thinker)" replace="/async|await for/[!$&!]/g"?>
 ```dart
 void main() [!async!] {
   // ...

--- a/src/content/language/branches.md
+++ b/src/content/language/branches.md
@@ -231,7 +231,7 @@ their possible values are known and fully enumerable.
 Use the [`sealed` modifier][sealed] on a class to enable
 exhaustiveness checking when switching over subtypes of that class:
 
-<?code-excerpt "language/lib/patterns/algebraic_datatypes.dart (algebraic_datatypes)"?>
+<?code-excerpt "language/lib/patterns/algebraic_datatypes.dart (algebraic-datatypes)"?>
 ```dart
 sealed class Shape {}
 

--- a/src/content/language/classes.md
+++ b/src/content/language/classes.md
@@ -138,7 +138,7 @@ To get an object's type at runtime,
 you can use the `Object` property `runtimeType`,
 which returns a [`Type`][] object.
 
-<?code-excerpt "misc/test/language_tour/classes_test.dart (runtimeType)"?>
+<?code-excerpt "misc/test/language_tour/classes_test.dart (runtime-type)"?>
 ```dart
 print('The type of a is ${a.runtimeType}');
 ```
@@ -177,7 +177,7 @@ Non-final instance variables and
 an implicit *setter* method. For details,
 check out [Getters and setters][].
 
-<?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class+main)" replace="/(double .*?;).*/$1/g" plaster="none"?>
+<?code-excerpt "misc/lib/language_tour/classes/point_with_main.dart (class-main)" replace="/(double .*?;).*/$1/g" plaster="none"?>
 ```dart
 class Point {
   double? x; // Declare instance variable x, initially null.
@@ -285,7 +285,7 @@ void main() {
 Here's an example of specifying that a class implements multiple
 interfaces:
 
-<?code-excerpt "misc/lib/language_tour/classes/misc.dart (point_interfaces)"?>
+<?code-excerpt "misc/lib/language_tour/classes/misc.dart (point-interfaces)"?>
 ```dart
 class Point implements Comparable, Location {...}
 ```

--- a/src/content/language/constructors.md
+++ b/src/content/language/constructors.md
@@ -56,9 +56,9 @@ class Point {
   final double x;
   final double y;
 
-  Point(this.x, this.y);
   // Sets the x and y instance variables
   // before the constructor body runs.
+  Point(this.x, this.y);
 }
 ```
 
@@ -100,6 +100,8 @@ class Point {
   final double x;
   final double y;
 
+  // Sets the x and y instance variables
+  // before the constructor body runs.
   Point(this.x, this.y);
 
   // Named constructor

--- a/src/content/language/generics.md
+++ b/src/content/language/generics.md
@@ -43,7 +43,7 @@ many types, while still taking advantage of static
 analysis. For example, say you create an interface for
 caching an object:
 
-<?code-excerpt "misc/lib/language_tour/generics/cache.dart (ObjectCache)"?>
+<?code-excerpt "misc/lib/language_tour/generics/cache.dart (object-cache)"?>
 ```dart
 abstract class ObjectCache {
   Object getByKey(String key);
@@ -54,7 +54,7 @@ abstract class ObjectCache {
 You discover that you want a string-specific version of this interface,
 so you create another interface:
 
-<?code-excerpt "misc/lib/language_tour/generics/cache.dart (StringCache)"?>
+<?code-excerpt "misc/lib/language_tour/generics/cache.dart (string-cache)"?>
 ```dart
 abstract class StringCache {
   String getByKey(String key);
@@ -68,7 +68,7 @@ interface... You get the idea.
 Generic types can save you the trouble of creating all these interfaces.
 Instead, you can create a single interface that takes a type parameter:
 
-<?code-excerpt "misc/lib/language_tour/generics/cache.dart (Cache)"?>
+<?code-excerpt "misc/lib/language_tour/generics/cache.dart (cache)"?>
 ```dart
 abstract class Cache<T> {
   T getByKey(String key);

--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -209,7 +209,7 @@ including string interpolation, literals, expressions, and the `toString()` meth
 
 You might use the `Spacecraft` class like this:
 
-<?code-excerpt "misc/test/samples_test.dart (use class)" plaster="none"?>
+<?code-excerpt "misc/test/samples_test.dart (use-class)" plaster="none"?>
 ```dart
 var voyager = Spacecraft('Voyager I', DateTime(1977, 9, 5));
 voyager.describe();
@@ -269,7 +269,7 @@ enum Planet {
 
 You might use the `Planet` enum like this:
 
-<?code-excerpt "misc/test/samples_test.dart (use enum)" plaster="none"?>
+<?code-excerpt "misc/test/samples_test.dart (use-enum)" plaster="none"?>
 ```dart
 final yourPlanet = Planet.earth;
 
@@ -386,7 +386,7 @@ Future<void> printWithDelay(String message) [!async!] {
 
 The method above is equivalent to:
 
-<?code-excerpt "misc/test/samples_test.dart (Future.then)"?>
+<?code-excerpt "misc/test/samples_test.dart (future-then)"?>
 ```dart
 Future<void> printWithDelay(String message) {
   return Future.delayed(oneSecond).then((_) {
@@ -421,7 +421,7 @@ Future<void> createDescriptions(Iterable<String> objects) async {
 
 You can also use `async*`, which gives you a nice, readable way to build streams.
 
-<?code-excerpt "misc/test/samples_test.dart (async*)"?>
+<?code-excerpt "misc/test/samples_test.dart (async-star)"?>
 ```dart
 Stream<String> report(Spacecraft craft, Iterable<String> objects) async* {
   for (final object in objects) {

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -366,7 +366,7 @@ method for the worker isolate.
 - Finally, add a listener to the new `ReceivePort`. This listener handles
   messages the main isolate sends to the worker isolate.
 
-<?code-excerpt "lib/basic_ports_example/complete.dart (startRemoteIsolate)"?>
+<?code-excerpt "lib/basic_ports_example/complete.dart (start-remote-isolate)"?>
 ```dart
 static void _startRemoteIsolate(SendPort port) {
   final receivePort = ReceivePort();
@@ -416,7 +416,7 @@ decoded JSON).
   type of decoded JSON. If so, handle that message with your
   application-specific logic. In this example, the message is printed. 
 
-<?code-excerpt "lib/basic_ports_example/complete.dart (handleResponses)"?>
+<?code-excerpt "lib/basic_ports_example/complete.dart (handle-responses)"?>
 ```dart
 void _handleResponsesFromIsolate(dynamic message) {
   if (message is SendPort) {
@@ -445,7 +445,7 @@ To handle this, use a [`Completer`][].
   worker isolate until it is spawned _and_ has sent its `SendPort` back to the
   main isolate.
 
-<?code-excerpt "lib/basic_ports_example/complete.dart (parseJson)"?>
+<?code-excerpt "lib/basic_ports_example/complete.dart (parse-json)"?>
 ```dart
 Future<void> parseJson(String message) async {
   await _isolateReady.future;

--- a/src/content/language/libraries.md
+++ b/src/content/language/libraries.md
@@ -121,7 +121,7 @@ import 'package:greetings/hello.dart' deferred as hello;
 When you need the library, invoke
 `loadLibrary()` using the library's identifier.
 
-<?code-excerpt "misc/lib/language_tour/libraries/greeter.dart (loadLibrary)"?>
+<?code-excerpt "misc/lib/language_tour/libraries/greeter.dart (load-library)"?>
 ```dart
 Future<void> greet() async {
   await hello.loadLibrary();

--- a/src/content/language/methods.md
+++ b/src/content/language/methods.md
@@ -17,7 +17,7 @@ Instance methods on objects can access instance variables and `this`.
 The `distanceTo()` method in the following sample is an example of an
 instance method:
 
-<?code-excerpt "misc/lib/language_tour/classes/point.dart (class-with-distanceTo)" plaster="none"?>
+<?code-excerpt "misc/lib/language_tour/classes/point.dart (class-with-distance-to)" plaster="none"?>
 ```dart
 import 'dart:math';
 
@@ -25,6 +25,8 @@ class Point {
   final double x;
   final double y;
 
+  // Sets the x and y instance variables
+  // before the constructor body runs.
   Point(this.x, this.y);
 
   double distanceTo(Point other) {

--- a/src/content/language/mixins.md
+++ b/src/content/language/mixins.md
@@ -18,7 +18,7 @@ They are intended to provide member implementations en masse.
 To use a mixin, use the `with` keyword followed by one or more mixin
 names. The following example shows two classes that use mixins:
 
-<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (Musician and Maestro)" replace="/(with.*) \{/[!$1!] {/g"?>
+<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (musician-and-maestro)" replace="/(with.*) \{/[!$1!] {/g"?>
 ```dart
 class Musician extends Performer [!with Musical!] {
   // ···
@@ -41,7 +41,7 @@ and must not declare any generative constructors.
 
 For example:
 
-<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (Musical)"?>
+<?code-excerpt "misc/lib/language_tour/classes/orchestra.dart (musical)"?>
 ```dart
 mixin Musical {
   bool canPlayPiano = false;

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -215,14 +215,14 @@ specified by `T`. For example, `obj is Object?` is always true.
 Use the `as` operator to cast an object to a particular type if and only if
 you are sure that the object is of that type. Example:
 
-<?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp as Person)"?>
+<?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp-as-person)"?>
 ```dart
 (employee as Person).firstName = 'Bob';
 ```
 
 If you aren't sure that the object is of type `T`, then use `is T` to check the
 type before using the object.
-<?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp is Person)"?>
+<?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp-is-person)"?>
 ```dart
 if (employee is Person) {
   // Type check

--- a/src/content/language/patterns.md
+++ b/src/content/language/patterns.md
@@ -331,7 +331,7 @@ the different type definitions.
 Instead of implementing the operation as an instance method for every type,
 keep the operation's variations in a single function that switches over the subtypes:
 
-<?code-excerpt "language/lib/patterns/algebraic_datatypes.dart (algebraic_datatypes)"?>
+<?code-excerpt "language/lib/patterns/algebraic_datatypes.dart (algebraic-datatypes)"?>
 ```dart
 sealed class Shape {}
 

--- a/src/content/libraries/dart-async.md
+++ b/src/content/libraries/dart-async.md
@@ -57,7 +57,7 @@ Consider the following function.  It uses Future's `then()` method
 to execute three asynchronous functions in a row,
 waiting for each one to complete before executing the next one.
 
-<?code-excerpt "misc/lib/library_tour/async/future.dart (runUsingFuture)"?>
+<?code-excerpt "misc/lib/library_tour/async/future.dart (run-using-future)"?>
 ```dart
 void runUsingFuture() {
   // ...
@@ -70,7 +70,7 @@ void runUsingFuture() {
 The equivalent code with await expressions
 looks more like synchronous code:
 
-<?code-excerpt "misc/lib/library_tour/async/future.dart (runUsingAsyncAwait)"?>
+<?code-excerpt "misc/lib/library_tour/async/future.dart (run-using-async-await)"?>
 ```dart
 Future<void> runUsingAsyncAwait() async {
   // ...
@@ -121,7 +121,7 @@ httpClient.read(url).then((String result) {
 Use `catchError()` to handle any errors or exceptions that a Future
 object might throw.
 
-<?code-excerpt "misc/lib/library_tour/async/basic.dart (catchError)"?>
+<?code-excerpt "misc/lib/library_tour/async/basic.dart (catch-error)"?>
 ```dart
 httpClient.read(url).then((String result) {
   print(result);
@@ -409,7 +409,7 @@ then use try-catch to handle errors.
 Code that executes after the stream is closed
 goes after the asynchronous for loop.
 
-<?code-excerpt "misc/lib/library_tour/async/stream.dart (readFileAwaitFor)" replace="/try|catch/[!$&!]/g"?>
+<?code-excerpt "misc/lib/library_tour/async/stream.dart (read-file-await-for)" replace="/try|catch/[!$&!]/g"?>
 ```dart
 Future<void> readFileAwaitFor() async {
   var config = File('config.txt');
@@ -433,7 +433,7 @@ then handle errors by registering an `onError` listener.
 Run code after the stream is closed by registering
 an `onDone` listener.
 
-<?code-excerpt "misc/lib/library_tour/async/stream.dart (onDone)" replace="/onDone|onError/[!$&!]/g"?>
+<?code-excerpt "misc/lib/library_tour/async/stream.dart (on-done)" replace="/onDone|onError/[!$&!]/g"?>
 ```dart
 var config = File('config.txt');
 Stream<List<int>> inputStream = config.openRead();

--- a/src/content/libraries/dart-core.md
+++ b/src/content/libraries/dart-core.md
@@ -41,7 +41,7 @@ have some basic utilities for working with numbers.
 You can convert a string into an integer or double with the `parse()`
 methods of int and double, respectively:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (int|double.parse)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (int-double-parse)"?>
 ```dart
 assert(int.parse('42') == 42);
 assert(int.parse('0x42') == 66);
@@ -71,7 +71,7 @@ of the decimal, use [toStringAsFixed().][toStringAsFixed()] To specify the
 number of significant digits in the string, use
 [toStringAsPrecision():][toStringAsPrecision()]
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (toString())"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (to-string)"?>
 ```dart
 // Convert an int to a string.
 assert(42.toString() == '42');
@@ -176,7 +176,7 @@ For this, the Dart team provides the
 You can easily convert strings to their uppercase and lowercase
 variants:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (toUpperCase-toLowerCase)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (case-conversions)"?>
 ```dart
 // Convert to uppercase.
 assert('web apps'.toUpperCase() == 'WEB APPS');
@@ -233,7 +233,7 @@ StringBuffer doesn't generate a new String object until `toString()` is
 called. The `writeAll()` method has an optional second parameter that
 lets you specify a separator—in this case, a space.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (StringBuffer)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (string-buffer)"?>
 ```dart
 var sb = StringBuffer();
 sb
@@ -252,7 +252,7 @@ The RegExp class provides the same capabilities as JavaScript regular
 expressions. Use regular expressions for efficient searching and pattern
 matching of strings.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (RegExp)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (regexp)"?>
 ```dart
 // Here's a regular expression for one or more digits.
 var numbers = RegExp(r'\d+');
@@ -309,7 +309,7 @@ initialize [lists](/language/collections#lists). Alternatively, use one of the L
 constructors. The List class also defines several methods for adding
 items to and removing items from lists.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (List)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (list)"?>
 ```dart
 // Create an empty list of strings.
 var grains = <String>[];
@@ -343,7 +343,7 @@ assert(vegetables.every((v) => v == 'broccoli'));
 
 Use `indexOf()` to find the index of an object in a list:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (indexOf)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (index-of)"?>
 ```dart
 var fruits = ['apples', 'oranges'];
 
@@ -360,7 +360,7 @@ function that compares two objects. This sorting function must return \<
 example uses `compareTo()`, which is defined by
 [Comparable][] and implemented by String.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (compareTo)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (compare-to)"?>
 ```dart
 var fruits = ['bananas', 'apples', 'oranges'];
 
@@ -374,7 +374,7 @@ Lists are parameterized types
 so you can specify the type that a list
 should contain:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (List-of-String)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (list-of-string)"?>
 ```dart
 // This list should contain only strings.
 var fruits = <String>[];
@@ -384,7 +384,7 @@ var fruit = fruits[0];
 assert(fruit is String);
 ```
 
-<?code-excerpt "misc/lib/library_tour/core/collections.dart (List-of-String)"?>
+<?code-excerpt "misc/lib/library_tour/core/collections.dart (list-of-string)"?>
 ```dart tag=fails-sa
 fruits.add(5); // Error: 'int' can't be assigned to 'String'
 ```
@@ -413,7 +413,7 @@ Refer to the [List API reference][List] for a full list of methods.
 A set in Dart is an unordered collection of unique items. Because a set
 is unordered, you can't get a set's items by index (position).
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Set)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (set)"?>
 ```dart
 // Create an empty set of strings.
 var ingredients = <String>{};
@@ -475,7 +475,7 @@ easy retrieval. Unlike in JavaScript, Dart objects are not maps.
 You can declare a map using a terse literal syntax, or you can use a
 traditional constructor:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Map)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (map)"?>
 ```dart
 // Maps often use strings as keys.
 var hawaiianBeaches = {
@@ -538,7 +538,7 @@ To check whether a map contains a key, use `containsKey()`. Because map
 values can be null, you cannot rely on simply getting the value for the
 key and checking for null to determine the existence of a key.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (containsKey)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (contains-key)"?>
 ```dart
 var hawaiianBeaches = {
   'Oahu': ['Waikiki', 'Kailua', 'Waimanalo'],
@@ -554,7 +554,7 @@ Use the `putIfAbsent()` method when you want to assign a value to a key
 if and only if the key does not already exist in a map. You must provide
 a function that returns the value.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (putIfAbsent)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (put-if-absent)"?>
 ```dart
 var teamAssignments = <String, String>{};
 teamAssignments.putIfAbsent('Catcher', () => pickToughestKid());
@@ -576,7 +576,7 @@ which List and Set implement.
 
 Use `isEmpty` or `isNotEmpty` to check whether a list, set, or map has items:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (isEmpty)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (is-empty)"?>
 ```dart
 var coffees = <String>[];
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
@@ -587,7 +587,7 @@ assert(teas.isNotEmpty);
 To apply a function to each item in a list, set, or map, you can use
 `forEach()`:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (List.forEach)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (list-for-each)"?>
 ```dart
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
@@ -597,7 +597,7 @@ teas.forEach((tea) => print('I drink $tea'));
 When you invoke `forEach()` on a map, your function must take two
 arguments (the key and value):
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Map.forEach)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (map-for-each)"?>
 ```dart
 hawaiianBeaches.forEach((k, v) {
   print('I want to visit $k and swim at $v');
@@ -609,7 +609,7 @@ hawaiianBeaches.forEach((k, v) {
 Iterables provide the `map()` method, which gives you all the results in
 a single object:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (List.map)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (list-map)"?>
 ```dart
 var teas = ['green', 'black', 'chamomile', 'earl grey'];
 
@@ -625,7 +625,7 @@ function isn't called until you ask for an item from the returned object.
 To force your function to be called immediately on each item, use
 `map().toList()` or `map().toSet()`:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (toList)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (to-list)"?>
 ```dart
 var loudTeas = teas.map((tea) => tea.toUpperCase()).toList();
 ```
@@ -683,7 +683,7 @@ URI (such as `/`, `:`, `&`, `#`), use the `encodeFull()` and
 `decodeFull()` methods. These methods are good for encoding or decoding
 a fully qualified URI, leaving intact special URI characters.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (encodeFull)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (encode-full)"?>
 ```dart
 var uri = 'https://example.org/api?foo=some message';
 
@@ -702,7 +702,7 @@ To encode and decode all of a string's characters that have special
 meaning in a URI, including (but not limited to) `/`, `&`, and `:`, use
 the `encodeComponent()` and `decodeComponent()` methods.
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (encodeComponent)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (encode-component)"?>
 ```dart
 var uri = 'https://example.org/api?foo=some message';
 
@@ -723,7 +723,7 @@ If you have a Uri object or a URI string, you can get its parts using
 Uri fields such as `path`. To create a Uri from a string, use the
 `parse()` static method:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Uri.parse)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (uri-parse)"?>
 ```dart
 var uri = Uri.parse('https://example.org:8080/foo/bar#frag');
 
@@ -741,7 +741,7 @@ See the [Uri API reference][Uri] for more URI components that you can get.
 You can build up a URI from individual parts using the `Uri()`
 constructor:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Uri)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (uri)"?>
 ```dart
 var uri = Uri(
     scheme: 'https',
@@ -756,7 +756,7 @@ If you don't need to specify a fragment,
 to create a URI with a http or https scheme,
 you can instead use the [`Uri.http`][] or [`Uri.https`][] factory constructors:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Uri-http)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (uri-http)"?>
 ```dart
 var httpUri = Uri.http('example.org', '/foo/bar', {'lang': 'dart'});
 var httpsUri = Uri.https('example.org', '/foo/bar', {'lang': 'dart'});
@@ -775,7 +775,7 @@ local time zone.
 
 You can create DateTime objects using several constructors and methods:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (DateTime)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (date-time)"?>
 ```dart
 // Get the current date and time.
 var now = DateTime.now();
@@ -807,7 +807,7 @@ Daylight Savings Time and other non-standard time adjustments.
 The `millisecondsSinceEpoch` property of a date returns the number of
 milliseconds since the "Unix epoch"—January 1, 1970, UTC:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (millisecondsSinceEpoch)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (milliseconds-since-epoch)"?>
 ```dart
 // 1/1/2000, UTC
 var y2k = DateTime.utc(2000);
@@ -821,7 +821,7 @@ assert(unixEpoch.millisecondsSinceEpoch == 0);
 Use the Duration class to calculate the difference between two dates and
 to shift a date forward or backward:
 
-<?code-excerpt "misc/test/library_tour/core_test.dart (Duration)"?>
+<?code-excerpt "misc/test/library_tour/core_test.dart (duration)"?>
 ```dart
 var y2k = DateTime.utc(2000);
 

--- a/src/content/libraries/dart-html.md
+++ b/src/content/libraries/dart-html.md
@@ -77,7 +77,7 @@ The `querySelector()` function returns the first element that matches
 the selector, while `querySelectorAll()`returns a collection of elements
 that match the selector.
 
-<?code-excerpt "html/lib/html.dart (querySelector)"?>
+<?code-excerpt "html/lib/html.dart (query-selector)"?>
 ```dart
 // Find an element by id (an-id).
 Element idElement = querySelector('#an-id')!;
@@ -226,7 +226,7 @@ querySelector('#inputs')!.nodes.add(elem);
 
 To replace a node, use the Node `replaceWith()` method:
 
-<?code-excerpt "html/lib/html.dart (replaceWith)"?>
+<?code-excerpt "html/lib/html.dart (replace-with)"?>
 ```dart
 querySelector('#status')!.replaceWith(elem);
 ```
@@ -302,7 +302,7 @@ name and <code><em>function</em></code> is the event handler.
 
 For example, here's how you can handle clicks on a button:
 
-<?code-excerpt "html/lib/html.dart (onClick)"?>
+<?code-excerpt "html/lib/html.dart (on-click)"?>
 ```dart
 // Find a button by ID and add an event handler.
 querySelector('#submitInfo')!.onClick.listen((e) {

--- a/src/content/libraries/dart-io.md
+++ b/src/content/libraries/dart-io.md
@@ -54,7 +54,7 @@ important, you can use `readAsLines()`. In both cases, a Future object
 is returned that provides the contents of the file as one or more
 strings.
 
-<?code-excerpt "misc/test/library_tour/io_test.dart (readAsString)" replace="/\btest_data\///g"?>
+<?code-excerpt "misc/test/library_tour/io_test.dart (read-as-string)" replace="/\btest_data\///g"?>
 ```dart
 void main() async {
   var config = File('config.txt');
@@ -76,7 +76,7 @@ The following code reads an entire file as bytes into a list of ints.
 The call to `readAsBytes()` returns a Future, which provides the result
 when it's available.
 
-<?code-excerpt "misc/test/library_tour/io_test.dart (readAsBytes)" replace="/\btest_data\///g"?>
+<?code-excerpt "misc/test/library_tour/io_test.dart (read-as-bytes)" replace="/\btest_data\///g"?>
 ```dart
 void main() async {
   var config = File('config.txt');

--- a/src/content/libraries/dart-math.md
+++ b/src/content/libraries/dart-math.md
@@ -77,7 +77,7 @@ print(sqrt2); // 1.4142135623730951
 Generate random numbers with the [Random][] class. You can
 optionally provide a seed to the Random constructor.
 
-<?code-excerpt "misc/test/library_tour/math_test.dart (Random)"?>
+<?code-excerpt "misc/test/library_tour/math_test.dart (random)"?>
 ```dart
 var random = Random();
 random.nextDouble(); // Between 0.0 and 1.0: [0, 1)
@@ -86,7 +86,7 @@ random.nextInt(10); // Between 0 and 9.
 
 You can even generate random booleans:
 
-<?code-excerpt "misc/test/library_tour/math_test.dart (Random-bool)"?>
+<?code-excerpt "misc/test/library_tour/math_test.dart (random-bool)"?>
 ```dart
 var random = Random();
 random.nextBool(); // true or false

--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -490,7 +490,7 @@ int x = '';
 
 To suppress more than one diagnostic, supply a comma-separated list:
 
-<?code-excerpt "analysis/lib/assignment.dart (ignore more)"?>
+<?code-excerpt "analysis/lib/assignment.dart (ignore-more)"?>
 ```dart
 // ignore: invalid_assignment, const_initialized_with_non_constant_value
 const x = y;

--- a/src/content/tools/non-promotion-reasons.md
+++ b/src/content/tools/non-promotion-reasons.md
@@ -109,7 +109,7 @@ Here's an example of creating a local variable
 (which can be named `i`)
 that holds the value of `i`:
 
-<?code-excerpt "non_promotion/lib/non_promotion.dart (property_copy)" replace="/final.*/[!$&!]/g"?>
+<?code-excerpt "non_promotion/lib/non_promotion.dart (property-copy)" replace="/final.*/[!$&!]/g"?>
 ```dart tag=good
 class C {
   int? i;
@@ -134,7 +134,7 @@ when you intend to update the field.
 
 And here's an example of using `i!`:
 
-<?code-excerpt "non_promotion/lib/non_promotion.dart (property_bang)" replace="/!/[!!!]/g"?>
+<?code-excerpt "non_promotion/lib/non_promotion.dart (property-bang)" replace="/!/[!!!]/g"?>
 ```dart tag=good
 print(i[!!!].isEven);
 ```
@@ -719,7 +719,7 @@ conditions in separate `if` statements.
 
 You might fix the problem by combining the two `if` statements:
 
-<?code-excerpt "non_promotion/lib/non_promotion.dart (write_combine_ifs)" replace="/else/[!$&!]/g"?>
+<?code-excerpt "non_promotion/lib/non_promotion.dart (write-combine-ifs)" replace="/else/[!$&!]/g"?>
 ```dart tag=good
 void f(bool b, int? i, int? j) {
   if (i == null) return;
@@ -737,7 +737,7 @@ when deciding whether to demote.
 As a result, another way to fix this code is
 to change the type of `j` to `int`.
 
-<?code-excerpt "non_promotion/lib/non_promotion.dart (write_change_type)" replace="/int j/[!$&!]/g"?>
+<?code-excerpt "non_promotion/lib/non_promotion.dart (write-change-type)" replace="/int j/[!$&!]/g"?>
 ```dart tag=good
 void f(bool b, int? i, [!int j!]) {
   if (i == null) return;
@@ -927,8 +927,6 @@ One possible solution is to create a new local variable so that
 the original variable is promoted to `Comparable`, and
 the new variable is promoted to `Pattern`:
 
-<!-- code-excerpt "non_promotion/lib/non_promotion.dart (closure-new-var)" replace="/var o2.*/[!$&!]/g;/o2\./[!o2!]./g"?>-->
-
 <?code-excerpt "non_promotion/lib/non_promotion.dart (subtype-variable)" replace="/Object o2.*/[!$&!]/g;/(o2)(\.| is)/[!$1!]$2/g"?>
 ```dart
 void f(Object o) {
@@ -965,7 +963,7 @@ If line 3 cares only about strings,
 then you can use `String` in your type check.
 Because `String` is a subtype of `Comparable`, the promotion works:
 
-<?code-excerpt "non_promotion/lib/non_promotion.dart (subtype-String)" replace="/is String/is [!String!]/g"?>
+<?code-excerpt "non_promotion/lib/non_promotion.dart (subtype-string)" replace="/is String/is [!String!]/g"?>
 ```dart tag=good
 void f(Object o) {
   if (o is Comparable /* (1) */) {

--- a/src/content/tutorials/language/streams.md
+++ b/src/content/tutorials/language/streams.md
@@ -34,7 +34,7 @@ for loop_ (commonly just called **await for**)
 iterates over the events of a stream like the **for loop** iterates
 over an [Iterable][]. For example:
 
-<?code-excerpt "misc/lib/tutorial/sum_stream.dart (sumStream)" replace="/async|await for/[!$&!]/g"?>
+<?code-excerpt "misc/lib/tutorial/sum_stream.dart (sum-stream)" replace="/async|await for/[!$&!]/g"?>
 ```dart
 Future<int> sumStream(Stream<int> stream) [!async!] {
   var sum = 0;
@@ -156,7 +156,7 @@ similar to the methods on an [Iterable.][Iterable]
 For example, you can find the last positive integer in a stream using
 `lastWhere()` from the Stream API.
 
-<?code-excerpt "misc/lib/tutorial/misc.dart (lastPositive)"?>
+<?code-excerpt "misc/lib/tutorial/misc.dart (last-positive)"?>
 ```dart
 Future<int> lastPositive(Stream<int> stream) =>
     stream.lastWhere((x) => x >= 0);
@@ -308,7 +308,7 @@ There is no recovering from that.
 The following code shows how to use `handleError()` to remove errors
 from a stream before using it in an **await for** loop.
 
-<?code-excerpt "misc/lib/tutorial/misc.dart (mapLogErrors)"?>
+<?code-excerpt "misc/lib/tutorial/misc.dart (map-log-errors)"?>
 ```dart
 Stream<S> mapLogErrors<S, T>(
   Stream<T> stream,

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -295,7 +295,7 @@ The following code from the `dcat` app
 writes the line numbers to `stdout` (if the `-n` option is specified)
 followed by the contents of the line from the file.
 
-<?code-excerpt "cli/bin/dcat.dart (showLineNumbers)" replace="/stdout\..*/[!$&!]/g"?>
+<?code-excerpt "cli/bin/dcat.dart (show-line-numbers)" replace="/stdout\..*/[!$&!]/g"?>
 ```dart
 if (showLineNumbers) {
   [!stdout.write('${lineNumber++} ');!]
@@ -489,7 +489,7 @@ The easiest way to write text to a file is to create a
 [`File`]({{ioAPI}}/File-class.html)
 object and use the `writeAsString()` method:
 
-<?code-excerpt "cli/lib/cmdline.dart (write quote)"?>
+<?code-excerpt "cli/lib/cmdline.dart (write-quote)"?>
 ```dart
 final quotes = File('quotes.txt');
 const stronger = 'That which does not kill us makes us stronger. -Nietzsche';


### PR DESCRIPTION
Updates code excerpt region openings, closings, and names to follow a consistent standard (`lower-case-with-dashes`) to make the site contribution experience more consistent and enable the new excerpter tool to warn about more potential mistakes. It also helps the implementation of the excerpter tool simpler as well :)

Contributes to https://github.com/dart-lang/site-www/issues/5593