### PR TITLE
Add destructuring named fields to "Records" page

### DIFF
--- a/examples/language/test/records_test.dart
+++ b/examples/language/test/records_test.dart
@@ -115,7 +115,7 @@ void main() {
   test('record-multiple-returns', () {
     // #docregion record-multiple-returns
     // Returns multiple values in a record:
-    (String, int) userInfo(Map<String, dynamic> json) {
+    (String name, int age) userInfo(Map<String, dynamic> json) {
       return (json['name'] as String, json['age'] as int);
     }
 
@@ -125,7 +125,7 @@ void main() {
       'color': 'blue',
     };
 
-    // Destructures using a record pattern:
+    // Destructures using a record pattern with positional fields:
     var (name, age) = userInfo(json);
 
     /* Equivalent to:
@@ -134,6 +134,27 @@ void main() {
       var age  = info.$2;
     */
     // #enddocregion record-multiple-returns
+    name;
+    age;
+  });
+
+  test('record-name-destructure', () {
+    // #docregion record-name-destructure
+    ({String name, int age}) userInfo(Map<String, dynamic> json)
+    // #enddocregion record-name-destructure
+    {
+      return (name: json['name'] as String, age: json['age'] as int);
+    }
+
+    final json = <String, dynamic>{
+      'name': 'Dash',
+      'age': 10,
+      'color': 'blue',
+    };
+    // #docregion record-name-destructure
+    // Destructures using a record pattern with named fields:
+    final (:name, :age) = userInfo(json);
+    // #enddocregion record-name-destructure
     name;
     age;
   });

--- a/src/content/language/patterns.md
+++ b/src/content/language/patterns.md
@@ -279,8 +279,8 @@ in a map. This section describes even more use cases, answering:
 
 ### Destructuring multiple returns
 
-[Records][] allow aggregating and returning multiple values from a single function
-call. Patterns add the ability to destructure a record's fields
+Records allow aggregating and [returning multiple values][] from a single
+function call. Patterns add the ability to destructure a record's fields
 directly into local variables, inline with the function call.
 
 Instead of individually declaring new local variables for each record field,
@@ -295,7 +295,8 @@ var age = info.$2;
 
 You can destructure the fields of a record that a function returns into local
 variables using a [variable declaration](#variable-declaration) or
-[assigment pattern](#variable-assignment), and a record pattern as its subpattern:
+[assigment pattern](#variable-assignment), and a [record pattern][record]
+as its subpattern:
 
 <?code-excerpt "language/lib/patterns/destructuring.dart (destructure-multiple-returns-2)"?>
 ```dart
@@ -424,7 +425,7 @@ This case pattern simultaneously validates that:
 [collection literals]: /language/collections#control-flow-operators
 [null-assert pattern]: /language/pattern-types#null-assert
 [record]: /language/pattern-types#record
-[Records]: /language/records
+[returning multiple values]: /language/records#multiple-returns
 [refutable]: /resources/glossary#refutable-pattern
 [constant]: /language/pattern-types#constant
 [list]: /language/pattern-types#list

--- a/src/content/language/records.md
+++ b/src/content/language/records.md
@@ -176,12 +176,12 @@ of their fields.
 
 Records allow functions to return multiple values bundled together.
 To retrieve record values from a return,
-destructure the values into local variables using [pattern matching][pattern].
+[destructure][] the values into local variables using [pattern matching][pattern].
 
 <?code-excerpt "language/test/records_test.dart (record-multiple-returns)"?>
 ```dart
 // Returns multiple values in a record:
-(String, int) userInfo(Map<String, dynamic> json) {
+(String name, int age) userInfo(Map<String, dynamic> json) {
   return (json['name'] as String, json['age'] as int);
 }
 
@@ -191,7 +191,7 @@ final json = <String, dynamic>{
   'color': 'blue',
 };
 
-// Destructures using a record pattern:
+// Destructures using a record pattern with positional fields:
 var (name, age) = userInfo(json);
 
 /* Equivalent to:
@@ -199,6 +199,18 @@ var (name, age) = userInfo(json);
   var name = info.$1;
   var age  = info.$2;
 */
+```
+
+You can also destructure a record using its [named fields](#record-fields),
+using the colon `:` syntax, which you can read more about on the
+[Pattern types][] page:
+
+<?code-excerpt "language/test/records_test.dart (record-name-destructure)"?>
+```dart
+({String name, int age}) userInfo(Map<String, dynamic> json)
+// ···
+// Destructures using a record pattern with named fields:
+final (:name, :age) = userInfo(json);
 ```
 
 You can return multiple values from a function without records,
@@ -217,3 +229,5 @@ parallelization of futures of different types, which you can read about in the
 [pattern]: /language/patterns#destructuring-multiple-returns
 [`dart:async` documentation]: /libraries/dart-async#handling-errors-for-multiple-futures
 [parameters and arguments]: /language/functions#parameters
+[destructure]: /language/patterns#destructuring
+[Pattern types]: /language/pattern-types#record


### PR DESCRIPTION
Fixes #5262 

Added an example (w/ code excerpt) of destructuring named fields to the "Multiple returns" section, and improved links connecting more info between the patterns, pattern types, and records pages