### PR TITLE
Update outdated mention that factory constructors can return null.

### DIFF
--- a/src/content/codelabs/dart-cheatsheet.md
+++ b/src/content/codelabs/dart-cheatsheet.md
@@ -1727,8 +1727,9 @@ void main() {
 
 ## Factory constructors
 
-Dart supports factory constructors,
-which can return instances of a class or even subtypes.
+Dart supports factory constructors.
+Factory constructors can return an instance of the surrounding class
+or a subtype of that class.
 To create a factory constructor, use the `factory` keyword:
 
 <?code-excerpt "misc/lib/cheatsheet/factory_constructors.dart"?>

--- a/src/content/codelabs/dart-cheatsheet.md
+++ b/src/content/codelabs/dart-cheatsheet.md
@@ -1728,7 +1728,7 @@ void main() {
 ## Factory constructors
 
 Dart supports factory constructors,
-which can return subtypes or even null.
+which can return instances of a class or even subtypes.
 To create a factory constructor, use the `factory` keyword:
 
 <?code-excerpt "misc/lib/cheatsheet/factory_constructors.dart"?>


### PR DESCRIPTION
Factory constructors no longer return null with null-safe Dart. Instead, they can be used to return instance of a class or subtypes.

Fixes <https://github.com/dart-lang/site-www/issues/5506>
