### PR TITLE
Fix incorrect optimization of gifs

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -126,7 +126,7 @@ export default function (eleventyConfig) {
     // Save in `_site/assets/img` and update links to there.
     eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
       extensions: 'html',
-      formats: ['avif', 'webp', 'png', 'svg'],
+      formats: ['webp', 'png', 'svg'],
       svgShortCircuit: true,
       widths: ['auto'],
       defaultAttributes: {
@@ -135,6 +135,10 @@ export default function (eleventyConfig) {
       },
       urlPath: '/assets/img/',
       outputDir: '_site/assets/img/',
+      sharpOptions: {
+        animated: true,
+        limitInputPixels: false,
+      },
     });
   } else {
     // To be more consistent with the production build,
@@ -150,6 +154,10 @@ export default function (eleventyConfig) {
       },
       urlPath: '/assets/img/',
       outputDir: '_site/assets/img/',
+      sharpOptions: {
+        animated: true,
+        limitInputPixels: false,
+      },
     });
   }
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -137,7 +137,6 @@ export default function (eleventyConfig) {
       outputDir: '_site/assets/img/',
       sharpOptions: {
         animated: true,
-        limitInputPixels: false,
       },
     });
   } else {
@@ -156,7 +155,6 @@ export default function (eleventyConfig) {
       outputDir: '_site/assets/img/',
       sharpOptions: {
         animated: true,
-        limitInputPixels: false,
       },
     });
   }


### PR DESCRIPTION
This was causing gifs to lose their animation such as on https://dart.dev/language/macros, as the gif to avif conversion is currently not functional.