### PR TITLE
js-to-dart.md - escape pipes so `OR` operators display correctly in tables

### DIFF
--- a/src/content/guides/language/coming-from/js-to-dart.md
+++ b/src/content/guides/language/coming-from/js-to-dart.md
@@ -1137,7 +1137,7 @@ as shown in the following table:
 | Meaning                                               | JavaScript operator | Dart operator |
 |-------------------------------------------------------|---------------------|---------------|
 | Bitwise AND                                           | `&`                 | `&`           |
-| Bitwise OR                                            | `|`                 | `|`           |
+| Bitwise OR                                            | `\|`                | `\|`          |
 | Bitwise XOR                                           | `^`                 | `^`           |
 | Unary bitwise complement (0s become 1s; 1s become 0s) | `~expr`             | `~expr`       |
 | Shift left                                            | `<<`                | `<<`          |

--- a/src/content/guides/language/coming-from/js-to-dart.md
+++ b/src/content/guides/language/coming-from/js-to-dart.md
@@ -1218,7 +1218,7 @@ The following table lists these assignment operators:
 | `<<=`    | Left shift assignment           |
 | `>>=`    | Right shift assignment          |
 | `&=`     | Bitwise AND assignment          |
-| `|=`     | Bitwise OR assignment           |
+| `\|=`    | Bitwise OR assignment           |
 
 {:.table .table-striped}
 

--- a/src/content/guides/language/coming-from/js-to-dart.md
+++ b/src/content/guides/language/coming-from/js-to-dart.md
@@ -1109,7 +1109,7 @@ of both languages are identical.
 | Meaning                                                        | JavaScript operator | Dart operator |
 |----------------------------------------------------------------|---------------------|---------------|
 | Inverts next expression (changes false to true and vice versa) | `!x`                | `!x`          |
-| Logical OR                                                     | `||`                | `||`          |
+| Logical OR                                                     | `\|\|`              | `\|\|`        |
 | Logical AND                                                    | `&&`                | `&&`          |
 
 {:.table .table-striped}


### PR DESCRIPTION
Just a quick fix for the `OR` logical, bitwise, and bitwise assignment operators so they are displayed correctly in the js-to-dart guide.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.