### PR TITLE
Update GitHub links on SDK page

### DIFF
--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -50,5 +50,5 @@ go to [the SDK issue tracker][sdk-issues].
 [Dart libraries]: /libraries
 [flutter]: {{site.flutter-docs}}/get-started/install
 [site SDK version]: {{site.dart-api}}/{{site.sdkInfo.channel}}/{{site.sdkInfo.version}}/index.html
-[readme]: ({{site.repo.dart.sdk}}/blob/main/README.dart-sdk)
-[sdk-issues]: ({{site.repo.dart.sdk}}/issues)
+[readme]: {{site.repo.dart.sdk}}/blob/main/README.dart-sdk
+[sdk-issues]: {{site.repo.dart.sdk}}/issues


### PR DESCRIPTION
Fixes #5942 

Links at the bottom of the page were formatted as inline Markdown links instead of reference links.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
