### PR TITLE
Revise "Web libraries and packages" page

### DIFF
--- a/src/content/web/libraries.md
+++ b/src/content/web/libraries.md
@@ -5,24 +5,26 @@ description: Libraries and packages that can help you write Dart web apps.
 ---
 
 Dart provides several packages and libraries to support
-web app development, the recommended option being [package:web][].
+web app development, the recommended option being [`package:web`][web].
 The [Dart SDK][] also contains other libraries that provide low-level web APIs.
 
 ## Web solutions
 
-[Migrate to package:web][migrate]
+[Migrate to `package:web`][migrate]
 : Learn how to migrate to `package:web`
-  from Dart's previous web solution, [dart:html][].
+  from Dart's previous web library solutions, like [`dart:html`][html].
 
-[package:web API reference][package:web]
-: Complete reference documentation for `package:web` on pub.dev.
+[`package:web` API reference][web]
+: Dart's recommended web interop solution `package:web` exposes browser
+  APIs with lightweight bindings built around static JS interop. 
 
-[JavaScript interoperability documentation](/interop/js-interop)
-: Interact with existing JavaScript or TypeScript libraries
+[JavaScript interoperability documentation][js]
+: Learn how to interact with existing JavaScript or TypeScript libraries
   using Dart's JS interop support.
 
-[The dart:js_interop documentation][js_interop]
-: Complete reference documentation for the `dart:js_interop` library.
+[`dart:js_interop` API reference][js_interop]
+: Dart's web library `dart:js_interop` provides all the necessary members to
+  facilitate sound interop between JavaScript and Dart types. 
 
 [Flutter web support][flutter-web]
 : The [Flutter framework][flutter] supports web development with Dart,
@@ -31,14 +33,15 @@ The [Dart SDK][] also contains other libraries that provide low-level web APIs.
 [Build a web app with Dart](/web/get-started)
 : A quick overview of how to build, run, and debug a web app with Dart.
 
-To find more support for writing web apps, 
+To find other libraries that support the web platform,
 search pub.dev for [web packages][].
 
-[package:web]: {{site.pub-pkg}}/web
+[web]: {{site.pub-pkg}}/web
 [Dart SDK]: {{site.dart-api}}/{{site.sdkInfo.channel}}
 [migrate]: /interop/js-interop/package-web
 [js_interop]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
 [flutter-web]: {{site.flutter-docs}}/platform-integration/web
 [flutter]: {{site.flutter}}
 [web packages]: {{site.pub}}/web
-[dart:html]: /libraries/dart-html
+[html]: /libraries/dart-html
+[js]: /interop/js-interop

--- a/src/content/web/libraries.md
+++ b/src/content/web/libraries.md
@@ -4,46 +4,41 @@ short-title: Web libraries
 description: Libraries and packages that can help you write Dart web apps.
 ---
 
-The [Dart SDK][] contains [dart:html][] and other libraries
-that provide low-level web APIs.
-You can supplement or replace these APIs using web packages.
+Dart provides several packages and libraries to support
+web app development, the recommended option being [package:web][].
+The [Dart SDK][] also contains other libraries that provide low-level web APIs.
 
-[Dart SDK]: /tools/sdk
-[dart:html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/dart-html-library.html
+## Web solutions
 
+[Migrate to package:web][migrate]
+: Learn how to migrate to `package:web`
+  from Dart's previous web solution, [dart:html][].
 
-## SDK libraries
+[package:web API reference][package:web]
+: Complete reference documentation for `package:web` on pub.dev.
 
-The Dart SDK contains dart:html and other libraries
-that provide low-level web APIs.
+[JavaScript interoperability documentation](/interop/js-interop)
+: Interact with existing JavaScript or TypeScript libraries
+  using Dart's JS interop support.
+
+[The dart:js_interop documentation][js_interop]
+: Complete reference documentation for the `dart:js_interop` library.
+
+[Flutter web support][flutter-web]
+: The [Flutter framework][flutter] supports web development with Dart,
+  in addition to mobile, desktop, and embedded device support.
 
 [Build a web app with Dart](/web/get-started)
 : A quick overview of how to build, run, and debug a web app with Dart.
 
-[The dart:html documentation](/libraries/dart-html)
-: An example-driven tour of using the dart:html library.
-  Topics include manipulating the DOM programmatically,
-  making HTTP requests, and using WebSockets.
-
-[dart:html API reference][dart:html]
-: Complete reference documentation for the dart:html library.
-
-
-## Web packages
-
-Many [packages](/guides/packages) support web development with Dart.
-In particular, the [Flutter framework][flutter] has [web support][flutter-web],
-in addition to mobile, desktop, and embedded device support.
-
-To find more libraries that support writing web apps, 
+To find more support for writing web apps, 
 search pub.dev for [web packages][].
 
-Your Dart code can also interact with existing
-JavaScript or TypeScript libraries
-using Dart's [JavaScript interoperability][] support.
-
+[package:web]: {{site.pub-pkg}}/web
+[Dart SDK]: {{site.dart-api}}/{{site.sdkInfo.channel}}
+[migrate]: /interop/js-interop/package-web
+[js_interop]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
+[flutter-web]: {{site.flutter-docs}}/platform-integration/web
 [flutter]: {{site.flutter}}
-[flutter-web]: {{site.flutter}}/web
-[js]: {{site.pub-pkg}}/js
-[JavaScript interoperability]: /interop/js-interop
 [web packages]: {{site.pub}}/web
+[dart:html]: /libraries/dart-html


### PR DESCRIPTION
Fixes #5608 

@parlough It ended up being a little more of a change than just replacing dart:html with package:web, since the page was all structured by "web libraries" vs "web packages". I got rid of that distinction and just listed everything together. 

The "note" about dart:html is in the description about the migration page, the first solutions link. Lmk if you wanted something more overt than that