### PR TITLE
Fix typo in language/macros.md

### DIFF
--- a/src/content/language/macros.md
+++ b/src/content/language/macros.md
@@ -270,7 +270,7 @@ Within the body of the macro declaration is where you define the code you want
 the macro to [generate](#view-the-generated-code), as well as any
 [diagnostics](#trigger-custom-diagnostics) you want the macro to emit.
 
-At a very high-level, writing macros essentially work by using builder methods
+At a very high-level, writing macros essentially works by using builder methods
 to piece together the *properties* of a declaration with *identifiers* on those
 properties. The macro gathers this information through deep [introspection][] of
 the program.


### PR DESCRIPTION
Incorrect: "[...] writing macros essentially work by [...]".

Correct: "[...] writing macros essentially works by [...]"

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.