### PR TITLE
Expand tests for named argument entry in cheatsheet

### DIFF
--- a/src/content/resources/dart-cheatsheet.md
+++ b/src/content/resources/dart-cheatsheet.md
@@ -1101,43 +1101,66 @@ class MyDataObject {
 void main() {
   final source = MyDataObject();
   final errs = <String>[];
-  
+
   try {
     final copy = source.copyWith(newInt: 12, newString: 'New!', newDouble: 3.0);
-    
+
     if (copy.anInt != 12) {
       errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), \n and the new object\'s anInt was ${copy.anInt} rather than the expected value (12).');
     }
-    
+
     if (copy.aString != 'New!') {
       errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), \n and the new object\'s aString was ${copy.aString} rather than the expected value (\'New!\').');
     }
-    
+
     if (copy.aDouble != 3) {
       errs.add('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0), \n and the new object\'s aDouble was ${copy.aDouble} rather than the expected value (3).');
     }
   } catch (e) {
     print('Called copyWith(newInt: 12, newString: \'New!\', newDouble: 3.0) \n and got an exception: ${e.runtimeType}');
   }
-  
+
   try {
     final copy = source.copyWith();
-    
+
     if (copy.anInt != 1) {
       errs.add('Called copyWith(), and the new object\'s anInt was ${copy.anInt} \n rather than the expected value (1).');
     }
-    
+
     if (copy.aString != 'Old!') {
       errs.add('Called copyWith(), and the new object\'s aString was ${copy.aString} \n rather than the expected value (\'Old!\').');
     }
-    
+
     if (copy.aDouble != 2) {
       errs.add('Called copyWith(), and the new object\'s aDouble was ${copy.aDouble} \n rather than the expected value (2).');
     }
   } catch (e) {
     print('Called copyWith() and got an exception: ${e.runtimeType}');
   }
-  
+
+  try {
+    final sourceWithoutDefaults = MyDataObject(
+      anInt: 520,
+      aString: 'Custom!',
+      aDouble: 20.25,
+    );
+    final copy = sourceWithoutDefaults.copyWith();
+
+    if (copy.anInt == 1) {
+      errs.add('Called `copyWith()` on an object with a non-default `anInt` value (${sourceWithoutDefaults.anInt}), but the new object\'s `anInt` was the default value of ${copy.anInt}.');
+    }
+
+    if (copy.aString == 'Old!') {
+      errs.add('Called `copyWith()` on an object with a non-default `aString` value (\'${sourceWithoutDefaults.aString}\'), but the new object\'s `aString` was the default value of \'${copy.aString}\'.');
+    }
+
+    if (copy.aDouble == 2.0) {
+      errs.add('Called copyWith() on an object with a non-default `aDouble` value (${sourceWithoutDefaults.aDouble}), but the new object\'s `aDouble` was the default value of ${copy.aDouble}.');
+    }
+  } catch (e) {
+    print('Called copyWith() and got an exception: ${e.runtimeType}');
+  }
+
   if (errs.isEmpty) {
     print('Success!');
   } else {
@@ -1158,13 +1181,13 @@ void main() {
   This is a chance to get more practice with the `??` operator!
 
   ```dart
-    MyDataObject copyWith({int? newInt, String? newString, double? newDouble}) {
-      return MyDataObject(
-        anInt: newInt ?? this.anInt,
-        aString: newString ?? this.aString,
-        aDouble: newDouble ?? this.aDouble,
-      );
-    }
+  MyDataObject copyWith({int? newInt, String? newString, double? newDouble}) {
+    return MyDataObject(
+      anInt: newInt ?? this.anInt,
+      aString: newString ?? this.aString,
+      aDouble: newDouble ?? this.aDouble,
+    );
+  }
   ```
 </details>
 


### PR DESCRIPTION
Adds specific tests for the default values from the constructor, in case the developer accidentally uses them as the default value in `copyWith`.

Fixes https://github.com/dart-lang/site-www/issues/5614