### PR TITLE
Update macros.md

### DIFF
--- a/src/content/language/macros.md
+++ b/src/content/language/macros.md
@@ -45,7 +45,7 @@ It generates two members, a `toJson` serialization method,
 and a `fromJson` deserialization constructor.
 
 [experimental flag]: /tools/experiment-flags
-[`JsonCodable`]: {{site.pub-pkg}}/json/versions/0.20.0
+[`JsonCodable`]: {{site.pub-pkg}}/json
 [channel]: https://dart.dev/get-dart#release-channels
 [flutter-channel]: {{site.flutter-docs}}/release/upgrade#other-channels
 


### PR DESCRIPTION
Hi,

I was going through the macros section, and the jsonCodeable hyperlink was point to a specific version which is not the latest. Which game me an impression that it no longer being worked at. but that is not the case.

so after discussing on dart discord, i had the confirmation it was a mistake. And hence raising this PR with the updated link.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
