### PR TITLE
Remove unused SDK channel config

### DIFF
--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -40,6 +40,4 @@ show_banner: true
 # in the `firebase.json` redirect rule.)
 og_image_vers: "?2"
 
-sdkInfo:
-  channel: stable
-  version: 3.5.3
+sdkVersion: 3.5.4

--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -4,7 +4,7 @@
 {% assign url = site.url | append: page.url -%}
 
 <p id="page-github-links">
-  <span>Unless stated otherwise, the documentation on this site reflects Dart {{site.sdkInfo.version}}. Page last updated on {{page.date | toSimpleDate}}.</span>
+  <span>Unless stated otherwise, the documentation on this site reflects Dart {{site.sdkVersion}}. Page last updated on {{page.date | toSimpleDate}}.</span>
   <a href="{{pageSource}}" target="_blank" rel="noopener">View source</a>
   <span> or </span>
   <a href="{{repo}}/issues/new?template=1_page_issue.yml&page-url={{url}}&page-source={{pageSource}}" title="Report an issue with this page" target="_blank" rel="noopener">report an issue</a>.

--- a/src/content/get-dart/archive/index.md
+++ b/src/content/get-dart/archive/index.md
@@ -11,8 +11,7 @@ js:
 
 Use this archive to download
 [specific versions](/get-dart#release-channels) of the
-[Dart SDK](/tools/sdk)
-and the [Dart API documentation.]({{site.dart-api}}/{{site.sdkInfo.channel}})
+[Dart SDK](/tools/sdk) and the [Dart API documentation]({{site.dart-api}}).
 
 Want to install Dart with your OS's package manager?
 [Get Dart.](/get-dart)

--- a/src/content/tools/linter-rules/all.md
+++ b/src/content/tools/linter-rules/all.md
@@ -6,7 +6,7 @@ show_breadcrumbs: true
 ---
 
 The following is an auto-generated list of all linter rules
-available in the Dart SDK as of version `{{site.sdkInfo.version}}`.
+available in the Dart SDK as of version `{{site.sdkVersion}}`.
 Add them to your
 [`analysis_options.yaml`](/tools/analysis) file
 and adjust as you see fit.

--- a/src/content/tools/linter-rules/index.md
+++ b/src/content/tools/linter-rules/index.md
@@ -113,7 +113,7 @@ To learn more about each rule,
 click on its name.
 
 For an auto-generated list containing all linter rules
-in Dart `{{site.sdkInfo.version}}`,
+in Dart `{{site.sdkVersion}}`,
 check out [All linter rules](/tools/linter-rules/all).
 
 {% render 'linter-rules-section.md', linter_rules:linter_rules %}

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -13,9 +13,9 @@ To learn about other tools you can use for Dart development,
 check out the [Dart tools](/tools) page.
 
 :::version-note
-This site's documentation and examples use
-{% if site.sdkInfo.channel == 'dev' %} the **dev channel** {% endif -%}
-version [{{site.sdkInfo.version}}][site SDK version] of the **Dart SDK**.
+Unless stated otherwise,
+this site's documentation and examples assume
+version `{{site.sdkVersion}}` of the **Dart SDK**.
 :::
 
 {% comment %}
@@ -49,6 +49,5 @@ go to [the SDK issue tracker][sdk-issues].
 
 [Dart libraries]: /libraries
 [flutter]: {{site.flutter-docs}}/get-started/install
-[site SDK version]: {{site.dart-api}}/{{site.sdkInfo.version}}/index.html
 [readme]: {{site.repo.dart.sdk}}/blob/main/README.dart-sdk
 [sdk-issues]: {{site.repo.dart.sdk}}/issues

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -9,9 +9,8 @@ prevpage:
   title: "Get started: Command-line and server apps"
 ---
 
-{% assign _api = site.dart-api | append: '/' | append: site.sdkInfo.channel -%}
 {% assign argsAPI = site.pub-api | append: '/args/latest/args' -%}
-{% assign ioAPI = _api | append: '/dart-io' -%}
+{% assign ioAPI = site.dart-api | append: '/dart-io' -%}
 
 <?code-excerpt replace="/ ?\/\/!tip.*//g"?>
 
@@ -27,8 +26,8 @@ prevpage:
 
 :::note
 This tutorial uses the `async` and `await` language features, which rely on
-the [`Future`]({{_api}}/dart-async/Future-class.html) and
-[`Stream`]({{_api}}/dart-async/Stream-class.html)
+the [`Future`]({{site.dart-api}}/dart-async/Future-class.html) and
+[`Stream`]({{_site.dart-api}}/dart-async/Stream-class.html)
 classes for asynchronous support.
 To learn more about these features, see the
 [asynchronous programming tutorial](/libraries/async/async-await) and the
@@ -191,7 +190,7 @@ $ dart run bin/dcat.dart -n pubspec.yaml
 4 # repository: https://github.com/my_org/my_repo
 5 
 6 environment:
-7   sdk: ^3.5.3
+7   sdk: ^3.5.4
 8 
 9 # Add regular dependencies here.
 10 dependencies:

--- a/tool/config/site_variable_scanner.yaml
+++ b/tool/config/site_variable_scanner.yaml
@@ -22,7 +22,6 @@ yaml_variable_scanner:
     - ^site\.branch$
     - ^site\.show_banner$
     - ^site\.og_image_vers$
-    - ^site\.sdkInfo\.
   
   # File path for check file contents
   #


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/site-www/commit/8c650cadb53e690c6058802f620e327fba2f003e, removing the `sdkInfo.channel` variable as we haven't deployed a non-stable version of the site in a long time.