### PR TITLE
fix: typo in concurrency.md

### DIFF
--- a/src/content/language/concurrency.md
+++ b/src/content/language/concurrency.md
@@ -74,7 +74,7 @@ For example, consider making a network request:
 ```dart
 http.get('https://example.com').then((response) {
   if (response.statusCode == 200) {
-    print('Success!')'
+    print('Success!');
   }  
 }
 ```


### PR DESCRIPTION
In network request code example ' is typed instead of ;

Fixes - typo
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.