### PR TITLE
Suggest null-check patterns for type promo

### DIFF
--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -358,22 +358,23 @@ class UploadException {
 
   @override
   String toString() {
-    // #enddocregion null-check-promo
+    // #enddocregion shadow-nullable-field
+    if (this.response case var response?) {
+      return 'Could not complete upload to ${response.url} '
+          '(error code ${response.errorCode}): ${response.reason}.';
+    }
+// #enddocregion null-check-promo
+// #docregion shadow-nullable-field
     final response = this.response;
     if (response != null) {
       return 'Could not complete upload to ${response.url} '
           '(error code ${response.errorCode}): ${response.reason}.';
     }
     // #docregion null-check-promo
-    if (this.response case var response?) {
-      return 'Could not complete upload to ${response.url} '
-          '(error code ${response.errorCode}): ${response.reason}.';
-    }
-
     return 'Could not upload (no response).';
   }
 }
-// #enddocregion shadow-nullable-field
+// #enddocregion shadow-nullable-field, null-check-promo
 
 //----------------------------------------------------------------------------
 

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -350,7 +350,7 @@ class Response {
   String get reason => '';
 }
 
-// #docregion shadow-nullable-field
+// #docregion shadow-nullable-field, null-check-promo
 class UploadException {
   final Response? response;
 
@@ -358,8 +358,14 @@ class UploadException {
 
   @override
   String toString() {
+    // #enddocregion null-check-promo
     final response = this.response;
     if (response != null) {
+      return 'Could not complete upload to ${response.url} '
+          '(error code ${response.errorCode}): ${response.reason}.';
+    }
+    // #docregion null-check-promo
+    if (this.response case var response?) {
       return 'Could not complete upload to ${response.url} '
           '(error code ${response.errorCode}): ${response.reason}.';
     }

--- a/src/content/effective-dart/_toc.md
+++ b/src/content/effective-dart/_toc.md
@@ -105,7 +105,7 @@ the project:
 * <a href='/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
 * <a href='/effective-dart/usage#dont-use-true-or-false-in-equality-operations'>DON'T use <code>true</code> or <code>false</code> in equality operations.</a>
 * <a href='/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized'>AVOID <code>late</code> variables if you need to check whether they are initialized.</a>
-* <a href='/effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields'>CONSIDER work arounds to enable type promotion for nullable fields.</a>
+* <a href='/effective-dart/usage#consider-type-promotion-or-null-check-patterns-for-using-nullable-types'>CONSIDER type promotion or null-check patterns for using nullable types.</a>
 
 **Strings**
 

--- a/src/content/effective-dart/_toc.md
+++ b/src/content/effective-dart/_toc.md
@@ -105,7 +105,7 @@ $ dart run dart_site effective-dart
 * <a href='/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
 * <a href='/effective-dart/usage#dont-use-true-or-false-in-equality-operations'>DON'T use <code>true</code> or <code>false</code> in equality operations.</a>
 * <a href='/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized'>AVOID <code>late</code> variables if you need to check whether they are initialized.</a>
-* <a href='/effective-dart/usage#consider-assigning-a-nullable-field-to-a-local-variable-to-enable-type-promotion'>CONSIDER assigning a nullable field to a local variable to enable type promotion.</a>
+* <a href='/effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields'>CONSIDER assigning a nullable field to a local variable to enable type promotion.</a>
 
 **Strings**
 

--- a/src/content/effective-dart/_toc.md
+++ b/src/content/effective-dart/_toc.md
@@ -105,7 +105,7 @@ the project:
 * <a href='/effective-dart/usage#dont-use-an-explicit-default-value-of-null'>DON'T use an explicit default value of <code>null</code>.</a>
 * <a href='/effective-dart/usage#dont-use-true-or-false-in-equality-operations'>DON'T use <code>true</code> or <code>false</code> in equality operations.</a>
 * <a href='/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized'>AVOID <code>late</code> variables if you need to check whether they are initialized.</a>
-* <a href='/effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields'>CONSIDER assigning a nullable field to a local variable to enable type promotion.</a>
+* <a href='/effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields'>CONSIDER work arounds to enable type promotion for nullable fields.</a>
 
 **Strings**
 

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -340,8 +340,9 @@ Declaring members [private][] and [final][], as we generally recommend, is often
 enough to bypass these limitations. But, that's not always an option.
 
 One pattern to work around type promotion limitations is to use a
-[null-check pattern][] to simultaneously confirm the member's value is not null,
-and bind that value to a new non-nullable variable of the same base type.
+[null-check pattern][]. This simultaneously confirms the member's value
+is not null, and binds that value to a new non-nullable variable of
+the same base type.
 
 <?code-excerpt "usage_good.dart (null-check-promo)"?>
 ```dart tag=good

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -326,7 +326,6 @@ then it probably does make sense to have a separate boolean field.
 
 
 ### CONSIDER work arounds to bypass type promotion limitations
-(or, "...to enable type promotion")
 
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
@@ -356,7 +355,7 @@ class UploadException {
       return 'Could not complete upload to ${response.url} '
           '(error code ${response.errorCode}): ${response.reason}.';
     }
-
+// ···
     return 'Could not upload (no response).';
   }
 }
@@ -375,12 +374,12 @@ class UploadException {
 
   @override
   String toString() {
+    // ···
     final response = this.response;
     if (response != null) {
       return 'Could not complete upload to ${response.url} '
           '(error code ${response.errorCode}): ${response.reason}.';
     }
-
     return 'Could not upload (no response).';
   }
 }

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -8,6 +8,7 @@ prevpage:
   url: /effective-dart/documentation
   title: Documentation
 ---
+<?code-excerpt plaster="none"?>
 <?code-excerpt replace="/([A-Z]\w*)\d\b/$1/g"?>
 <?code-excerpt path-base="misc/lib/effective_dart"?>
 
@@ -325,7 +326,7 @@ Of course, if `null` is a valid initialized value for the variable,
 then it probably does make sense to have a separate boolean field.
 
 
-### CONSIDER work arounds to bypass type promotion limitations
+### CONSIDER work arounds to enable type promotion for nullable fields
 
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it
@@ -355,7 +356,6 @@ class UploadException {
       return 'Could not complete upload to ${response.url} '
           '(error code ${response.errorCode}): ${response.reason}.';
     }
-// ···
     return 'Could not upload (no response).';
   }
 }
@@ -374,7 +374,6 @@ class UploadException {
 
   @override
   String toString() {
-    // ···
     final response = this.response;
     if (response != null) {
       return 'Could not complete upload to ${response.url} '

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -326,7 +326,7 @@ Of course, if `null` is a valid initialized value for the variable,
 then it probably does make sense to have a separate boolean field.
 
 
-### CONSIDER work arounds to enable type promotion for nullable fields
+### CONSIDER type promotion or null-check patterns for using nullable types
 
 Checking that a nullable variable is not equal to `null` promotes the variable
 to a non-nullable type. That lets you access members on the variable and pass it

--- a/src/content/guides/whats-new.md
+++ b/src/content/guides/whats-new.md
@@ -126,7 +126,7 @@ we made the following changes to this site:
 * Reorganized and simplified site infrastructure across the board, in preparation
   to [move away from using Jekyll][].
 
-[type promotion]: /effective-dart/usage#consider-assigning-a-nullable-field-to-a-local-variable-to-enable-type-promotion
+[type promotion]: /effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields
 [Understanding Null Safety]: /null-safety/understanding-null-safety
 [C interop]: /interop/c-interop#native-assets
 [Breaking changes]: /resources/breaking-changes

--- a/src/content/guides/whats-new.md
+++ b/src/content/guides/whats-new.md
@@ -126,7 +126,7 @@ we made the following changes to this site:
 * Reorganized and simplified site infrastructure across the board, in preparation
   to [move away from using Jekyll][].
 
-[type promotion]: /effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields
+[type promotion]: /effective-dart/usage#consider-type-promotion-or-null-check-patterns-for-using-nullable-types
 [Understanding Null Safety]: /null-safety/understanding-null-safety
 [C interop]: /interop/c-interop#native-assets
 [Breaking changes]: /resources/breaking-changes


### PR DESCRIPTION
Fixes #5666 

**Staged:** https://dart-dev--pr5679-null-check-wujb9sng.web.app/effective-dart/usage#consider-work-arounds-to-enable-type-promotion-for-nullable-fields