### PR TITLE
yellow is not a primary colour

### DIFF
--- a/src/content/language/patterns.md
+++ b/src/content/language/patterns.md
@@ -192,7 +192,7 @@ body in switch expressions or statements:
 <?code-excerpt "language/lib/patterns/switch.dart (or-share-body)"?>
 ```dart
 var isPrimary = switch (color) {
-  Color.red || Color.yellow || Color.blue => true,
+  Color.red || Color.green || Color.blue => true,
   _ => false
 };
 ```


### PR DESCRIPTION
Changed yellow to green, as yellow is not a primary color, so the example is wrong


