### PR TITLE
Move away from linted/deprecated `Map` constructor

### DIFF
--- a/examples/misc/test/language_tour/generics_test.dart
+++ b/examples/misc/test/language_tour/generics_test.dart
@@ -1,4 +1,6 @@
-// ignore_for_file: argument_type_not_assignable, prefer_collection_literals
+// ignore_for_file: type_annotate_public_apis
+import 'dart:collection';
+
 import 'package:examples/language_tour/generics/base_class.dart';
 import 'package:test/test.dart';
 
@@ -9,14 +11,14 @@ void main() {
     var names = <String>[];
     names.addAll(['Seth', 'Kathy', 'Lars']);
     // #docregion constructor-1
-    var nameSet = Set<String>.from(names);
+    var nameSet = Set<String>.of(names);
     // #enddocregion constructor-1
     expect(nameSet.length, 3);
   });
 
   test('constructor-2', () {
     // #docregion constructor-2
-    var views = Map<int, View>();
+    var views = SplayTreeMap<int, View>();
     // #enddocregion constructor-2
     expect(views.length, 0);
   });

--- a/src/content/language/generics.md
+++ b/src/content/language/generics.md
@@ -107,15 +107,15 @@ angle brackets (`<...>`) just after the class name. For example:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (constructor-1)"?>
 ```dart
-var nameSet = Set<String>.from(names);
+var nameSet = Set<String>.of(names);
 ```
 
-The following code creates a map that has integer keys and values of
-type View:
+The following code creates a map `SplayTreeMap` has integer keys and
+values of type `View`:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (constructor-2)"?>
 ```dart
-var views = Map<int, View>();
+var views = SplayTreeMap<int, View>();
 ```
 
 

--- a/src/content/language/generics.md
+++ b/src/content/language/generics.md
@@ -110,8 +110,8 @@ angle brackets (`<...>`) just after the class name. For example:
 var nameSet = Set<String>.of(names);
 ```
 
-The following code creates a map `SplayTreeMap` has integer keys and
-values of type `View`:
+The following code creates a `SplayTreeMap` that has
+integer keys and values of type `View`:
 
 <?code-excerpt "misc/test/language_tour/generics_test.dart (constructor-2)"?>
 ```dart


### PR DESCRIPTION
Also migrates nearby `Set.from` to `Set.of` which is preferred due to improved type safety.

Fixes https://github.com/dart-lang/site-www/issues/5036