### PR TITLE
Separate primary build check from other workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on:
+  # Run on PRs and pushes to the default branch.
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Run build check every day at 3 AM PST.
+    - cron: "0 11 * * 0"
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  # Configure analytics reporting for pub.
+  PUB_ENVIRONMENT: bot.github
+  # The Node version to use for site infra. Generally should be the latest LTS.
+  NODE_VERSION: '22'
+
+jobs:
+  build:
+    name: Build site and check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          submodules: recursive
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: stable
+      - name: Fetch Dart packages
+        run: dart pub get
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - name: Install Node dependencies
+        run: pnpm install
+      - name: Build site
+        run: dart run dart_site build
+      - name: Check for broken Markdown links
+        run: dart run dart_site check-link-references
+      - name: Check internal site links are functional
+        run: dart run dart_site check-links

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,10 @@ on:
 permissions: read-all
 
 env:
-  # Keep for Dart SDK reporting
+  # Configure analytics reporting for pub.
   PUB_ENVIRONMENT: bot.github
-  # LTS
-  NODE_VERSION: '20'
-  # Tool location
-  BASE_DIR: ${{ github.workspace }}
-  TOOL_DIR: ${{ github.workspace }}/tool
+  # The Node version to use for site infra. Generally should be the latest LTS.
+  NODE_VERSION: '22'
 
 jobs:
   test:
@@ -66,32 +63,6 @@ jobs:
         run: dart pub get
       - name: Check if excerpts are up to date
         run: dart run dart_site refresh-excerpts --fail-on-update --dry-run
-
-  linkcheck:
-    name: Build site and check links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          submodules: recursive
-      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
-        with:
-          sdk: stable
-      - name: Fetch Dart packages
-        run: dart pub get
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-      - name: Install node dependencies
-        run: pnpm install
-      - name: Build site
-        run: dart run dart_site build
-      - name: Check for broken Markdown links
-        run: dart run dart_site check-link-references
-      - name: Check internal site links are functional
-        run: dart run dart_site check-links
 
   site-variable-scanner:
     name: Check if text can be replaced with site variables


### PR DESCRIPTION
This will highlight that this is the most important check and also fix the broken  build status image in the [README](https://github.com/dart-lang/site-www/blob/main/README.md).

Also removes some unneeded _(from previous infrastructure setups)_ environment configuration from the existing workflows.