### PR TITLE
Separate excerpts check from other tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   test:
-    name: Check excerpts and run tests
+    name: Analyze and test code examples
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,19 @@ jobs:
         run: dart run dart_site analyze-dart
       - name: Run Dart tests
         run: dart run dart_site test-dart
+
+  excerpts:
+    name: Check if code excerpts are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          submodules: recursive
+      - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
+        with:
+          sdk: stable
+      - name: Fetch Dart packages
+        run: dart pub get
       - name: Check if excerpts are up to date
         run: dart run dart_site refresh-excerpts --fail-on-update
 


### PR DESCRIPTION
Excerpt checking is independent of Dart channels and the formatting, analysis, or testing of the Dart code, so it can be pulled out to a separate job. This reduces duplicated checks and results in CI being completed slightly faster, enabling quicker visibility into failure reasons :D 