### PR TITLE
Fix the code sample from dart web get started guide

### DIFF
--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -124,9 +124,9 @@ Let's customize the app you just created.
 
    void main() {
     final output = querySelector('#output');
-    [!for (final item in thingsTodo()) {
-      output?.appendChild(newLI(item));
-    }!]
+    [!for (final item in thingsTodo()) {!]
+      [!output?.appendChild(newLI(item));!]
+    [!}!]
   }
    ```
 

--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -105,29 +105,29 @@ Let's customize the app you just created.
    It creates a new `LIElement` containing the specified `String`.
 
    ```dart
-   Iterable<String> thingsTodo() sync* { ... }
+   Iterable<String> thingsTodo() sync* { /* ... */ }
 
    [!HTMLLIElement newLI(String itemText) =>!]
      [!(document.createElement('li') as HTMLLIElement)..text = itemText;!]
     
-   void main() { ... }
+   void main() { /* ... */ }
    ```
 
-3. In the `main()` function, append content to the `output` element using
-   `thingsTodo()`:
+3. In the `main()` function, append content to the `output` element
+   using `appendChild` and the values from `thingsTodo()`:
 
    ```dart
-   Iterable<String> thingsTodo() sync* { ... }
+   Iterable<String> thingsTodo() sync* { /* ... */ }
 
    HTMLLIElement newLI(String itemText) =>
-    (document.createElement('li') as HTMLLIElement)..text = itemText;
+     (document.createElement('li') as HTMLLIElement)..text = itemText;
 
    void main() {
     final output = querySelector('#output');
     [!for (final item in thingsTodo()) {!]
       [!output?.appendChild(newLI(item));!]
     [!}!]
-  }
+   }
    ```
 
 4. Save your changes.

--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -107,22 +107,27 @@ Let's customize the app you just created.
    ```dart
    Iterable<String> thingsTodo() sync* { ... }
 
-   [!LIElement newLI(String itemText) => LIElement()..text = itemText;!]
-
+   [!HTMLLIElement newLI(String itemText) =>
+    (document.createElement('li') as HTMLLIElement)..text = itemText;!]
+    
    void main() { ... }
    ```
 
-3. In the `main()` function, initialize the `output` element using
+3. In the `main()` function, append content to the `output` element using
    `thingsTodo()`:
 
    ```dart
    Iterable<String> thingsTodo() sync* { ... }
 
-   LIElement newLI(String itemText) => LIElement()..text = itemText;
+   HTMLLIElement newLI(String itemText) =>
+    (document.createElement('li') as HTMLLIElement)..text = itemText;
 
    void main() {
-     querySelector('#output')?[!.children.addAll(thingsTodo().map(newLI));!]
-   }
+    final output = querySelector('#output');
+    [!for (final item in thingsTodo()) {
+      output?.appendChild(newLI(item));
+    }!]
+  }
    ```
 
 4. Save your changes.

--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -107,8 +107,8 @@ Let's customize the app you just created.
    ```dart
    Iterable<String> thingsTodo() sync* { ... }
 
-   [!HTMLLIElement newLI(String itemText) =>
-    (document.createElement('li') as HTMLLIElement)..text = itemText;!]
+   [!HTMLLIElement newLI(String itemText) =>!]
+     [!(document.createElement('li') as HTMLLIElement)..text = itemText;!]
     
    void main() { ... }
    ```


### PR DESCRIPTION
I have discovered that the dart web [get started](https://dart.dev/web/get-started) code example does not match the new dart:web interface. Therefore I have updated the documentation.

Fixes: There is no specific issue, but it certainly helps #5674 and #5525

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
