### PR TITLE
Fix incorrect code in inference using bounds

### DIFF
--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -432,10 +432,10 @@ without losing type safety or specific type information.
 (X, Y) f<X extends Iterable<Y>, Y>(X x) => (x, x.first);
 
 void main() {
-  var (myList, myInt) = f1();
+  var (myList, myInt) = f([1]);
   myInt.whatever; // Compile-time error, `myInt` has type `int`.
 
-  var (mySet, myString) = f1({'Hello!'});
+  var (mySet, myString) = f({'Hello!'});
   mySet.union({}); // Works, `mySet` has type `Set<String>`.
 }
 ```


### PR DESCRIPTION
The function calls were using the wrong name, first example was missing its argument. I believe the intention was to pass in a `List<int>`, perhaps `[1]`.