### PR TITLE
Remove JetBrains Space from Dart package repositories as a service section in custom-package-repositories

### DIFF
--- a/src/content/tools/pub/custom-package-repositories.md
+++ b/src/content/tools/pub/custom-package-repositories.md
@@ -215,10 +215,6 @@ your own custom package repository:
 <li>
   <img src="/assets/img/tools/proget.svg" class="list-image" alt="Inedo ProGet logo">
   <a href="https://docs.inedo.com/docs/proget/feeds/pub"><b>Inedo ProGet</b></a>
-</li>  
-<li>
-  <img src="/assets/img/tools/jetbrains-space.svg" class="list-image" alt="JetBrains Space logo">
-  <a href="https://www.jetbrains.com/help/space/dart-package-repository.html"><b>JetBrains Space</b></a>
 </li>
 <li>
   <img src="/assets/img/tools/jfrog.svg" class="list-image" alt="JFrog logo">


### PR DESCRIPTION
Given JetBrains Space's pivot to [SpaceCode](https://blog.jetbrains.com/space/2024/05/27/the-future-of-space/), which will not include package management functionality as confirmed in the [official migration documentation](https://www.jetbrains.com/help/space/migrate-from-space-to-spacecode.html#what-will-not-stay-in-spacecode), SpaceCode should no longer be recommended for teams or projects that require integrated package management solutions.

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
