### PR TITLE
Adjusted proposal for grammar-like code block on extension page

### DIFF
--- a/src/content/language/extension-methods.md
+++ b/src/content/language/extension-methods.md
@@ -197,8 +197,8 @@ to avoid a name conflict when invoking an extension explicitly.
 Use the following syntax to create an extension:
 
 ```plaintext
-extension <extension name> on <type> { // extension-name is optional
-  (<member definition>) // can provide one or more member-definitions
+extension <extension name>? on <type> { // <extension-name> is optional
+  (<member definition>)* // Can provide one or more <member definition>.
 }
 ```
 


### PR DESCRIPTION
Follow-up proposal to https://github.com/dart-lang/site-www/pull/5856:

_Copying my thoughts from https://github.com/dart-lang/site-www/pull/5856#discussion_r1610519500:_

> @MaryaBelanger Can we keep the original symbols as well as the comments? Otherwise to those that are familiar with the syntax or skim past the comments, it might look like only one member definition is allowed.
> 
> With both the syntax and the comments, all readers are accounted for, plus the readers may become more familiar with the syntax as a result :) 