### PR TITLE
Mark IA32 support as deprecated in system requirements table

### DIFF
--- a/src/_sass/_site.scss
+++ b/src/_sass/_site.scss
@@ -588,7 +588,13 @@ thead:has(th:empty) {
 .content > p {
   > i.material-symbols, > span.material-symbols {
     vertical-align: bottom;
+    user-select: none;
   }
+}
+
+// Make icons used in system requirements table unselectable.
+.system-support {
+  user-select: none;
 }
 
 // Overwrite bootstrap's breadcrumbs

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -20,7 +20,7 @@ to develop and run Dart code.
 
 {% assign yes = '<span class="material-symbols system-support" style="color: #158477;" aria-label="Supported">verified</span>' %}
 {% assign no = '<span class="material-symbols system-support" style="color: #D43324" aria-label="Not supported">dangerous</span>' %}
-{% assign dep = '<span class="material-symbols system-support" style="color: #E64A19" aria-label="Deprecated">warning</span>' %}
+{% assign dep = '<span class="material-symbols system-support" style="color: #EF6C00" aria-label="Deprecated">error</span>' %}
 {% assign beta = '<span class="material-symbols system-support" style="color: #11796d" aria-label="Supported on the beta and dev channels">gpp_maybe</span>' %}
 {% assign na = '<span class="material-symbols system-support" style="color: #DADCE0" aria-label="Platform combination does not exist">do_not_disturb_on</span>' %}
 {% assign macversions = 'Latest three versions of macOS:<br>' %}

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -21,7 +21,6 @@ to develop and run Dart code.
 {% assign yes = '<span class="material-symbols system-support" style="color: #158477;" aria-label="Supported">verified</span>' %}
 {% assign no = '<span class="material-symbols system-support" style="color: #D43324" aria-label="Not supported">dangerous</span>' %}
 {% assign dep = '<span class="material-symbols system-support" style="color: #EF6C00" aria-label="Deprecated">error</span>' %}
-{% assign beta = '<span class="material-symbols system-support" style="color: #11796d" aria-label="Supported on the beta and dev channels">gpp_maybe</span>' %}
 {% assign na = '<span class="material-symbols system-support" style="color: #DADCE0" aria-label="Platform combination does not exist">do_not_disturb_on</span>' %}
 {% assign macversions = 'Latest three versions of macOS:<br>' %}
 {% for version in macos limit:3 %}
@@ -45,7 +44,6 @@ to develop and run Dart code.
 {{yes}} Supported on all channels.<br>
 {{dep}} Support is deprecated and might be dropped in a future Dart release.<br>
 {{no}} Unsupported on all channels.<br>
-{{beta}} Supported on the `beta`, `dev`, and `main` channels only.<br>
 {{na}} Unsupported by the operating system.<br>
 
 ## Choose an installation option

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -18,10 +18,10 @@ To learn more about the Dart SDK, consult the [Dart SDK overview](/tools/sdk).
 Dart supports the following hardware architectures and platform versions
 to develop and run Dart code.
 
-{% assign yes = '<span class="material-symbols system-support" style="color: #158477;" aria-label="Supported">verified</span>' %}
-{% assign no = '<span class="material-symbols system-support" style="color: #D43324" aria-label="Not supported">dangerous</span>' %}
-{% assign dep = '<span class="material-symbols system-support" style="color: #EF6C00" aria-label="Deprecated">error</span>' %}
-{% assign na = '<span class="material-symbols system-support" style="color: #DADCE0" aria-label="Platform combination does not exist">do_not_disturb_on</span>' %}
+{% assign yes = '<span class="material-symbols system-support" style="color: #158477;" aria-label="Supported" title="Supported">verified</span>' %}
+{% assign no = '<span class="material-symbols system-support" style="color: #D43324" aria-label="Not supported" title="Not supported">dangerous</span>' %}
+{% assign dep = '<span class="material-symbols system-support" style="color: #EF6C00" aria-label="Deprecated" title="Deprecated">error</span>' %}
+{% assign na = '<span class="material-symbols system-support" style="color: #DADCE0" aria-label="Does not exist" title="Does not exist">do_not_disturb_on</span>' %}
 {% assign macversions = 'Latest three versions of macOS:<br>' %}
 {% for version in macos limit:3 %}
 {%- if version.eol == false -%}

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -43,6 +43,7 @@ to develop and run Dart code.
 {:.table .table-striped}
 
 {{yes}} Supported on all channels.<br>
+{{dep}} Support is deprecated and might be dropped in a future Dart release.<br>
 {{no}} Unsupported on all channels.<br>
 {{beta}} Supported on the `beta`, `dev`, and `main` channels only.<br>
 {{na}} Unsupported by the operating system.<br>

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -18,10 +18,11 @@ To learn more about the Dart SDK, consult the [Dart SDK overview](/tools/sdk).
 Dart supports the following hardware architectures and platform versions
 to develop and run Dart code.
 
-{% assign yes = '<span class="material-symbols" style="color: #158477;">verified</span>' %}
-{% assign no = '<span class="material-symbols" style="color: #D43324">dangerous</span>' %}
-{% assign beta = '<span class="material-symbols" style="color: #13C2AD">gpp_maybe</span>' %}
-{% assign na = '<span class="material-symbols" style="color: #DADCE0">do_not_disturb_on</span>' %}
+{% assign yes = '<span class="material-symbols system-support" style="color: #158477;" aria-label="Supported">verified</span>' %}
+{% assign no = '<span class="material-symbols system-support" style="color: #D43324" aria-label="Not supported">dangerous</span>' %}
+{% assign dep = '<span class="material-symbols system-support" style="color: #E64A19" aria-label="Deprecated">warning</span>' %}
+{% assign beta = '<span class="material-symbols system-support" style="color: #11796d" aria-label="Supported on the beta and dev channels">gpp_maybe</span>' %}
+{% assign na = '<span class="material-symbols system-support" style="color: #DADCE0" aria-label="Platform combination does not exist">do_not_disturb_on</span>' %}
 {% assign macversions = 'Latest three versions of macOS:<br>' %}
 {% for version in macos limit:3 %}
 {%- if version.eol == false -%}
@@ -35,8 +36,8 @@ to develop and run Dart code.
 
 | Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                       |
 |----------|:----------:|:-------:|:-------:|:-------:|:---------------:|-----------------------------------|
-| Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10] (32-bit, 64-bit), [11][]     |
-| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][], [Ubuntu LTS][] |
+| Windows  |  {{dep}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10], [11][]                      |
+| Linux    |  {{dep}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][], [Ubuntu LTS][] |
 | macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                   |
 
 {:.table .table-striped}


### PR DESCRIPTION
This change doesn't commit to anything but indicates to developers that support for IA32 might be less and that there is a chance for removal in the future.

Adds a new deprecated icon to facilitate this and adds aria-labels to each entry for improved accessibility of the table cells.

Contributes to https://github.com/dart-lang/sdk/issues/49969

**Staged:** https://dart-dev--pr5607-misc-mark-ia32-as-deprecated-8mye30gd.web.app/get-dart#system-requirements