### PR TITLE
Link `prefer_const_constructors` with related Effective Dart

### DIFF
--- a/src/content/effective-dart/design.md
+++ b/src/content/effective-dart/design.md
@@ -687,6 +687,8 @@ constructors*.
 
 ### CONSIDER making your constructor `const` if the class supports it
 
+{% render 'linter-rule-mention.md', rules:'prefer_const_constructors' %}
+
 If you have a class where all the fields are final, and the constructor does
 nothing but initialize them, you can make that constructor `const`. That lets
 users create instances of your class in places where constants are


### PR DESCRIPTION
Links the Effect Dart entry "CONSIDER making your constructor const if the class supports it" to the `prefer_const_constructors` lint.

Section staged here: https://dart-dev--pr5862-const-lint-aiwlnawg.web.app/effective-dart/design#consider-making-your-constructor-const-if-the-class-supports-it