### PR TITLE
Fix occurrences of superfluous `*`

### DIFF
--- a/src/content/tools/pub/automated-publishing.md
+++ b/src/content/tools/pub/automated-publishing.md
@@ -101,12 +101,12 @@ on:
   push:
     tags:
     # must align with the tag-pattern configured on pub.dev, often just replace
-      # {% raw %}{{version}}{% endraw %} with [0-9]+.[0-9]+.[0-9]+*
-    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v{% raw %}{{version}}{% endraw %}'
+      # {% raw %}{{version}}{% endraw %} with [0-9]+.[0-9]+.[0-9]+
+    - 'v[0-9]+.[0-9]+.[0-9]+' # tag-pattern on pub.dev: 'v{% raw %}{{version}}{% endraw %}'
     # If you prefer tags like '1.2.3', without the 'v' prefix, then use:
-    # - '[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: '{% raw %}{{version}}{% endraw %}'
+    # - '[0-9]+.[0-9]+.[0-9]+' # tag-pattern on pub.dev: '{% raw %}{{version}}{% endraw %}'
     # If your repository contains multiple packages consider a pattern like:
-    # - 'my_package_name-v[0-9]+.[0-9]+.[0-9]+*'
+    # - 'my_package_name-v[0-9]+.[0-9]+.[0-9]+'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:
@@ -145,7 +145,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag pattern on pub.dev: 'v{% raw %}{{version}{% endraw %}'
+    - 'v[0-9]+.[0-9]+.[0-9]+' # tag pattern on pub.dev: 'v{% raw %}{{version}{% endraw %}'
 
 # Publish using custom workflow
 jobs:
@@ -260,7 +260,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+*' # for tags like: 'v1.2.3'
+    - 'v[0-9]+.[0-9]+.[0-9]+' # for tags like: 'v1.2.3'
 
 jobs:
   publish:


### PR DESCRIPTION
Fix occurrences of superfluous `*` in regex `v[0-9]+.[0-9]+.[0-9]+*`

In [GitHub's documentation for Patterns to match branches and tags](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags), GitHub gives the example:

```
v[12].[0-9]+.[0-9]+
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
