### PR TITLE
Add a shell script to validate setup and defer to tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,37 +162,44 @@ following the instructions in [Get the prerequisites](#get-the-prerequisites).
    pnpm install
    ```
 
-5. From the root directory, serve the site locally.
+5. From the root directory, run the `dash_site` tool to
+   validate your setup and learn about the available commands.
 
    ```terminal
-   dart run dart_site serve
+   ./dash_site --help
+   ```
+
+6. From the root directory, serve the site locally.
+
+   ```terminal
+   ./dash_site serve
    ```
 
    This command generates and serves the site on a
    local port that's printed to your terminal.
 
-6. View your changes in the browser by navigating to <http://localhost:4000>.
+7. View your changes in the browser by navigating to <http://localhost:4000>.
 
    Note the port might be different if `4000` is taken.
    
    If you want to check the raw, generated HTML output and structure,
    view the `_site` directory in a file explorer or an IDE.
 
-7. Make your changes to the local repo.
+8. Make your changes to the local repo.
 
    The site should automatically rebuild on most changes, but if
    something doesn't update, exit the process and rerun the command.
    Improvements to this functionality are planned.
    Please open a new issue to track the issue if this occurs.
 
-8. Commit your changes to the branch and submit your PR.
+9. Commit your changes to the branch and submit your PR.
 
    If your change is large, or you'd like to test it,
    consider [validating your changes](#validate-your-changes).
 
 > [!TIP]
 > To find additional commands that you can run,
-> run `dart run dart_site --help` from the repository's root directory.
+> run `./dash_site --help` from the repository's root directory.
 
 [`corepack`]: https://nodejs.org/api/corepack.html
 [`pnpm`]: https://pnpm.io/
@@ -207,7 +214,7 @@ commit your work, then run the following command to
 verify it is up to date and matches the site standards.
 
 ```terminal
-dart run dart_site check-all
+./dash_site check-all
 ```
 
 If this script reports any errors or warnings,
@@ -247,7 +254,7 @@ you can build a full version and upload it to Firebase.
 2. From the root directory of the repository, build the site:
 
    ```terminal
-   dart run dart_site build
+   ./dash_site build
    ```
 
    This will build the site and copy it to your local `_site` directory.

--- a/dash_site
+++ b/dash_site
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+REQUIRED_DART_VERSION="3.3"
+REQUIRED_NODE_VERSION="20.10"
+REQUIRED_PNPM_VERSION="8.14"
+
+# Check that the 'dart' command is available on the user's path.
+if ! command -v dart &> /dev/null; then
+  echo "Dart not found. To learn how to setup Dart, follow the instructions at https://dart.dev/get-dart."
+  exit 1
+fi
+
+# Check that the current version of a tool is the same or
+# newer than a required version.
+version_is_new_enough() {
+  required_version="$1"
+  current_version="$2"
+
+  # Split the version strings into lists based on the dot separators.
+  IFS='.' read -ra required_list <<< "$required_version"
+  IFS='.' read -ra current_list <<< "$current_version"
+
+  # Compare each portion of the version number.
+  for ((i = 0; i < ${#required_list[@]}; i += 1)); do
+    required_segment="${required_list[i]:-0}"
+    current_segment="${current_list[i]:-0}"
+
+    if [[ "$required_segment" -gt "$current_segment" ]]; then
+      # The current version is too low.
+      return 0
+    elif [[ "$required_segment" -lt "$current_segment" ]]; then
+      # The current version is higher, which is ok.
+      return 1
+    fi
+  done
+
+  # The current version is (mostly) the same as the required version.
+  return 1
+}
+
+
+# Determine the available Dart SDK version.
+dart_version=$(dart --version | grep -oE 'Dart SDK version: [0-9.]+' | cut -d ' ' -f 4)
+
+# Validate the version of the installed Dart SDK.
+if version_is_new_enough "$REQUIRED_DART_VERSION" "$dart_version"; then
+  echo "Dart version $dart_version is too low. Version $REQUIRED_DART_VERSION or later is required."
+  exit 1
+fi
+
+# Check that the 'node' command is available on the user's path.
+if ! command -v node &> /dev/null; then
+  echo "'node' command not found. To learn how to install and setup Node, reference the repository README."
+  exit 1
+fi
+
+# Determine the available Node version.
+node_version=$(node --version | cut -d 'v' -f 2)
+
+# Validate the version of the Node installation.
+if version_is_new_enough "$REQUIRED_NODE_VERSION" "$node_version"; then
+  echo "Node version $node_version is too low. Version $REQUIRED_NODE_VERSION or later is required."
+  exit 1
+fi
+
+# Check that the 'npx' command is available on the user's path.
+if ! command -v npx &> /dev/null; then
+  echo "'npx' command from Node not found. Check your Node installation."
+  exit 1
+fi
+
+# Run extra logic if the 'pnpm' command is available on the user's path.
+if command -v pnpm &> /dev/null; then
+  # Determine the available pnpm version.
+  pnpm_version=$(pnpm --version)
+
+  # Validate the version of the pnpm installation.
+  if version_is_new_enough "$REQUIRED_PNPM_VERSION" "$pnpm_version"; then
+    echo "pnpm version $pnpm_version is too low. Version $REQUIRED_PNPM_VERSION or later is required."
+    exit 1
+  fi
+fi
+
+# Verify that Node packages have been installed.
+if [[ ! -d "node_modules" ]]; then
+  if command -v pnpm &> /dev/null; then
+    echo "Node packages not found. Installing with 'pnpm install'..."
+    pnpm install
+  elif command -v npm &> /dev/null; then
+    echo "Node packages not found. Installing with 'npm install'..."
+    npm install
+  else
+    echo "Neither 'pnpm' nor 'npm' found. To learn how to setup pnpm, reference the repository README."
+    exit 1
+  fi
+fi
+
+# Verify that Dart dependencies have been retrieved.
+if [[ ! -d ".dart_tool" ]]; then
+  dart pub get
+fi
+
+# Run the Dart site tool and pass through all arguments.
+dart run dart_site "$@"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.1"
+    "pnpm": ">=8.14.0"
   },
   "packageManager": "pnpm@8.15.1",
   "dependencies": {


### PR DESCRIPTION
This will simplify `dart run dart_site <command>` to just `./dash_site <command>`. The command also validates that the setup has been completed correctly and with the correct versions, with tips if not, and then defers to the underlying `dart_site` tool.

This only works on macOS and Linux for now as I don't currently have a Windows device with me to build and test a Powershell equivalent. Windows users can keep using `dart run dart_site` for now, but I'll work on get an equivalent ps alternative added as soon as possible.

Fixes https://github.com/dart-lang/site-www/issues/5596
