### PR TITLE
Add go link for documentation about workspaces

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -160,7 +160,8 @@
       { "source": "/go/false-secrets", "destination": "/tools/pub/pubspec#false_secrets", "type": 301 },
       { "source": "/go/ffi", "destination": "/interop/c-interop", "type": 301 },
       { "source": "/go/flutter-upper-bound-deprecation", "destination": "https://github.com/flutter/flutter/issues/68143", "type": 301 },
-      
+      { "source": "/go/pub-workspaces", "destination": "https://flutter.dev/go/pub-workspace", "type": 301 },
+
       { "source": "/go/non-promo-conflicting-getter", "destination": "/tools/non-promotion-reasons#getter-name", "type": 301 },
       { "source": "/go/non-promo-conflicting-non-promotable-field", "destination": "/tools/non-promotion-reasons#field-name", "type": 301 },
       { "source": "/go/non-promo-conflicting-noSuchMethod-forwarder", "destination": "/tools/non-promotion-reasons#nosuchmethod", "type": 301 },


### PR DESCRIPTION
Part of https://github.com/dart-lang/pub/issues/4127
This link is referred in https://github.com/dart-lang/pub/pull/4186

Later it should be updated to point at the actual documentation. For now it is pointing at the design doc.