### PR TITLE
Update documentation for generative constructor with optional positio…

### DIFF
--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -6,12 +6,12 @@
 ///
 // #docregion idiomatic-constructor
 class Point {
-  // Initializer list of variables and values
-  double x = 2.0;
-  double y = 2.0;
+  // Instance variables to hold the coordinates of the point.
+  double x;
+  double y;
 
-  // Generative constructor with initializing formal parameters:
-  Point(this.x, this.y);
+  // Generative constructor with optional positional parameters and default values.
+  Point([this.x = 2.0, this.y = 2.0]);
   // #enddocregion idiomatic-constructor
 
   // #docregion initializer-list

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -10,8 +10,8 @@ class Point {
   double x;
   double y;
 
-  // Generative constructor with optional positional parameters and default values.
-  Point([this.x = 2.0, this.y = 2.0]);
+  // Generative constructor with initializing formal parameters:
+  Point(this.x, this.y);
   // #enddocregion idiomatic-constructor
 
   // #docregion initializer-list

--- a/src/content/language/constructors.md
+++ b/src/content/language/constructors.md
@@ -55,8 +55,8 @@ class Point {
   double x;
   double y;
 
-  // Generative constructor with optional positional parameters and default values.
-  Point([this.x = 2.0, this.y = 2.0]);
+  // Generative constructor with initializing formal parameters:
+  Point(this.x, this.y);
 }
 ```
 

--- a/src/content/language/constructors.md
+++ b/src/content/language/constructors.md
@@ -51,12 +51,12 @@ To instantiate a class, use a generative constructor.
 <?code-excerpt "point_alt.dart (idiomatic-constructor)" plaster="none"?>
 ```dart
 class Point {
-  // Initializer list of variables and values
-  double x = 2.0;
-  double y = 2.0;
+  // Instance variables to hold the coordinates of the point.
+  double x;
+  double y;
 
-  // Generative constructor with initializing formal parameters:
-  Point(this.x, this.y);
+  // Generative constructor with optional positional parameters and default values.
+  Point([this.x = 2.0, this.y = 2.0]);
 }
 ```
 


### PR DESCRIPTION
Update documentation for generative constructor with optional positional parameters

- Updated the example for generative constructors to reflect the use of optional positional parameters with default values.
- Clarified the behavior of the constructor to indicate that `x` and `y` have default values of 2.0 when not passed explicitly.
