### PR TITLE
Update variables.md incorrect reference to the `final bar` variable

### DIFF
--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -249,8 +249,8 @@ final bar = const [];
 const baz = []; // Equivalent to `const []`
 ```
 
-You can omit `const` from the initializing expression of a `const` declaration,
-like for `baz` above. For details, see [DON'T use const redundantly][].
+You can omit `const` from the initializing expression of a `final` declaration,
+like for `bar` above. For details, see [DON'T use const redundantly][].
 
 You can change the value of a non-final, non-const variable,
 even if it used to have a `const` value:


### PR DESCRIPTION
Fixes the comment that mentions omitting `const` from variables defined as `final`.