### PR TITLE
Update class-modifiers.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules
 pubspec.lock
 package-lock.json
 tmp
-.vscode
 
 # Misc
 trash

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules
 pubspec.lock
 package-lock.json
 tmp
+.vscode
 
 # Misc
 trash

--- a/examples/language/lib/class_modifiers/ex1/b.dart
+++ b/examples/language/lib/class_modifiers/ex1/b.dart
@@ -6,15 +6,16 @@ import 'a.dart';
 // Error: Can't be constructed.
 Vehicle myVehicle = Vehicle();
 
+
 // Can be extended.
 class Car extends Vehicle {
   int passengers = 4;
-  // #enddocregion abstract-usages
+  
   @override
   void moveForward(int meters) {
     // ...
   }
-  // #docregion abstract-usages
+  
 }
 
 // Can be implemented.

--- a/examples/language/lib/class_modifiers/ex1/b.dart
+++ b/examples/language/lib/class_modifiers/ex1/b.dart
@@ -6,16 +6,14 @@ import 'a.dart';
 // Error: Can't be constructed.
 Vehicle myVehicle = Vehicle();
 
-
 // Can be extended.
 class Car extends Vehicle {
   int passengers = 4;
-  
+
   @override
   void moveForward(int meters) {
     // ...
   }
-  
 }
 
 // Can be implemented.

--- a/src/content/language/class-modifiers.md
+++ b/src/content/language/class-modifiers.md
@@ -80,7 +80,7 @@ Vehicle myVehicle = Vehicle();
 // Can be extended.
 class Car extends Vehicle {
   int passengers = 4;
-  
+
   @override
   void moveForward(int meters) {
     // ...

--- a/src/content/language/class-modifiers.md
+++ b/src/content/language/class-modifiers.md
@@ -80,7 +80,11 @@ Vehicle myVehicle = Vehicle();
 // Can be extended.
 class Car extends Vehicle {
   int passengers = 4;
-  // ···
+  
+  @override
+  void moveForward(int meters) {
+    // ...
+  }
 }
 
 // Can be implemented.


### PR DESCRIPTION
The example for abstract classes has an issue. I think it's a typo. The extending class `Car` does not override the abstract method moveForward from abstract class Vehicle. So I just override the method `moveForward` in class `Car`. It was already implement in the code excerpts at [here](https://github.com/dart-lang/site-www/blob/8288d78e4013437f4a498b62fbcbc3a682405aec/examples/language/lib/class_modifiers/ex1/b.dart#L14C2-L16C4)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
