### PR TITLE
Remove 'next page' link from lang intro page

### DIFF
--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -2,9 +2,6 @@
 title: Introduction to Dart
 description: A brief introduction to Dart programs and important concepts.
 short-title: Dart basics
-nextpage:
-  url: /language/variables
-  title: Variables
 ---
 
 This page provides a brief introduction to the Dart language


### PR DESCRIPTION
This 'next page' link on the very first page under Language, Language Introduction, is very confusing. You'd think that it navigates you to the Variables content just below the top content, but it takes you entirely out of the Language Introduction and deep into a very detailed topic on variables. I think just the off-ramp links at the bottom at https://dart.dev/language#additional-resources are sufficient without the 'next page' links.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
