### PR TITLE
Clarify Ubuntu LTS support is for standard LTS

### DIFF
--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -33,11 +33,11 @@ to develop and run Dart code.
 {%- endif %}
 {% endfor %}
 
-| Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                       |
-|----------|:----------:|:-------:|:-------:|:-------:|:---------------:|-----------------------------------|
-| Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10] (32-bit, 64-bit), [11][]     |
-| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][], [Ubuntu LTS][] |
-| macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                   |
+| Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                                              |
+|----------|:----------:|:-------:|:-------:|:-------:|:---------------:|----------------------------------------------------------|
+| Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10], [11][]                                             |
+| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][],<br>[Ubuntu LTS in standard support][] |
+| macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                                          |
 
 {:.table .table-striped}
 

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -33,11 +33,11 @@ to develop and run Dart code.
 {%- endif %}
 {% endfor %}
 
-| Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                                              |
-|----------|:----------:|:-------:|:-------:|:-------:|:---------------:|----------------------------------------------------------|
-| Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10], [11][]                                             |
-| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][],<br>[Ubuntu LTS in standard support][] |
-| macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                                          |
+| Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                                                 |
+|----------|:----------:|:-------:|:-------:|:-------:|:---------------:|-------------------------------------------------------------|
+| Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10], [11][]                                                |
+| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][],<br>[Ubuntu LTS under standard support][] |
+| macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                                             |
 
 {:.table .table-striped}
 

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -36,7 +36,7 @@ to develop and run Dart code.
 | Platform | IA32 (x86) |   x64   |  Arm32  |  Arm64  | RISC-V (RV64GC) | OS Versions                                                 |
 |----------|:----------:|:-------:|:-------:|:-------:|:---------------:|-------------------------------------------------------------|
 | Windows  |  {{yes}}   | {{yes}} | {{no}}  | {{yes}} |     {{na}}      | [10], [11][]                                                |
-| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][],<br>[Ubuntu LTS under standard support][] |
+| Linux    |  {{yes}}   | {{yes}} | {{yes}} | {{yes}} |     {{yes}}     | [Debian stable][],<br>[Ubuntu LTS][] under standard support |
 | macOS    |   {{no}}   | {{yes}} | {{na}}  | {{yes}} |     {{na}}      | {{macversions}}                                             |
 
 {:.table .table-striped}


### PR DESCRIPTION
Clarify that only Ubuntu LTS releases [under standard support](https://wiki.ubuntu.com/supportperiod) are supported as Dart doesn't explicitly support LTS releases currently in "Expanded Security Maintenance". This matches the policy before the recent design changes to the page.

It was also suggested to consider listing specific versions, but this will be easier to maintain.