### PR TITLE
atproto verification for BlueSky

### DIFF
--- a/src/content/.well-known/atproto-did
+++ b/src/content/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:wt6ocslei6uszk4atkqhdqlq

--- a/src/content/.well-known/atproto-did
+++ b/src/content/.well-known/atproto-did
@@ -1,1 +1,0 @@
-did:plc:wt6ocslei6uszk4atkqhdqlq

--- a/src/content/.well-known/atproto-did.liquid
+++ b/src/content/.well-known/atproto-did.liquid
@@ -1,6 +1,7 @@
 ---
 layout: none
 permalink: atproto-did
+eleventyAllowMissingExtension: true
 skipFreshness: true
 ---
 did:plc:wt6ocslei6uszk4atkqhdqlq

--- a/src/content/.well-known/atproto-did.liquid
+++ b/src/content/.well-known/atproto-did.liquid
@@ -1,6 +1,6 @@
 ---
 layout: none
-permalink: atproto-did
+permalink: .well-known/atproto-did
 eleventyAllowMissingExtension: true
 skipFreshness: true
 ---

--- a/src/content/.well-known/atproto-did.liquid
+++ b/src/content/.well-known/atproto-did.liquid
@@ -1,0 +1,6 @@
+---
+layout: none
+permalink: atproto-did
+skipFreshness: true
+---
+did:plc:wt6ocslei6uszk4atkqhdqlq


### PR DESCRIPTION
Turns https://bsky.app/profile/dartlang.bsky.social into https://bsky.app/profile/dart.dev