### PR TITLE
Remove /stable/ from api doc urls

### DIFF
--- a/src/_includes/tools/dart-compile-js-options.md
+++ b/src/_includes/tools/dart-compile-js-options.md
@@ -78,10 +78,10 @@ Some other handy options include:
 : Displays version information for `dart`.
 
 [Dart package configuration file]: {{site.repo.dart.lang}}/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md
-[`String.fromEnvironment`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/String/String.fromEnvironment.html
-[`int.fromEnvironment`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int/int.fromEnvironment.html
-[`bool.fromEnvironment`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/bool/bool.fromEnvironment.html
-[`bool.hasEnvironment`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/bool/bool.hasEnvironment.html
+[`String.fromEnvironment`]: {{site.dart-api}}/dart-core/String/String.fromEnvironment.html
+[`int.fromEnvironment`]: {{site.dart-api}}/dart-core/int/int.fromEnvironment.html
+[`bool.fromEnvironment`]: {{site.dart-api}}/dart-core/bool/bool.fromEnvironment.html
+[`bool.hasEnvironment`]: {{site.dart-api}}/dart-core/bool/bool.hasEnvironment.html
 [Configuring apps with compilation environment declarations]: /guides/environment-declarations
 
 ###### Display options

--- a/src/content/effective-dart/design.md
+++ b/src/content/effective-dart/design.md
@@ -1471,7 +1471,7 @@ marginally more useful than using `dynamic`. If you're going to annotate, prefer
 a full function type that includes the parameters and return type of the
 function.
 
-[Function]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Function-class.html
+[Function]: {{site.dart-api}}/dart-core/Function-class.html
 
 <?code-excerpt "design_good.dart (avoid-function)" replace="/bool Function(\(.*?\))?/[!$&!]/g"?>
 ```dart tag=good

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -68,7 +68,7 @@ A doc comment is any comment that appears before a declaration
 and uses the special `///` syntax that `dart doc` looks for.
 
 [`dart doc`]: /tools/dart-doc
-[docs]: {{site.dart-api}}/{{site.sdkInfo.channel}}
+[docs]: {{site.dart-api}}
 
 ### DO use `///` doc comments to document members and types
 

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -557,7 +557,7 @@ The [Iterable][] contract does not require that a collection know its length or
 be able to provide it in constant time. Calling `.length` just to see if the
 collection contains *anything* can be painfully slow.
 
-[iterable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
+[iterable]: {{site.dart-api}}/dart-core/Iterable-class.html
 
 Instead, there are faster and more readable getters: `.isEmpty` and
 `.isNotEmpty`. Use the one that doesn't require you to negate the result.
@@ -683,7 +683,7 @@ That's verbose and causes two wrappers to be created, with two layers of
 indirection and redundant runtime checking. Fortunately, the core library has
 the [`whereType()`][where-type] method for this exact use case:
 
-[where-type]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable/whereType.html
+[where-type]: {{site.dart-api}}/dart-core/Iterable/whereType.html
 
 <?code-excerpt "../../test/effective_dart_test.dart (where-type)"?>
 ```dart tag=good
@@ -705,7 +705,7 @@ existing transformations can change the type.
 If you're already calling `toList()`, replace that with a call to
 [`List<T>.from()`][list-from] where `T` is the type of resulting list you want.
 
-[list-from]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List/List.from.html
+[list-from]: {{site.dart-api}}/dart-core/List/List.from.html
 
 <?code-excerpt "usage_good.dart (cast-list)"?>
 ```dart tag=good
@@ -1650,7 +1650,7 @@ primitives, and interfacing with asynchronous code that doesn't use futures.
 Most other code should use async/await or [`Future.then()`][then], because
 they're clearer and make error handling easier.
 
-[then]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future/then.html
+[then]: {{site.dart-api}}/dart-async/Future/then.html
 
 <?code-excerpt "usage_good.dart (avoid-completer)"?>
 ```dart tag=good
@@ -1716,9 +1716,9 @@ In the bad example, if you pass it a `Future<Object>`, it incorrectly treats it
 like a bare, synchronous value.
 
 [pokemon]: https://blog.codinghorror.com/new-programming-jargon/
-[Error]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Error-class.html
-[StackOverflowError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/StackOverflowError-class.html
-[OutOfMemoryError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/OutOfMemoryError-class.html
-[ArgumentError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/ArgumentError-class.html
-[AssertionError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/AssertionError-class.html
-[Exception]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Exception-class.html
+[Error]: {{site.dart-api}}/dart-core/Error-class.html
+[StackOverflowError]: {{site.dart-api}}/dart-core/StackOverflowError-class.html
+[OutOfMemoryError]: {{site.dart-api}}/dart-core/OutOfMemoryError-class.html
+[ArgumentError]: {{site.dart-api}}/dart-core/ArgumentError-class.html
+[AssertionError]: {{site.dart-api}}/dart-core/AssertionError-class.html
+[Exception]: {{site.dart-api}}/dart-core/Exception-class.html

--- a/src/content/guides/environment-declarations.md
+++ b/src/content/guides/environment-declarations.md
@@ -105,10 +105,10 @@ if (const bool.hasEnvironment('DEBUG')) {
 }
 ```
 
-[string-from]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/String/String.fromEnvironment.html
-[int-from]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int/int.fromEnvironment.html
-[bool-from]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/bool/bool.fromEnvironment.html
-[bool-has]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/bool/bool.hasEnvironment.html
+[string-from]: {{site.dart-api}}/dart-core/String/String.fromEnvironment.html
+[int-from]: {{site.dart-api}}/dart-core/int/int.fromEnvironment.html
+[bool-from]: {{site.dart-api}}/dart-core/bool/bool.fromEnvironment.html
+[bool-has]: {{site.dart-api}}/dart-core/bool/bool.hasEnvironment.html
 
 ## Specifying environment declarations
 

--- a/src/content/guides/language/numbers.md
+++ b/src/content/guides/language/numbers.md
@@ -504,5 +504,5 @@ provides strict 64-bit signed numbers, even on the web.
 Use these types with care, though:
 they often result in significantly bigger and slower code.
 
-[`BigInt`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/BigInt-class.html
+[`BigInt`]: {{site.dart-api}}/dart-core/BigInt-class.html
 [`fixnum`]: {{site.pub-pkg}}/fixnum

--- a/src/content/guides/language/sound-problems.md
+++ b/src/content/guides/language/sound-problems.md
@@ -631,7 +631,7 @@ The `covariant` keyword applies to a single parameter and is
 also supported on setters and fields.
 
 [bottom type]: https://en.wikipedia.org/wiki/Bottom_type
-[cast()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable/cast.html
-[Iterable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
-[List]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List-class.html
+[cast()]: {{site.dart-api}}/dart-core/Iterable/cast.html
+[Iterable]: {{site.dart-api}}/dart-core/Iterable-class.html
+[List]: {{site.dart-api}}/dart-core/List-class.html
 [top type]: https://en.wikipedia.org/wiki/Top_type

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -188,7 +188,7 @@ The following native types can be used as markers in type signatures.
 They or their subtypes _can_ be instantiated in Dart code.
 
 {% capture dart-ffi -%}
-{{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi
+{{site.dart-api}}/dart-ffi
 {%- endcapture %}
 
 | **Dart type**   | **Description**                                                  |

--- a/src/content/interop/js-interop/js-types.md
+++ b/src/content/interop/js-interop/js-types.md
@@ -264,17 +264,17 @@ otherwise as it will be faster.
 See [`toExternalReference`] and [`toDartObject`] to convert to and from an
 `ExternalDartReference`.
 
-[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
+[`dart:js_interop`]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
 [`external`]: /language/functions#external
-[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`dart:js_interop` API docs]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html#extension-types
-[`typeofEquals`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/typeofEquals.html
-[`instanceOfString`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/instanceOfString.html
-[`isA`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/isA.html
+[`Function.toJS`]: {{site.dart-api}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`dart:js_interop` API docs]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html#extension-types
+[`typeofEquals`]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension/typeofEquals.html
+[`instanceOfString`]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension/instanceOfString.html
+[`isA`]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension/isA.html
 [#4841]: {{site.repo.dart.org}}/linter/issues/4841
 [#54025]: {{site.repo.dart.sdk}}/issues/54025
-[`JSBoxedDartObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSBoxedDartObject-extension-type.html
-[`ExternalDartReference`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/ExternalDartReference-extension-type.html
-[`toExternalReference`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/ObjectToExternalDartReference/toExternalReference.html
-[`toDartObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/ExternalDartReferenceToObject/toDartObject.html
+[`JSBoxedDartObject`]: {{site.dart-api}}/dart-js_interop/JSBoxedDartObject-extension-type.html
+[`ExternalDartReference`]: {{site.dart-api}}/dart-js_interop/ExternalDartReference-extension-type.html
+[`toExternalReference`]: {{site.dart-api}}/dart-js_interop/ObjectToExternalDartReference/toExternalReference.html
+[`toDartObject`]: {{site.dart-api}}/dart-js_interop/ExternalDartReferenceToObject/toDartObject.html
 [Wasm]: /web/wasm

--- a/src/content/interop/js-interop/mock.md
+++ b/src/content/interop/js-interop/mock.md
@@ -117,8 +117,8 @@ non-instance members unless the user explicitly replaces the real API in JS.
 {% endcomment %}
 
 [Usage]: /interop/js-interop/usage
-[`createJSInteropWrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/createJSInteropWrapper.html
-[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`@JSExport`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSExport-class.html
+[`createJSInteropWrapper`]: {{site.dart-api}}/dart-js_interop/createJSInteropWrapper.html
+[`Function.toJS`]: {{site.dart-api}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`@JSExport`]: {{site.dart-api}}/dart-js_interop/JSExport-class.html
 [limitation is true for extension members]: {{site.repo.dart.org}}/mockito/blob/master/FAQ.md#how-do-i-mock-an-extension-method
 [extension types]: /language/extension-types

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -298,10 +298,10 @@ Do we have any other package migrations to show off here?
 
 [`package:web`]: {{site.pub-pkg}}/web
 [Wasm]: /web/wasm
-[html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/dart-html-library.html
-[svg]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-svg/dart-svg-library.html
-[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
-[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[html]: {{site.dart-api}}/dart-html/dart-html-library.html
+[svg]: {{site.dart-api}}/dart-svg/dart-svg-library.html
+[`dart:js_interop`]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
 [idl]: https://www.npmjs.com/package/@webref/idl
 [interop members]: /interop/js-interop/usage#interop-members
 [interop types]: /interop/js-interop/usage#interop-types
@@ -310,14 +310,14 @@ Do we have any other package migrations to show off here?
 [helpers]: {{site.repo.dart.org}}/web/tree/main/web/lib/src/helpers
 [zones]: /libraries/async/zones
 [Conversions]: /interop/js-interop/js-types#conversions
-[interop methods]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension.html#instance-methods
+[interop methods]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension.html#instance-methods
 [alternative interop declarations]: /interop/js-interop/usage
 [Compatibility, type checks, and casts]: /interop/js-interop/js-types#compatibility-type-checks-and-casts
 [Upgrading `url_launcher` to `package:web`]: https://github.com/flutter/packages/pull/5451/files
 [stream helpers]: {{site.repo.dart.org}}/web/blob/main/web/lib/src/helpers/events/streams.dart
 [not possible]: /language/extension-types
-[`JSObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSObject-extension-type.html
-[`isA`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/isA.html
+[`JSObject`]: {{site.dart-api}}/dart-js_interop/JSObject-extension-type.html
+[`isA`]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension/isA.html
 [restricts]: /interop/js-interop/js-types#requirements-on-external-declarations-and-function-tojs
 [#54507]: {{site.repo.dart.sdk}}/issues/54507
 [mocking tutorial]: /interop/js-interop/mock

--- a/src/content/interop/js-interop/past-js-interop.md
+++ b/src/content/interop/js-interop/past-js-interop.md
@@ -106,19 +106,19 @@ TODO: add links (with stable) when ready:
 TODO: Link to `package:web` section
 {% endcomment %}
 
-[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop
-[`dart:html`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html
+[`dart:js_interop`]: {{site.dart-api}}/dart-js_interop
+[`dart:html`]: {{site.dart-api}}/dart-html
 [`package:web`]: /interop/js-interop/package-web
-[`dart:js`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js
-[`object wrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js/JsObject-class.html
-[`allowInterop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_util/allowInterop.html
+[`dart:js`]: {{site.dart-api}}/dart-js
+[`object wrapper`]: {{site.dart-api}}/dart-js/JsObject-class.html
+[`allowInterop`]: {{site.dart-api}}/dart-js_util/allowInterop.html
 [`package:js`]: {{site.pub-pkg}}/js
-[`JSObject`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSObject-extension-type.html
+[`JSObject`]: {{site.dart-api}}/dart-js_interop/JSObject-extension-type.html
 [`@JS`]: {{site.repo.dart.sdk}}/blob/main/sdk/lib/js/_js_annotations.dart#L11
 [tutorial on mocking]: /interop/js-interop/mock
 [`@anonymous`]: {{site.repo.dart.sdk}}/blob/main/sdk/lib/js/_js_annotations.dart#L40
 [`@staticInterop`]: {{site.repo.dart.sdk}}/blob/main/sdk/lib/js/_js_annotations.dart#L48
-[`dart:js_util`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_util
-[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe
+[`dart:js_util`]: {{site.dart-api}}/dart-js_util
+[`Function.toJS`]: {{site.dart-api}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/dart-js_interop_unsafe
 [Wasm]: /web/wasm

--- a/src/content/interop/js-interop/usage.md
+++ b/src/content/interop/js-interop/usage.md
@@ -481,19 +481,19 @@ TODO: Some of these are not available on stable. How do we link to dev?
 [object literal]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer
 [54801]: {{site.repo.dart.sdk}}/issues/54801
 [property accessors]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation
-[utility functions]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyOperatorExtension.html
-[`@JS()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JS-class.html
-[`Function.toJS`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
-[`@JSExport`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSExport-class.html
-[`createJSInteropWrapper`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/createJSInteropWrapper.html
+[utility functions]: {{site.dart-api}}/dart-js_interop/JSAnyOperatorExtension.html
+[`@JS()`]: {{site.dart-api}}/dart-js_interop/JS-class.html
+[`Function.toJS`]: {{site.dart-api}}/dart-js_interop/FunctionToJSExportedDartFunction/toJS.html
+[`@JSExport`]: {{site.dart-api}}/dart-js_interop/JSExport-class.html
+[`createJSInteropWrapper`]: {{site.dart-api}}/dart-js_interop/createJSInteropWrapper.html
 [mocking tutorial]: /interop/js-interop/mock
-[`dart:js_interop`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop
-[`globalContext`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/globalContext.html
-[Helpers to inspect the type of JS values]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension.html
-[`dartify`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/JSAnyUtilityExtension/dartify.html
-[`jsify`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/NullableObjectUtilExtension/jsify.html
-[`importModule`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/importModule.html
-[`dart:js_interop_unsafe`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[`dart:js_interop`]: {{site.dart-api}}/dart-js_interop
+[`globalContext`]: {{site.dart-api}}/dart-js_interop/globalContext.html
+[Helpers to inspect the type of JS values]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension.html
+[`dartify`]: {{site.dart-api}}/dart-js_interop/JSAnyUtilityExtension/dartify.html
+[`jsify`]: {{site.dart-api}}/dart-js_interop/NullableObjectUtilExtension/jsify.html
+[`importModule`]: {{site.dart-api}}/dart-js_interop/importModule.html
+[`dart:js_interop_unsafe`]: {{site.dart-api}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
 [extensions]: /language/extension-methods
 [extension type]: /language/extension-types
 [runtime guarantee]: /language/extension-types#type-considerations

--- a/src/content/language/async.md
+++ b/src/content/language/async.md
@@ -213,6 +213,6 @@ void main() [!async!] {
 For more information about Dart's asynchronous programming support,
 check out the [`dart:async`](/libraries/dart-async) library documentation.
 
-[`Future`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
-[`Stream`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
+[`Future`]: {{site.dart-api}}/dart-async/Future-class.html
+[`Stream`]: {{site.dart-api}}/dart-async/Stream-class.html
 [unawaited_futures linter rule]: /tools/linter-rules/unawaited_futures

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -422,17 +422,17 @@ Symbol literals are compile-time constants.
 [iteration]: /libraries/dart-core#iteration
 [generator functions]: /language/functions#generators
 [Understanding null safety]: /null-safety/understanding-null-safety#top-and-bottom
-[`int`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int-class.html
-[`double`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/double-class.html
-[`num`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num-class.html
-[dart:math]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-math
+[`int`]: {{site.dart-api}}/dart-core/int-class.html
+[`double`]: {{site.dart-api}}/dart-core/double-class.html
+[`num`]: {{site.dart-api}}/dart-core/num-class.html
+[dart:math]: {{site.dart-api}}/dart-math
 [bitwise and shift operator]: /language/operators#bitwise-and-shift-operators
 [dart-numbers]: /guides/language/numbers
-[runes]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Runes-class.html
+[runes]: {{site.dart-api}}/dart-core/Runes-class.html
 [characters package]: {{site.pub-pkg}}/characters
 [grapheme clusters]: https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries
 [`Characters`]: {{site.pub-api}}/characters/latest/characters/Characters-class.html
 [characters API]: {{site.pub-api}}/characters
 [characters example]: {{site.pub-pkg}}/characters/example
-[`Symbol`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Symbol-class.html
+[`Symbol`]: {{site.dart-api}}/dart-core/Symbol-class.html
 [language version]: /guides/language/evolution#language-versioning

--- a/src/content/language/classes.md
+++ b/src/content/language/classes.md
@@ -361,12 +361,12 @@ You can use static methods as compile-time constants. For example, you
 can pass a static method as a parameter to a constant constructor.
 
 
-[`Object`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Object-class.html
+[`Object`]: {{site.dart-api}}/dart-core/Object-class.html
 [top-and-bottom]: /null-safety/understanding-null-safety#top-and-bottom
 [Extension methods]: /language/extension-methods
 [Class modifiers]: /language/class-modifiers
 [constant constructors]: /language/constructors#constant-constructors
-[`Type`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Type-class.html
+[`Type`]: {{site.dart-api}}/dart-core/Type-class.html
 [type test operator]: /language/operators#type-test-operators
 [Getters and setters]: /language/methods#getters-and-setters
 [initializer list]: /language/constructors#use-an-initializer-list

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -321,11 +321,11 @@ For more details and examples of using collection `if` and `for`, see the
 
 [collections]: /libraries/dart-core#collections
 [type inference]: /language/type-system#type-inference
-[`List`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List-class.html
-[`Map`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Map-class.html
+[`List`]: {{site.dart-api}}/dart-core/List-class.html
+[`Map`]: {{site.dart-api}}/dart-core/Map-class.html
 [Using constructors]: /language/classes#using-constructors
 [collections proposal]: {{site.repo.dart.lang}}/blob/main/accepted/2.3/control-flow-collections/feature-specification.md
 [spread proposal]: {{site.repo.dart.lang}}/blob/main/accepted/2.3/spread-collections/feature-specification.md
 [generics]: /language/generics
-[`Set`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Set-class.html
+[`Set`]: {{site.dart-api}}/dart-core/Set-class.html
 [if-case]: /language/branches#if-case

--- a/src/content/language/comments.md
+++ b/src/content/language/comments.md
@@ -96,6 +96,6 @@ and `[Food]` becomes a link to the docs for the `Food` class.
 To parse Dart code and generate HTML documentation, you can use Dart's
 documentation generation tool, [`dart doc`](/tools/dart-doc).
 For an example of generated documentation, see the 
-[Dart API documentation.]({{site.dart-api}}/{{site.sdkInfo.channel}}) 
+[Dart API documentation.]({{site.dart-api}}) 
 For advice on how to structure your comments, see
 [Effective Dart: Documentation.](/effective-dart/documentation)

--- a/src/content/language/concurrency.md
+++ b/src/content/language/concurrency.md
@@ -92,7 +92,7 @@ holding onto a callback to execute later
 This same model is generally how the event loop handles all other
 asynchronous events in Dart, such as [`Stream`][] objects.
 
-[`Stream`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
+[`Stream`]: {{site.dart-api}}/dart-async/Stream-class.html
 
 ## Asynchronous programming
 
@@ -379,7 +379,7 @@ However, `spawnUri()` is much slower than `spawn()`, and the new isolate isn't
 in its spawner's isolate group. Another performance consequence is that message
 passing is slower when isolates are in different groups.
 
-[`Isolate.spawnUri()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/spawnUri.html
+[`Isolate.spawnUri()`]: {{site.dart-api}}/dart-isolate/Isolate/spawnUri.html
 
 ### Limitations of isolates
 
@@ -419,14 +419,14 @@ Check out the [`SendPort.send`][] documentation for more information.
 Note that `Isolate.spawn()` and `Isolate.exit()` abstract over `SendPort` 
 objects, so they're subject to the same limitations.
 
-[`SendPort.send`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort/send.html
-[`Socket`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/Socket-class.html
-[`DynamicLibrary`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/DynamicLibrary-class.html
-[`Finalizable`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/Finalizable-class.html
-[`Finalizer`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Finalizer-class.html
-[`NativeFinalizer`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/NativeFinalizer-class.html
-[`Pointer`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/Pointer-class.html
-[`UserTag`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-developer/UserTag-class.html
+[`SendPort.send`]: {{site.dart-api}}/dart-isolate/SendPort/send.html
+[`Socket`]: {{site.dart-api}}/dart-io/Socket-class.html
+[`DynamicLibrary`]: {{site.dart-api}}/dart-ffi/DynamicLibrary-class.html
+[`Finalizable`]: {{site.dart-api}}/dart-ffi/Finalizable-class.html
+[`Finalizer`]: {{site.dart-api}}/dart-core/Finalizer-class.html
+[`NativeFinalizer`]: {{site.dart-api}}/dart-ffi/NativeFinalizer-class.html
+[`Pointer`]: {{site.dart-api}}/dart-ffi/Pointer-class.html
+[`UserTag`]: {{site.dart-api}}/dart-developer/UserTag-class.html
 
 #### Synchronous blocking communication between isolates
 
@@ -498,8 +498,8 @@ as the spawning isolate. Web workers don't have an equivalent API.
 [`IsolateNameServer`]: {{site.flutter-api}}/flutter/dart-ui/IsolateNameServer-class.html
 [`package:isolate_name_server`]: {{site.pub-pkg}}/isolate_name_server
 [Actor model]: https://en.wikipedia.org/wiki/Actor_model
-[`Isolate.run()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/run.html
-[`Isolate.exit()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/exit.html
-[`Isolate.spawn()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/spawn.html
-[`ReceivePort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/ReceivePort-class.html
-[`SendPort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort-class.html
+[`Isolate.run()`]: {{site.dart-api}}/dart-isolate/Isolate/run.html
+[`Isolate.exit()`]: {{site.dart-api}}/dart-isolate/Isolate/exit.html
+[`Isolate.spawn()`]: {{site.dart-api}}/dart-isolate/Isolate/spawn.html
+[`ReceivePort`]: {{site.dart-api}}/dart-isolate/ReceivePort-class.html
+[`SendPort`]: {{site.dart-api}}/dart-isolate/SendPort-class.html

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -169,7 +169,7 @@ like you would on a normal object:
 print(Vehicle.car.carbonFootprint);
 ```
 
-[`Enum`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Enum-class.html
+[`Enum`]: {{site.dart-api}}/dart-core/Enum-class.html
 [trailing commas]: /language/collections#lists
 [classes]: /language/classes
 [mixins]: /language/mixins

--- a/src/content/language/error-handling.md
+++ b/src/content/language/error-handling.md
@@ -216,13 +216,13 @@ In production code, assertions are ignored, and
 the arguments to `assert` aren't evaluated.
 
 [trailing comma]: /language/collections#trailing-comma
-[`AssertionError`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/AssertionError-class.html
+[`AssertionError`]: {{site.dart-api}}/dart-core/AssertionError-class.html
 [Flutter debug mode]: {{site.flutter-docs}}/testing/debugging#debug-mode-assertions
 [`webdev serve`]: /tools/webdev#serve
 [`dart run`]: /tools/dart-run
 [`dart compile js`]: /tools/dart-compile#js
 
 [isolate]: /language/concurrency#isolates
-[`Error`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Error-class.html
-[`Exception`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Exception-class.html
-[`StackTrace`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/StackTrace-class.html
+[`Error`]: {{site.dart-api}}/dart-core/Error-class.html
+[`Exception`]: {{site.dart-api}}/dart-core/Exception-class.html
+[`StackTrace`]: {{site.dart-api}}/dart-core/StackTrace-class.html

--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -575,8 +575,8 @@ Iterable<int> naturalsDownFrom(int n) sync* {
 ```
 
 
-[`Iterable`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
-[`Stream`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
+[`Iterable`]: {{site.dart-api}}/dart-core/Iterable-class.html
+[`Stream`]: {{site.dart-api}}/dart-async/Stream-class.html
 
 ## External functions {:#external}
 
@@ -607,7 +607,7 @@ is not `final`) an external setter.
 [C]: /interop/c-interop
 [JavaScript]: /interop/js-interop
 
-[Function API reference]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Function-class.html
+[Function API reference]: {{site.dart-api}}/dart-core/Function-class.html
 [Callable objects]: /language/callable-objects
 [type annotations for public APIs]: /effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious
 [if statement]: /language/branches#if

--- a/src/content/language/generics.md
+++ b/src/content/language/generics.md
@@ -217,6 +217,6 @@ allows you to use the type argument `T` in several places:
 * In the type of an argument (`List<T>`).
 * In the type of a local variable (`T tmp`).
 
-[`List`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List-class.html
+[`List`]: {{site.dart-api}}/dart-core/List-class.html
 [By convention]: /effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters
 [top-and-bottom]: /null-safety/understanding-null-safety#top-and-bottom

--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -561,7 +561,7 @@ This site's code follows the conventions in the
 [Strings]: /language/built-in-types#strings
 [The main() function]: /language/functions#the-main-function
 [ns]: /null-safety
-[`Object`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Object-class.html
+[`Object`]: {{site.dart-api}}/dart-core/Object-class.html
 [language version]: /guides/language/evolution#language-versioning
 [ObjectVsDynamic]: /effective-dart/design#avoid-using-dynamic-unless-you-want-to-disable-static-checking
 [Libraries and imports]: /language/libraries

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -55,7 +55,7 @@ setting up and managing worker isolates:
 5. Terminates the isolate once work is complete.
 6. Checks, captures, and throws exceptions and errors back to the main isolate.
 
-[`Isolate.run()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/run.html
+[`Isolate.run()`]: {{site.dart-api}}/dart-isolate/Isolate/run.html
 
 :::flutter-note
 If you're using Flutter, you can use [Flutter's `compute` function][]
@@ -180,11 +180,11 @@ The first example, [Basic ports](#basic-ports-example), introduces the process
 at a high-level. The second example, [Robust ports](#robust-ports-example),
 gradually adds more practical, real-world functionality to the first.
 
-[`Isolate.exit()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/exit.html
-[`Isolate.spawn()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/spawn.html
-[`ReceivePort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/ReceivePort-class.html
-[`SendPort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort-class.html
-[`SendPort.send()` method]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort/send.html
+[`Isolate.exit()`]: {{site.dart-api}}/dart-isolate/Isolate/exit.html
+[`Isolate.spawn()`]: {{site.dart-api}}/dart-isolate/Isolate/spawn.html
+[`ReceivePort`]: {{site.dart-api}}/dart-isolate/ReceivePort-class.html
+[`SendPort`]: {{site.dart-api}}/dart-isolate/SendPort-class.html
+[`SendPort.send()` method]: {{site.dart-api}}/dart-isolate/SendPort/send.html
 [main isolate]: /language/concurrency#isolates
 
 
@@ -1094,17 +1094,17 @@ class Worker {
 
 </details>
 
-[`Isolate.exit()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/exit.html
-[`Isolate.spawn()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/Isolate/spawn.html
-[`ReceivePort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/ReceivePort-class.html
-[`SendPort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort-class.html
-[`SendPort.send()` method]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/SendPort/send.html
+[`Isolate.exit()`]: {{site.dart-api}}/dart-isolate/Isolate/exit.html
+[`Isolate.spawn()`]: {{site.dart-api}}/dart-isolate/Isolate/spawn.html
+[`ReceivePort`]: {{site.dart-api}}/dart-isolate/ReceivePort-class.html
+[`SendPort`]: {{site.dart-api}}/dart-isolate/SendPort-class.html
+[`SendPort.send()` method]: {{site.dart-api}}/dart-isolate/SendPort/send.html
 [main isolate]: /language/concurrency#isolates
-[`Stream`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
-[`BroadcastStream`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/BroadcastStream-class.html
-[`Completer`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Completer-class.html
-[`RawReceivePort`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/RawReceivePort-class.html
+[`Stream`]: {{site.dart-api}}/dart-async/Stream-class.html
+[`BroadcastStream`]: {{site.dart-api}}/dart-async/BroadcastStream-class.html
+[`Completer`]: {{site.dart-api}}/dart-async/Completer-class.html
+[`RawReceivePort`]: {{site.dart-api}}/dart-isolate/RawReceivePort-class.html
 [record]: /language/records
 [previous example]: #basic-ports-example
 [`try`/`catch` block]: /language/error-handling#catch
-[`RemoteError`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/RemoteError-class.html
+[`RemoteError`]: {{site.dart-api}}/dart-isolate/RemoteError-class.html

--- a/src/content/language/libraries.md
+++ b/src/content/language/libraries.md
@@ -173,6 +173,6 @@ for advice on how to implement a package, including:
 * How to use conditional imports and exports to implement
   a library that supports multiple platforms.
 
-[dart:html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html
+[dart:html]: {{site.dart-api}}/dart-html
 [doc comments]: /effective-dart/documentation#consider-writing-a-library-level-doc-comment
 [metadata annotations]: /language/metadata

--- a/src/content/language/loops.md
+++ b/src/content/language/loops.md
@@ -145,6 +145,6 @@ candidates
 [exceptions]: /language/error-handling
 [branching]: /language/branches
 [iteration]: /libraries/dart-core#iteration
-[forEach()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable/forEach.html
-[`Iterable`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
+[forEach()]: {{site.dart-api}}/dart-core/Iterable/forEach.html
+[`Iterable`]: {{site.dart-api}}/dart-core/Iterable-class.html
 [pattern]: /language/patterns

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -68,9 +68,9 @@ Metadata can appear before a library, class, typedef, type parameter,
 constructor, factory, function, field, parameter, or variable
 declaration and before an import or export directive.
 
-[`@Deprecated`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Deprecated-class.html
-[`@deprecated`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/deprecated-constant.html
-[`@override`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/override-constant.html
-[`@pragma`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/pragma-class.html
+[`@Deprecated`]: {{site.dart-api}}/dart-core/Deprecated-class.html
+[`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
+[`@override`]: {{site.dart-api}}/dart-core/override-constant.html
+[`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
 [dep-lint]: /tools/linter-rules/provide_deprecation_message
 [Extending a class]: /language/extend

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -542,7 +542,7 @@ For more information about the `.`, `?.`, and `..` operators, see
 
 [operators as class members]: /language/methods#operators
 [Dart language specification]: /guides/language/spec
-[identical()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/identical.html
+[identical()]: {{site.dart-api}}/dart-core/identical.html
 [Operators]: /language/methods#operators
 [library prefixes]: /language/libraries#specifying-a-library-prefix
 [if-else]: /language/branches#if

--- a/src/content/language/patterns.md
+++ b/src/content/language/patterns.md
@@ -446,5 +446,5 @@ This case pattern simultaneously validates that:
 [check]: /language/pattern-types#null-check
 [assert]: /language/pattern-types#null-assert
 [object]: /language/pattern-types#object
-[`MapEntry`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/MapEntry-class.html
+[`MapEntry`]: {{site.dart-api}}/dart-core/MapEntry-class.html
 [algebraic data type]: https://en.wikipedia.org/wiki/Algebraic_data_type

--- a/src/content/libraries/async/async-await.md
+++ b/src/content/libraries/async/async-await.md
@@ -672,11 +672,11 @@ that does the following:
   * Example return value from `changeUsername()`: `"jane_smith_92"`
 * Catches any error that occurs and returns the string value of the error.
   * You can use the
-    [toString()]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/ArgumentError/toString.html)
+    [toString()]({{site.dart-api}}/dart-core/ArgumentError/toString.html)
     method to stringify both
-    [Exceptions]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Exception-class.html) 
+    [Exceptions]({{site.dart-api}}/dart-core/Exception-class.html) 
     and
-    [Errors.]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Error-class.html)
+    [Errors.]({{site.dart-api}}/dart-core/Error-class.html)
 
 ```dartpad theme="dark"
 // TODO: Implement changeUsername here.
@@ -1088,7 +1088,7 @@ are some suggestions for where to go next:
 - Get the [Dart SDK](/get-dart)!
 
 [Dart videos]: {{site.yt.playlist}}PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J
-[Future]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
+[Future]: {{site.dart-api}}/dart-async/Future-class.html
 [style guide]: /effective-dart/style
 [documentation guide]: /effective-dart/documentation
 [usage guide]: /effective-dart/usage

--- a/src/content/libraries/async/creating-streams.md
+++ b/src/content/libraries/async/creating-streams.md
@@ -14,8 +14,8 @@ April 2013 (updated May 2021)_
 
 The dart:async library contains two types
 that are important for many Dart APIs:
-[Stream]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html) and
-[Future.]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html)
+[Stream]({{site.dart-api}}/dart-async/Stream-class.html) and
+[Future.]({{site.dart-api}}/dart-async/Future-class.html)
 Where a Future represents the result of a single computation,
 a stream is a _sequence_ of results.
 You listen on a stream to get notified of the results
@@ -117,7 +117,7 @@ such as the following:
 Often, a transforming method is all you need.
 However, if you need even more control over the transformation,
 you can specify a
-[StreamTransformer]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamTransformer-class.html)
+[StreamTransformer]({{site.dart-api}}/dart-async/StreamTransformer-class.html)
 with `Stream`'s `transform()` method.
 The platform libraries provide stream transformers for many common tasks.
 For example, the following code uses the `utf8.decoder` and `LineSplitter`
@@ -216,7 +216,7 @@ That's where the `StreamController` class comes in.
 If the events of your stream comes from different parts of your program,
 and not just from a stream or futures that can traversed by an `async` function,
 then use a
-[StreamController]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamController-class.html)
+[StreamController]({{site.dart-api}}/dart-async/StreamController-class.html)
 to create and populate the stream.
 
 A `StreamController` gives you a new stream
@@ -424,7 +424,7 @@ keep these tips in mind:
   one created using `StreamController(sync: true)`.
   When you send an event on an unpaused synchronous controller
   (for example, using the `add()`, `addError()`, or `close()` methods defined by
-  [EventSink]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/EventSink-class.html)),
+  [EventSink]({{site.dart-api}}/dart-async/EventSink-class.html)),
   the event is sent immediately to all listeners on the stream.
   `Stream` listeners must never be called until
   the code that added the listener has fully returned,

--- a/src/content/libraries/async/futures-error-handling.md
+++ b/src/content/libraries/async/futures-error-handling.md
@@ -409,4 +409,4 @@ also prevents errors from *accidentally* leaking out of your function.
 See the [Future API reference][Future class]
 for more information on Futures.
 
-[Future class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
+[Future class]: {{site.dart-api}}/dart-async/Future-class.html

--- a/src/content/libraries/async/using-streams.md
+++ b/src/content/libraries/async/using-streams.md
@@ -397,13 +397,13 @@ and asynchronous programming in Dart.
   an article that explains how to handle errors using the Future API
 * [Asynchrony support](/language/async),
   a section in the [language tour](/language)
-* [Stream API reference]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html)
+* [Stream API reference]({{site.dart-api}}/dart-async/Stream-class.html)
 
-[bind()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamTransformer/bind.html
-[LineSplitter]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/LineSplitter-class.html
-[Future]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
-[Iterable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
-[Stream]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
-[StreamSubscription]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamSubscription-class.html
-[StreamTransformer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamTransformer-class.html
-[Utf8Decoder]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/Utf8Decoder-class.html
+[bind()]: {{site.dart-api}}/dart-async/StreamTransformer/bind.html
+[LineSplitter]: {{site.dart-api}}/dart-convert/LineSplitter-class.html
+[Future]: {{site.dart-api}}/dart-async/Future-class.html
+[Iterable]: {{site.dart-api}}/dart-core/Iterable-class.html
+[Stream]: {{site.dart-api}}/dart-async/Stream-class.html
+[StreamSubscription]: {{site.dart-api}}/dart-async/StreamSubscription-class.html
+[StreamTransformer]: {{site.dart-api}}/dart-async/StreamTransformer-class.html
+[Utf8Decoder]: {{site.dart-api}}/dart-convert/Utf8Decoder-class.html

--- a/src/content/libraries/async/zones.md
+++ b/src/content/libraries/async/zones.md
@@ -30,9 +30,9 @@ Review the techniques covered in
 [Futures and Error Handling](/libraries/async/futures-error-handling)
 before reading this article.
 
-[dart:async]: ({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/dart-async-library.html)
-[`runZoned()`]: ({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/runZoned.html)
-[`runZonedGuarded()`]: ({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/runZonedGuarded.html)
+[dart:async]: ({{site.dart-api}}/dart-async/dart-async-library.html)
+[`runZoned()`]: ({{site.dart-api}}/dart-async/runZoned.html)
+[`runZonedGuarded()`]: ({{site.dart-api}}/dart-async/runZonedGuarded.html)
 
 Zones make the following tasks possible:
 
@@ -180,9 +180,9 @@ _Other zone APIs that facilitate uncaught error handling include
 [`Zone.fork`][], [`Zone.runGuarded`][]
 and [`ZoneSpecification.uncaughtErrorHandler`][]._
 
-[`Zone.fork`]:  ({{site.dart-api}}/{{site.sdkInfo.channel}}dart-async/Zone/fork.html)
-[`Zone.runGuarded`]:  ({{site.dart-api}}/{{site.sdkInfo.channel}}dart-async/Zone/runGuarded.html)
-[`ZoneSpecification.uncaughtErrorHandler`]:  ({{site.dart-api}}/{{site.sdkInfo.channel}}dart-async/ZoneSpecification/handleUncaughtError.html)
+[`Zone.fork`]:  {{site.dart-api}}/dart-async/Zone/fork.html
+[`Zone.runGuarded`]:  {{site.dart-api}}/dart-async/Zone/runGuarded.html
+[`ZoneSpecification.uncaughtErrorHandler`]:  {{site.dart-api}}/dart-async/ZoneSpecification/handleUncaughtError.html
 
 The preceding code has an asynchronous callback
 (through `Timer.run()`) that throws an exception.
@@ -463,7 +463,7 @@ that works in asynchronous contexts.
 Use the `zoneSpecification` argument to `runZoned()`
 to override functionality that is managed by zones.
 The argument's value is a
-[ZoneSpecification]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/ZoneSpecification-class.html) object,
+[ZoneSpecification]({{site.dart-api}}/dart-async/ZoneSpecification-class.html) object,
 with which you can override any of the following functionality:
 
 * Forking child zones
@@ -759,11 +759,11 @@ that you can use for functionality such as profiling.
 
 Zone-related API documentation
 : Read the docs for
-  [runZoned()]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/runZoned.html),
-  [runZonedGuarded()]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/runZonedGuarded.html),
-  [Zone]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Zone-class.html),
-  [ZoneDelegate]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/ZoneDelegate-class.html), and
-  [ZoneSpecification]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/ZoneSpecification-class.html).
+  [runZoned()]({{site.dart-api}}/dart-async/runZoned.html),
+  [runZonedGuarded()]({{site.dart-api}}/dart-async/runZonedGuarded.html),
+  [Zone]({{site.dart-api}}/dart-async/Zone-class.html),
+  [ZoneDelegate]({{site.dart-api}}/dart-async/ZoneDelegate-class.html), and
+  [ZoneSpecification]({{site.dart-api}}/dart-async/ZoneSpecification-class.html).
 
 stack_trace
 : With the stack_trace library's

--- a/src/content/libraries/collections/iterables.md
+++ b/src/content/libraries/collections/iterables.md
@@ -1218,11 +1218,11 @@ here are some suggestions for where to go next:
 * Read the [Iterable API reference][iterable class]
   to learn about methods that this tutorial doesn't cover.
 
-[hashmap class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-collection/HashMap-class.html
-[iterable class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
-[iterator class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterator-class.html
-[list class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List-class.html
-[map class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Map-class.html
-[set class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Set-class.html
-[StateError class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/StateError-class.html
-[String class]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/String-class.html
+[hashmap class]: {{site.dart-api}}/dart-collection/HashMap-class.html
+[iterable class]: {{site.dart-api}}/dart-core/Iterable-class.html
+[iterator class]: {{site.dart-api}}/dart-core/Iterator-class.html
+[list class]: {{site.dart-api}}/dart-core/List-class.html
+[map class]: {{site.dart-api}}/dart-core/Map-class.html
+[set class]: {{site.dart-api}}/dart-core/Set-class.html
+[StateError class]: {{site.dart-api}}/dart-core/StateError-class.html
+[String class]: {{site.dart-api}}/dart-core/String-class.html

--- a/src/content/libraries/convert/converters-and-codecs.md
+++ b/src/content/libraries/convert/converters-and-codecs.md
@@ -11,7 +11,7 @@ February 2014 (updated March 2015)_
 
 Converting data between different representations is a common task in computer
 engineering. Dart is no exception and comes with
-[dart:convert]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/dart-convert-library.html), a
+[dart:convert]({{site.dart-api}}/dart-convert/dart-convert-library.html), a
 core library that provides a set of converters
 and useful tools to build new converters.
 Examples of converters provided by the library include those
@@ -62,7 +62,7 @@ As can be seen, codecs provide convenience methods such as `encode()` and
 method and `inverted` getter allow you to fuse converters and
 change the direction of a codec, respectively.
 The base implementation of
-[Codec]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/Codec-class.html)
+[Codec]({{site.dart-api}}/dart-convert/Codec-class.html)
 for these two members
 provides a solid default implementation
 and implementers usually don't need to worry about them.
@@ -70,7 +70,7 @@ and implementers usually don't need to worry about them.
 The `encode()` and `decode()`
 methods, too, may be left untouched, but they can be extended for additional
 arguments. For example, the
-[JsonCodec]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/JsonCodec-class.html)
+[JsonCodec]({{site.dart-api}}/dart-convert/JsonCodec-class.html)
 adds named arguments to `encode()` and `decode()`
 to make these methods more useful:
 
@@ -103,7 +103,7 @@ T convert(S input);  // where T is the target and S the source type.
 ```
 
 A minimal converter implementation only needs to extend the
-[Converter]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/Converter-class.html) class and
+[Converter]({{site.dart-api}}/dart-convert/Converter-class.html) class and
 implement the `convert()` method. Similar to the Codec class, converters can be
 made configurable by extending the constructors and adding named arguments to
 the `convert()` method.
@@ -112,11 +112,11 @@ Such a minimal converter works in synchronous settings, but
 does not work when used with chunks (either synchronously or asynchronously). In
 particular, such a simple converter doesn't work as a transformer (one of the
 nicer features of Converters). A fully implemented converter implements the
-[StreamTransformer]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamTransformer-class.html)
+[StreamTransformer]({{site.dart-api}}/dart-async/StreamTransformer-class.html)
 interface and can thus be given to the `Stream.transform()` method.
 
 Probably the most common use case is the decoding of UTF-8 with
-[utf8.decoder]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/Utf8Codec-class.html):
+[utf8.decoder]({{site.dart-api}}/dart-convert/Utf8Codec-class.html):
 
 ```dart
 File.openRead().transform(utf8.decoder).
@@ -127,7 +127,7 @@ File.openRead().transform(utf8.decoder).
 The concept of chunked conversions can be confusing, but at its core, it is
 relatively simple. When a chunked conversion (including a stream
 transformation) is started, the converter's
-[startChunkedConversion]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/Converter/startChunkedConversion.html)
+[startChunkedConversion]({{site.dart-api}}/dart-convert/Converter/startChunkedConversion.html)
 method is invoked with an output-
 sink as argument. The method then returns an input sink into which the caller
 puts data.
@@ -167,11 +167,11 @@ is currently (January 2014) implemented.
 
 Interestingly, the type of chunked conversion cannot be extrapolated from its
 synchronous conversion. For example, the
-[HtmlEscape]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/HtmlEscape-class.html)
+[HtmlEscape]({{site.dart-api}}/dart-convert/HtmlEscape-class.html)
 converter synchronously
 converts Strings to Strings, and asynchronously converts chunks of Strings to
 chunks of Strings (String→String). The
-[LineSplitter]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/LineSplitter-class.html)
+[LineSplitter]({{site.dart-api}}/dart-convert/LineSplitter-class.html)
 converter synchronously
 converts Strings to List<String> (the individual lines). Despite the difference
 in the synchronous signature, the chunked version of the LineSplitter converter
@@ -207,17 +207,17 @@ useful case when used as a StreamTransformer.
 
 ### ChunkedConversionSink
 
-[ChunkedConversionSinks]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/ChunkedConversionSink-class.html)
+[ChunkedConversionSinks]({{site.dart-api}}/dart-convert/ChunkedConversionSink-class.html)
 are used to add new data to a
 converter or as output from converters. The basic ChunkedConversionSink comes
 with two methods: `add()` and `close()`. These have the same functionality as in
 all other sinks of the system such as
-[StringSinks]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/StringSink-class.html)
+[StringSinks]({{site.dart-api}}/dart-core/StringSink-class.html)
 or
-[StreamSinks]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/StreamSink-class.html).
+[StreamSinks]({{site.dart-api}}/dart-async/StreamSink-class.html).
 
 The ChunkedConversionSinks semantics are similar to that of
-[IOSinks]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/IOSink-class.html):
+[IOSinks]({{site.dart-api}}/dart-io/IOSink-class.html):
 data added to the
 sink must not be modified unless it can be guaranteed that the data has been
 handled. For Strings this is not a problem (since they are immutable), but for
@@ -226,7 +226,7 @@ can be inefficient and the dart:convert library thus comes with subclasses of
 ChunkedConversionSink that support more efficient ways of passing data.
 
 For instance, the
-[ByteConversionSink]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/ByteConversionSink-class.html),
+[ByteConversionSink]({{site.dart-api}}/dart-convert/ByteConversionSink-class.html),
 has the additional method:
 
 ```dart
@@ -397,7 +397,7 @@ the cost of allocating a new list for every chunk is killing performance
 (a reasonable assumption).
 
 We start by making the allocation cost cheaper: by using a
-[typed byte-list]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-typed_data/Uint8List-class.html)
+[typed byte-list]({{site.dart-api}}/dart-typed_data/Uint8List-class.html)
 we can reduce the size of the allocated list by a factor of 8 (on 64-bit
 machines). This one line change doesn't remove the allocation, but makes it much
 cheaper.

--- a/src/content/libraries/dart-async.md
+++ b/src/content/libraries/dart-async.md
@@ -211,8 +211,8 @@ or with an error if any of the provided futures fail.
 
 ### Handling errors for multiple futures
 
-You can also wait for parallel operations on an [iterable]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/FutureIterable/wait.html)
-or [record]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/FutureRecord2/wait.html)
+You can also wait for parallel operations on an [iterable]({{site.dart-api}}/dart-async/FutureIterable/wait.html)
+or [record]({{site.dart-api}}/dart-async/FutureRecord2/wait.html)
 of futures.
 
 These extensions return a future with the resulting values of all provided
@@ -462,9 +462,9 @@ Also see these articles and tutorials:
 - [Dart asynchronous programming: Isolates and event loops](/language/concurrency)
 
 
-[Future.wait()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future/wait.html
-[Future]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
-[`ParallelWaitError`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/ParallelWaitError-class.html
-[Stream]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Stream-class.html
-[dart:async]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/dart-async-library.html
+[Future.wait()]: {{site.dart-api}}/dart-async/Future/wait.html
+[Future]: {{site.dart-api}}/dart-async/Future-class.html
+[`ParallelWaitError`]: {{site.dart-api}}/dart-async/ParallelWaitError-class.html
+[Stream]: {{site.dart-api}}/dart-async/Stream-class.html
+[dart:async]: {{site.dart-api}}/dart-async/dart-async-library.html
 [dart:io documentation]: /libraries/dart-io

--- a/src/content/libraries/dart-convert.md
+++ b/src/content/libraries/dart-convert.md
@@ -139,4 +139,4 @@ The dart:convert library also has converters for ASCII and ISO-8859-1
 
 [JSON]: https://www.json.org/
 [UTF-8]: https://en.wikipedia.org/wiki/UTF-8
-[dart:convert]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/dart-convert-library.html
+[dart:convert]: {{site.dart-api}}/dart-convert/dart-convert-library.html

--- a/src/content/libraries/dart-core.md
+++ b/src/content/libraries/dart-core.md
@@ -765,8 +765,8 @@ assert(httpUri.toString() == 'http://example.org/foo/bar?lang=dart');
 assert(httpsUri.toString() == 'https://example.org/foo/bar?lang=dart');
 ```
 
-[`Uri.http`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Uri/Uri.http.html
-[`Uri.https`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Uri/Uri.https.html
+[`Uri.http`]: {{site.dart-api}}/dart-core/Uri/Uri.http.html
+[`Uri.https`]: {{site.dart-api}}/dart-core/Uri/Uri.https.html
 
 ## Dates and times
 
@@ -899,9 +899,9 @@ you can use either [`Object.hashAll()`][] (if element order matters)
 or [`Object.hashAllUnordered()`][].
 :::
 
-[`Object.hash()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Object/hash.html
-[`Object.hashAll()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Object/hashAll.html
-[`Object.hashAllUnordered()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Object/hashAllUnordered.html
+[`Object.hash()`]: {{site.dart-api}}/dart-core/Object/hash.html
+[`Object.hashAll()`]: {{site.dart-api}}/dart-core/Object/hashAll.html
+[`Object.hashAllUnordered()`]: {{site.dart-api}}/dart-core/Object/hashAllUnordered.html
 
 {% comment %}
 Note: There's disagreement over whether to include identical() in the ==
@@ -1057,33 +1057,33 @@ Support for weak references and finalizers was added in Dart 2.17.
 :::
 
 
-[ArgumentError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/ArgumentError-class.html
-[Comparable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Comparable-class.html
-[DateTime]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/DateTime-class.html
-[Duration]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Duration-class.html
-[Exception]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Exception-class.html
-[Expando]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Expando-class.html
-[Finalizable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/Finalizable-class.html
-[Finalizer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Finalizer-class.html
-[Iterable]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterable-class.html
-[Iterator]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Iterator-class.html
-[List]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List-class.html
-[Map]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Map-class.html
-[Match]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Match-class.html
-[NativeFinalizer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/NativeFinalizer-class.html
-[NoSuchMethodError]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/NoSuchMethodError-class.html
-[Pattern]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Pattern-class.html
-[RegExp]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/RegExp-class.html
-[Set]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Set-class.html
-[StringBuffer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/StringBuffer-class.html
-[String]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/String-class.html
-[Uri]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Uri-class.html
-[WeakReference]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/WeakReference-class.html
-[dart:core]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/dart-core-library.html
+[ArgumentError]: {{site.dart-api}}/dart-core/ArgumentError-class.html
+[Comparable]: {{site.dart-api}}/dart-core/Comparable-class.html
+[DateTime]: {{site.dart-api}}/dart-core/DateTime-class.html
+[Duration]: {{site.dart-api}}/dart-core/Duration-class.html
+[Exception]: {{site.dart-api}}/dart-core/Exception-class.html
+[Expando]: {{site.dart-api}}/dart-core/Expando-class.html
+[Finalizable]: {{site.dart-api}}/dart-ffi/Finalizable-class.html
+[Finalizer]: {{site.dart-api}}/dart-core/Finalizer-class.html
+[Iterable]: {{site.dart-api}}/dart-core/Iterable-class.html
+[Iterator]: {{site.dart-api}}/dart-core/Iterator-class.html
+[List]: {{site.dart-api}}/dart-core/List-class.html
+[Map]: {{site.dart-api}}/dart-core/Map-class.html
+[Match]: {{site.dart-api}}/dart-core/Match-class.html
+[NativeFinalizer]: {{site.dart-api}}/dart-ffi/NativeFinalizer-class.html
+[NoSuchMethodError]: {{site.dart-api}}/dart-core/NoSuchMethodError-class.html
+[Pattern]: {{site.dart-api}}/dart-core/Pattern-class.html
+[RegExp]: {{site.dart-api}}/dart-core/RegExp-class.html
+[Set]: {{site.dart-api}}/dart-core/Set-class.html
+[StringBuffer]: {{site.dart-api}}/dart-core/StringBuffer-class.html
+[String]: {{site.dart-api}}/dart-core/String-class.html
+[Uri]: {{site.dart-api}}/dart-core/Uri-class.html
+[WeakReference]: {{site.dart-api}}/dart-core/WeakReference-class.html
+[dart:core]: {{site.dart-api}}/dart-core/dart-core-library.html
 [dart:ffi]: /guides/libraries/c-interop
-[double]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/double-class.html
+[double]: {{site.dart-api}}/dart-core/double-class.html
 [garbage-collected]: https://medium.com/flutter/flutter-dont-fear-the-garbage-collector-d69b3ff1ca30
-[int]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int-class.html
-[num]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num-class.html
-[toStringAsFixed()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num/toStringAsFixed.html
-[toStringAsPrecision()]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num/toStringAsPrecision.html
+[int]: {{site.dart-api}}/dart-core/int-class.html
+[num]: {{site.dart-api}}/dart-core/num-class.html
+[toStringAsFixed()]: {{site.dart-api}}/dart-core/num/toStringAsFixed.html
+[toStringAsPrecision()]: {{site.dart-api}}/dart-core/num/toStringAsPrecision.html

--- a/src/content/libraries/dart-html.md
+++ b/src/content/libraries/dart-html.md
@@ -449,17 +449,17 @@ Dart has additional libraries for more specialized web APIs, such as
 For more information about Dart web libraries, see the
 [web library overview.][web library overview]
 
-[AnchorElement]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/AnchorElement-class.html
-[dart:html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/dart-html-library.html
+[AnchorElement]: {{site.dart-api}}/dart-html/AnchorElement-class.html
+[dart:html]: {{site.dart-api}}/dart-html/dart-html-library.html
 [Fetch data from the internet]: /tutorials/server/fetch-data
-[Document]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/Document-class.html
-[Element]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/Element-class.html
-[`HttpRequest`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/HttpRequest-class.html
-[IndexedDB]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-indexed_db/dart-indexed_db-library.html
-[MessageEvent]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/MessageEvent-class.html
-[Nodes]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/Node-class.html
-[web audio]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-web_audio/dart-web_audio-library.html
-[WebGL]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-web_gl/dart-web_gl-library.html
-[WebSocket]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/WebSocket-class.html
+[Document]: {{site.dart-api}}/dart-html/Document-class.html
+[Element]: {{site.dart-api}}/dart-html/Element-class.html
+[`HttpRequest`]: {{site.dart-api}}/dart-html/HttpRequest-class.html
+[IndexedDB]: {{site.dart-api}}/dart-indexed_db/dart-indexed_db-library.html
+[MessageEvent]: {{site.dart-api}}/dart-html/MessageEvent-class.html
+[Nodes]: {{site.dart-api}}/dart-html/Node-class.html
+[web audio]: {{site.dart-api}}/dart-web_audio/dart-web_audio-library.html
+[WebGL]: {{site.dart-api}}/dart-web_gl/dart-web_gl-library.html
+[WebSocket]: {{site.dart-api}}/dart-html/WebSocket-class.html
 [web library overview]: /web/libraries
-[Window]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/Window-class.html
+[Window]: {{site.dart-api}}/dart-html/Window-class.html

--- a/src/content/libraries/dart-io.md
+++ b/src/content/libraries/dart-io.md
@@ -265,14 +265,14 @@ For more information about server-side and command-line app development, see the
 [server-side Dart overview.](/server)
 
 
-[dart:io]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/dart-io-library.html
-[Directory]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/Directory-class.html
+[dart:io]: {{site.dart-api}}/dart-io/dart-io-library.html
+[Directory]: {{site.dart-api}}/dart-io/Directory-class.html
 [Fetch data from the internet]: /tutorials/server/fetch-data
-[File]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/File-class.html
-[HttpClient]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/HttpClient-class.html
-[HttpRequest]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/HttpRequest-class.html
-[HttpServer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/HttpServer-class.html
-[IOSink]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/IOSink-class.html
-[Process]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/Process-class.html
-[Socket]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/Socket-class.html
-[WebSocket]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/WebSocket-class.html
+[File]: {{site.dart-api}}/dart-io/File-class.html
+[HttpClient]: {{site.dart-api}}/dart-io/HttpClient-class.html
+[HttpRequest]: {{site.dart-api}}/dart-html/HttpRequest-class.html
+[HttpServer]: {{site.dart-api}}/dart-io/HttpServer-class.html
+[IOSink]: {{site.dart-api}}/dart-io/IOSink-class.html
+[Process]: {{site.dart-api}}/dart-io/Process-class.html
+[Socket]: {{site.dart-api}}/dart-io/Socket-class.html
+[WebSocket]: {{site.dart-api}}/dart-io/WebSocket-class.html

--- a/src/content/libraries/dart-math.md
+++ b/src/content/libraries/dart-math.md
@@ -104,9 +104,9 @@ use the [`Random.secure()`][] constructor.
 Refer to the [Math API reference][dart:math] for a full list of methods.
 Also see the API reference for [num,][num] [int,][int] and [double.][double]
 
-[Random]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-math/Random-class.html
-[`Random.secure()`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-math/Random/Random.secure.html
-[dart:math]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-math/dart-math-library.html
-[double]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/double-class.html
-[int]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int-class.html
-[num]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num-class.html
+[Random]: {{site.dart-api}}/dart-math/Random-class.html
+[`Random.secure()`]: {{site.dart-api}}/dart-math/Random/Random.secure.html
+[dart:math]: {{site.dart-api}}/dart-math/dart-math-library.html
+[double]: {{site.dart-api}}/dart-core/double-class.html
+[int]: {{site.dart-api}}/dart-core/int-class.html
+[num]: {{site.dart-api}}/dart-core/num-class.html

--- a/src/content/libraries/index.md
+++ b/src/content/libraries/index.md
@@ -70,7 +70,7 @@ the [Flutter API reference][api-flutter].
 To learn more about the Dart language,
 check out the [language documentation and samples](/language).
 
-[Dart API]: {{site.dart-api}}/{{site.sdkInfo.channel}}
+[Dart API]: {{site.dart-api}}
 [webdev libraries]: /web/libraries
 [api-flutter]: {{site.flutter-api}}
 
@@ -130,42 +130,42 @@ The latest, recommended tools are **bolded**, and legacy tools are *italicized*
 <!---
 Multi-platform libraries
 -->
-[dart-core]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/dart-core-library.html
-[dart-async]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/dart-async-library.html
+[dart-core]: {{site.dart-api}}/dart-core/dart-core-library.html
+[dart-async]: {{site.dart-api}}/dart-async/dart-async-library.html
 [package-async]: {{site.pub-pkg}}/async
-[dart-collection]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-collection/dart-collection-library.html
+[dart-collection]: {{site.dart-api}}/dart-collection/dart-collection-library.html
 [package-collection]: {{site.pub-pkg}}/collection
-[dart-convert]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/dart-convert-library.html
+[dart-convert]: {{site.dart-api}}/dart-convert/dart-convert-library.html
 [package-convert]: {{site.pub-pkg}}/convert
-[dart-developer]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-developer/dart-developer-library.html
-[dart-math]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-math/dart-math-library.html
-[dart-typed_data]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-typed_data/dart-typed_data-library.html
+[dart-developer]: {{site.dart-api}}/dart-developer/dart-developer-library.html
+[dart-math]: {{site.dart-api}}/dart-math/dart-math-library.html
+[dart-typed_data]: {{site.dart-api}}/dart-typed_data/dart-typed_data-library.html
 [package-typed_data]: {{site.pub-pkg}}/typed_data
 
 <!---
 Native platform libraries
 -->
-[dart-ffi]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-ffi/dart-ffi-library.html
+[dart-ffi]: {{site.dart-api}}/dart-ffi/dart-ffi-library.html
 [package-ffi]: {{site.pub-pkg}}/ffi
-[dart-io]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/dart-io-library.html
+[dart-io]: {{site.dart-api}}/dart-io/dart-io-library.html
 [package-io]: {{site.pub-pkg}}/io
-[dart-isolate]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-isolate/dart-isolate-library.html
-[dart-mirrors]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-mirrors/dart-mirrors-library.html
+[dart-isolate]: {{site.dart-api}}/dart-isolate/dart-isolate-library.html
+[dart-mirrors]: {{site.dart-api}}/dart-mirrors/dart-mirrors-library.html
 
 <!---
 Web platform libraries
 -->
 [pkg-web]: {{site.pub-pkg}}/web
-[js-interop]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
-[js-interop-unsafe]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
-[dart-html]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-html/dart-html-library.html
-[dart-indexed_db]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-indexed_db/dart-indexed_db-library.html
-[dart-js]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js/dart-js-library.html
+[js-interop]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
+[js-interop-unsafe]: {{site.dart-api}}/dart-js_interop_unsafe/dart-js_interop_unsafe-library.html
+[dart-html]: {{site.dart-api}}/dart-html/dart-html-library.html
+[dart-indexed_db]: {{site.dart-api}}/dart-indexed_db/dart-indexed_db-library.html
+[dart-js]: {{site.dart-api}}/dart-js/dart-js-library.html
 [package-js]: {{site.pub-pkg}}/js
-[dart-js_util]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_util/dart-js_util-library.html
-[dart-svg]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-svg/dart-svg-library.html
-[dart-web_audio]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-web_audio/dart-web_audio-library.html
-[dart-web_gl]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-web_gl/dart-web_gl-library.html
+[dart-js_util]: {{site.dart-api}}/dart-js_util/dart-js_util-library.html
+[dart-svg]: {{site.dart-api}}/dart-svg/dart-svg-library.html
+[dart-web_audio]: {{site.dart-api}}/dart-web_audio/dart-web_audio-library.html
+[dart-web_gl]: {{site.dart-api}}/dart-web_gl/dart-web_gl-library.html
 
 <!---
 Misc

--- a/src/content/null-safety/faq.md
+++ b/src/content/null-safety/faq.md
@@ -180,7 +180,7 @@ Until everything is fully migrated and the code switches to running
 with sound null safety, `arg` might be set to `null`.
 
 The simplest way to preserve behavior is change the check into
-[`ArgumentError.checkNotNull`]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/ArgumentError/checkNotNull.html).
+[`ArgumentError.checkNotNull`]({{site.dart-api}}/dart-core/ArgumentError/checkNotNull.html).
 
 The same applies to some runtime type checks. If `arg`
 has static type `String`, then `if (arg is! String)` is actually checking
@@ -212,7 +212,7 @@ In such cases, you have two options:
 ## How do I signal that the return value from a Map is non-nullable?
 
 The
-[lookup operator]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Map/operator_get.html)
+[lookup operator]({{site.dart-api}}/dart-core/Map/operator_get.html)
 on Map (`[]`) by default returns a nullable type. There's no way to signal to
 the language that the value is guaranteed to be there.
 
@@ -244,7 +244,7 @@ initializing the list with length and filling it in via a loop.
 
 If you are simply initializing the list with the same value, you should instead
 use the 
-[`filled`]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List/List.filled.html) 
+[`filled`]({{site.dart-api}}/dart-core/List/List.filled.html) 
 constructor.
 
 ```dart tag=bad
@@ -284,7 +284,7 @@ with the `growable` parameter set to `false`:
 _jellyPoints = List.generate(jellyMax, (_) => Vec2D(), growable: false);
 ```
 
-[`List.generate`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List/List.generate.html
+[`List.generate`]: {{site.dart-api}}/dart-core/List/List.generate.html
 
 {% comment %}
   Would preferably suggest a language syntax here,

--- a/src/content/resources/dart-3-migration.md
+++ b/src/content/resources/dart-3-migration.md
@@ -341,24 +341,24 @@ that applies to all Dart 3 code.
   Existing bidirectional iterators can still work, they just don't have
   a shared supertype locking them to a specific name for moving backwards.
 
-[`List.filled`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/List/List.filled.html
-[`int.parse`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/int/parse.html
-[`double.parse`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/double/parse.html
-[`num.parse`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num/parse.html
-[`tryParse`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/num/tryParse.html
+[`List.filled`]: {{site.dart-api}}/dart-core/List/List.filled.html
+[`int.parse`]: {{site.dart-api}}/dart-core/int/parse.html
+[`double.parse`]: {{site.dart-api}}/dart-core/double/parse.html
+[`num.parse`]: {{site.dart-api}}/dart-core/num/parse.html
+[`tryParse`]: {{site.dart-api}}/dart-core/num/tryParse.html
 [`Deprecated.expires`]: {{site.dart-api}}/stable/2.19.6/dart-core/Deprecated/expires.html
-[`Deprecated.message`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/Deprecated/message.html
+[`Deprecated.message`]: {{site.dart-api}}/dart-core/Deprecated/message.html
 [`AbstractClassInstantiationError`]: {{site.dart-api}}/stable/2.19.6/dart-core/AbstractClassInstantiationError-class.html
 [`CastError`]: {{site.dart-api}}/stable/2.19.6/dart-core/CastError-class.html
 [`FallThroughError`]: {{site.dart-api}}/stable/2.19.6/dart-core/FallThroughError-class.html
 [`NoSuchMethodError`]: {{site.dart-api}}/stable/2.19.6/dart-core/NoSuchMethodError/NoSuchMethodError.html
-[`NoSuchMethodError.withInvocation`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/NoSuchMethodError/NoSuchMethodError.withInvocation.html
+[`NoSuchMethodError.withInvocation`]: {{site.dart-api}}/dart-core/NoSuchMethodError/NoSuchMethodError.withInvocation.html
 [`CyclicInitializationError`]: {{site.dart-api}}/stable/2.19.6/dart-core/CyclicInitializationError-class.html
 [`Provisional`]: {{site.dart-api}}/stable/2.19.6/dart-core/Provisional-class.html
 [`provisional`]: {{site.dart-api}}/stable/2.19.6/dart-core/provisional-constant.html
 [`proxy`]: {{site.dart-api}}/stable/2.19.6/dart-core/proxy-constant.html
 [`CastError`]: {{site.dart-api}}/stable/2.19.6/dart-core/CastError-class.html
-[`TypeError`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-core/TypeError-class.html
+[`TypeError`]: {{site.dart-api}}/dart-core/TypeError-class.html
 [`FallThroughError`]: {{site.dart-api}}/stable/2.19.6/dart-core/FallThroughError-class.html
 [`NullThrownError`]: {{site.dart-api}}/stable/2.19.6/dart-core/NullThrownError-class.html
 [`AbstractClassInstantiationError`]: {{site.dart-api}}/stable/2.19.6/dart-core/AbstractClassInstantiationError-class.html
@@ -381,7 +381,7 @@ that applies to all Dart 3 code.
   and [`Gauge`][] classes as they have been broken since Dart 2.0.
 
 [`MAX_USER_TAGS`]: {{site.dart-api}}/stable/2.19.6/dart-developer/UserTag/MAX_USER_TAGS-constant.html
-[`maxUserTags`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-developer/UserTag/maxUserTags-constant.html
+[`maxUserTags`]: {{site.dart-api}}/dart-developer/UserTag/maxUserTags-constant.html
 [`Metrics`]: {{site.dart-api}}/stable/2.19.6/dart-developer/Metrics-class.html
 [`Metric`]: {{site.dart-api}}/stable/2.19.6/dart-developer/Metric-class.html
 [`Counter`]: {{site.dart-api}}/stable/2.19.6/dart-developer/Counter-class.html

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -352,5 +352,5 @@ either of those lists results in a runtime exception.
 [dart analyze]: /tools/dart-analyze
 [webdev]: /tools/webdev
 
-[dart-mirror]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-mirrors
+[dart-mirror]: {{site.dart-api}}/dart-mirrors
 [pub-cmd]: /tools/pub/cmd

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -66,7 +66,7 @@ You might find the following tutorials helpful.
 
 ## More resources
 
-[Dart API]({{site.dart-api}}/{{site.sdkInfo.channel}})
+[Dart API]({{site.dart-api}})
 : API reference for dart:* libraries.
 
 [dart:io documentation](/libraries/dart-io)

--- a/src/content/server/libraries.md
+++ b/src/content/server/libraries.md
@@ -8,7 +8,7 @@ The [Dart SDK][] contains [dart:io][] and other libraries
 that provide low-level command-line & server APIs.
 
 [Dart SDK]: /tools/sdk
-[dart:io]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-io/dart-io-library.html
+[dart:io]: {{site.dart-api}}/dart-io/dart-io-library.html
 
 ## SDK libraries
 

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -49,6 +49,6 @@ go to [the SDK issue tracker][sdk-issues].
 
 [Dart libraries]: /libraries
 [flutter]: {{site.flutter-docs}}/get-started/install
-[site SDK version]: {{site.dart-api}}/{{site.sdkInfo.channel}}/{{site.sdkInfo.version}}/index.html
+[site SDK version]: {{site.dart-api}}/{{site.sdkInfo.version}}/index.html
 [readme]: {{site.repo.dart.sdk}}/blob/main/README.dart-sdk
 [sdk-issues]: {{site.repo.dart.sdk}}/issues

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -631,7 +631,7 @@ that help with parsing and using command-line arguments:
 For more classes, functions, and properties,
 consult the API docs for
 [`dart:io`]({{ioAPI}}/dart-io-library.html),
-[`dart:convert`]({{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/dart-convert-library.html),
+[`dart:convert`]({{site.dart-api}}/dart-convert/dart-convert-library.html),
 and [`package:args`]({{argsAPI}}/args-library.html).
 
 For another example of a command line app, 

--- a/src/content/tutorials/server/fetch-data.md
+++ b/src/content/tutorials/server/fetch-data.md
@@ -302,7 +302,7 @@ await http.get(Uri.https('dart.dev', '/f/packages/http.json'),
 [http-read]: {{site.pub-api}}/http/latest/http/read.html
 [http-client-exc]: {{site.pub-api}}/http/latest/http/ClientException-class.html
 [mock-http-json]: /f/packages/http.json
-[`Future`]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-async/Future-class.html
+[`Future`]: {{site.dart-api}}/dart-async/Future-class.html
 [status code]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 [headers]: https://developer.mozilla.org/docs/Web/HTTP/Headers
 [http-get]: {{site.pub-api}}/http/latest/http/get.html
@@ -399,7 +399,7 @@ void main() async {
 }
 ```
 
-[decode-docs]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/JsonCodec/decode.html
+[decode-docs]: {{site.dart-api}}/dart-convert/JsonCodec/decode.html
 
 ### Create a structured class to store the data
 
@@ -652,6 +652,6 @@ to prevent your interface from becoming unresponsive.
 
 [URI]: https://wikipedia.org/wiki/Uniform_Resource_Identifier
 [Using JSON]: /guides/json
-[convert-docs]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-convert/dart-convert-library.html
+[convert-docs]: {{site.dart-api}}/dart-convert/dart-convert-library.html
 [http-pub]: {{site.pub-pkg}}/http
 [http-docs]: {{site.pub-api}}/http

--- a/src/content/web/libraries.md
+++ b/src/content/web/libraries.md
@@ -37,9 +37,9 @@ To find other libraries that support the web platform,
 search pub.dev for [web packages][].
 
 [web]: {{site.pub-pkg}}/web
-[Dart SDK]: {{site.dart-api}}/{{site.sdkInfo.channel}}
+[Dart SDK]: {{site.dart-api}}
 [migrate]: /interop/js-interop/package-web
-[js_interop]: {{site.dart-api}}/{{site.sdkInfo.channel}}/dart-js_interop/dart-js_interop-library.html
+[js_interop]: {{site.dart-api}}/dart-js_interop/dart-js_interop-library.html
 [flutter-web]: {{site.flutter-docs}}/platform-integration/web
 [flutter]: {{site.flutter}}
 [web packages]: {{site.pub}}/web


### PR DESCRIPTION
Fixes #6210 

I did a find-and-replace to remove the redirects to `/stable/` (`{{site.sdkInfo.channel}}`), based on this note from the new api backend launch comms: 

> - [api.dart.dev/](http://api.dart.dev/) serves the latest stable directly (no longer redirects to /stable/<latest stable version>).
> - [api.dart.dev/(main|dev|beta)](http://api.dart.dev/(main%7Cdev%7Cbeta)) redirects to [api.dart.dev/(main|dev|beta)/latest](http://api.dart.dev/(main%7Cdev%7Cbeta)/latest).

But I didn't account for the second bullet, any possible main/dev/beta redirects, will that be an issue? 

I also came across [this note](https://github.com/dart-lang/site-www/blob/main/src/content/tools/sdk.md?plain=1#L17) that uses `site.sdkInfo.channel` as a condition...So I'm starting to think that blanket-removing all of them might not be the right move. Please advise @parlough!