### PR TITLE
Documentation style: Document conceptual properties as properties

### DIFF
--- a/examples/misc/lib/effective_dart/docs_bad.dart
+++ b/examples/misc/lib/effective_dart/docs_bad.dart
@@ -64,7 +64,7 @@ class C<ChunkBuilder, Flag, LineWriter> {
   /// @returns The new flag.
   /// @throws ArgumentError If there is already an option with
   ///     the given name or abbreviation.
-  Flag addFlag(String name, String abbr) => ellipsis();
+  Flag addFlag(String name, String abbreviation) => ellipsis();
   // #enddocregion no-annotations
 }
 

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -31,10 +31,14 @@ void miscDeclAnalyzedButNotTested() {
 
   <Flag>() {
     // #docregion no-annotations
-    /// Defines a flag.
+    /// Defines a flag with the given [name] and [abbr] as abbreviation.
     ///
-    /// Throws an [ArgumentError] if there is already an option named [name] or
-    /// there is already an option using abbreviation [abbr]. Returns the new flag.
+    /// The [name] and [abbr] strings must not be empty.
+    ///
+    /// Returns a new flag.
+    ///
+    /// Throws a [DuplicateFlagException] if there is already an option named [name]
+    /// or there is already an option using the abbreviation [abbr].
     Flag addFlag(String name, String abbr) => ellipsis();
     // #enddocregion no-annotations
   };
@@ -64,19 +68,17 @@ void miscDeclAnalyzedButNotTested() {
 
   <T>() {
     // #docregion third-person
-    /// Returns `true` if every element satisfies the [predicate].
-    bool all(bool predicate(T element)) => ellipsis();
-
+    /// Connects to server and fetches results of query.
+    Stream<QueryResult> fetchResults(Query query) => ellipsis();
+      
     /// Starts the stopwatch if not already running.
-    void start() {
-      ellipsis();
-    }
+    void start() => ellipsis();
 
     // #enddocregion third-person
   };
 
   // #docregion code-sample
-  /// Returns the lesser of two numbers.
+  /// The lesser of two numbers.
   ///
   /// ```dart
   /// min(5, 3) == 3
@@ -157,6 +159,8 @@ void miscDeclAnalyzedButNotTested() {
   // #enddocregion markdown
 }
 
+class DuplicateFlagException implements Exception {}
+
 class IOError {}
 
 class PermissionError {}
@@ -165,8 +169,9 @@ class Widget {}
 
 // #docregion redundant
 class RadioButtonWidget extends Widget {
-  /// Sets the tooltip to [lines], which should have been word wrapped using
-  /// the current font.
+  /// Sets the tooltip to [lines].
+  ///
+  /// The lines should be word wrapped using the current font.
   void tooltip(List<String> lines) {
     ellipsis();
   }
@@ -222,6 +227,18 @@ class Modal {
 
 //----------------------------------------------------------------------------
 
+abstract class Iterable<E> {
+  // @docregion noun-for-func-returning-value
+  /// The [index]th element of this iterable in iteration order.
+  E elementAt(int index);
+  
+  /// Whether this iterable contains an element equal to [element].
+  bool contains(Object? element);
+  // #enddocregion noun-for-func-returning-value
+}
+
+//----------------------------------------------------------------------------
+
 class Pool {
   // #docregion getter-and-setter
   /// The pH level of the water in the pool.
@@ -259,10 +276,10 @@ class ToggleComponent {}
 
 // #docregion this
 class Box {
-  /// The value this wraps.
+  /// The value this box wraps.
   Object? _value;
 
-  /// True if this box contains a value.
+  /// Whether this box contains a value.
   bool get hasValue => _value != null;
 }
 

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -165,6 +165,10 @@ class IOError {}
 
 class PermissionError {}
 
+class Query {}
+
+class QueryResult {}
+
 class Widget {}
 
 // #docregion redundant
@@ -227,7 +231,7 @@ class Modal {
 
 //----------------------------------------------------------------------------
 
-abstract class Iterable<E> {
+abstract class MyIterable<E> {
   // #docregion noun-for-func-returning-value
   /// The [index]th element of this iterable in iteration order.
   E elementAt(int index);

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -37,8 +37,8 @@ void miscDeclAnalyzedButNotTested() {
     ///
     /// Returns a new flag.
     ///
-    /// Throws a [DuplicateFlagException] if there is already an option named [name]
-    /// or there is already an option using the abbreviation [abbr].
+    /// Throws a [DuplicateFlagException] if there is already an option named
+    /// [name] or there is already an option using the abbreviation [abbr].
     Flag addFlag(String name, String abbr) => ellipsis();
     // #enddocregion no-annotations
   };
@@ -70,7 +70,7 @@ void miscDeclAnalyzedButNotTested() {
     // #docregion third-person
     /// Connects to server and fetches results of query.
     Stream<QueryResult> fetchResults(Query query) => ellipsis();
-      
+
     /// Starts the stopwatch if not already running.
     void start() => ellipsis();
 
@@ -231,7 +231,7 @@ abstract class Iterable<E> {
   // #docregion noun-for-func-returning-value
   /// The [index]th element of this iterable in iteration order.
   E elementAt(int index);
-  
+
   /// Whether this iterable contains an element equal to [element].
   bool contains(Object? element);
   // #enddocregion noun-for-func-returning-value

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -68,7 +68,7 @@ void miscDeclAnalyzedButNotTested() {
 
   <T>() {
     // #docregion third-person
-    /// Connects to server and fetches results of query.
+    /// Connects to the server and fetches the query results.
     Stream<QueryResult> fetchResults(Query query) => ellipsis();
 
     /// Starts the stopwatch if not already running.

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -228,7 +228,7 @@ class Modal {
 //----------------------------------------------------------------------------
 
 abstract class Iterable<E> {
-  // @docregion noun-for-func-returning-value
+  // #docregion noun-for-func-returning-value
   /// The [index]th element of this iterable in iteration order.
   E elementAt(int index);
   

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -31,15 +31,15 @@ void miscDeclAnalyzedButNotTested() {
 
   <Flag>() {
     // #docregion no-annotations
-    /// Defines a flag with the given [name] and [abbr] as abbreviation.
+    /// Defines a flag with the given [name] and [abbreviation].
     ///
-    /// The [name] and [abbr] strings must not be empty.
+    /// The [name] and [abbreviation] strings must not be empty.
     ///
     /// Returns a new flag.
     ///
     /// Throws a [DuplicateFlagException] if there is already an option named
-    /// [name] or there is already an option using the abbreviation [abbr].
-    Flag addFlag(String name, String abbr) => ellipsis();
+    /// [name] or there is already an option using the [abbreviation].
+    Flag addFlag(String name, String abbreviation) => ellipsis();
     // #enddocregion no-annotations
   };
 

--- a/src/content/effective-dart/_toc.md
+++ b/src/content/effective-dart/_toc.md
@@ -38,7 +38,7 @@ the project:
 
 * <a href='/effective-dart/style#do-format-your-code-using-dart-format'>DO format your code using <code>dart format</code>.</a>
 * <a href='/effective-dart/style#consider-changing-your-code-to-make-it-more-formatter-friendly'>CONSIDER changing your code to make it more formatter-friendly.</a>
-* <a href='/effective-dart/style#avoid-lines-longer-than-80-characters'>AVOID lines longer than 80 characters.</a>
+* <a href='/effective-dart/style#prefer-lines-80-characters-or-fewer'>PREFER lines 80 characters or fewer.</a>
 * <a href='/effective-dart/style#do-use-curly-braces-for-all-flow-control-statements'>DO use curly braces for all flow control statements.</a>
 
 </div>
@@ -62,9 +62,10 @@ the project:
 * <a href='/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary'>DO start doc comments with a single-sentence summary.</a>
 * <a href='/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph'>DO separate the first sentence of a doc comment into its own paragraph.</a>
 * <a href='/effective-dart/documentation#avoid-redundancy-with-the-surrounding-context'>AVOID redundancy with the surrounding context.</a>
-* <a href='/effective-dart/documentation#prefer-starting-function-or-method-comments-with-third-person-verbs'>PREFER starting function or method comments with third-person verbs.</a>
+* <a href='/effective-dart/documentation#prefer-starting-comments-of-a-function-or-method-with-third-person-verbs-if-its-main-purpose-is-a-side-effect'>PREFER starting comments of a function or method with third-person verbs if its main purpose is a side effect.</a>
 * <a href='/effective-dart/documentation#prefer-starting-a-non-boolean-variable-or-property-comment-with-a-noun-phrase'>PREFER starting a non-boolean variable or property comment with a noun phrase.</a>
 * <a href='/effective-dart/documentation#prefer-starting-a-boolean-variable-or-property-comment-with-whether-followed-by-a-noun-or-gerund-phrase'>PREFER starting a boolean variable or property comment with &quot;Whether&quot; followed by a noun or gerund phrase.</a>
+* <a href='/effective-dart/documentation#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose'>PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.</a>
 * <a href='/effective-dart/documentation#dont-write-documentation-for-both-the-getter-and-setter-of-a-property'>DON'T write documentation for both the getter and setter of a property.</a>
 * <a href='/effective-dart/documentation#prefer-starting-library-or-type-comments-with-noun-phrases'>PREFER starting library or type comments with noun phrases.</a>
 * <a href='/effective-dart/documentation#consider-including-code-samples-in-doc-comments'>CONSIDER including code samples in doc comments.</a>

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -232,7 +232,7 @@ It's better to say nothing
 than waste a reader's time telling them something they already know.
 
 
-### PREFER starting comments of a function or method with third-person verbs, if its main purpose is a side effect
+### PREFER starting comments of a function or method with third-person verbs if its main purpose is a side effect
 
 The doc comment should focus on what the code *does*.
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -302,6 +302,7 @@ E elementAt(int index);
 bool contains(Object? element);
 ```
 
+:::note
 This guideline should be applied based on whether the declaration is 
 conceptually seen as a property.
 Sometimes a method has no side effects, and may conceptually be seen
@@ -309,6 +310,7 @@ as a property, but is still simpler to name with a verb phrase like
 `list.take()`. Then a noun phrase should still be used to document it.
 _For example `Iterable.take` can be described as
 "The first \[count\] elements of ..."._
+:::
 
 [parameterized_property_name]: design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -427,7 +427,7 @@ and highlight parameters using square brackets.
 Consider having sections starting with "The \[paramameter\]" to describe 
 parameters, with "Returns" for the returned value and "Throws" for exceptions.
 Errors can be documented the same way as exceptions,
-or just are requirments that must be satified, without documenting the
+or just as requirements that must be satified, without documenting the
 precise error which will be thrown.
 
 <?code-excerpt "docs_good.dart (no-annotations)"?>

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -436,8 +436,8 @@ precise error which will be thrown.
 ///
 /// Returns a new flag.
 ///
-/// Throws a [DuplicateFlagException] if there is already an option named [name]
-/// or there is already an option using the abbreviation [abbr].
+/// Throws a [DuplicateFlagException] if there is already an option named
+/// [name] or there is already an option using the abbreviation [abbr].
 Flag addFlag(String name, String abbr) => ...
 ```
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -231,6 +231,7 @@ then omit the doc comment.
 It's better to say nothing
 than waste a reader's time telling them something they already know.
 
+<a id="prefer-starting-function-or-method-comments-with-third-person-verbs" aria-hidden="true"></a>
 
 ### PREFER starting comments of a function or method with third-person verbs if its main purpose is a side effect
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -205,8 +205,9 @@ spelled out in the doc comment. Instead, focus on explaining what the reader
 <?code-excerpt "docs_good.dart (redundant)"?>
 ```dart tag=good
 class RadioButtonWidget extends Widget {
-  /// Sets the tooltip to [lines], which should have been word wrapped using
-  /// the current font.
+  /// Sets the tooltip to [lines].
+  ///
+  /// The lines should be word wrapped using the current font.
   void tooltip(List<String> lines) {
     ...
   }
@@ -231,19 +232,17 @@ It's better to say nothing
 than waste a reader's time telling them something they already know.
 
 
-### PREFER starting function or method comments with third-person verbs
+### PREFER starting comments of a function or method with third-person verbs, if its main purpose is a side effect
 
 The doc comment should focus on what the code *does*.
 
 <?code-excerpt "docs_good.dart (third-person)"?>
 ```dart tag=good
-/// Returns `true` if every element satisfies the [predicate].
-bool all(bool predicate(T element)) => ...
+/// Connects to server and fetches results of query.
+Stream<QueryResult> fetchResults(Query query) => ...
 
 /// Starts the stopwatch if not already running.
-void start() {
-  ...
-}
+void start() => ...
 ```
 
 ### PREFER starting a non-boolean variable or property comment with a noun phrase
@@ -285,6 +284,33 @@ cases, usage of "or not" with "whether" is superfluous and can be omitted,
 especially when used in this context.
 :::
 
+### PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose
+
+If a method is *syntactically* a method, but *conceptually* it is a property,
+and is therefore [named with a noun phrase or non-imperative verb phrase][parameterized_property_name],
+it should also be documented as such.
+Use a noun-phrase for such non-boolean functions, and a phrase starting
+with "Whether" for such boolean functions, just as for a syntactic property
+or variable.
+
+<?code-excerpt "design_good.dart (noun-for-func-returning-value)"?>
+```dart tag=good
+/// The [index]th element of this iterable in iteration order.
+E elementAt(int index);
+
+/// Whether this iterable contains an element equal to [element].
+bool contains(Object? element);
+```
+
+This guideline is deliberately softer than the previous ones. Sometimes a method
+has no side effects but is still simpler to name with a verb phrase like
+`list.take()` or `string.split()`, and then a verb phrase may still apply.
+_For example `Iterable.take` can be described both as "An iterable of ..."
+or as "Creates a new iterable of ...", depending on whether it being a new
+iterable is important._
+
+[parameterized_property_name]: design.md##prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
+
 ### DON'T write documentation for both the getter and setter of a property
 
 If a property has both a getter and a setter, then create a doc comment for
@@ -317,6 +343,8 @@ program. They describe the type's invariants, establish the terminology it uses,
 and provide context to the other doc comments for the class's members. A little
 extra effort here can make all of the other members simpler to document.
 
+The documentation should describe an *instance* of the type.
+
 <?code-excerpt "docs_good.dart (noun-phrases-for-type-or-lib)"?>
 ```dart tag=good
 /// A chunk of non-breaking output text terminated by a hard or soft newline.
@@ -331,7 +359,7 @@ class Chunk {
 
 <?code-excerpt "docs_good.dart (code-sample)"?>
 ````dart tag=good
-/// Returns the lesser of two numbers.
+/// The lesser of two numbers.
 ///
 /// ```dart
 /// min(5, 3) == 3
@@ -393,12 +421,22 @@ Flag addFlag(String name, String abbr) => ...
 The convention in Dart is to integrate that into the description of the method
 and highlight parameters using square brackets.
 
+Consider having sections starting with "The \[paramameter\]" to describe 
+parameters, with "Returns" for the returned value and "Throws" for exceptions.
+Errors can be documented the same way as exceptions,
+or just are requirments that must be satified, without documenting the
+precise error which will be thrown.
+
 <?code-excerpt "docs_good.dart (no-annotations)"?>
 ```dart tag=good
-/// Defines a flag.
+/// Defines a flag with the given [name] and [abbr] as abbreviation.
 ///
-/// Throws an [ArgumentError] if there is already an option named [name] or
-/// there is already an option using abbreviation [abbr]. Returns the new flag.
+/// The [name] and [abbr] strings must not be empty.
+///
+/// Returns a new flag.
+///
+/// Throws a [DuplicateFlagException] if there is already an option named [name]
+/// or there is already an option using the abbreviation [abbr].
 Flag addFlag(String name, String abbr) => ...
 ```
 
@@ -417,7 +455,6 @@ class ToggleComponent {}
 /// A button that can be flipped on and off.
 class ToggleComponent {}
 ```
-
 
 ## Markdown
 
@@ -548,14 +585,15 @@ think.
 
 When documenting a member for a class, you often need to refer back to the
 object the member is being called on. Using "the" can be ambiguous.
+Prefer having some qualifier after "this", a sole "this" can ambiguous too.
 
 <?code-excerpt "docs_good.dart (this)"?>
 ```dart
 class Box {
-  /// The value this wraps.
+  /// The value this box wraps.
   Object? _value;
 
-  /// True if this box contains a value.
+  /// Whether this box contains a value.
   bool get hasValue => _value != null;
 }
 ```

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -293,7 +293,7 @@ Use a noun-phrase for such non-boolean functions, and a phrase starting
 with "Whether" for such boolean functions, just as for a syntactic property
 or variable.
 
-<?code-excerpt "design_good.dart (noun-for-func-returning-value)"?>
+<?code-excerpt "docs_good.dart (noun-for-func-returning-value)"?>
 ```dart tag=good
 /// The [index]th element of this iterable in iteration order.
 E elementAt(int index);
@@ -302,14 +302,15 @@ E elementAt(int index);
 bool contains(Object? element);
 ```
 
-This guideline is deliberately softer than the previous ones. Sometimes a method
-has no side effects but is still simpler to name with a verb phrase like
-`list.take()` or `string.split()`, and then a verb phrase may still apply.
-_For example `Iterable.take` can be described both as "An iterable of ..."
-or as "Creates a new iterable of ...", depending on whether it being a new
-iterable is important._
+This guideline should be applied based on whether the declaration is 
+conceptually seen as a property.
+Sometimes a method has no side effects, and may conceptually be seen
+as a property, but is still simpler to name with a verb phrase like
+`list.take()`. Then a noun phrase should still be used to document it.
+_For example `Iterable.take` can be described as
+"The first \[count\] elements of ..."._
 
-[parameterized_property_name]: design.md##prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
+[parameterized_property_name]: design.md#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
 
 ### DON'T write documentation for both the getter and setter of a property
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -380,7 +380,7 @@ makes an API easier to learn.
 
 If you surround things like variable, method, or type names in square brackets,
 then `dart doc` looks up the name and links to the relevant API docs.
-Parentheses are optional, 
+Parentheses are optional,
 but can make it clearer when you're referring to a method or constructor.
 
 <?code-excerpt "docs_good.dart (identifiers)"?>
@@ -425,10 +425,10 @@ Flag addFlag(String name, String abbr) => ...
 The convention in Dart is to integrate that into the description of the method
 and highlight parameters using square brackets.
 
-Consider having sections starting with "The \[paramameter\]" to describe 
+Consider having sections starting with "The \[parameter\]" to describe
 parameters, with "Returns" for the returned value and "Throws" for exceptions.
 Errors can be documented the same way as exceptions,
-or just as requirements that must be satified, without documenting the
+or just as requirements that must be satisfied, without documenting the
 precise error which will be thrown.
 
 <?code-excerpt "docs_good.dart (no-annotations)"?>
@@ -589,7 +589,7 @@ think.
 
 When documenting a member for a class, you often need to refer back to the
 object the member is being called on. Using "the" can be ambiguous.
-Prefer having some qualifier after "this", a sole "this" can ambiguous too.
+Prefer having some qualifier after "this", a sole "this" can be ambiguous too.
 
 <?code-excerpt "docs_good.dart (this)"?>
 ```dart

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -239,7 +239,7 @@ The doc comment should focus on what the code *does*.
 
 <?code-excerpt "docs_good.dart (third-person)"?>
 ```dart tag=good
-/// Connects to server and fetches results of query.
+/// Connects to the server and fetches the query results.
 Stream<QueryResult> fetchResults(Query query) => ...
 
 /// Starts the stopwatch if not already running.

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -263,8 +263,8 @@ int get checkedCount => ...
 
 ### PREFER starting a boolean variable or property comment with "Whether" followed by a noun or gerund phrase
 
-The doc comment should clarify the states this variable represents. 
-This is true even for getters which may do calculation or other work. 
+The doc comment should clarify the states this variable represents.
+This is true even for getters which may do calculation or other work.
 What the caller cares about is the *result* of that work, not the work itself.
 
 <?code-excerpt "docs_good.dart (noun-phrases-for-boolean-var-etc)"?>
@@ -290,9 +290,9 @@ especially when used in this context.
 If a method is *syntactically* a method, but *conceptually* it is a property,
 and is therefore [named with a noun phrase or non-imperative verb phrase][parameterized_property_name],
 it should also be documented as such.
-Use a noun-phrase for such non-boolean functions, and a phrase starting
-with "Whether" for such boolean functions, just as for a syntactic property
-or variable.
+Use a noun-phrase for such non-boolean functions, and
+a phrase starting with "Whether" for such boolean functions,
+just as for a syntactic property or variable.
 
 <?code-excerpt "docs_good.dart (noun-for-func-returning-value)"?>
 ```dart tag=good
@@ -304,11 +304,13 @@ bool contains(Object? element);
 ```
 
 :::note
-This guideline should be applied based on whether the declaration is 
+This guideline should be applied based on whether the declaration is
 conceptually seen as a property.
-Sometimes a method has no side effects, and may conceptually be seen
-as a property, but is still simpler to name with a verb phrase like
-`list.take()`. Then a noun phrase should still be used to document it.
+
+Sometimes a method has no side effects, and might
+conceptually be seen as a property, but is still
+simpler to name with a verb phrase like `list.take()`.
+Then a noun phrase should still be used to document it.
 _For example `Iterable.take` can be described as
 "The first \[count\] elements of ..."._
 :::
@@ -419,7 +421,7 @@ and returns of a method are.
 /// @returns The new flag.
 /// @throws ArgumentError If there is already an option with
 ///     the given name or abbreviation.
-Flag addFlag(String name, String abbr) => ...
+Flag addFlag(String name, String abbreviation) => ...
 ```
 
 The convention in Dart is to integrate that into the description of the method
@@ -433,15 +435,15 @@ precise error which will be thrown.
 
 <?code-excerpt "docs_good.dart (no-annotations)"?>
 ```dart tag=good
-/// Defines a flag with the given [name] and [abbr] as abbreviation.
+/// Defines a flag with the given [name] and [abbreviation].
 ///
-/// The [name] and [abbr] strings must not be empty.
+/// The [name] and [abbreviation] strings must not be empty.
 ///
 /// Returns a new flag.
 ///
 /// Throws a [DuplicateFlagException] if there is already an option named
-/// [name] or there is already an option using the abbreviation [abbr].
-Flag addFlag(String name, String abbr) => ...
+/// [name] or there is already an option using the [abbreviation].
+Flag addFlag(String name, String abbreviation) => ...
 ```
 
 ### DO put doc comments before metadata annotations

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -310,7 +310,7 @@ as a property, but is still simpler to name with a verb phrase like
 _For example `Iterable.take` can be described as
 "The first \[count\] elements of ..."._
 
-[parameterized_property_name]: design.md#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
+[parameterized_property_name]: design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose
 
 ### DON'T write documentation for both the getter and setter of a property
 


### PR DESCRIPTION
Say explicitly that a function that is named like a property (noun phrase or non-imperative verb phrase, as described in `design.md`) should also be documented like a property (noun-phrase or "Whether ...", basically).

(I keep seeing people documenting a noun-phrased function with "Returns noun-phrase", just because the style guide does not have any exceptions for using verb-phrases for functions. If it's treated as a property, which is allowed, it should also be documented as a property.)

Tweaks some examples to not contradict other rules. For example, don't have a two-statement first paragraph "good" example after the "single statement first paragraph" rule.)

(Will update good/bad examples too..)