### PR TITLE
Tighten guidelines around dynamic

### DIFF
--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -133,9 +133,9 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion prefer-dynamic
+    // #docregion prefer-object-question
     mergeJson(original, changes) => ellipsis();
-    // #enddocregion prefer-dynamic
+    // #enddocregion prefer-object-question
   }
 
   // #docregion avoid-function

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -271,21 +271,9 @@ void miscDeclAnalyzedButNotTested() {
   }
 
   {
-    // #docregion prefer-dynamic
-    dynamic mergeJson(dynamic original, dynamic changes) => ellipsis();
-    // #enddocregion prefer-dynamic
-  }
-
-  {
-    // #docregion infer-dynamic
-    Map<String, dynamic> readJson() => ellipsis();
-
-    void printUsers() {
-      var json = readJson();
-      var users = json['users'];
-      print(users);
-    }
-    // #enddocregion infer-dynamic
+    // #docregion prefer-object-question
+    Object? mergeJson(Object? original, Object? changes) => ellipsis();
+    // #enddocregion prefer-object-question
   }
 
   // #docregion avoid-function


### PR DESCRIPTION
As the language and ecosystem has grown the target for static safety has
moved up. Previously it was considered enough to be explicit about the
places where `dynamic` is introduced, and then it is OK to silently do
dynamic things with it, and write code that keeps references `dynamic`
throughout. It is more common today to want to be explicit about places
where `dynamic` is used, not just where it is introduced. We can see
this in expanded use of stricter static checking and the
`avoid_dynamic_calls` lint.

Rephrase two guidelines to move towards being strict about using
dynamic.
- Recommend annotating with `Object?` instead of `dynamic` when
  inferences fails. Update the code sample to use `Object?` in the
  method arguments are return types for the JSON related API. Update the
  text to explain how `Object?` is treated differently and more strictly
  statically, which makes the unsafe operations visible in syntax.
- Rephrase from using dynamic to "disable static checking" to using it
  to "invoke dynamic members". The wording for the rule already focused
  on using dynamic to "permit all operations". Remove the paragraph
  about retaining the `dynamic` type when working with APIs that use it,
  instead recommending to move away from `dynamic` at those boundaries
  and using `Object?` in most code.
