### PR TITLE
Add spread to Operators page

### DIFF
--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -33,10 +33,11 @@ You can implement many of these [operators as class members][].
 | equality                                | `==`    `!=`                                                                                                                                                                                      | None          |
 | logical AND                             | `&&`                                                                                                                                                                                              | Left          |
 | logical OR                              | <code>&#124;&#124;</code>                                                                                                                                                                                             | Left          |
-| if null                                 | `??`                                                                                                                                                                                              | Left          |
+| if-null                                 | `??`                                                                                                                                                                                              | Left          |
 | conditional                             | <code><em>expr1</em> ? <em>expr2</em> : <em>expr3</em></code>                                                                                                                                     | Right         |
 | cascade                                 | `..` &nbsp;&nbsp; `?..`                                                                                                                                                                           | Left          |
 | assignment                              | `=`    `*=`    `/=`    `+=`    `-=`    `&=`    `^=`    <em>etc.</em>                                                                                                                              | Right         |
+| spread  ([See note](#spread-operators)) | `...`    `...?`                                                                                                                             | Left         |
 
 {:.table .table-striped}
 
@@ -499,6 +500,25 @@ and you can't construct a cascade on `void`.
 Strictly speaking, the "double dot" notation for cascades isn't an operator.
 It's just part of the Dart syntax.
 :::
+
+## Spread operators
+
+The spread operator evaluates an expression that yields a collection,
+unpacks the resulting values, and inserts them into another collection.
+
+**The spread operator isn't actually an operator expression**.
+The `...`/`...?` syntax is part of the collection literal itself.
+So, you can learn more about spread operators on the
+[Collections](/language/collections#spread-operators) page.
+
+Because it isn't an operator, the syntax doesn't
+have any "[operator precedence](#operators)".
+Effectively, it has the lowest "precedence" &mdash;
+any kind of expression is valid as the spread target, such as:
+
+```dart
+[...a + b]
+```
 
 ## Other operators
 

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -37,7 +37,7 @@ You can implement many of these [operators as class members][].
 | conditional                             | *`expr1`*    `?`    *`expr2`*    `:`    *`expr3`*                                                  | Right         |
 | cascade                                 | `..`    `?..`                                                                                      | Left          |
 | assignment                              | `=`    `*=`    `/=`    `+=`    `-=`    `&=`    `^=`    *etc.*                                      | Right         |
-| spread  ([See note](#spread-operators)) | `...`    `...?`                                                                                    | Left          |
+| spread  ([See note](#spread-operators)) | `...`    `...?`                                                                                    | None          |
 
 {:.table .table-striped}
 
@@ -503,7 +503,7 @@ It's just part of the Dart syntax.
 
 ## Spread operators
 
-The spread operator evaluates an expression that yields a collection,
+Spread operators evaluate an expression that yields a collection,
 unpacks the resulting values, and inserts them into another collection.
 
 **The spread operator isn't actually an operator expression**.


### PR DESCRIPTION
I'd like to land #5639 first and update this PR accordingly. 

Fixes #5599 
Fixes #5635 

Adding spread to the table, and a section on the page. 

However, _the spread operator is not actually an operator expression_. So, it goes to the bottom of the precedence table and its section on the page basically just says "its part of collection syntax so read about them there" (taken from the [spec](https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md#:~:text=It%20makes%20the,target%2C%20such%20as%3A))