### PR TITLE
Language evolution 3.6

### DIFF
--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -173,6 +173,8 @@ const msUntilRetry = secondsUntilRetry * msPerSecond;
 
 For more information, see [Numbers in Dart][dart-numbers].
 
+<a id="digit-separators"></a>
+
 You can use one or more underscores (`_`) as digit separators
 to make long number literals more readable.
 Multiple digit separators allow for higher level grouping.

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -42,6 +42,19 @@ on the Dart language GitHub repo.
 
 ## Changes in each release
 
+### Dart 3.6
+_Released 11 December 2024_
+| [Dart 3.6 announcement](https://medium.com/dartlang/announcing-dart-3-6-778dd7a80983)
+
+Dart 3.6 added the [digit separator][] underscore (`_`) to the language.
+Digit separators improve readability of long number literals.
+
+```dart
+var m = 100__000_000__000_000__000_000
+```
+
+[digit separator]: /language/built-in-types#digit-separators
+
 ### Dart 3.5
 _Released 6 August 2024_
 | [Dart 3.5 announcement](https://medium.com/dartlang/dart-3-5-6ca36259fa2f)


### PR DESCRIPTION
Also added an id to the section that talks about digit separators in the language tour, so we have something to point to. 

fixes #6267 