### PR TITLE
Fix arrow symbol typo in the functions.md

### DIFF
--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -49,7 +49,7 @@ The <code>=> <em>expr</em></code> syntax is a shorthand for
 is sometimes referred to as _arrow_ syntax.
 
 :::note
-Only _expressions_ can appear between the arrow (`=\>`) and the semicolon (`;`).
+Only _expressions_ can appear between the arrow (`=>`) and the semicolon (`;`).
 Expressions evaluate to values.
 This means that you can't write a statement where Dart expects a value.
 For example,


### PR DESCRIPTION
In the first note, in the first sentence, the arrow symbol is written as '=\\>'. The backslash character must be removed.