### PR TITLE
Update specified version for 3.6.2 release

### DIFF
--- a/examples/analysis/pubspec.yaml
+++ b/examples/analysis/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/analysis_alt/pubspec.yaml
+++ b/examples/analysis_alt/pubspec.yaml
@@ -3,4 +3,4 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1

--- a/examples/async_await/pubspec.yaml
+++ b/examples/async_await/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/build_runner_usage/pubspec.yaml
+++ b/examples/build_runner_usage/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev build_runner example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dev_dependencies:
   args: ^2.5.0

--- a/examples/cli/pubspec.yaml
+++ b/examples/cli/pubspec.yaml
@@ -3,7 +3,7 @@ description: Examples for CLI tutorials on dart.dev
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   args: ^2.5.0

--- a/examples/concurrency/pubspec.yaml
+++ b/examples/concurrency/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   http: any

--- a/examples/create_libraries/pubspec.yaml
+++ b/examples/create_libraries/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dev_dependencies:
   test: ^1.25.8

--- a/examples/extension_methods/pubspec.yaml
+++ b/examples/extension_methods/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dev_dependencies:
   test: ^1.25.8

--- a/examples/fetch_data/pubspec.yaml
+++ b/examples/fetch_data/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   http: ^1.2.2

--- a/examples/futures/pubspec.yaml
+++ b/examples/futures/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/html/pubspec.yaml
+++ b/examples/html/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dev_dependencies:
   test: ^1.25.8

--- a/examples/iterables/pubspec.yaml
+++ b/examples/iterables/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dev_dependencies:
   examples_util: {path: ../util}

--- a/examples/language/pubspec.yaml
+++ b/examples/language/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   examples_util: { path: ../util }

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   args: ^2.5.0

--- a/examples/non_promotion/pubspec.yaml
+++ b/examples/non_promotion/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   mockito: ^5.4.4

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 workspace:
   - analysis

--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -157,7 +157,6 @@ abstract class C implements List<int> {}
 // #enddocregion compatible-generics
 
 // #docregion conflicting-generics
-// ignore: inconsistent_inheritance, conflicting_generic_interfaces,
-// ignore: duplicate_definition
+// ignore: duplicate_definition, inconsistent_inheritance, conflicting_generic_interfaces
 abstract class C implements List<int>, Iterable<num> {}
 // #enddocregion conflicting-generics

--- a/examples/type_system/pubspec.yaml
+++ b/examples/type_system/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev type system examples.
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   examples_util: {path: ../util}

--- a/examples/util/pubspec.yaml
+++ b/examples/util/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   test: ^1.25.8

--- a/examples/vector_victor/pubspec.yaml
+++ b/examples/vector_victor/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 # dependencies:
 #   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 homepage: https://dart.dev
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 workspace:
   - tool/dart_site

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -40,4 +40,4 @@ show_banner: false
 # in the `firebase.json` redirect rule.)
 og_image_vers: "?2"
 
-sdkVersion: 3.6.0
+sdkVersion: 3.6.2

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -190,7 +190,7 @@ $ dart run bin/dcat.dart -n pubspec.yaml
 4 # repository: https://github.com/my_org/my_repo
 5 
 6 environment:
-7   sdk: ^3.6.0
+7   sdk: ^3.6.1
 8 
 9 # Add regular dependencies here.
 10 dependencies:

--- a/tool/dart_site/pubspec.yaml
+++ b/tool/dart_site/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   args: ^2.5.0

--- a/tool/get-dart/archive/pubspec.yaml
+++ b/tool/get-dart/archive/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   dart_sdk_archive:

--- a/tool/get-dart/dart_sdk_archive/pubspec.yaml
+++ b/tool/get-dart/dart_sdk_archive/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   http: ^1.2.2

--- a/tool/get-dart/pubspec.yaml
+++ b/tool/get-dart/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 workspace:
   - archive

--- a/tool/get-dart/sdk_builds/pubspec.yaml
+++ b/tool/get-dart/sdk_builds/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.6.1
 
 dependencies:
   googleapis: ^13.2.0


### PR DESCRIPTION
Also require 3.6.1 for site infra and samples, as it includes a necessary fix for workspaces to work properly.