### PR TITLE
Explain that `platforms` precedes flutter plugin declaration

### DIFF
--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -298,7 +298,7 @@ platforms:
   macos:
 ```
 
-:::If you use Flutter
+:::note If you use Flutter
 Flutter plugins platform support is by default derived from the
 [plugin declarations][].
 

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -298,9 +298,13 @@ platforms:
   macos:
 ```
 
-:::flutter-note
-Flutter plugins use [plugin declarations][]
-instead of this field.
+:::
+flutter-note Flutter plugins platform support is by default derived from the
+[plugin declarations][].
+
+If there is a discrepancy between the plugin declaration and the actual platform
+support, a top-level `platforms` declaration can still be used and takes
+precedence over the Flutter plugin declaration when deciding platform support.
 :::
 
 :::version-note

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -298,8 +298,8 @@ platforms:
   macos:
 ```
 
-:::
-flutter-note Flutter plugins platform support is by default derived from the
+:::If you use Flutter
+Flutter plugins platform support is by default derived from the
 [plugin declarations][].
 
 If there is a discrepancy between the plugin declaration and the actual platform


### PR DESCRIPTION
https://github.com/dart-lang/pub-dev/issues/7884