### PR TITLE
Add section on exporting members in usage

### DIFF
--- a/src/content/interop/js-interop/mock.md
+++ b/src/content/interop/js-interop/mock.md
@@ -98,8 +98,8 @@ void main() {
 `@JSExport` allows you to declare a class that can be used in
 `createJSInteropWrapper`. `createJSInteropWrapper` will create an object literal
 that maps each of the class' instance member names (or renames) to a JS
-callback, which is created using [`Function.toJS`]. This JS callback then calls
-the instance member when called. In the above example, getting and setting
+callback, which is created using [`Function.toJS`]. When called, the JS callback
+will in turn call the instance member. In the above example, getting and setting
 `counter.value` gets and sets `fakeCounter.value`.
 
 You can specify only some members of a class to be exported by omitting the

--- a/src/content/interop/js-interop/mock.md
+++ b/src/content/interop/js-interop/mock.md
@@ -97,9 +97,10 @@ void main() {
 
 `@JSExport` allows you to declare a class that can be used in
 `createJSInteropWrapper`. `createJSInteropWrapper` will create an object literal
-that maps each of the class' instance member names (or renames) to a JS callback
-that triggers the instance member when called. In the above example, getting and
-setting `counter.value` gets and sets `fakeCounter.value`.
+that maps each of the class' instance member names (or renames) to a JS
+callback, which is created using [`Function.toJS`]. This JS callback then calls
+the instance member when called. In the above example, getting and setting
+`counter.value` gets and sets `fakeCounter.value`.
 
 You can specify only some members of a class to be exported by omitting the
 annotation from the class and instead only annotate the specific members. You
@@ -117,6 +118,7 @@ non-instance members unless the user explicitly replaces the real API in JS.
 
 [Usage]: /interop/js-interop/usage
 [`createJSInteropWrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/createJSInteropWrapper.html
+[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
 [`@JSExport`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSExport-class.html
 [limitation is true for extension members]: {{site.repo.dart.org}}/mockito/blob/master/FAQ.md#how-do-i-mock-an-extension-method
 [extension types]: /language/extension-types

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -389,14 +389,13 @@ but can often be elided on and within interop types and on extension members as
 the compiler can tell it is a JS interop type from the representation type and
 on-type.
 
-## Exporting Dart code to JS
+## Exporting Dart functions and objects to JS
 
 The above sections show how to call JS members from Dart. It's also useful to
-*export* Dart code so that it can be used in JS. The mechanism to do this
-involves exporting Dart functions, which requires a conversion like
-[`Function.toJS`] that wraps the Dart function with a JS function. Once
-converted, we can pass the resulting JS function to JS through an interop
-member, which can then be called later in JS.
+*export* Dart code so that it can be used in JS. To export a Dart function to
+JS, first convert it using [`Function.toJS'], which wraps the Dart function with
+a JS function. Then, pass the wrapped function to JS through an interop member.
+At that point, it's ready to be called by other JS code.
 
 For example, this code converts a Dart function and uses interop to set it in a
 global property, which is then called in JS:
@@ -424,11 +423,10 @@ Functions that are exported this way have type [restrictions] similar to those
 of interop members.
 
 Sometimes it's useful to export an entire Dart interface so that JS can interact
-with a Dart object instead of individual functions. In order to do this, the
-class should be marked as exportable using [`@JSExport`] and an instance of that
-class should be wrapped using [`createJSInteropWrapper`]. For a more detailed
-look on how to do that and how it can be used to mock JS values, see the
-[mocking tutorial].
+with a Dart object. To do this, mark the Dart class as exportable using
+[`@JSExport`] and wrap instances of that class using [`createJSInteropWrapper`].
+For a more detailed explanation of this technique, including how to mock JS
+values, see the [mocking tutorial].
 
 ## `dart:js_interop` and `dart:js_interop_unsafe`
 

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -393,7 +393,7 @@ on-type.
 
 The above sections show how to call JS members from Dart. It's also useful to
 *export* Dart code so that it can be used in JS. To export a Dart function to
-JS, first convert it using [`Function.toJS'], which wraps the Dart function with
+JS, first convert it using [`Function.toJS`], which wraps the Dart function with
 a JS function. Then, pass the wrapped function to JS through an interop member.
 At that point, it's ready to be called by other JS code.
 

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -389,6 +389,47 @@ but can often be elided on and within interop types and on extension members as
 the compiler can tell it is a JS interop type from the representation type and
 on-type.
 
+## Exporting Dart code to JS
+
+The above sections show how to call JS members from Dart. It's also useful to
+*export* Dart code so that it can be used in JS. The mechanism to do this
+involves exporting Dart functions, which requires a conversion like
+[`Function.toJS`] that wraps the Dart function with a JS function. Once
+converted, we can pass the resulting JS function to JS through an interop
+member, which can then be called later in JS.
+
+For example, this code converts a Dart function and uses interop to set it in a
+global property, which is then called in JS:
+
+```dart
+import 'dart:js_interop';
+
+@JS()
+external set exportedFunction(JSFunction value);
+
+void printString(JSString string) {
+  print(string.toDart);
+}
+
+void main() {
+  exportedFunction = printString.toJS;
+}
+```
+
+```JS
+globalThis.exportedFunction('hello world');
+```
+
+Functions that are exported this way have type [restrictions] similar to those
+of interop members.
+
+Sometimes it's useful to export an entire Dart interface so that JS can interact
+with a Dart object instead of individual functions. In order to do this, the
+class should be marked as exportable using [`@JSExport`] and an instance of that
+class should be wrapped using [`createJSInteropWrapper`]. For a more detailed
+look on how to do that and how it can be used to mock JS values, see the
+[mocking tutorial].
+
 ## `dart:js_interop` and `dart:js_interop_unsafe`
 
 [`dart:js_interop`] contains all the necessary members you should need,
@@ -443,6 +484,10 @@ TODO: Some of these are not available on stable. How do we link to dev?
 [property accessors]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation
 [utility functions]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyOperatorExtension.html
 [`@JS()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JS-class.html
+[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`@JSExport`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSExport-class.html
+[`createJSInteropWrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/createJSInteropWrapper.html
+[mocking tutorial]: /interop/js-interop/mock
 [`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop
 [`globalContext`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/globalContext.html
 [Helpers to inspect the type of JS values]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension.html

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -416,7 +416,7 @@ void main() {
 }
 ```
 
-```JS
+```js
 globalThis.exportedFunction('hello world');
 ```
 


### PR DESCRIPTION
Addresses https://github.com/dart-lang/sdk/issues/56327#issuecomment-2257230135

Being able to call Dart code from JS is a common
use case (e.g. event listeners). We should add a
section that shows how to export functions and
links to our section on exporting entire Dart
instances.