### PR TITLE
Only surface prev and next buttons at bottom of page

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -19,7 +19,6 @@
       {% endif -%}
       <article>
         <div class="content">
-          {% include 'navigation-sub.html' -%}
           <div id="site-content-title">
             {% if underscore_breaker_titles -%}
             <h1>{{title | underscoreBreaker}}</h1>
@@ -34,7 +33,7 @@
           {% include 'navigation-toc-top.html', tocContents:tocContents -%}
           {% endif -%}
           {{ content }}
-          {% include 'navigation-sub.html' -%}
+          {% render 'navigation-sub.html', prevpage:prevpage, nextpage:nextpage %}
 
           {% include 'page-github-links.html' -%}
         </div>


### PR DESCRIPTION
An alternative to https://github.com/dart-lang/site-www/pull/6316 that removes the previous and next page buttons at the top of each page, keeping the buttons at the bottom.

This fits the primary purpose of the buttons and eases the transition to future site designs, which will overhaul this anyway.

Closes https://github.com/dart-lang/site-www/pull/6316
Contribute to https://github.com/dart-lang/site-www/issues/5768