### PR TITLE
Fix: Bug in dart_site/check_link_references tool during matching

### DIFF
--- a/tool/dart_site/lib/src/commands/check_link_references.dart
+++ b/tool/dart_site/lib/src/commands/check_link_references.dart
@@ -136,7 +136,7 @@ final _pullRequestTitlePattern = RegExp(
 /// by @craiglabenz in https://github.com/flutter/flutter/pull/100316</li>
 /// ```
 final _pullRequestTitleInListItemPattern = RegExp(
-  r'<li>.*? in.*?https://github.com/.*?/pull/.*?</li>',
+  r'<li>(?:(?!<li>).)*?in\s+(?:<a[^>]*?href="https://github\.com/[^/]+/[^/]+/pull/\d+">[\d]+</a>|https://github\.com/[^/]+/[^/]+/pull/\d+)(?:(?!<li>).)*?</li>',
   dotAll: true,
 );
 


### PR DESCRIPTION
ref https://github.com/flutter/website/pull/11111

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
