### PR TITLE
Fix and standardize various links in JS interop docs

### DIFF
--- a/src/content/interop/js-interop/index.md
+++ b/src/content/interop/js-interop/index.md
@@ -37,17 +37,18 @@ iterations.
 [recently]: https://medium.com/dartlang/dart-3-3-325bf2bf6c13
 [Wasm]: {{site.flutter-docs}}/platform-integration/web/wasm
 [`package:web`]: {{site.pub-pkg}}/web
-[`dart:html`]: {{site.dart-api}}/dev/dart-html/dart-html-library.html
-[`dart:svg`]: {{site.dart-api}}/dev/dart-svg/dart-svg-library.html
-[`dart:indexed_db`]: {{site.dart-api}}/dev/dart-indexed_db/dart-indexed_db-library.html
-[`dart:web_audio`]: {{site.dart-api}}/dev/dart-web_audio/dart-web_audio-library.html
-[`dart:web_gl`]: {{site.dart-api}}/dev/dart-web_gl/dart-web_gl-library.html
-[`dart:js_interop`]: {{site.dart-api}}/dev/dart-js_interop/dart-js_interop-library.html
-[`dart:js_interop_unsafe`]: {{site.dart-api}}/dev/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[`dart:html`]: {{site.dart-api}}/dart-html/dart-html-library.html
+[`dart:svg`]: {{site.dart-api}}/dart-svg/dart-svg-library.html
+[`dart:indexed_db`]: {{site.dart-api}}/dart-indexed_db/dart-indexed_db-library.html
+[`dart:web_audio`]: {{site.dart-api}}/dart-web_audio/dart-web_audio-library.html
+[`dart:web_gl`]: {{site.dart-api}}/dart-web_gl/dart-web_gl-library.html
+[`dart:js_interop`]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
 [`package:js`]: {{site.pub-api}}/js
-[`dart:js`]: {{site.dart-api}}/dev/dart-js/dart-js-library.html
-[`dart:js_util`]: {{site.dart-api}}/dev/dart-js_util/dart-js_util-library.html
+[`dart:js`]: {{site.dart-api}}/dart-js/dart-js-library.html
+[`dart:js_util`]: {{site.dart-api}}/dart-js_util/dart-js_util-library.html
 [Past JS interop]: /interop/js-interop/past-js-interop/
+
 ## Overview
 
 For information on how to write and use JavaScript interop:
@@ -72,5 +73,5 @@ For additional documentation on JavaScript interop:
 [`package:web` and migration]: /interop/js-interop/package-web
 [How to mock JavaScript interop objects]: /interop/js-interop/mock
 [Past JS interop]: /interop/js-interop/past-js-interop
-[`dart:js_interop` API reference]: {{site.dart-api}}/dev/dart-js_interop/dart-js_interop-library.html
-[`dart:js_interop_unsafe` API reference]: {{site.dart-api}}/dev/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[`dart:js_interop` API reference]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
+[`dart:js_interop_unsafe` API reference]: {{site.dart-api}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html

--- a/src/content/interop/js-interop/js-types.md
+++ b/src/content/interop/js-interop/js-types.md
@@ -224,7 +224,7 @@ error if the value returned was JS `null` or `undefined` to ensure soundness.
 :::warning
 There is a subtle inconsistency with regards to `undefined` between compiling to
 JS and Wasm. While compiling to JS *treats* `undefined` values as if they were
-Dart `null`, it doesn’t actually *change* the value itself. If an interop member
+Dart `null`, it doesn't actually *change* the value itself. If an interop member
 returns `undefined` and you pass that value back into JS, JS will see
 `undefined`, *not* `null`, when compiling to JS.
 
@@ -244,12 +244,12 @@ but this will likely change in the future. See [#54025] for more details.
 TODO: add links (with stable) when ready:
 {% endcomment %}
 
-[`dart:js_interop`]: https://api.dart.dev/dev/dart-js_interop/dart-js_interop-library.html
-[`external`]: https://dart.dev/language/functions#external
-[`Function.toJS`]: https://api.dart.dev/dev/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`dart:js_interop` API docs]: https://api.dart.dev/dev/dart-js_interop/dart-js_interop-library.html#extension-types
-[`typeofEquals`]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension/typeofEquals.html
-[`instanceOfString`]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension/instanceOfString.html
-[`isA`]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension/isA.html
+[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
+[`external`]: /language/functions#external
+[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`dart:js_interop` API docs]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html#extension-types
+[`typeofEquals`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/typeofEquals.html
+[`instanceOfString`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/instanceOfString.html
+[`isA`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/isA.html
 [#4841]: https://github.com/dart-lang/linter/issues/4841
 [#54025]: https://github.com/dart-lang/sdk/issues/54025

--- a/src/content/interop/js-interop/mock.md
+++ b/src/content/interop/js-interop/mock.md
@@ -116,7 +116,7 @@ non-instance members unless the user explicitly replaces the real API in JS.
 {% endcomment %}
 
 [Usage]: /interop/js-interop/usage
-[`createJSInteropWrapper`]: https://api.dart.dev/dart-js_interop/createJSInteropWrapper.html
-[`@JSExport`]: https://api.dart.dev/dart-js_interop/JSExport-class.html
+[`createJSInteropWrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/createJSInteropWrapper.html
+[`@JSExport`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSExport-class.html
 [limitation is true for extension members]: https://github.com/dart-lang/mockito/blob/master/FAQ.md#how-do-i-mock-an-extension-method
 [extension types]: /language/extension-types

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -283,8 +283,8 @@ Do we have any other package migrations to show off here?
 [Wasm]: https://github.com/dart-lang/sdk/blob/main/pkg/dart2wasm/README.md
 [html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/dart-html-library.html
 [svg]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-svg/dart-svg-library.html
-[`dart:js_interop`]: https://api.dart.dev/dev/dart-js_interop/dart-js_interop-library.html
-[`dart:js_interop_unsafe`]: https://api.dart.dev/dev/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
 [idl]: https://www.npmjs.com/package/@webref/idl
 [interop members]: /interop/js-interop/usage#interop-members
 [interop types]: /interop/js-interop/usage#interop-types
@@ -293,14 +293,14 @@ Do we have any other package migrations to show off here?
 [helpers]: https://github.com/dart-lang/web/tree/main/lib/src/helpers
 [zones]: /articles/archive/zones
 [Conversions]: /interop/js-interop/js-types#conversions
-[interop methods]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension.html#instance-methods
+[interop methods]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension.html#instance-methods
 [alternative interop declarations]: /interop/js-interop/usage
 [Compatibility, type checks, and casts]: /interop/js-interop/js-types#compatibility-type-checks-and-casts
 [Upgrading `url_launcher` to `package:web`]: https://github.com/flutter/packages/pull/5451/files
 [stream helpers]: https://github.com/dart-lang/web/blob/main/lib/src/helpers/events/streams.dart
 [not possible]: /language/extension-types
-[`JSObject`]: https://api.dart.dev/dev/dart-js_interop/JSObject-extension-type.html
-[`isA`]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension/isA.html
+[`JSObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSObject-extension-type.html
+[`isA`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/isA.html
 [restricts]: /interop/js-interop/js-types#requirements-on-external-declarations-and-function-tojs
 [#54507]: https://github.com/dart-lang/sdk/issues/54507
 [mocking tutorial]: /interop/js-interop/mock

--- a/src/content/interop/js-interop/past-js-interop.md
+++ b/src/content/interop/js-interop/past-js-interop.md
@@ -106,18 +106,18 @@ TODO: add links (with stable) when ready:
 TODO: Link to `package:web` section
 {% endcomment %}
 
-[`dart:js_interop`]: https://api.dart.dev/dev/dart-js_interop
+[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop
 [`dart:html`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html
 [`package:web`]: /interop/js-interop/package-web
 [`dart:js`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js
 [`object wrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js/JsObject-class.html
 [`allowInterop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_util/allowInterop.html
-[`package:js`]: https://pub.dev/packages/js
-[`JSObject`]: https://api.dart.dev/dev/dart-js_interop/JSObject-extension-type.html
+[`package:js`]: {{site.pub-pkg}}/js
+[`JSObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSObject-extension-type.html
 [`@JS`]: https://github.com/dart-lang/sdk/blob/main/sdk/lib/js/_js_annotations.dart#L11
 [tutorial on mocking]: /interop/js-interop/mock
 [`@anonymous`]: https://github.com/dart-lang/sdk/blob/main/sdk/lib/js/_js_annotations.dart#L40
 [`@staticInterop`]: https://github.com/dart-lang/sdk/blob/main/sdk/lib/js/_js_annotations.dart#L48
 [`dart:js_util`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_util
-[`Function.toJS`]: https://api.dart.dev/dev/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`dart:js_interop_unsafe`]: https://api.dart.dev/dev/dart-js_interop_unsafe
+[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -429,27 +429,27 @@ more difficult to guarantee and may lead to violations, which is why it can be
 TODO: Some of these are not available on stable. How do we link to dev?
 {% endcomment %}
 
-[global JS scope]: https://developer.mozilla.org/en-US/docs/Glossary/Global_scope
+[global JS scope]: https://developer.mozilla.org/docs/Glossary/Global_scope
 [conversion functions]: /interop/js-interop/js-types#conversions
 [contains a primitive type]: /interop/js-interop/js-types#requirements-on-external-declarations-and-function-tojs
 ["JS type"]: /interop/js-interop/js-types
-[`Window`]: https://developer.mozilla.org/en-US/docs/Web/API/Window
+[`Window`]: https://developer.mozilla.org/docs/Web/API/Window
 [check the type of the JS value through interop]: /interop/js-interop/js-types#compatibility-type-checks-and-casts
 [`package:web`]: {{site.pub-pkg}}/web
 [`external`]: /language/functions#external
 [restrictions]: /interop/js-interop/js-types#requirements-on-external-declarations-and-function-tojs
-[object literal]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer
+[object literal]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer
 [54801]: https://github.com/dart-lang/sdk/issues/54801
-[property accessors]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation
-[utility functions]: https://api.dart.dev/dev/dart-js_interop/JSAnyOperatorExtension.html
-[`@JS()`]: https://api.dart.dev/dev/dart-js_interop/JS-class.html
-[`dart:js_interop`]: https://api.dart.dev/dev/dart-js_interop
-[`globalContext`]: https://api.dart.dev/dev/dart-js_interop/globalContext.html
-[Helpers to inspect the type of JS values]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension.html
-[`dartify`]: https://api.dart.dev/dev/dart-js_interop/JSAnyUtilityExtension/dartify.html
-[`jsify`]: https://api.dart.dev/dev/dart-js_interop/NullableObjectUtilExtension/jsify.html
-[`importModule`]: https://api.dart.dev/dev/dart-js_interop/importModule.html
-[`dart:js_interop_unsafe`]: https://api.dart.dev/dev/dart-js_interop_unsafe
+[property accessors]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation
+[utility functions]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyOperatorExtension.html
+[`@JS()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JS-class.html
+[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop
+[`globalContext`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/globalContext.html
+[Helpers to inspect the type of JS values]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension.html
+[`dartify`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/dartify.html
+[`jsify`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/NullableObjectUtilExtension/jsify.html
+[`importModule`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/importModule.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
 [extensions]: /language/extension-methods
 [extension type]: /language/extension-types
 [runtime guarantee]: /language/extension-types#type-considerations


### PR DESCRIPTION
- Don't link to `dev` version of API docs
- Use site variables where possible
- Don't link to en-US MDN docs, so the site can choose the appropriate locale for the user