### PR TITLE
Extended examples for getters and setters in methods.md

### DIFF
--- a/src/content/examples/example_synthetic_field.dart
+++ b/src/content/examples/example_synthetic_field.dart
@@ -1,0 +1,32 @@
+// example_synthetic_field.dart
+import 'dart:math';
+
+class ExampleSyntheticField {
+  double angle = 0.0;
+
+  static double _canonicalize(double x) {
+    if (x >= 0.0) {
+      return x.remainder(2.0 * pi);
+    } else {
+      return 2 * pi + x.remainder(2.0 * pi);
+    }
+  }
+
+  double get opposite => _canonicalize(angle + pi);
+  set opposite(double x) => angle = _canonicalize(x - pi);
+}
+
+void main() {
+  final obj = ExampleSyntheticField();
+
+  obj.angle = 0.5 * pi;
+  print("The opposite of ${obj.angle / pi} π is ${obj.opposite / pi} π");
+
+  obj.opposite = 0.5 * pi;
+  print(
+      "If the opposite is ${obj.opposite / pi} π, the angle is ${obj.angle / pi} π");
+
+  obj.opposite += 0.25 * pi;
+  print(
+      "If the opposite is ${obj.opposite / pi} π, the angle is ${obj.angle / pi} π");
+}

--- a/src/content/examples/point_example.dart
+++ b/src/content/examples/point_example.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+class Point {
+  final double x;
+  final double y;
+
+  // Constructor initializes x and y instance variables.
+  Point(this.x, this.y);
+
+  // Method to calculate the distance to another point.
+  double distanceTo(Point other) {
+    var dx = x - other.x;
+    var dy = y - other.y;
+    return sqrt(dx * dx + dy * dy);
+  }
+}
+
+void main() {
+  // Create two points.
+  var point1 = Point(0, 0);
+  var point2 = Point(3, 4);
+
+  // Calculate the distance between point1 and point2.
+  var distance = point1.distanceTo(point2);
+
+  // Print the distance.
+  print('Distance between point1 and point2: $distance');
+}

--- a/src/content/examples/rectangle_example.dart
+++ b/src/content/examples/rectangle_example.dart
@@ -1,0 +1,22 @@
+// rectangle_example.dart
+class Rectangle {
+  double left, top, width, height;
+
+  Rectangle(this.left, this.top, this.width, this.height);
+
+  double get right => left + width;
+  set right(double value) => left = value - width;
+
+  double get bottom => top + height;
+  set bottom(double value) => top = value - height;
+}
+
+void main() {
+  var rect = Rectangle(3, 4, 20, 15);
+
+  print(
+      'Left: ${rect.left}, Right: ${rect.right}'); // Should print Left: 3.0, Right: 23.0
+  rect.right = 12;
+  print(
+      'Updated Left: ${rect.left}, Right: ${rect.right}'); // Should print Updated Left: -8.0, Right: 12.0
+}

--- a/src/content/examples/vector_example.dart
+++ b/src/content/examples/vector_example.dart
@@ -1,0 +1,30 @@
+// vector_example.dart
+class Vector {
+  final int x, y;
+
+  Vector(this.x, this.y);
+
+  Vector operator +(Vector v) => Vector(x + v.x, y + v.y);
+  Vector operator -(Vector v) => Vector(x - v.x, y - v.y);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Vector && x == other.x && y == other.y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+}
+
+void main() {
+  final v1 = Vector(2, 3);
+  final v2 = Vector(2, 2);
+
+  final sum = v1 + v2;
+  final difference = v1 - v2;
+
+  print('Sum of vectors: (${sum.x}, ${sum.y})'); // Should print (4, 5)
+  print(
+      'Difference of vectors: (${difference.x}, ${difference.y})'); // Should print (0, 1)
+
+  print('Vectors equal: ${v1 == Vector(2, 3)}'); // Should print true
+}

--- a/src/content/language/methods.md
+++ b/src/content/language/methods.md
@@ -126,7 +126,113 @@ void main() {
   rect.right = 12;
   assert(rect.left == -8);
 }
+class Example {
+  int a;
+  int _b;
+  final int c;
+  static int d = 1000;
+
+  Example(this.a, this._b, this.c);
+}
+
+void handleExample() {
+  final ex = Example(1, 2, 3);
+  final v = ex.a; // Getter for 'a'
+  ex.a = 10;      // Setter for 'a'
+  ex.a++;         // Increment 'a'
+  assert(ex.a == 11);
+
+  final u = ex._b; // Getter for '_b' (private to library)
+  ex._b = 20;      // Setter for '_b'
+  assert(ex._b == 20);
+
+  final w = ex.c; // Getter for 'c' (final field)
+  // ex.c = 10; // Error: 'c' is final
+
+  final z = Example.d; // Static getter for 'd'
+  Example.d = 10;      // Static setter for 'd'
+  Example.d++;
+  assert(Example.d == 11);
+}
+//fautly examples
+/*
+These examples illustrate common mistakes when using getters and setters. They show how attempting to use methods as getters or setters, or vice versa, results in errors.
+*/
+class ExampleFaulty extends Example {
+  ExampleFaulty(super.a, super._b, super.c);
+
+  int a() {
+    return a; // Error: Cannot use method as a getter
+  }
+
+  void a(int x) {
+    a = x; // Error: Cannot use method as a setter
+  }
+}
+//java style getters and setters
+/*This example demonstrates a Java-style approach to getters and setters. Instead of using Dart's get and set keywords, methods are used to achieve similar functionality. This style is not typical in Dart but is shown here for comparison.*/
+class ExampleJavaStyleGetterSetter extends Example {
+  ExampleJavaStyleGetterSetter(super.a, super._b, super.c);
+
+  int getA() {
+    return a;
+  }
+
+  void setA(int x) {
+    a = x;
+  }
+}
+//over riding getters and setters
+class ExampleOverrideGetterSetterOfA1 extends Example {
+  ExampleOverrideGetterSetterOfA1(super.a, super._b, super.c);
+
+  set a(int x) => a = x;
+  int get a => a;
+}
+
+class ExampleOverrideAccessorsOfA2 extends Example {
+  ExampleOverrideAccessorsOfA2(super.a, super._b, super.c);
+
+  set a(int x) {
+    print("Setter for 'a' called");
+    a = x;
+  }
+
+  int get a {
+    print("Getter for 'a' called");
+    return a;
+  }
+}
+//synthetic field example
+class ExampleSyntheticField {
+  double angle = 0.0;
+
+  static double _canonicalize(double x) {
+    if (x >= 0.0) {
+      return x.remainder(2.0 * pi);
+    } else {
+      return 2 * pi + x.remainder(2.0 * pi);
+    }
+  }
+
+  double get opposite => _canonicalize(angle + pi);
+  set opposite(double x) => angle = _canonicalize(x - pi);
+}
+
+void handleExampleSyntheticField() {
+  final obj = ExampleSyntheticField();
+  obj.angle = 0.5 * pi;
+  print("The opposite of ${obj.angle / pi} π is ${obj.opposite / pi} π");
+  obj.opposite = 0.5 * pi;
+  print("If the opposite is ${obj.opposite / pi} π, the angle is ${obj.angle / pi} π");
+  obj.opposite += 0.25 * pi;
+  print("If the opposite is ${obj.opposite / pi} π, the angle is ${obj.angle / pi} π");
+}
+
+
 ```
+
+
 
 With getters and setters, you can start with instance variables, later
 wrapping them with methods, all without changing client code.


### PR DESCRIPTION
### Description of Changes

This pull request addresses issue #5759 

At https://dart.dev/language/methods#getters-and-setters we read about getters and setters but the text feels much too short and the example could be extended (the example code also does not really tell a good story, IMHO).

I have added more examples to illustrate various setter/getter "do's" and "don'ts" (including one involving a final field that creates a recursive call). Especially for people coming from Java, this is helpful.

**New Examples Added:**
- `point_example.dart`
- `vector_example.dart`
- `rectangle_example.dart`
- `example_synthetic_field.dart`

**Updated `methods.md`:**
- Added new sections with detailed examples and explanations.

Please review the changes and merge if appropriate.
