### PR TITLE
Update breaking changes to account for waitFor removal

### DIFF
--- a/src/content/resources/breaking-changes.md
+++ b/src/content/resources/breaking-changes.md
@@ -83,7 +83,7 @@ accounting for them before the 3.4.0 release.
 #### `dart:cli`
 
 * **Experimental** **Removed**: [The `waitFor` function][52121]
-  is set to be removed.
+  has been removed.
 
 [52121]: https://github.com/dart-lang/sdk/issues/52121
 


### PR DESCRIPTION
It was removed in https://github.com/dart-lang/sdk/commit/9e11d796570bc1b83ea15709c3b40266b5cc0c54.