### PR TITLE
Update abstract class example in class-modifiers.md

### DIFF
--- a/src/content/language/class-modifiers.md
+++ b/src/content/language/class-modifiers.md
@@ -66,7 +66,7 @@ an outside library. Abstract classes often have [abstract methods][].
 <?code-excerpt "language/lib/class_modifiers/ex1/a.dart"?>
 ```dart title="a.dart"
 abstract class Vehicle {
-  void moveForward(int meters);
+  void moveForward(int meters){}
 }
 ```
 


### PR DESCRIPTION
The example for abstract classes has an issue. I think it's a typo. The extending class `Car` does not override the abstract method `moveForward` from abstract class `Vehicle`. So I just made the method `moveForward` a normal method rather than abstract method that it was. If suggested, I can also change the `Car` class to implement the original abstract `moveForward` method. But I think making it normal, will clarify the difference between `extends` and `implements`. 

Fixes <Replace with issue link>

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
