### PR TITLE
Wrap cookie notice buttons in very narrow layouts

### DIFF
--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -4,7 +4,7 @@
   display: none;
   justify-content: center;
   background-color: $site-color-white;
-  padding: 1.5rem;
+  padding: 1.25rem;
   position: fixed;
   bottom: 0;
   width: 100%;
@@ -28,12 +28,17 @@
 
   .container {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     max-width: 1080px;
     min-width: 0;
     width: auto;
-    gap: 1.5rem;
+    gap: 1rem;
+    flex-wrap: wrap;
+
+    @media (min-width: 576px) {
+      flex-wrap: nowrap;
+    }
 
     .button-group {
       display: flex;


### PR DESCRIPTION
Now wraps the buttons to a new line if on a too narrow layout.

### After:
<br>

<img width="400" alt="Screenshot of cookie notice with wrapping" src="https://github.com/user-attachments/assets/d8c0b7a0-16fb-4029-8ceb-bf612069effe" />

### Before:
<br>

<img width="320" alt="Screenshot of cookie notice without wrapping" src="https://github.com/user-attachments/assets/3a520a8c-1e45-445f-afaf-6d336336eadb" />
