### PR TITLE
Fix typo: Correct 'Ave' to 'ave' in bad examples for acronym capitalization

### DIFF
--- a/src/content/effective-dart/style.md
+++ b/src/content/effective-dart/style.md
@@ -259,7 +259,7 @@ HTTP // "hypertext transfer protocol"
 NASA // "national aeronautics and space administration"
 URI // "uniform resource identifier"
 esq // "esquire"
-ave // "avenue" (exception: lowercase in some contexts)
+ave // "avenue"
 
 Id // "identifier"
 Tv // "television"

--- a/src/content/effective-dart/style.md
+++ b/src/content/effective-dart/style.md
@@ -259,7 +259,7 @@ HTTP // "hypertext transfer protocol"
 NASA // "national aeronautics and space administration"
 URI // "uniform resource identifier"
 esq // "esquire"
-Ave // "avenue"
+ave // "avenue" (exception: lowercase in some contexts)
 
 Id // "identifier"
 Tv // "television"


### PR DESCRIPTION
**Description of the Issue:**
The word 'Ave' appears in both the "bad" and "good" examples in the "DO capitalize acronyms and abbreviations longer than two letters like words" section. This is inconsistent and likely a typo, as 'Ave' (short for "avenue") should be written as 'ave' in the "bad" examples.

**Changes Made:**
- Corrected 'Ave' to 'ave' in the "bad" examples to align with the guideline that abbreviations longer than two letters should be capitalized like words.
- Ensured consistency with the intended style rule.

**Related Issue:**
Fixes #6313.