### PR TITLE
Fix typo in versioning.md

### DIFF
--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -197,7 +197,7 @@ evolution now. Let's see how they play together and what pub does.
 When you define your package, you list its
 [immediate dependencies][immediate-dep].
 These are packages that your package uses.
-For each of these package, you specify the range of versions your package allows.
+For each of these packages, you specify the range of versions your package allows.
 Each of those dependent packages might then have their own dependencies.
 These are called [transitive dependencies][transitive-dep].
 Pub traverses these and builds the entire dependency graph for your app.


### PR DESCRIPTION
Fix for a small typo: "these package" -> "these packages" (correct use of plural)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
