### PR TITLE
Fix text button font size on linter rules page

### DIFF
--- a/src/_sass/components/_linter-rules.scss
+++ b/src/_sass/components/_linter-rules.scss
@@ -188,6 +188,7 @@ body.linter-rules {
 
     padding: 0 .5rem;
     height: 1.75rem;
+    font-size: 1rem;
 
     &:hover {
       @include interaction-style(4%);

--- a/src/_sass/components/_toc.scss
+++ b/src/_sass/components/_toc.scss
@@ -22,7 +22,7 @@
 
   display: none;
   position: sticky;
-  top: 0;
+  top: $site-header-height;
   order: 2;
   width: 15rem;
   min-width: 15rem;


### PR DESCRIPTION
Before this change, the font size of the trailing text button was too large compared to the nearby chips.

**Before:**
<img width="400" alt="Screenshot of linter rule filter chips with too big text button" src="https://github.com/user-attachments/assets/e96f5c37-be1a-4865-9617-96e3a2be6e56" />

**After:**
<img width="400" alt="Screenshot of linter rule filter chips with fixed text button" src="https://github.com/user-attachments/assets/9cef84a5-5125-4d52-a74d-13f62c94ce1f" />