### PR TITLE
Fix: Page GitHub links with '. /'

### DIFF
--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -4,7 +4,7 @@ Style the button pair using the `#page-github-links` selector.
 {% endcomment -%}
 
 {% assign repo = repo | default: site.repo.this -%}
-{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath}} {%- endcapture -%}
+{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath | regex_replace: '^./'}} {%- endcapture -%}
 {% assign siteTitle = title | default: page.url -%}
 {% assign url = site.url | append: page.url -%}
 

--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -4,7 +4,7 @@ Style the button pair using the `#page-github-links` selector.
 {% endcomment -%}
 
 {% assign repo = repo | default: site.repo.this -%}
-{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath | regex_replace: '^./'}} {%- endcapture -%}
+{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath | replace: './', ''}} {%- endcapture -%}
 {% assign siteTitle = title | default: page.url -%}
 {% assign url = site.url | append: page.url -%}
 


### PR DESCRIPTION
![image](https://github.com/dart-lang/site-www/assets/32262985/8a3f7480-3fe8-4606-b72c-a10a7f636c5a)

```diff
- https://github.com/dart-lang/site-www/tree/main/./src/xx/xx.md
+ https://github.com/dart-lang/site-www/tree/main/src/xx/xx.md
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
