### PR TITLE
Changed skip to physical button

### DIFF
--- a/src/_sass/_site.scss
+++ b/src/_sass/_site.scss
@@ -877,12 +877,19 @@ div.tabs__content h1, h2, h3, h4, h5, h6 {
 }
 
 #skip {
-  position: absolute;
-  top: -1000%;
-  left: -1000%;
-}
-
-#skip:focus {
   top: 10px;
   left: 10px;
+  position: absolute;
+  z-index: $site-z-skip;
+  padding: 1rem;
+  background-color: $site-color-primary;
+  color: $site-color-white;
+  border-radius: 0.5rem;
+  transform: translateY(-5rem);
+}
+
+
+#skip:focus {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/src/_sass/core/_variables.scss
+++ b/src/_sass/core/_variables.scss
@@ -24,9 +24,10 @@ $site-color-footer: $site-color-dark-background;
 $site-color-primary: $flutter-color-blue-500;
 
 // Layer stack
-$site-z-header: 10000;
+$site-z-header: 1000;
 $site-z-footer: 99;
 $site-z-snackbar: 150;
+$site-z-skip: 2000;
 $hero-layer-1-z: 40;
 $hero-layer-2-z: 41;
 $hero-layer-3-z: 42;


### PR DESCRIPTION
The first PR (https://github.com/dart-lang/site-www/pull/5894) covered an undisplayed link. Per best practices for a11y, this button should be visible. Using https://github.com/flutter/website/pull/10800 as the guideline.

Fixes #5948