### PR TITLE
Mention IsolateNameServer on isolates.md

### DIFF
--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -224,6 +224,15 @@ main isolate. Isolates can only communicate via message passing.
 They can’t “see”  inside each others’ memory, 
 which is where the name “isolate” comes from.
 
+:::note
+In some cases when you don't have easy access to the point isolates are created
+and cannot pass the communication channel during `Isolate.spawn` call,
+you can instead use the [IsolateNameServer](https://api.flutter.dev/flutter/dart-ui/IsolateNameServer-class.html).
+It is a global mapping of names to ports where 
+isolates can dynamically register themselves 
+for future discovery among other isolates.
+:::
+
 To set up this 2-way communication, first create a [`ReceivePort`][] 
 in the main isolate, then pass its [`SendPort`][] as an argument to the 
 new isolate when spawning it with `Isolate.spawn`.


### PR DESCRIPTION
I had a use case where I needed to communicate between isolates. The isolate that needs to send a message was not being created by me but created by a library(flutter_local_notification's notification action)

During my search for a solution to create a communication channel in such a case, I found the excerpt that is just above my addition very confusing since it makes me believe that there is no solution to my problem. (Since I cannot interfere with the `Isolate.spawn` call directly, I thought I cannot obtain a communication channel between the isolates.)

This is why I'm doing that contribution to the doc. In my opinion, it is essential to mention the IsolateNameServer class inside isolates.md file, and state that it can allow dynamical registration of ports even though you cannot control the creation of the isolate. 

I am very open for any suggestions and other changes to make that mention more blended to the rest of the document. 

Thank you in advance!

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
