### PR TITLE
Replace custom mini-toc container with secondary

### DIFF
--- a/src/_11ty/plugins/markdown.js
+++ b/src/_11ty/plugins/markdown.js
@@ -30,7 +30,6 @@ export const markdown = (() => {
     });
 
   _registerAsides(markdown);
-  _registerContainers(markdown);
 
   return markdown;
 })();
@@ -99,26 +98,4 @@ function _registerAsides(markdown) {
   );
 
   _registerAside(markdown, 'secondary', null, null, 'alert-secondary');
-}
-
-/**
- * Registers custom containers used on the site.
- *
- * @param {import('markdown-it/lib').MarkdownIt} markdown
- * @private
- */
-function _registerContainers(markdown) {
-  // TODO(parlough): Consider removing all usages of mini-toc.
-  markdown.use(markdownItContainer, 'mini-toc', {
-    render: function (tokens, index) {
-      if (tokens[index].nesting === 1) {
-        const header = /\s+(.*)/.exec(tokens[index].info)[1];
-        return `<div class="mini-toc">
-<h4 class="no_toc">${header}</h4>
-`;
-      } else {
-        return '</div>\n';
-      }
-    },
-  });
 }

--- a/src/_sass/_site.scss
+++ b/src/_sass/_site.scss
@@ -460,20 +460,6 @@ li.card {
   margin: 0 auto;
 }
 
-.mini-toc {
-  @extend .alert;
-  background-color: $gray-light;
-
-  h4 {
-    margin-top: 0;
-  }
-
-  ul {
-    padding-left: 1.5rem;
-    margin-bottom: 0;
-  }
-}
-
 .table {
   width: 100%;
   @extend .table-striped;

--- a/src/content/tutorials/language/streams.md
+++ b/src/content/tutorials/language/streams.md
@@ -4,7 +4,7 @@ description: Learn how to consume single-subscriber and broadcast streams.
 js: [{url: 'https://old-dartpad-3ce3f.web.app/inject_embed.dart.js', defer: true}]
 ---
 
-:::mini-toc What's the point?
+:::secondary What's the point?
 * Streams provide an asynchronous sequence of data.
 * Data sequences include user-generated events and data read from files.
 * You can process a stream using either **await for** or

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -15,7 +15,7 @@ prevpage:
 
 <?code-excerpt replace="/ ?\/\/!tip.*//g"?>
 
-:::mini-toc What's the point?
+:::secondary What's the point?
 * Command-line applications need to do input and output.
 * The `dart:io` library provides I/O functionality.
 * The args package helps define and parse command-line arguments.

--- a/src/content/tutorials/server/fetch-data.md
+++ b/src/content/tutorials/server/fetch-data.md
@@ -12,7 +12,7 @@ nextpage:
 
 <?code-excerpt path-base="fetch_data"?>
 
-:::mini-toc What you'll learn
+:::secondary What you'll learn
 * The basics of what HTTP requests and URIs are and what they are used for.
 * Making HTTP requests using `package:http`.
 * Decoding JSON strings into Dart objects with `dart:convert`.


### PR DESCRIPTION
The `mini-toc` styling and setup are so similar to the secondary asides now that we can set custom titles for them. So this PR removes support for the `mini-toc` container type in favor of reusing `secondary`, reducing mostly duplicated JS and CSS.