### PR TITLE
Make `pub add` source descriptor compatible with powershell

### DIFF
--- a/src/content/tools/pub/cmd/pub-add.md
+++ b/src/content/tools/pub/cmd/pub-add.md
@@ -106,7 +106,7 @@ The syntax reflects how dependencies are written in `pubspec.yaml`.
 Follow the same format including spaces.
 
 ```plaintext
-"<package>:{<source>: <descriptor>[<source>: <descriptor>], version: <constraint>}"
+"<package>:{<source>: <descriptor>[, <source>: <descriptor>], version: <constraint>}"
 ```
 
 ### `git`

--- a/src/content/tools/pub/cmd/pub-add.md
+++ b/src/content/tools/pub/cmd/pub-add.md
@@ -103,9 +103,10 @@ $ dart pub add [options] [{dev|override}:]<package>[:descriptor] [[{dev|override
 ```
 
 The syntax reflects how dependencies are written in `pubspec.yaml`.
+Follow the same format including spaces.
 
 ```plaintext
-'<package>:{"<source>":"<descriptor>"[,"<source>":"<descriptor>"],"version":"<constraint>"}'
+"<package>:{<source>: <descriptor>[<source>: <descriptor>], version: <constraint>}"
 ```
 
 ### `git`
@@ -113,14 +114,14 @@ The syntax reflects how dependencies are written in `pubspec.yaml`.
 Adds a [git dependency](/tools/pub/dependencies#git-packages).
 
 ```console
-$ dart pub add 'foo:{"git":"https://github.com/foo/foo"}'
+$ dart pub add "foo:{git: https://github.com/foo/foo}"
 ```
 
 You can specify the repository, and the branch or commit, or exact location,
 within that repository:
 
 ```console
-$ dart pub add 'foo:{"git":{"url":"../foo.git","ref":"branch","path":"subdir"}}'
+$ dart pub add "foo:{git:{url: ../foo.git, ref: branch, path: subdir}}"
 ```
 
 #### `url`
@@ -155,7 +156,7 @@ Adds a [hosted dependency][] that depends on
 the package server at the specified URL.
 
 ```console
-$ dart pub add 'foo:{"hosted":"my-pub.dev"}'
+$ dart pub add "foo:{hosted: my-pub.dev}"
 ```
 
 _Previously the `--hosted-url=<package_server_url>` option_.
@@ -167,7 +168,7 @@ _Previously the `--hosted-url=<package_server_url>` option_.
 Adds a [path dependency][] on a locally stored package.
 
 ```console
-$ dart pub add 'foo:{"path":"../foo"}'
+$ dart pub add "foo:{path: ../foo}"
 ```
 
 _Previously the `--path=<directory_path>` option_.
@@ -179,7 +180,7 @@ _Previously the `--path=<directory_path>` option_.
 Adds a package from the specified SDK source.
 
 ```console
-$ dart pub add 'foo:{"sdk":"flutter"}'
+$ dart pub add "foo:{sdk: flutter}"
 ```
 
 _Previously the `--sdk=<sdk_name>` option_:


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/4470#issuecomment-2726982546

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
