### PR TITLE
Fix 404 page missing from site

### DIFF
--- a/src/content/404.html
+++ b/src/content/404.html
@@ -3,7 +3,9 @@ layout: error
 title: "404: Page not found"
 description: "dart.dev's 404 page."
 sitemap: false
+permalink: /404.html
 ---
+
 <div class="text-center">
   <h1>404</h1>
   <h2>Page not found</h2>


### PR DESCRIPTION
After https://github.com/dart-lang/site-www/commit/faa3ca3ad31e374f3a6573403c092fea107ac535, the 404 page was generating but being placed in a folder instead of in the root directory, causing it to not be found.

Before fix: https://dart.dev/parker-is-cool
After fix: https://dart-dev--pr5707-fix-404-missing-9rfsj1qx.web.app/parker-is-cool