### PR TITLE
Uncomment digit separators code excerpt

### DIFF
--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -37,16 +37,15 @@ void miscDeclAnalyzedButNotTested() {
     // #enddocregion const-num
   }
 
-  // Uncomment when feature is stable:
-  // {
-  //   // #docregion digit-separators
-  //   var n1 = 1_000_000;
-  //   var n2 = 0.000_000_000_01;
-  //   var n3 = 0x00_14_22_01_23_45;  // MAC address
-  //   var n4 = 555_123_4567;  // US Phone number
-  //   var n5 = 100__000_000__000_000;  // one hundred million million!
-  //   // #enddocregion digit-separators
-  // }
+  {
+    // #docregion digit-separators
+    var n1 = 1_000_000;
+    var n2 = 0.000_000_000_01;
+    var n3 = 0x00_14_22_01_23_45;  // MAC address
+    var n4 = 555_123_4567;  // US Phone number
+    var n5 = 100__000_000__000_000;  // one hundred million million!
+    // #enddocregion digit-separators
+  }
 
   {
     // #docregion quoting

--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -41,9 +41,9 @@ void miscDeclAnalyzedButNotTested() {
     // #docregion digit-separators
     var n1 = 1_000_000;
     var n2 = 0.000_000_000_01;
-    var n3 = 0x00_14_22_01_23_45;  // MAC address
-    var n4 = 555_123_4567;  // US Phone number
-    var n5 = 100__000_000__000_000;  // one hundred million million!
+    var n3 = 0x00_14_22_01_23_45; // MAC address
+    var n4 = 555_123_4567; // US Phone number
+    var n5 = 100__000_000__000_000; // one hundred million million!
     // #enddocregion digit-separators
   }
 

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -183,9 +183,9 @@ Multiple digit separators allow for higher level grouping.
 ```dart
 var n1 = 1_000_000;
 var n2 = 0.000_000_000_01;
-var n3 = 0x00_14_22_01_23_45;  // MAC address
-var n4 = 555_123_4567;  // US Phone number
-var n5 = 100__000_000__000_000;  // one hundred million million!
+var n3 = 0x00_14_22_01_23_45; // MAC address
+var n4 = 555_123_4567; // US Phone number
+var n5 = 100__000_000__000_000; // one hundred million million!
 ```
 
 :::version-note

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -179,11 +179,7 @@ You can use one or more underscores (`_`) as digit separators
 to make long number literals more readable.
 Multiple digit separators allow for higher level grouping.
 
-{% comment %}
-Attach code excerpt misc/lib/language_tour/built_in_types.dart (digit-separators)
-when feature is stable:
-{% endcomment %}
-
+<?code-excerpt "misc/lib/language_tour/built_in_types.dart (digit-separators)"?>
 ```dart
 var n1 = 1_000_000;
 var n2 = 0.000_000_000_01;


### PR DESCRIPTION
Just noticed some comments around digit separators that said to uncomment after 3.6!