### PR TITLE
Fix missing whitespace

### DIFF
--- a/src/content/tools/pub/publishing.md
+++ b/src/content/tools/pub/publishing.md
@@ -511,7 +511,7 @@ Once you discontinue a package, the package will:
 To mark a package as discontinued:
 
 1. Sign in to pub.dev using a Google Account with uploader or
-   [verified publisher][]permissions for the package.
+   [verified publisher][] permissions for the package.
 
 1. Navigate to the package's **Admin** tab.
 


### PR DESCRIPTION
Looks like we're missing a space:
![image](https://github.com/user-attachments/assets/7f1b5aa1-291c-4b22-a0c6-f37e2711f9f2)
