### PR TITLE
Cross link from diagnostic message docs to related lint rule

### DIFF
--- a/src/_sass/components/_tags.scss
+++ b/src/_sass/components/_tags.scss
@@ -1,4 +1,5 @@
 @use '../base/variables' as *;
+@use '../base/mixins';
 
 .tag-label {
   user-select: none;
@@ -26,20 +27,20 @@
   background-color: #DADCE0;
 }
 
-.lint-tags {
+.tags {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   gap: 0.5rem;
 
-  div.tag-label {
+  .tag-label {
     display: flex;
     flex-direction: row;
     align-items: center;
     background-color: rgb(194 229 255);
     gap: 0.25rem;
     font-size: 1rem;
-    padding: 0.15rem 0.5rem;
+    padding: 0.1rem 0.4rem;
 
     span.material-symbols {
       fill: currentcolor;
@@ -58,6 +59,25 @@
 
     &.red {
       background-color: rgb(255, 205, 200);
+    }
+  }
+
+  span.tag-label {
+    display: inline-flex;
+  }
+
+  a.tag-label {
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      @include mixins.interaction-style(6%);
+      text-decoration: none;
+    }
+
+    &:active {
+      @include mixins.interaction-style(10%);
+      text-decoration: none;
     }
   }
 }

--- a/src/content/resources/glossary.md
+++ b/src/content/resources/glossary.md
@@ -86,6 +86,8 @@ The following are definitions of terms used across the Dart documentation.
     code_blocks
   {% when "diagnostic", "lint" %}
     lightbulb
+  {% when "lint" %}
+    toggle_on
   {% else %}
     article
 {% endcase -%}

--- a/src/content/tools/diagnostic-messages.md
+++ b/src/content/tools/diagnostic-messages.md
@@ -6175,8 +6175,7 @@ extension E on String {
 
 #### Common fixes
 
-If the value can be computed without storing it in a field,
-then try using a getter or a method:
+If the value can be computed without storing it in a field, then try using a getter or a method:
 
 ```dart
 extension E on String {
@@ -6186,8 +6185,7 @@ extension E on String {
 }
 ```
 
-If the value must be stored, but is the same for every instance,
-try using a static field:
+If the value must be stored, but is the same for every instance, try using a static field:
 
 ```dart
 extension E on String {
@@ -6195,8 +6193,7 @@ extension E on String {
 }
 ```
 
-If each instance needs to have its own value stored,
-then try using a getter and setter pair backed by a static `Expando`:
+If each instance needs to have its own value stored, then try using a getter and setter pair backed by a static Expando:
 
 ```dart
 extension E on SomeType {
@@ -24526,6 +24523,17 @@ Iterable<String> get zero sync* {
 
 ### always_declare_return_types
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/always_declare_return_types"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The function '{0}' should have a return type but doesn't._
 
 _The method '{0}' should have a return type but doesn't._
@@ -24553,6 +24561,17 @@ void f() {}
 ```
 
 ### always_put_control_body_on_new_line
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/always_put_control_body_on_new_line"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Statement should be on a separate line._
 
@@ -24587,6 +24606,17 @@ void f(bool b) {
 
 ### always_put_required_named_parameters_first
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/always_put_required_named_parameters_first"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Required named parameters should be before optional named parameters._
 
 #### Description
@@ -24613,6 +24643,17 @@ void f({required int x, int? y}) {}
 ```
 
 ### always_use_package_imports
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/always_use_package_imports"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'package:' imports for files in the 'lib' directory._
 
@@ -24641,6 +24682,17 @@ import 'package:p/a.dart';
 ```
 
 ### annotate_overrides
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/annotate_overrides"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The member '{0}' overrides an inherited member but isn't annotated with
 '@override'._
@@ -24697,6 +24749,17 @@ class B extends A {
 
 ### avoid_empty_else
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_empty_else"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Empty statements are not allowed in an 'else' clause._
 
 #### Description
@@ -24748,6 +24811,17 @@ void f(int x, int y) {
 
 ### avoid_function_literals_in_foreach_calls
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_function_literals_in_foreach_calls"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Function literals shouldn't be passed to 'forEach'._
 
 #### Description
@@ -24788,6 +24862,17 @@ void f(Iterable<String> s) {
 ```
 
 ### avoid_futureor_void
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_futureor_void"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Don't use the type 'FutureOr<void>'._
 
@@ -24838,6 +24923,17 @@ useful remedy to replace `FutureOr<void>` by the type `void`.
 
 ### avoid_init_to_null
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_init_to_null"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Redundant initialization to 'null'._
 
 #### Description
@@ -24885,6 +24981,17 @@ class C {
 
 ### avoid_print
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_print"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Don't invoke 'print' in production code._
 
 #### Description
@@ -24925,6 +25032,17 @@ information.
 
 ### avoid_relative_lib_imports
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_relative_lib_imports"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Can't use a relative path to import a library in 'lib'._
 
 #### Description
@@ -24956,6 +25074,17 @@ import 'a.dart';
 ```
 
 ### avoid_renaming_method_parameters
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_renaming_method_parameters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The parameter name '{0}' doesn't match the name '{1}' in the overridden
 method._
@@ -24999,6 +25128,17 @@ class B extends A {
 
 ### avoid_return_types_on_setters
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_return_types_on_setters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary return type on a setter._
 
 #### Description
@@ -25027,6 +25167,17 @@ set s(int p) {}
 ```
 
 ### avoid_returning_null_for_void
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_returning_null_for_void"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Don't return 'null' from a function with a return type of 'void'._
 
@@ -25059,6 +25210,17 @@ void f() {
 ```
 
 ### avoid_shadowing_type_parameters
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_shadowing_type_parameters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The type parameter '{0}' shadows a type parameter from the enclosing {1}._
 
@@ -25094,6 +25256,17 @@ class C<T> {
 
 ### avoid_single_cascade_in_expression_statements
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_single_cascade_in_expression_statements"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary cascade expression._
 
 #### Description
@@ -25124,6 +25297,17 @@ void f(String s) {
 ```
 
 ### avoid_slow_async_io
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_slow_async_io"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use of an async 'dart:io' method._
 
@@ -25171,6 +25355,17 @@ void g(File f) {
 
 ### avoid_type_to_string
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_type_to_string"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Using 'toString' on a 'Type' is not safe in production code._
 
 #### Description
@@ -25210,6 +25405,17 @@ class C {}
 ```
 
 ### avoid_types_as_parameter_names
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_types_as_parameter_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The parameter name '{0}' matches a visible type name._
 
@@ -25251,6 +25457,17 @@ void f(int_) {}
 ```
 
 ### avoid_unnecessary_containers
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_unnecessary_containers"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary instance of 'Container'._
 
@@ -25318,6 +25535,17 @@ Widget buildRow() {
 
 ### avoid_web_libraries_in_flutter
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/avoid_web_libraries_in_flutter"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Don't use web-only libraries outside Flutter web plugins._
 
 #### Description
@@ -25372,6 +25600,17 @@ for more information.
 
 ### await_only_futures
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/await_only_futures"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Uses 'await' on an instance of '{0}', which is not a subtype of 'Future'._
 
 #### Description
@@ -25409,6 +25648,17 @@ void f() async {
 
 ### camel_case_extensions
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/camel_case_extensions"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The extension name '{0}' isn't an UpperCamelCase identifier._
 
 #### Description
@@ -25443,6 +25693,17 @@ extension on String {}
 
 ### camel_case_types
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/camel_case_types"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The type name '{0}' isn't an UpperCamelCase identifier._
 
 #### Description
@@ -25469,6 +25730,17 @@ class C {}
 ```
 
 ### cancel_subscriptions
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/cancel_subscriptions"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Uncancelled instance of 'StreamSubscription'._
 
@@ -25506,6 +25778,17 @@ void f(Stream stream) {
 
 ### close_sinks
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/close_sinks"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unclosed instance of 'Sink'._
 
 #### Description
@@ -25542,6 +25825,17 @@ void g(File f) {
 ```
 
 ### collection_methods_unrelated_type
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/collection_methods_unrelated_type"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The argument type '{0}' isn't related to '{1}'._
 
@@ -25590,6 +25884,17 @@ bool f(List<String> l)  => l.contains('1');
 
 ### constant_identifier_names
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/constant_identifier_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The constant name '{0}' isn't a lowerCamelCase identifier._
 
 #### Description
@@ -25615,6 +25920,17 @@ const emptyString = '';
 ```
 
 ### control_flow_in_finally
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/control_flow_in_finally"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use of '{0}' in a 'finally' clause._
 
@@ -25671,6 +25987,17 @@ int f() {
 
 ### curly_braces_in_flow_control_structures
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/curly_braces_in_flow_control_structures"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Statements in {0} should be enclosed in a block._
 
 #### Description
@@ -25705,6 +26032,17 @@ int f(bool b) {
 ```
 
 ### dangling_library_doc_comments
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/dangling_library_doc_comments"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Dangling library doc comment._
 
@@ -25758,6 +26096,17 @@ class C {}
 ```
 
 ### depend_on_referenced_packages
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/depend_on_referenced_packages"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The imported package '{0}' isn't a dependency of the importing package._
 
@@ -25815,6 +26164,17 @@ dev_dependencies:
 ```
 
 ### empty_catches
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/empty_catches"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Empty catch block._
 
@@ -25877,6 +26237,17 @@ void f() {
 
 ### empty_constructor_bodies
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/empty_constructor_bodies"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Empty constructor bodies should be written using a ';' rather than '{}'._
 
 #### Description
@@ -25906,6 +26277,17 @@ class C {
 ```
 
 ### empty_statements
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/empty_statements"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary empty statement._
 
@@ -25971,6 +26353,17 @@ void g() {}
 
 ### file_names
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/file_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The file name '{0}' isn't a lower\_case\_with\_underscores identifier._
 
 #### Description
@@ -25989,6 +26382,17 @@ Rename the file to use the lower_case_with_underscores convention, such as
 `slider_menu.dart`.
 
 ### hash_and_equals
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/hash_and_equals"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Missing a corresponding override of '{0}'._
 
@@ -26057,6 +26461,17 @@ class C {
 
 ### implementation_imports
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/implementation_imports"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Import of a library in the 'lib/src' directory of another package._
 
 #### Description
@@ -26091,6 +26506,17 @@ it's possible, or open an issue asking the package authors to make it part
 of the public API.
 
 ### implicit_call_tearoffs
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/implicit_call_tearoffs"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Implicit tear-off of the 'call' method._
 
@@ -26138,6 +26564,17 @@ void f() {
 ```
 
 ### invalid_runtime_check_with_js_interop_types
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/invalid_runtime_check_with_js_interop_types"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Cast from '{0}' to '{1}' casts a Dart value to a JS interop type, which might
 not be platform-consistent._
@@ -26263,6 +26700,17 @@ void emulateCrashWithOtherFunctionality() {
 
 ### library_annotations
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/library_annotations"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _This annotation should be attached to a library directive._
 
 #### Description
@@ -26300,6 +26748,17 @@ void main() {}
 
 ### library_names
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/library_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The library name '{0}' isn't a lower\_case\_with\_underscores identifier._
 
 #### Description
@@ -26333,6 +26792,17 @@ library library_name;
 
 ### library_prefixes
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/library_prefixes"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The prefix '{0}' isn't a lower\_case\_with\_underscores identifier._
 
 #### Description
@@ -26359,6 +26829,17 @@ import 'package:ffi/ffi.dart' as ffi_support;
 ```
 
 ### library_private_types_in_public_api
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/library_private_types_in_public_api"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Invalid use of a private type in a public API._
 
@@ -26402,6 +26883,17 @@ class C {}
 ```
 
 ### literal_only_boolean_expressions
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/literal_only_boolean_expressions"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The Boolean expression has a constant value._
 
@@ -26461,6 +26953,17 @@ void f() {
 
 ### no_adjacent_strings_in_list
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_adjacent_strings_in_list"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Don't use adjacent strings in a list literal._
 
 #### Description
@@ -26502,6 +27005,17 @@ List<String> list = ['a' + 'b', 'c'];
 ```
 
 ### no_duplicate_case_values
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_duplicate_case_values"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The value of the case clause ('{0}') is equal to the value of an earlier case
 clause ('{1}')._
@@ -26563,6 +27077,17 @@ void f(int v) {
 
 ### no_leading_underscores_for_library_prefixes
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_leading_underscores_for_library_prefixes"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The library prefix '{0}' starts with an underscore._
 
 #### Description
@@ -26592,6 +27117,17 @@ import 'dart:core' as core;
 
 ### no_leading_underscores_for_local_identifiers
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_leading_underscores_for_local_identifiers"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The local variable '{0}' starts with an underscore._
 
 #### Description
@@ -26620,6 +27156,17 @@ int f(String s) => s.length;
 ```
 
 ### no_logic_in_create_state
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_logic_in_create_state"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Don't put any logic in 'createState'._
 
@@ -26669,6 +27216,17 @@ class MyState extends State {
 ```
 
 ### no_wildcard_variable_uses
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/no_wildcard_variable_uses"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The referenced identifier is a wildcard._
 
@@ -26724,6 +27282,17 @@ void f() {
 
 ### non_constant_identifier_names
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/non_constant_identifier_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The variable name '{0}' isn't a lowerCamelCase identifier._
 
 #### Description
@@ -26752,6 +27321,17 @@ var count = 0;
 ```
 
 ### null_check_on_nullable_type_parameter
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/null_check_on_nullable_type_parameter"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The null check operator shouldn't be used on a variable whose type is a
 potentially nullable type parameter._
@@ -26790,6 +27370,17 @@ T f<T>(T? t) => t as T;
 ```
 
 ### overridden_fields
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/overridden_fields"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Field overrides a field inherited from '{0}'._
 
@@ -26850,6 +27441,17 @@ find a different way to implement the semantics you need.
 
 ### package_names
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/package_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The package name '{0}' isn't a lower\_case\_with\_underscores identifier._
 
 #### Description
@@ -26876,6 +27478,17 @@ name: some_package
 ```
 
 ### package_prefixed_library_names
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/package_prefixed_library_names"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The library name is not a dot-separated path prefixed by the package name._
 
@@ -26912,6 +27525,17 @@ Change the name of the library to conform to the guidelines.
 
 ### prefer_adjacent_string_concatenation
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_adjacent_string_concatenation"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _String literals shouldn't be concatenated by the '+' operator._
 
 #### Description
@@ -26937,6 +27561,17 @@ var s = 'a' 'b';
 ```
 
 ### prefer_collection_literals
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_collection_literals"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary constructor invocation._
 
@@ -26964,6 +27599,17 @@ var m = <String, String>{};
 ```
 
 ### prefer_conditional_assignment
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_conditional_assignment"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The 'if' statement could be replaced by a null-aware assignment._
 
@@ -27000,6 +27646,17 @@ int f(String? s) {
 ```
 
 ### prefer_const_constructors
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_const_constructors"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'const' with the constructor to improve performance._
 
@@ -27046,6 +27703,17 @@ C c = const C();
 ```
 
 ### prefer_const_constructors_in_immutables
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_const_constructors_in_immutables"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Constructors in '@immutable' classes should be declared as 'const'._
 
@@ -27098,6 +27766,17 @@ class C {
 
 ### prefer_const_declarations
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_const_declarations"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use 'const' for final variables initialized to a constant value._
 
 #### Description
@@ -27146,6 +27825,17 @@ class C {
 ```
 
 ### prefer_const_literals_to_create_immutables
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_const_literals_to_create_immutables"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'const' literals as arguments to constructors of '@immutable' classes._
 
@@ -27227,6 +27917,17 @@ C c = C(const [1]);
 
 ### prefer_contains
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_contains"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Always 'false' because 'indexOf' is always greater than or equal to -1._
 
 _Always 'true' because 'indexOf' is always greater than or equal to -1._
@@ -27266,6 +27967,17 @@ void f(List<String> l, String s) {
 
 ### prefer_double_quotes
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_double_quotes"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of single quotes._
 
 #### Description
@@ -27296,6 +28008,17 @@ void f(String name) {
 ```
 
 ### prefer_final_fields
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_final_fields"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The private field {0} could be 'final'._
 
@@ -27331,6 +28054,17 @@ class C {
 ```
 
 ### prefer_for_elements_to_map_fromiterable
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_for_elements_to_map_fromIterable"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'for' elements when building maps from iterables._
 
@@ -27369,6 +28103,17 @@ void f(Iterable<String> data) {
 
 ### prefer_function_declarations_over_variables
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_function_declarations_over_variables"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use a function declaration rather than a variable assignment to bind a function
 to a name._
 
@@ -27402,6 +28147,17 @@ void g() {
 
 ### prefer_generic_function_type_aliases
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_generic_function_type_aliases"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use the generic function type syntax in 'typedef's._
 
 #### Description
@@ -27428,6 +28184,17 @@ typedef F<T> = void Function();
 ```
 
 ### prefer_if_null_operators
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_if_null_operators"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use the '??' operator rather than '?:' when testing for 'null'._
 
@@ -27456,6 +28223,17 @@ String f(String? s) => s ?? '';
 ```
 
 ### prefer_initializing_formals
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_initializing_formals"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use an initializing formal to assign a parameter to a field._
 
@@ -27490,6 +28268,17 @@ class C {
 ```
 
 ### prefer_inlined_adds
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_inlined_adds"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The addition of a list item could be inlined._
 
@@ -27545,6 +28334,17 @@ List<String> f(String a, List<String> b) {
 
 ### prefer_interpolation_to_compose_strings
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_interpolation_to_compose_strings"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use interpolation to compose strings and values._
 
 #### Description
@@ -27575,6 +28375,17 @@ String f(List<String> l) {
 ```
 
 ### prefer_is_empty
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_is_empty"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The comparison is always 'false' because the length is always greater than or
 equal to 0._
@@ -27612,6 +28423,17 @@ void f(Iterable<int> p) => p.isEmpty ? 0 : p.first;
 
 ### prefer_is_not_empty
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_is_not_empty"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use 'isNotEmpty' rather than negating the result of 'isEmpty'._
 
 #### Description
@@ -27637,6 +28459,17 @@ void f(Iterable<int> p) => p.isNotEmpty ? p.first : 0;
 ```
 
 ### prefer_is_not_operator
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_is_not_operator"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use the 'is!' operator rather than negating the value of the 'is' operator._
 
@@ -27674,6 +28507,17 @@ String f(Object o) {
 
 ### prefer_iterable_wheretype
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_iterable_whereType"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use 'whereType' to select elements of a given type._
 
 #### Description
@@ -27702,6 +28546,17 @@ This might also allow you to tighten the types in your code or remove
 other type checks.
 
 ### prefer_null_aware_operators
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_null_aware_operators"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use the null-aware operator '?.' rather than an explicit 'null' comparison._
 
@@ -27735,6 +28590,17 @@ int? f(List<int>? p) {
 
 ### prefer_relative_imports
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_relative_imports"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use relative imports for files in the 'lib' directory._
 
 #### Description
@@ -27761,6 +28627,17 @@ import 'bar.dart';
 ```
 
 ### prefer_single_quotes
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_single_quotes"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary use of double quotes._
 
@@ -27792,6 +28669,17 @@ void f(String name) {
 ```
 
 ### prefer_typing_uninitialized_variables
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_typing_uninitialized_variables"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _An uninitialized field should have an explicit type annotation._
 
@@ -27843,6 +28731,17 @@ Object f() {
 
 ### prefer_void_to_null
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/prefer_void_to_null"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of the type 'Null'._
 
 #### Description
@@ -27868,6 +28767,17 @@ Future<void> f() async {}
 ```
 
 ### provide_deprecation_message
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/provide_deprecation_message"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Missing a deprecation message._
 
@@ -27896,6 +28806,17 @@ void f() {}
 ```
 
 ### recursive_getters
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/recursive_getters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The getter '{0}' recursively returns itself._
 
@@ -27931,6 +28852,17 @@ class C {
 
 ### secure_pubspec_urls
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/secure_pubspec_urls"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The '{0}' protocol shouldn't be used because it isn't secure._
 
 #### Description
@@ -27960,6 +28892,17 @@ dependencies:
 ```
 
 ### sized_box_for_whitespace
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sized_box_for_whitespace"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use a 'SizedBox' to add whitespace to a layout._
 
@@ -28016,6 +28959,17 @@ Widget buildRow() {
 ```
 
 ### sized_box_shrink_expand
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sized_box_shrink_expand"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'SizedBox.{0}' to avoid needing to specify the 'height' and 'width'._
 
@@ -28085,6 +29039,17 @@ Widget build() {
 
 ### slash_for_doc_comments
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/slash_for_doc_comments"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use the end-of-line form ('///') for doc comments._
 
 #### Description
@@ -28114,6 +29079,17 @@ void f() {}
 ```
 
 ### sort_child_properties_last
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sort_child_properties_last"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The '{0}' argument should be last in widget constructor invocations._
 
@@ -28157,6 +29133,17 @@ Widget createWidget() {
 
 ### sort_constructors_first
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sort_constructors_first"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Constructor declarations should be before non-constructor declarations._
 
 #### Description
@@ -28191,6 +29178,17 @@ class C {
 
 ### sort_pub_dependencies
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sort_pub_dependencies"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Dependencies not sorted alphabetically._
 
 #### Description
@@ -28222,6 +29220,17 @@ dependencies:
 ```
 
 ### sort_unnamed_constructors_first
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/sort_unnamed_constructors_first"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Invalid location for the unnamed constructor._
 
@@ -28256,6 +29265,17 @@ class C {
 ```
 
 ### test_types_in_equals
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/test_types_in_equals"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Missing type test for '{0}' in '=='._
 
@@ -28301,6 +29321,17 @@ class C {
 
 ### throw_in_finally
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/throw_in_finally"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use of '{0}' in 'finally' block._
 
 #### Description
@@ -28342,6 +29373,17 @@ void f() {
 ```
 
 ### type_init_formals
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/type_init_formals"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Don't needlessly type annotate initializing formals._
 
@@ -28397,6 +29439,17 @@ class C {
 ```
 
 ### type_literal_in_constant_pattern
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/type_literal_in_constant_pattern"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'TypeName \_' instead of a type literal._
 
@@ -28454,6 +29507,17 @@ void f(Object? x) {
 
 ### unawaited_futures
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unawaited_futures"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Missing an 'await' for the 'Future' computed by this expression._
 
 #### Description
@@ -28504,6 +29568,17 @@ Future<int> g() => Future.value(0);
 ```
 
 ### unintended_html_in_doc_comment
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unintended_html_in_doc_comment"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Angle brackets will be interpreted as HTML._
 
@@ -28558,6 +29633,17 @@ String f(List<int> l) => '';
 
 ### unnecessary_brace_in_string_interps
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_brace_in_string_interps"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary braces in a string interpolation._
 
 #### Description
@@ -28589,6 +29675,17 @@ String f(String s) {
 
 ### unnecessary_const
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_const"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary 'const' keyword._
 
 #### Description
@@ -28618,6 +29715,17 @@ const l = <int>[];
 
 ### unnecessary_constructor_name
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_constructor_name"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary '.new' constructor name._
 
 #### Description
@@ -28644,6 +29752,17 @@ var o = Object();
 ```
 
 ### unnecessary_final
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_final"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Local variables should not be marked as 'final'._
 
@@ -28688,6 +29807,17 @@ void f(int a, int b) {
 
 ### unnecessary_getters_setters
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_getters_setters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of getter and setter to wrap a field._
 
 #### Description
@@ -28722,6 +29852,17 @@ class C {
 
 ### unnecessary_ignore
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_ignore"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The diagnostic '{0}' isn't produced at this location so it doesn't need to be
 ignored._
 
@@ -28752,6 +29893,17 @@ void f() {}
 ```
 
 ### unnecessary_lambdas
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_lambdas"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Closure should be a tearoff._
 
@@ -28787,6 +29939,17 @@ void f(List<String> strings) {
 
 ### unnecessary_late
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_late"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary 'late' modifier._
 
 #### Description
@@ -28818,6 +29981,17 @@ class C {
 ```
 
 ### unnecessary_library_name
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_library_name"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Library names are not necessary._
 
@@ -28852,6 +30026,17 @@ the library name should be updated to use the URI of the library instead.
 
 ### unnecessary_new
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_new"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary 'new' keyword._
 
 #### Description
@@ -28877,6 +30062,17 @@ var o = Object();
 ```
 
 ### unnecessary_null_aware_assignments
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_null_aware_assignments"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary assignment of 'null'._
 
@@ -28917,6 +30113,17 @@ void f(String? s) {
 
 ### unnecessary_null_in_if_null_operators
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_null_in_if_null_operators"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of '??' with 'null'._
 
 #### Description
@@ -28951,6 +30158,17 @@ String? f(String? s) => s;
 
 ### unnecessary_nullable_for_final_variable_declarations
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_nullable_for_final_variable_declarations"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Type could be non-nullable._
 
 #### Description
@@ -28976,6 +30194,17 @@ final int i = 1;
 ```
 
 ### unnecessary_overrides
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_overrides"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary override._
 
@@ -29049,6 +30278,17 @@ class D extends C {}
 
 ### unnecessary_parenthesis
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_parenthesis"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of parentheses._
 
 #### Description
@@ -29074,6 +30314,17 @@ int f(int a, int b) => a + b;
 ```
 
 ### unnecessary_raw_strings
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_raw_strings"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary use of a raw string._
 
@@ -29101,6 +30352,17 @@ var s = 'abc';
 ```
 
 ### unnecessary_statements
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_statements"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary statement._
 
@@ -29150,6 +30412,17 @@ void f(int Function() first, int Function() second) {
 
 ### unnecessary_string_escapes
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_string_escapes"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary escape in string literal._
 
 #### Description
@@ -29175,6 +30448,17 @@ var s = "Don't use a backslash here.";
 ```
 
 ### unnecessary_string_interpolations
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_string_interpolations"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary use of string interpolation._
 
@@ -29203,6 +30487,17 @@ String f(String s) => s;
 ```
 
 ### unnecessary_this
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_this"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary 'this.' qualifier._
 
@@ -29237,6 +30532,17 @@ class C {
 ```
 
 ### unnecessary_to_list_in_spreads
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_to_list_in_spreads"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Unnecessary use of 'toList' in a spread._
 
@@ -29275,6 +30581,17 @@ List<String> toLowercase(List<String> strings) {
 
 ### unnecessary_underscores
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unnecessary_underscores"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Unnecessary use of multiple underscores._
 
 #### Description
@@ -29300,6 +30617,17 @@ void function(int _) { }
 ```
 
 ### unrelated_type_equality_checks
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unrelated_type_equality_checks"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _The type of the operand ('{0}') isn't a subtype or a supertype of the value
 being matched ('{1}')._
@@ -29349,6 +30677,17 @@ bool f(String s) {
 ```
 
 ### unsafe_variance
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/unsafe_variance"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _This type is unsafe: a type parameter occurs in a non-covariant position._
 
@@ -29433,6 +30772,17 @@ reasons.
 
 ### use_build_context_synchronously
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_build_context_synchronously"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Don't use 'BuildContext's across async gaps, guarded by an unrelated 'mounted'
 check._
 
@@ -29496,6 +30846,17 @@ class MyWidget extends Widget {
 
 ### use_colored_box
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_colored_box"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use a 'ColoredBox' rather than a 'Container' with only a 'Color'._
 
 #### Description
@@ -29535,6 +30896,17 @@ Widget build() {
 ```
 
 ### use_decorated_box
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_decorated_box"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'DecoratedBox' rather than a 'Container' with only a 'Decoration'._
 
@@ -29586,6 +30958,17 @@ Widget buildArea() {
 
 ### use_full_hex_values_for_flutter_colors
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_full_hex_values_for_flutter_colors"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Instances of 'Color' should be created using an 8-digit hexadecimal integer
 (such as '0xFFFFFFFF')._
 
@@ -29618,6 +31001,17 @@ Color c = Color(0x00000001);
 
 ### use_function_type_syntax_for_parameters
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_function_type_syntax_for_parameters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use the generic function type syntax to declare the parameter '{0}'._
 
 #### Description
@@ -29643,6 +31037,17 @@ void g(bool Function(String) f) {}
 ```
 
 ### use_if_null_to_convert_nulls_to_bools
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_if_null_to_convert_nulls_to_bools"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use an if-null operator to convert a 'null' to a 'bool'._
 
@@ -29677,6 +31082,17 @@ void f(bool? b) {
 ```
 
 ### use_key_in_widget_constructors
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_key_in_widget_constructors"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Constructors for public widgets should have a named 'key' parameter._
 
@@ -29723,6 +31139,17 @@ class MyWidget extends StatelessWidget {
 
 ### use_late_for_private_fields_and_variables
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_late_for_private_fields_and_variables"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use 'late' for private members with a non-nullable type._
 
 #### Description
@@ -29759,6 +31186,17 @@ late int _i;
 ```
 
 ### use_named_constants
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_named_constants"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use the constant '{0}' rather than a constructor returning the same object._
 
@@ -29815,6 +31253,17 @@ f(int? x) => [?x];
 
 ### use_raw_strings
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_raw_strings"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use a raw string to avoid using escapes._
 
 #### Description
@@ -29842,6 +31291,17 @@ var s = r'A string with only \ and $';
 ```
 
 ### use_rethrow_when_possible
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_rethrow_when_possible"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use 'rethrow' to rethrow a caught exception._
 
@@ -29881,6 +31341,17 @@ void f() {
 
 ### use_setters_to_change_properties
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_setters_to_change_properties"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The method is used to change a property._
 
 #### Description
@@ -29915,6 +31386,17 @@ class C {
 ```
 
 ### use_string_buffers
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_string_buffers"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Use a string buffer rather than '+' to compose strings._
 
@@ -29955,6 +31437,17 @@ String f() {
 
 ### use_string_in_part_of_directives
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_string_in_part_of_directives"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _The part-of directive uses a library name._
 
 #### Description
@@ -29989,6 +31482,17 @@ part of 'lib.dart';
 ```
 
 ### use_super_parameters
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_super_parameters"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Parameter '{0}' could be a super parameter._
 
@@ -30029,6 +31533,17 @@ class B extends A {
 
 ### use_truncating_division
 
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/use_truncating_division"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
+
 _Use truncating division._
 
 #### Description
@@ -30057,6 +31572,17 @@ int divide(int x, int y) => x ~/ y;
 ```
 
 ### valid_regexps
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/valid_regexps"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Invalid regular expression syntax._
 
@@ -30087,6 +31613,17 @@ var r = RegExp(r'\(');
 ```
 
 ### void_checks
+
+<div class="tags">
+  <a class="tag-label" 
+      href="/tools/linter-rules/void_checks"
+      title="Learn about the lint rule that enables this diagnostic."
+      aria-label="Learn about the lint rule that enables this diagnostic."
+      target="_blank">
+    <span class="material-symbols" aria-hidden="true">toggle_on</span>
+    <span>Lint rule</span>
+  </a>
+</div>
 
 _Assignment to a variable of type 'void'._
 

--- a/src/content/tools/linter-rules/individual-rules.md
+++ b/src/content/tools/linter-rules/individual-rules.md
@@ -13,7 +13,7 @@ eleventyComputed:
 skipFreshness: true
 ---
 
-<div class="lint-tags">
+<div class="tags">
 {% if lint.sinceDartSdk == "Unreleased" or lint.sinceDartSdk contains "-wip" -%}
 <div class="tag-label orange" title="Lint is unreleased or work in progress." aria-label="Lint is unreleased or work in progress.">
 <span class="material-symbols" aria-hidden="true">pending</span>

--- a/tool/dart_site/lib/src/diagnostics/diagnostics.dart
+++ b/tool/dart_site/lib/src/diagnostics/diagnostics.dart
@@ -89,7 +89,7 @@ class DiagnosticInformation {
       sink.writeln();
       sink.writeln('''
 <div class="tags">
-  <a class="tag-label" 
+  <a class="tag-label"
       href="/tools/linter-rules/$name"
       title="Learn about the lint rule that enables this diagnostic."
       aria-label="Learn about the lint rule that enables this diagnostic."

--- a/tool/dart_site/lib/src/diagnostics/linter.dart
+++ b/tool/dart_site/lib/src/diagnostics/linter.dart
@@ -14,7 +14,7 @@ import '../utils.dart';
 String get _outputPath =>
     path.join(repositoryRoot, 'src', '_data', 'linter_rules.json');
 
-Future<void> fetchAndUpdate() async {
+final Future<List<Map<String, Object?>>> _lintDocs = () async {
   final rawRulesInfoUri = Uri.parse(
     'https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/pkg/linter/tool/machine/rules.json',
   );
@@ -41,9 +41,17 @@ Future<void> fetchAndUpdate() async {
     }.toList(growable: false);
   }
 
+  return rulesInfo;
+}();
+
+Future<Set<String>> get allLintNames async {
+  return (await _lintDocs).map((l) => l['name'] as String).toSet();
+}
+
+Future<void> fetchAndUpdate() async {
   final formattedRuleInfo = const JsonEncoder.withIndent(
     '  ',
-  ).convert(rulesInfo);
+  ).convert(await _lintDocs);
 
   File(_outputPath).writeAsStringSync(formattedRuleInfo);
 }


### PR DESCRIPTION
Adds a `Lint rule` tag after the header of the diagnostics resulting from enabled lints.

<img width="515" alt="Screenshot of the tag for the prefer_relative_imports diagnostic" src="https://github.com/user-attachments/assets/44ca3f24-b0d8-4042-b827-7f3cc87fdddd" />
