### PR TITLE
Provide more details on error when Markdown code block is misformatted

### DIFF
--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -46,6 +46,12 @@ export async function configureHighlighting(markdown) {
     const token = tokens[index];
 
     const splitTokenInfo = token.info.match(/(\S+)\s?(.*?)$/m);
+
+    if (!splitTokenInfo) {
+      throw new Error('Each Markdown code block should specify a language ' +
+          'after the opening backticks like: ```dart.');
+    }
+
     const language = splitTokenInfo.length > 1 ? splitTokenInfo[1] : '';
     const attributes = splitTokenInfo.length > 2 ? splitTokenInfo[2] : '';
 


### PR DESCRIPTION
@MaryaBelanger I believe https://github.com/dart-lang/site-www/issues/5732 is caused by a code block without a language specified in your local branch in the `/src/content/language/macros.md` file. This PR makes that more obvious by providing an error explaining that.

I'll follow-up with a better error message, but wanted to make sure this actually was the issue you're facing. I'm also open to changing the requirement of a language if that's helpful or important to you. Thanks!