### PR TITLE
Remove unused anchor

### DIFF
--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -347,10 +347,8 @@ either of those lists results in a runtime exception.
 
 [number-js]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type
 [ppwsize]: https://work.j832.com/2012/11/excited-to-see-dart2js-minified-output.html
-[package:js]: {{site.pub-pkg}}/js
 [dart compile]: /tools/dart-compile
 [dart analyze]: /tools/dart-analyze
 [webdev]: /tools/webdev
-
 [dart-mirror]: {{site.dart-api}}/dart-mirrors/dart-mirrors-library.html
 [pub-cmd]: /tools/pub/cmd


### PR DESCRIPTION
Unused link to package:js (deprecated) on faq page

Fixes #6278 