### PR TITLE
Add note about if-null operator

### DIFF
--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -33,7 +33,7 @@ You can implement many of these [operators as class members][].
 | equality                                | `==`    `!=`                                                                                       | None          |
 | logical AND                             | `&&`                                                                                               | Left          |
 | logical OR                              | <code>&#124;&#124;</code>                                                                          | Left          |
-| if null                                 | `??`                                                                                               | Left          |
+| if-null                                 | `??`                                                                                               | Left          |
 | conditional                             | *`expr1`*    `?`    *`expr2`*    `:`    *`expr3`*                                                  | Right         |
 | cascade                                 | `..`    `?..`                                                                                      | Left          |
 | assignment                              | `=`    `*=`    `/=`    `+=`    `-=`    `&=`    `^=`    *etc.*                                      | Right         |
@@ -373,7 +373,7 @@ that might otherwise require [if-else][] statements:
 
 When you need to assign a value
 based on a boolean expression,
-consider using `?` and `:`.
+consider using the conditional operator `?` and `:`.
 
 <?code-excerpt "misc/lib/language_tour/operators.dart (if-then-else-operator)"?>
 ```dart
@@ -381,7 +381,8 @@ var visibility = isPublic ? 'public' : 'private';
 ```
 
 If the boolean expression tests for null,
-consider using `??`.
+consider using the if-null operator `??`
+(also known as the null-coalescing operator).
 
 <?code-excerpt "misc/test/language_tour/operators_test.dart (if-null)"?>
 ```dart


### PR DESCRIPTION
Wanted to address a side point @dtonhofer made in #5635 

> Additionally, the "if null" operator `a ?? b` is apparently generally called a ["null-coalescing"](https://en.wikipedia.org/wiki/Null_coalescing_operator) operator. One might want to note that.

Not trying to rename it, it seems like we use if-null across the board. But I confirmed we do use "null coalescing" to describe our if-null operator in the spec at least once: 

<img width="461" alt="image" src="https://github.com/dart-lang/site-www/assets/111139605/eb308b65-dea0-4d69-9eba-a0f55232a7b2">

So I think it makes sense to say "also known as the null coalescing operator" in at least one place, for people more familiar with that term.