### PR TITLE
Fix heading levels on libraries pages

### DIFF
--- a/src/_11ty/filters.js
+++ b/src/_11ty/filters.js
@@ -146,7 +146,7 @@ export function generateToc(contents) {
     } else if (header.tagName === 'h3') {
       // A level-3 header must be under a level-2 header.
       if (currentH2 === null) {
-        continue;
+        throw new Error(`The h3 header "${id}" must be under an h2.`);
       }
 
       currentH2.children.push({ text: text, id: `#${id}` });

--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -339,7 +339,7 @@ function _wrapMarkedText(spans, ranges) {
   for (const span of spans) {
     const [child, ...otherChildren] = span.children;
     if (otherChildren.length > 0 || child.type !== 'text') {
-      throw Error('Each span should have exactly one text child.');
+      throw new Error('Each span should have exactly one text child.');
     }
 
     /** The text within the current span. */

--- a/src/content/articles/archive/converters-and-codecs.md
+++ b/src/content/articles/archive/converters-and-codecs.md
@@ -6,8 +6,6 @@ date: 2015-03-17
 obsolete: true
 ---
 
-### **_How to write efficient conversions_**
-
 _Written by Florian Loitsch <br>
 February 2014 (updated March 2015)_
 

--- a/src/content/articles/archive/zones.md
+++ b/src/content/articles/archive/zones.md
@@ -21,7 +21,7 @@ obsolete: true
 }
 </style>
 
-### Asynchronous dynamic extents
+## Asynchronous dynamic extents
 
 This article discusses zone-related APIs in the [dart:async][] library,
 with a focus on the top-level [`runZoned()`][]

--- a/src/content/libraries/dart-async.md
+++ b/src/content/libraries/dart-async.md
@@ -40,14 +40,14 @@ You don't need to import dart:async to use the Future and
 Stream APIs, because dart:core exports those classes.
 :::
 
-### Future
+## Future
 
 Future objects appear throughout the Dart libraries, often as the object
 returned by an asynchronous method. When a future *completes*, its value
 is ready to use.
 
 
-#### Using await
+### Using await
 
 Before you directly use the Future API, consider using `await` instead.
 Code that uses `await` expressions can be easier to understand
@@ -104,7 +104,7 @@ For more information on using `await` and related Dart language features,
 see the [asynchronous programming codelab](/codelabs/async-await).
 
 
-#### Basic usage
+### Basic usage
 
 You can use `then()` to schedule code that runs when the future completes. For
 example, [`Client.read()`][] returns a Future, since HTTP requests
@@ -142,7 +142,7 @@ but not from the handler registered by `then()`.
 
 [`Client.read()`]: {{site.pub-api}}/http/latest/http/Client/read.html
 
-#### Chaining multiple asynchronous methods
+### Chaining multiple asynchronous methods
 
 The `then()` method returns a Future, providing a useful way to run
 multiple asynchronous functions in a certain order. 
@@ -185,7 +185,7 @@ try {
 ```
 
 
-#### Waiting for multiple futures
+### Waiting for multiple futures
 
 Sometimes your algorithm needs to invoke many asynchronous functions and
 wait for them all to complete before continuing. Use the [Future.wait()][]
@@ -209,7 +209,7 @@ print('Done with all the long steps!');
 futures have completed. It completes either with their results,
 or with an error if any of the provided futures fail. 
 
-#### Handling errors for multiple futures
+### Handling errors for multiple futures
 
 You can also wait for parallel operations on an [iterable]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/FutureIterable/wait.html)
 or [record]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/FutureRecord2/wait.html)
@@ -275,14 +275,14 @@ void main() async {
 }
 ```
 
-### Stream
+## Stream
 
 Stream objects appear throughout Dart APIs, representing sequences of
 data. For example, HTML events such as button clicks are delivered using
 streams. You can also read a file as a stream.
 
 
-#### Using an asynchronous for loop
+### Using an asynchronous for loop
 
 Sometimes you can use an asynchronous for loop (`await for`)
 instead of using the Stream API.
@@ -345,7 +345,7 @@ Dart language features, see the
 [asynchronous programming codelab](/codelabs/async-await).
 
 
-#### Listening for stream data
+### Listening for stream data
 
 To get each value as it arrives, either use `await for` or
 subscribe to the stream using the `listen()` method:
@@ -376,7 +376,7 @@ If you care about a subset of events, you can use methods such as
 {% endcomment %}
 
 
-#### Transforming stream data
+### Transforming stream data
 
 Often, you need to change the format of a stream's data before you can
 use it. Use the `transform()` method to produce a stream with a
@@ -398,7 +398,7 @@ separate lines. These transformers are from the dart:convert library (see the
 {% endcomment %}
 
 
-#### Handling errors and completion
+### Handling errors and completion
 
 How you specify error and completion handling code
 depends on whether you use an asynchronous for loop (`await for`)
@@ -449,7 +449,7 @@ inputStream.transform(utf8.decoder).transform(const LineSplitter()).listen(
 ```
 
 
-### More information
+## More information
 
 For some examples of using Future and Stream in command-line apps,
 check out the [dart:io documentation][].

--- a/src/content/libraries/dart-convert.md
+++ b/src/content/libraries/dart-convert.md
@@ -27,7 +27,7 @@ import 'dart:convert';
 ```
 
 
-### Decoding and encoding JSON
+## Decoding and encoding JSON
 
 Decode a JSON-encoded string into a Dart object with `jsonDecode()`:
 
@@ -83,7 +83,7 @@ For more examples and links to JSON-related packages, see
 [Using JSON](/guides/json).
 
 
-### Decoding and encoding UTF-8 characters
+## Decoding and encoding UTF-8 characters
 
 Use `utf8.decode()` to decode UTF8-encoded bytes to a Dart string:
 
@@ -132,7 +132,7 @@ for (int i = 0; i < encoded.length; i++) {
 ```
 
 
-### Other functionality
+## Other functionality
 
 The dart:convert library also has converters for ASCII and ISO-8859-1
 (Latin1). For details, see the [API reference for the dart:convert library.][dart:convert]

--- a/src/content/libraries/dart-core.md
+++ b/src/content/libraries/dart-core.md
@@ -17,7 +17,7 @@ provides a small but critical set of built-in functionality.
 This library is automatically imported into every Dart program.
 
 
-### Printing to the console
+## Printing to the console
 
 The top-level `print()` method takes a single argument (any Object)
 and displays that object's string value (as returned by `toString()`)
@@ -33,7 +33,7 @@ For more information on basic strings and `toString()`, see
 [Strings](/language/built-in-types#strings) in the language tour.
 
 
-### Numbers
+## Numbers
 
 The dart:core library defines the num, int, and double classes, which
 have some basic utilities for working with numbers.
@@ -91,7 +91,7 @@ For more information, see the API documentation for
 [int,][int] [double,][double] and [num.][num] Also see
 the [dart:math section](/libraries/dart-math)
 
-### Strings and regular expressions
+## Strings and regular expressions
 
 A string in Dart is an immutable sequence of UTF-16 code units.
 The language tour has more information about
@@ -103,7 +103,7 @@ replace parts of strings.
 The String class defines such methods as `split()`, `contains()`,
 `startsWith()`, `endsWith()`, and more.
 
-#### Searching inside a string
+### Searching inside a string
 
 You can find particular locations within a string, as well as check
 whether a string begins with or ends with a particular pattern. For
@@ -124,7 +124,7 @@ assert('Never odd or even'.endsWith('even'));
 assert('Never odd or even'.indexOf('odd') == 6);
 ```
 
-#### Extracting data from a string
+### Extracting data from a string
 
 You can get the individual characters from a string as Strings or ints,
 respectively. To be precise, you actually get individual UTF-16 code
@@ -171,7 +171,7 @@ For this, the Dart team provides the
 [`characters` package.]({{site.pub-pkg}}/characters)
 :::
 
-#### Converting to uppercase or lowercase
+### Converting to uppercase or lowercase
 
 You can easily convert strings to their uppercase and lowercase
 variants:
@@ -191,7 +191,7 @@ alphabet's dotless *I* is converted incorrectly.
 :::
 
 
-#### Trimming and empty strings
+### Trimming and empty strings
 
 Remove all leading and trailing white space with `trim()`. To check
 whether a string is empty (length is zero), use `isEmpty`.
@@ -208,7 +208,7 @@ assert(''.isEmpty);
 assert('  '.isNotEmpty);
 ```
 
-#### Replacing part of a string
+### Replacing part of a string
 
 Strings are immutable objects, which means you can create them but you
 can't change them. If you look closely at the [String API reference,][String]
@@ -226,7 +226,7 @@ var greeting = greetingTemplate.replaceAll(RegExp('NAME'), 'Bob');
 assert(greeting != greetingTemplate);
 ```
 
-#### Building a string
+### Building a string
 
 To programmatically generate a string, you can use StringBuffer. A
 StringBuffer doesn't generate a new String object until `toString()` is
@@ -246,7 +246,7 @@ var fullString = sb.toString();
 assert(fullString == 'Use a StringBuffer for efficient string creation.');
 ```
 
-#### Regular expressions
+### Regular expressions
 
 The RegExp class provides the same capabilities as JavaScript regular
 expressions. Use regular expressions for efficient searching and pattern
@@ -286,13 +286,13 @@ for (final match in numbers.allMatches(someDigits)) {
 }
 ```
 
-#### More information
+### More information
 
 Refer to the [String API reference][String] for a full list of
 methods. Also see the API reference for [StringBuffer,][StringBuffer]
 [Pattern,][Pattern] [RegExp,][RegExp] and [Match.][Match]
 
-### Collections
+## Collections
 
 Dart ships with a core collections API, which includes classes for
 lists, sets, and maps.
@@ -302,7 +302,7 @@ To practice using APIs that are available to both lists and sets,
 follow the [Iterable collections codelab](/codelabs/iterables).
 :::
 
-#### Lists
+### Lists
 
 As the language tour shows, you can use literals to create and
 initialize [lists](/language/collections#lists). Alternatively, use one of the List
@@ -408,7 +408,7 @@ or `<Person>[]` or something similar.
 
 Refer to the [List API reference][List] for a full list of methods.
 
-#### Sets
+### Sets
 
 A set in Dart is an unordered collection of unique items. Because a set
 is unordered, you can't get a set's items by index (position).
@@ -466,7 +466,7 @@ assert(intersection.contains('xenon'));
 
 Refer to the [Set API reference][Set] for a full list of methods.
 
-#### Maps
+### Maps
 
 A map, commonly known as a *dictionary* or *hash*, is an unordered
 collection of key-value pairs. Maps associate a key to some value for
@@ -563,7 +563,7 @@ assert(teamAssignments['Catcher'] != null);
 
 Refer to the [Map API reference][Map] for a full list of methods.
 
-#### Common collection methods
+### Common collection methods
 
 List, Set, and Map share common functionality found in many collections.
 Some of this common functionality is defined by the Iterable class,
@@ -664,7 +664,7 @@ For a full list of methods, refer to the [Iterable API reference,][Iterable]
 as well as those for [List,][List] [Set,][Set] and [Map.][Map]
 
 
-### URIs
+## URIs
 
 The [Uri class][Uri] provides
 functions to encode and decode strings for use in URIs (which you might
@@ -676,7 +676,7 @@ components of a URI—host, port, scheme, and so on.
 constructors: Uri.http, Uri.https, Uri.file, per floitsch's suggestion}
 {% endcomment %}
 
-#### Encoding and decoding fully qualified URIs
+### Encoding and decoding fully qualified URIs
 
 To encode and decode characters *except* those with special meaning in a
 URI (such as `/`, `:`, `&`, `#`), use the `encodeFull()` and
@@ -696,7 +696,7 @@ assert(uri == decoded);
 
 Notice how only the space between `some` and `message` was encoded.
 
-#### Encoding and decoding URI components
+### Encoding and decoding URI components
 
 To encode and decode all of a string's characters that have special
 meaning in a URI, including (but not limited to) `/`, `&`, and `:`, use
@@ -717,7 +717,7 @@ assert(uri == decoded);
 Notice how every special character is encoded. For example, `/` is
 encoded to `%2F`.
 
-#### Parsing URIs
+### Parsing URIs
 
 If you have a Uri object or a URI string, you can get its parts using
 Uri fields such as `path`. To create a Uri from a string, use the
@@ -736,7 +736,7 @@ assert(uri.origin == 'https://example.org:8080');
 
 See the [Uri API reference][Uri] for more URI components that you can get.
 
-#### Building URIs
+### Building URIs
 
 You can build up a URI from individual parts using the `Uri()`
 constructor:
@@ -768,7 +768,7 @@ assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
 [`Uri.http`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Uri/Uri.http.html
 [`Uri.https`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Uri/Uri.https.html
 
-### Dates and times
+## Dates and times
 
 A DateTime object is a point in time. The time zone is either UTC or the
 local time zone.
@@ -850,12 +850,12 @@ For a full list of methods,
 refer to the API reference for [DateTime][] and [Duration.][Duration]
 
 
-### Utility classes
+## Utility classes
 
 The core library contains various utility classes, useful for sorting,
 mapping values, and iterating.
 
-#### Comparing objects
+### Comparing objects
 
 Implement the [Comparable][]
 interface to indicate that an object can be compared to another object,
@@ -879,7 +879,7 @@ void main() {
 }
 ```
 
-#### Implementing map keys
+### Implementing map keys
 
 Each object in Dart automatically provides an integer hash code, and
 thus can be used as a key in a map. However, you can override the
@@ -942,7 +942,7 @@ void main() {
 }
 ```
 
-#### Iteration
+### Iteration
 
 The [Iterable][] and [Iterator][] classes
 support sequential access to a collection of values.
@@ -981,7 +981,7 @@ void main() {
 }
 ```
 
-### Exceptions
+## Exceptions
 
 The Dart core library defines many common exceptions and errors.
 Exceptions are considered conditions that you can plan ahead for and
@@ -1018,7 +1018,7 @@ For more information, see
 [Exceptions](/language/error-handling#exceptions)
 (in the language tour) and the [Exception API reference.][Exception]
 
-### Weak references and finalizers
+## Weak references and finalizers
 
 Dart is a [garbage-collected][] language,
 which means that any Dart object

--- a/src/content/libraries/dart-html.md
+++ b/src/content/libraries/dart-html.md
@@ -39,7 +39,7 @@ import 'dart:html';
 [`package:web`]: {{site.pub-pkg}}/web
 [Migrate to package:web]: /interop/js-interop/package-web
 
-### Manipulating the DOM
+## Manipulating the DOM
 
 To use the DOM, you need to know about *windows*, *documents*,
 *elements*, and *nodes*.
@@ -61,7 +61,7 @@ elements, but they can also be attributes, text, comments, and other DOM
 types. Except for the root node, which has no parent, each node in the
 DOM has one parent and might have many children.
 
-#### Finding elements
+### Finding elements
 
 To manipulate an element, you first need an object that represents it.
 You can get this object using a query.
@@ -99,7 +99,7 @@ List<Element> textInputElements = querySelectorAll(
 List<Element> specialParagraphElements = querySelectorAll('#id p.class');
 ```
 
-#### Manipulating elements
+### Manipulating elements
 
 You can use properties to change the state of an element. Node and its
 subtype Element define the properties that all elements have. For
@@ -174,7 +174,7 @@ example of setting an attribute's value:
 elem.attributes['someAttribute'] = 'someValue';
 ```
 
-#### Creating elements
+### Creating elements
 
 You can add to existing HTML pages by creating new elements and
 attaching them to the DOM. Here's an example of creating a paragraph
@@ -208,7 +208,7 @@ elements are accessible (as a `List<Element>`) from the `children` property.
 document.body!.children.add(elem2);
 ```
 
-#### Adding, replacing, and removing nodes
+### Adding, replacing, and removing nodes
 
 Recall that elements are just a kind of node. You can find all the
 children of a node using the `nodes` property of Node, which returns a
@@ -239,7 +239,7 @@ To remove a node, use the Node `remove()` method:
 querySelector('#expendable')?.remove();
 ```
 
-#### Manipulating CSS styles
+### Manipulating CSS styles
 
 CSS, or *cascading style sheets*, defines the presentation styles of DOM
 elements. You can change the appearance of an element by attaching ID
@@ -286,7 +286,7 @@ message.style
   ..fontSize = '3em';
 ```
 
-#### Handling events
+### Handling events
 
 To respond to external events such as clicks, changes of focus, and
 selections, add an event listener. You can add an event listener to any
@@ -334,7 +334,7 @@ subclasses. Some common events include:
 -   mouseUp
 
 
-### Using HTTP resources with HttpRequest
+## Using HTTP resources with HttpRequest
 
 You should avoid directly using `dart:html` to make HTTP requests.
 The [`HttpRequest`][] class in `dart:html` is platform-dependent
@@ -346,7 +346,7 @@ The [Fetch data from the internet][] tutorial
 explains how to make HTTP requests
 using `package:http`.
 
-### Sending and receiving real-time data with WebSockets
+## Sending and receiving real-time data with WebSockets
 
 A WebSocket allows your web app to exchange data with a server
 interactively—no polling necessary. A server creates the WebSocket and
@@ -370,7 +370,7 @@ the websocket sample app.
 var ws = WebSocket('ws://echo.websocket.org');
 ```
 
-#### Sending data
+### Sending data
 
 To send string data on the WebSocket, use the `send()` method:
 
@@ -379,7 +379,7 @@ To send string data on the WebSocket, use the `send()` method:
 ws.send('Hello from Dart!');
 ```
 
-#### Receiving data
+### Receiving data
 
 To receive data on the WebSocket, register a listener for message
 events:
@@ -394,7 +394,7 @@ ws.onMessage.listen((MessageEvent e) {
 The message event handler receives a [MessageEvent][] object.
 This object's `data` field has the data from the server.
 
-#### Handling WebSocket events
+### Handling WebSocket events
 
 Your app can handle the following WebSocket events: open, close, error,
 and (as shown earlier) message. Here's an example of a method that
@@ -438,7 +438,7 @@ void initWebSocket([int retrySeconds = 1]) {
 ```
 
 
-### More information
+## More information
 
 This section barely scratched the surface of using the dart:html
 library. For more information, see the documentation for

--- a/src/content/libraries/dart-io.md
+++ b/src/content/libraries/dart-io.md
@@ -36,7 +36,7 @@ To use the dart:io library you must import it:
 import 'dart:io';
 ```
 
-### Files and directories
+## Files and directories
 
 The I/O library enables command-line apps to read and write files and
 browse directories. You have two choices for reading the contents of a
@@ -46,7 +46,7 @@ large or you want to process it while reading it, you should use a
 Stream, as described in
 [Streaming file contents](#streaming-file-contents).
 
-#### Reading a file as text
+### Reading a file as text
 
 When reading a text file encoded using UTF-8, you can read the entire
 file contents with `readAsString()`. When the individual lines are
@@ -70,7 +70,7 @@ void main() async {
 ```
 
 
-#### Reading a file as binary
+### Reading a file as binary
 
 The following code reads an entire file as bytes into a list of ints.
 The call to `readAsBytes()` returns a Future, which provides the result
@@ -86,7 +86,7 @@ void main() async {
 }
 ```
 
-#### Handling errors
+### Handling errors
 
 To capture errors so they don't result in uncaught exceptions, you can
 register a `catchError` handler on the Future,
@@ -105,7 +105,7 @@ void main() async {
 }
 ```
 
-#### Streaming file contents
+### Streaming file contents
 
 Use a Stream to read a file, a little at a time.
 You can use either the [Stream API](/libraries/dart-async#stream)
@@ -133,7 +133,7 @@ void main() async {
 }
 ```
 
-#### Writing file contents
+### Writing file contents
 
 You can use an [IOSink][] to
 write data to a file. Use the File `openWrite()` method to get an IOSink
@@ -160,7 +160,7 @@ var sink = logFile.openWrite(mode: FileMode.append);
 To write binary data, use `add(List<int> data)`.
 
 
-#### Listing files in a directory
+### Listing files in a directory
 
 Finding all files and subdirectories for a directory is an asynchronous
 operation. The `list()` method returns a Stream that emits an object
@@ -187,7 +187,7 @@ void main() async {
 ```
 
 
-#### Other common functionality
+### Other common functionality
 
 The File and Directory classes contain other functionality, including
 but not limited to:
@@ -201,12 +201,12 @@ Refer to the API docs for [File][] and [Directory][] for a full
 list of methods.
 
 
-### HTTP clients and servers
+## HTTP clients and servers
 
 The dart:io library provides classes that command-line apps can use for
 accessing HTTP resources, as well as running HTTP servers.
 
-#### HTTP server
+### HTTP server
 
 The [HttpServer][] class
 provides the low-level functionality for building web servers. You can
@@ -243,7 +243,7 @@ void processRequest(HttpRequest request) {
 }
 ```
 
-#### HTTP client
+### HTTP client
 
 You should avoid directly using `dart:io` to make HTTP requests.
 The [HttpClient][] class in `dart:io` is platform-dependent
@@ -255,7 +255,7 @@ The [Fetch data from the internet][] tutorial
 explains how to make HTTP requests
 using `package:http`.
 
-### More information
+## More information
 
 This page showed how to use the major features of the [dart:io][] library.
 Besides the APIs discussed in this section, the dart:io library also

--- a/src/content/libraries/dart-math.md
+++ b/src/content/libraries/dart-math.md
@@ -25,7 +25,7 @@ import 'dart:math';
 ```
 
 
-### Trigonometry
+## Trigonometry
 
 The Math library provides basic trigonometric functions:
 
@@ -48,7 +48,7 @@ These functions use radians, not degrees!
 :::
 
 
-### Maximum and minimum
+## Maximum and minimum
 
 The Math library provides `max()` and `min()` methods:
 
@@ -59,7 +59,7 @@ assert(min(1, -1000) == -1000);
 ```
 
 
-### Math constants
+## Math constants
 
 Find your favorite constants—*pi*, *e*, and more—in the Math library:
 
@@ -72,7 +72,7 @@ print(sqrt2); // 1.4142135623730951
 ```
 
 
-### Random numbers
+## Random numbers
 
 Generate random numbers with the [Random][] class. You can
 optionally provide a seed to the Random constructor.
@@ -99,7 +99,7 @@ To create a cryptographically secure random number generator,
 use the [`Random.secure()`][] constructor.
 :::
 
-### More information
+## More information
 
 Refer to the [Math API reference][dart:math] for a full list of methods.
 Also see the API reference for [num,][num] [int,][int] and [double.][double]


### PR DESCRIPTION
I also added a check to the build to ensure `h3` headers are always located below an `h2`, so that this doesn't happen again :)

Fixes https://github.com/dart-lang/site-www/issues/5573