### PR TITLE
Adapt implicit cast example for type system page

### DIFF
--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -40,15 +40,15 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion downcast-check
-    void assumeStrings(dynamic objects) {
+    int assumeString(dynamic object) {
       // ignore: stable, beta, dev, invalid_assignment
-      List<String> strings = objects; // Runtime downcast check.
-      String string = strings[0];
+      String string = object; // Check at run time that `object` is a `String`.
+      return string.length;
     }
     // #enddocregion downcast-check
 
     // #docregion fail-downcast-check
-    assumeStrings(<int>[1, 2, 3]);
+    final length = assumeString(1);
     // #enddocregion fail-downcast-check
   }
 

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -39,17 +39,31 @@ void _miscDeclAnalyzedButNotTested() {
   }
 
   {
+    // #docregion downcast-check
+    void assumeStrings(dynamic objects) {
+      // ignore: stable, beta, dev, invalid_assignment
+      List<String> strings = objects; // Runtime downcast check.
+      String string = strings[0];
+    }
+    // #enddocregion downcast-check
+
+    // #docregion fail-downcast-check
+    assumeStrings(<int>[1, 2, 3]);
+    // #enddocregion fail-downcast-check
+  }
+
+  {
     // #docregion type-inference-1-orig
-    Map<String, dynamic> arguments = {'argA': 'hello', 'argB': 42};
+    Map<String, Object?> arguments = {'argA': 'hello', 'argB': 42};
     // #enddocregion type-inference-1-orig
 
     // ignore: stable, beta, dev, argument_type_not_assignable
     arguments[1] = null;
 
     // #docregion type-inference-2-orig
-    Map<String, dynamic> message = {
+    Map<String, Object?> message = {
       'method': 'someMethod',
-      'args': <Map<String, dynamic>>[arguments],
+      'args': <Map<String, Object?>>[arguments],
     };
     // #enddocregion type-inference-2-orig
   }

--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -50,9 +50,14 @@ pre {
     padding-left: 1.25rem;
     padding-right: 1.25rem;
     width: 100%;
+    display: inline-block;
+    min-width: 100%;
+    border-left: 2px solid rgba(0, 0, 0, 0);
 
     &.highlighted-line {
       background: color.change($brand-primary, $alpha: 0.1);
+      min-width: 100%;
+      border-left-color: $brand-primary;
     }
   }
 
@@ -198,6 +203,12 @@ pre {
 
     &:not([lang="console"]) {
       line-height: 1.8;
+    }
+
+    code {
+      display: block;
+      min-width: fit-content;
+      width: 100%;
     }
   }
 }

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -277,28 +277,28 @@ void main() {
 }
 ```
 
-### Implicit casts
+### Implicit downcasts from `dynamic`
 
 Expressions with a static type of `dynamic` can be
 implicitly cast to a more specific type.
-If the actual type doesn't match, the cast throws an error at runtime.
-Consider the following `assumeStrings` method:
+If the actual type doesn't match, the cast throws an error at run time.
+Consider the following `assumeString` method:
 
-<?code-excerpt "lib/strong_analysis.dart (downcast-check)" replace="/strings = objects/[!$&!]/g"?>
+<?code-excerpt "lib/strong_analysis.dart (downcast-check)" replace="/string = object/[!$&!]/g"?>
 ```dart tag=passes-sa
-void assumeStrings(dynamic objects) {
-  List<String> [!strings = objects!]; // Runtime downcast check.
-  String string = strings[0];
+int assumeString(dynamic object) {
+  String [!string = object!]; // Check at run time that `object` is a `String`.
+  return string.length;
 }
 ```
 
-In this example, if `objects` is a `List<String>`, the cast succeeds.
-If it's not a subtype of `List<String>`, such as `List<int>`,
+In this example, if `object` is a `String`, the cast succeeds.
+If it's not a subtype of `String`, such as `int`,
 a `TypeError` is thrown:
 
-<?code-excerpt "lib/strong_analysis.dart (fail-downcast-check)" replace="/\[.*\]/[!$&!]/g"?>
+<?code-excerpt "lib/strong_analysis.dart (fail-downcast-check)" replace="/1/[!$&!]/g"?>
 ```dart tag=runtime-fail
-assumeStrings(<int>[![1, 2, 3]!]);
+final length = assumeString([!1!]);
 ```
 
 :::tip

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -277,6 +277,43 @@ void main() {
 }
 ```
 
+### Implicit casts
+
+Expressions with a static type of `dynamic` can be
+implicitly cast to a more specific type.
+If the actual type doesn't match, the cast throws an error at runtime.
+Consider the following `assumeStrings` method:
+
+<?code-excerpt "lib/strong_analysis.dart (downcast-check)" replace="/strings = objects/[!$&!]/g"?>
+```dart tag=passes-sa
+void assumeStrings(dynamic objects) {
+  List<String> [!strings = objects!]; // Runtime downcast check.
+  String string = strings[0];
+}
+```
+
+In this example, if `objects` is a `List<String>`, the cast succeeds.
+If it's not a subtype of `List<String>`, such as `List<int>`,
+a `TypeError` is thrown:
+
+<?code-excerpt "lib/strong_analysis.dart (fail-downcast-check)" replace="/\[.*\]/[!$&!]/g"?>
+```dart tag=runtime-fail
+assumeStrings(<int>[![1, 2, 3]!]);
+```
+
+:::tip
+To prevent implicit downcasts from `dynamic` and avoid this issue,
+consider enabling the analyzer's _strict casts_ mode.
+
+```yaml analysis_options.yaml
+analyzer:
+  language:
+    strict-casts: true
+```
+
+To learn more about customizing the analyzer's behavior,
+check out [Customizing static analysis](/tools/analysis).
+:::
 
 ## Type inference
 
@@ -291,9 +328,9 @@ pairs string keys with values of various types.
 
 If you explicitly type the variable, you might write this:
 
-<?code-excerpt "lib/strong_analysis.dart (type-inference-1-orig)" replace="/Map<String, dynamic\x3E/[!$&!]/g"?>
+<?code-excerpt "lib/strong_analysis.dart (type-inference-1-orig)" replace="/Map<String, Object\?\x3E/[!$&!]/g"?>
 ```dart
-[!Map<String, dynamic>!] arguments = {'argA': 'hello', 'argB': 42};
+[!Map<String, Object?>!] arguments = {'argA': 'hello', 'argB': 42};
 ```
 
 Alternatively, you can use `var` or `final` and let Dart infer the type:

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -305,7 +305,7 @@ assumeStrings(<int>[![1, 2, 3]!]);
 To prevent implicit downcasts from `dynamic` and avoid this issue,
 consider enabling the analyzer's _strict casts_ mode.
 
-```yaml analysis_options.yaml
+```yaml title="analysis_options.yaml" highlightLines=3
 analyzer:
   language:
     strict-casts: true


### PR DESCRIPTION
Adds a section about implicit cast runtime errors to the "Type system" page, based off the [Invalid casts section](https://dart.dev/deprecated/sound-problems#invalid-casts) of the deprecated sound problems page.

Contributes to https://github.com/dart-lang/site-www/issues/6265

**Staged:** https://dart-dev--pr6478-feat-type-system-implicit-casts-j5bzqnf7.web.app/language/type-system#implicit-casts