### PR TITLE
Slightly clean up cheatsheet

### DIFF
--- a/examples/misc/lib/cheatsheet/named_parameters.dart
+++ b/examples/misc/lib/cheatsheet/named_parameters.dart
@@ -5,6 +5,6 @@ void printName(String firstName, String lastName, {String? middleName}) {
 void main() {
   printName('Dash', 'Dartisan');
   printName('John', 'Smith', middleName: 'Who');
-  // Named arguments can be placed anywhere in the argument list
+  // Named arguments can be placed anywhere in the argument list.
   printName('John', middleName: 'Who', 'Smith');
 }

--- a/src/content/resources/dart-cheatsheet.md
+++ b/src/content/resources/dart-cheatsheet.md
@@ -14,7 +14,7 @@ the most important of these language features.
 The embedded editors in this tutorial have partially completed code snippets.
 You can use these editors to test your knowledge by completing the code and
 clicking the **Run** button. The editors also contain thorough test code;
-**don't edit the test code**, but feel free to study it to learn about testing. 
+**don't edit the test code**, but feel free to study it to learn about testing.
 
 
 If you need help, expand the **Solution for...** dropdown beneath each DartPad
@@ -38,7 +38,7 @@ Here are some examples of using string interpolation:
 | `'${"word".toUpperCase()}'` | `'WORD'`                           |
 | `'$myObject'`               | The value of `myObject.toString()` |
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 The following function takes two integers as parameters.
 Make it return a string containing both integers separated by a space.
@@ -50,7 +50,7 @@ String stringify(int x, int y) {
 }
 
 
-// Tests your solution (Don't edit!): 
+// Tests your solution (Don't edit!):
 void main() {
   assert(stringify(2, 3) == '2 3',
       "Your stringify method returned '${stringify(2, 3)}' instead of '2 3'");
@@ -110,7 +110,7 @@ int? a; // The initial value of a is null.
 To learn more about null safety in Dart,
 read the [sound null safety guide](/null-safety).
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Declare two variables in this DartPad:
 
@@ -123,11 +123,11 @@ Ignore all initial errors in the DartPad.
 // TODO: Declare the two variables here
 
 
-// Tests your solution (Don't edit!): 
+// Tests your solution (Don't edit!):
 void main() {
   try {
     if (name == 'Jane' && address == null) {
-      // verify that "name" is nullable
+      // Verify that "name" is nullable.
       name = null;
       print('Success!');
     } else {
@@ -180,7 +180,7 @@ print(1 ?? 3); // <-- Prints 1.
 print(null ?? 12); // <-- Prints 12.
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Try substituting in the `??=` and `??` operators
 to implement the described behavior in the following snippet.
@@ -204,7 +204,7 @@ void updateSomeVars() {
 void main() {
   try {
     updateSomeVars();
-    
+
     if (foo != 'a string') {
       print('Looks like foo somehow ended up with the wrong value.');
     } else if (bar != 'a string') {
@@ -217,7 +217,6 @@ void main() {
   } catch (e) {
     print('Exception: ${e.runtimeType}.');
   }
-  
 }
 ```
 
@@ -232,7 +231,7 @@ void main() {
   ```dart
   // Substitute an operator that makes 'a string' be assigned to baz.
   String? baz = foo ?? bar;
-  
+
   void updateSomeVars() {
     // Substitute an operator that makes 'a string' be assigned to bar.
     bar ??= 'a string';
@@ -267,13 +266,12 @@ myObject?.someProperty?.someMethod()
 ```
 
 The preceding code returns null (and never calls `someMethod()`) if either
-`myObject` or `myObject.someProperty` is
-null.
+`myObject` or `myObject.someProperty` is null.
 
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
-The following function takes a nullable string as a parameter. 
+The following function takes a nullable string as a parameter.
 Try using conditional property access to make it
 return the uppercase version of `str`, or `null` if `str` is `null`.
 
@@ -295,7 +293,7 @@ void main() {
   } catch (e) {
     print('Tried calling upperCaseIt(null) and got an exception: \n ${e.runtimeType}.');
   }
-  
+
   try {
     String? two = upperCaseIt('a string');
     if (two == null) {
@@ -359,7 +357,7 @@ but still want the list to be `List<BaseType>`:
 final aListOfBaseType = <BaseType>[SubType(), SubType()];
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Try setting the following variables to the indicated values. Replace the existing null values.
 
@@ -386,7 +384,7 @@ final anEmptyMapOfDoublesToInts = null;
 // Tests your solution (Don't edit!):
 void main() {
   final errs = <String>[];
-  
+
   if (aListOfStrings is! List<String>) {
     errs.add('aListOfStrings should have the type List<String>.');
   } else if (aListOfStrings.length != 3) {
@@ -440,7 +438,7 @@ void main() {
 <details>
   <summary>Solution for collection literals example</summary>
 
-  Add a list, set, or map literal after each equals sign.
+  Add a list, set, or map literal after each equal sign (`=`).
   Remember to specify the types for the empty declarations,
   since they can't be inferred.
 
@@ -489,7 +487,7 @@ Here's a simpler way to write that code:
 bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Try finishing the following statements, which use arrow syntax.
 
@@ -498,15 +496,15 @@ class MyClass {
   int value1 = 2;
   int value2 = 3;
   int value3 = 5;
-  
+
   // Returns the product of the above values:
   int get product => TODO();
-  
+
   // Adds 1 to value1:
   void incrementValue1() => TODO();
-  
+
   // Returns a string containing each item in the
-  // list, separated by commas (e.g. 'a,b,c'): 
+  // list, separated by commas (e.g. 'a,b,c'):
   String joinWithCommas(List<String> strings) => TODO();
 }
 
@@ -515,13 +513,13 @@ class MyClass {
 void main() {
   final obj = MyClass();
   final errs = <String>[];
-  
+
   try {
     final product = obj.product;
-    
+
     if (product != 30) {
-      errs.add('The product property returned $product \n instead of the expected value (30).'); 
-    } 
+      errs.add('The product property returned $product \n instead of the expected value (30).');
+    }
   } catch (e) {
     print('Tried to use MyClass.product, but encountered an exception: \n ${e.runtimeType}.');
     return;
@@ -529,10 +527,10 @@ void main() {
 
   try {
     obj.incrementValue1();
-    
+
     if (obj.value1 != 3) {
-      errs.add('After calling incrementValue, value1 was ${obj.value1} \n instead of the expected value (3).'); 
-    } 
+      errs.add('After calling incrementValue, value1 was ${obj.value1} \n instead of the expected value (3).');
+    }
   } catch (e) {
     print('Tried to use MyClass.incrementValue1, but encountered an exception: \n ${e.runtimeType}.');
     return;
@@ -540,10 +538,10 @@ void main() {
 
   try {
     final joined = obj.joinWithCommas(['one', 'two', 'three']);
-    
+
     if (joined != 'one,two,three') {
-      errs.add('Tried calling joinWithCommas([\'one\', \'two\', \'three\']) \n and received $joined instead of the expected value (\'one,two,three\').'); 
-    } 
+      errs.add('Tried calling joinWithCommas([\'one\', \'two\', \'three\']) \n and received $joined instead of the expected value (\'one,two,three\').');
+    }
   } catch (e) {
     print('Tried to use MyClass.joinWithCommas, but encountered an exception: \n ${e.runtimeType}.');
     return;
@@ -572,12 +570,12 @@ void main() {
 
     // Returns the product of the above values:
     int get product => value1 * value2 * value3;
-    
+
     // Adds 1 to value1:
-    void incrementValue1() => value1++; 
-    
+    void incrementValue1() => value1++;
+
     // Returns a string containing each item in the
-    // list, separated by commas (e.g. 'a,b,c'): 
+    // list, separated by commas (e.g. 'a,b,c'):
     String joinWithCommas(List<String> strings) => strings.join(',');
   }
   ```
@@ -622,8 +620,8 @@ button?.onClick.listen((e) => web.window.alert('Confirmed!'));
 button?.scrollIntoView();
 ```
 
-To instead use cascades, 
-you can start with the _null-shorting_ cascade (`?..`), 
+To instead use cascades,
+you can start with the _null-shorting_ cascade (`?..`),
 which guarantees that none of the cascade operations
 are attempted on a `null` object.
 Using cascades shortens the code
@@ -638,7 +636,7 @@ web.document.querySelector('#confirm')
   ..scrollIntoView();
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Use cascades to create a single statement that
 sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
@@ -651,7 +649,7 @@ class BigObject {
   String aString = '';
   List<double> aList = [];
   bool _done = false;
-  
+
   void allDone() {
     _done = true;
   }
@@ -695,7 +693,7 @@ void main() {
           'The value found in aList was ${obj.aList[0]} \n rather than the expected (3.0).');
     }
   }
-  
+
   if (!obj._done) {
     errs.add('It looks like allDone() wasn\'t called.');
   }
@@ -769,10 +767,10 @@ class MyClass {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
-Imagine you have a shopping cart class that keeps a private `List<double>`
-of prices.
+Imagine you have a shopping cart class that keeps a
+private `List<double>` of prices.
 Add the following:
 
 * A getter called `total` that returns the sum of the prices
@@ -787,7 +785,7 @@ class InvalidPriceException {}
 
 class ShoppingCart {
   List<double> _prices = [];
-  
+
   // TODO: Add a "total" getter here:
 
   // TODO: Add a "prices" setter here:
@@ -797,7 +795,7 @@ class ShoppingCart {
 // Tests your solution (Don't edit!):
 void main() {
   var foundException = false;
-  
+
   try {
     final cart = ShoppingCart();
     cart.prices = [12.0, 12.0, -23.0];
@@ -807,21 +805,21 @@ void main() {
     print('Tried setting a negative price and received a ${e.runtimeType} \n instead of an InvalidPriceException.');
     return;
   }
-  
+
   if (!foundException) {
     print('Tried setting a negative price \n and didn\'t get an InvalidPriceException.');
     return;
   }
-  
+
   final secondCart = ShoppingCart();
-  
+
   try {
     secondCart.prices = [1.0, 2.0, 3.0];
   } catch(e) {
     print('Tried setting prices with a valid list, \n but received an exception: ${e.runtimeType}.');
     return;
   }
-  
+
   if (secondCart._prices.length != 3) {
     print('Tried setting prices with a list of three values, \n but _prices ended up having length ${secondCart._prices.length}.');
     return;
@@ -832,21 +830,21 @@ void main() {
     print('Tried setting prices with a list of three values (1, 2, 3), \n but incorrect ones ended up in the price list ($vals) .');
     return;
   }
-  
+
   var sum = 0.0;
-  
+
   try {
     sum = secondCart.total;
   } catch (e) {
     print('Tried to get total, but received an exception: ${e.runtimeType}.');
     return;
   }
-  
+
   if (sum != 6.0) {
     print('After setting prices to (1, 2, 3), total returned $sum instead of 6.');
     return;
   }
-  
+
   print('Success!');
 }
 ```
@@ -854,23 +852,23 @@ void main() {
 <details>
   <summary>Solution for getters and setters example</summary>
 
-  Two functions are handy for this exercise. 
+  Two functions are handy for this exercise.
   One is `fold`, which can reduce a list to a single value
   (use it to calculate the total).
   The other is `any`, which can check each item in a list
   with a function you give it
-  (use it to check if there are any negative prices in the prices setter).
+  (use it to check if there are any negative prices in the `prices` setter).
 
   ```dart
-  // Add a "total" getter here:
+  /// The total price of the shopping cart.
   double get total => _prices.fold(0, (e, t) => e + t);
 
-  // Add a "prices" setter here:
+  /// Set [prices] to the [value] list of item prices.
   set prices(List<double> value) {
     if (value.any((p) => p < 0)) {
       throw InvalidPriceException();
     }
-    
+
     _prices = value;
   }
   ```
@@ -880,7 +878,7 @@ void main() {
 
 ## Optional positional parameters
 
-Dart has two kinds of function parameters: positional and named. 
+Dart has two kinds of function parameters: positional and named.
 Positional parameters are the kind you're likely familiar with:
 
 <?code-excerpt "misc/lib/cheatsheet/optional_positional_args.dart (optional-positional-args)"?>
@@ -925,7 +923,7 @@ void main() {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Implement a function called `joinWithCommas()` that accepts one to
 five integers, then returns a string of those numbers separated by commas.
@@ -948,13 +946,13 @@ String joinWithCommas(int a, [int? b, int? c, int? d, int? e]) {
 // Tests your solution (Don't edit!):
 void main() {
   final errs = <String>[];
-  
+
   try {
     final value = joinWithCommas(1);
-    
+
     if (value != '1') {
-      errs.add('Tried calling joinWithCommas(1) \n and got $value instead of the expected (\'1\').'); 
-    } 
+      errs.add('Tried calling joinWithCommas(1) \n and got $value instead of the expected (\'1\').');
+    }
   } on UnimplementedError {
     print('Tried to call joinWithCommas but failed. \n Did you implement the method?');
     return;
@@ -965,10 +963,10 @@ void main() {
 
   try {
     final value = joinWithCommas(1, 2, 3);
-    
+
     if (value != '1,2,3') {
-      errs.add('Tried calling joinWithCommas(1, 2, 3) \n and got $value instead of the expected (\'1,2,3\').'); 
-    } 
+      errs.add('Tried calling joinWithCommas(1, 2, 3) \n and got $value instead of the expected (\'1,2,3\').');
+    }
   } on UnimplementedError {
     print('Tried to call joinWithCommas but failed. \n Did you implement the method?');
     return;
@@ -979,10 +977,10 @@ void main() {
 
   try {
     final value = joinWithCommas(1, 2, 3, 4, 5);
-    
+
     if (value != '1,2,3,4,5') {
-      errs.add('Tried calling joinWithCommas(1, 2, 3, 4, 5) \n and got $value instead of the expected (\'1,2,3,4,5\').'); 
-    } 
+      errs.add('Tried calling joinWithCommas(1, 2, 3, 4, 5) \n and got $value instead of the expected (\'1,2,3,4,5\').');
+    }
   } on UnimplementedError {
     print('Tried to call joinWithCommas but failed. \n Did you implement the method?');
     return;
@@ -1037,7 +1035,7 @@ void printName(String firstName, String lastName, {String? middleName}) {
 void main() {
   printName('Dash', 'Dartisan');
   printName('John', 'Smith', middleName: 'Who');
-  // Named arguments can be placed anywhere in the argument list
+  // Named arguments can be placed anywhere in the argument list.
   printName('John', middleName: 'Who', 'Smith');
 }
 ```
@@ -1063,7 +1061,7 @@ void printName(String firstName, String lastName, {String middleName[! = ''!]}) 
 A function can't have both optional positional and named parameters.
 
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Add a `copyWith()` instance method to the `MyDataObject`
 class. It should take three named, nullable parameters:
@@ -1258,7 +1256,7 @@ try {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Implement `tryFunction()` below. It should execute an untrustworthy method and
 then do the following:
@@ -1298,57 +1296,57 @@ class MyLogger extends Logger {
   Type? lastType;
   String lastMessage = '';
   bool done = false;
-  
+
   void logException(Type t, [String? message]) {
     lastType = t;
     lastMessage = message ?? lastMessage;
   }
-  
-  void doneLogging() => done = true;  
+
+  void doneLogging() => done = true;
 }
 
 void main() {
   final errs = <String>[];
   var logger = MyLogger();
-  
+
   try {
     tryFunction(() => throw Exception(), logger);
-  
+
     if ('${logger.lastType}' != 'Exception' && '${logger.lastType}' != '_Exception') {
       errs.add('Untrustworthy threw an Exception, but a different type was logged: \n ${logger.lastType}.');
     }
-    
+
     if (logger.lastMessage != '') {
       errs.add('Untrustworthy threw an Exception with no message, but a message \n was logged anyway: \'${logger.lastMessage}\'.');
     }
-    
+
     if (!logger.done) {
       errs.add('Untrustworthy threw an Exception, \n and doneLogging() wasn\'t called afterward.');
     }
   } catch (e) {
     print('Untrustworthy threw an exception, and an exception of type \n ${e.runtimeType} was unhandled by tryFunction.');
   }
-  
+
   logger = MyLogger();
-  
+
   try {
     tryFunction(() => throw ExceptionWithMessage('Hey!'), logger);
-  
+
     if (logger.lastType != ExceptionWithMessage) {
       errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), but a \n different type was logged: ${logger.lastType}.');
     }
-    
+
     if (logger.lastMessage != 'Hey!') {
       errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), but a \n different message was logged: \'${logger.lastMessage}\'.');
     }
-    
+
     if (!logger.done) {
       errs.add('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), \n and doneLogging() wasn\'t called afterward.');
     }
   } catch (e) {
     print('Untrustworthy threw an ExceptionWithMessage(\'Hey!\'), \n and an exception of type ${e.runtimeType} was unhandled by tryFunction.');
   }
-  
+
   logger = MyLogger();
   bool caughtStringException = false;
 
@@ -1361,27 +1359,27 @@ void main() {
   if (!caughtStringException) {
     errs.add('Untrustworthy threw a string, and it was incorrectly handled inside tryFunction().');
   }
-  
+
   logger = MyLogger();
-  
+
   try {
     tryFunction(() {}, logger);
-  
+
     if (logger.lastType != null) {
       errs.add('Untrustworthy didn\'t throw an Exception, \n but one was logged anyway: ${logger.lastType}.');
     }
-    
+
     if (logger.lastMessage != '') {
       errs.add('Untrustworthy didn\'t throw an Exception with no message, \n but a message was logged anyway: \'${logger.lastMessage}\'.');
     }
-    
+
     if (!logger.done) {
       errs.add('Untrustworthy didn\'t throw an Exception, \n but doneLogging() wasn\'t called afterward.');
     }
   } catch (e) {
     print('Untrustworthy didn\'t throw an exception, \n but an exception of type ${e.runtimeType} was unhandled by tryFunction anyway.');
   }
-  
+
   if (errs.isEmpty) {
     print('Success!');
   } else {
@@ -1437,10 +1435,10 @@ final color = MyColor(80, 80, 128);
 This technique works for named parameters, too.
 Property names become the names of the parameters:
 
-<?code-excerpt "misc/lib/cheatsheet/this_constructor.dart (required-named)" replace="/int.*;/.../g; /olorRN/olor/g;"?>
+<?code-excerpt "misc/lib/cheatsheet/this_constructor.dart (required-named)" replace="/int.*;/\/\/ .../g; /olorRN/olor/g;"?>
 ```dart
 class MyColor {
-  ...
+  // ...
 
   MyColor({required this.red, required this.green, required this.blue});
 }
@@ -1459,7 +1457,7 @@ MyColor([this.red = 0, this.green = 0, this.blue = 0]);
 MyColor({this.red = 0, this.green = 0, this.blue = 0});
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Add a one-line constructor to `MyClass` that uses
 `this.` syntax to receive and assign values for
@@ -1472,7 +1470,7 @@ class MyClass {
   final int anInt;
   final String aString;
   final double aDouble;
-  
+
   // TODO: Create the constructor here.
 }
 
@@ -1480,10 +1478,10 @@ class MyClass {
 // Tests your solution (Don't edit!):
 void main() {
   final errs = <String>[];
-  
+
   try {
     final obj = MyClass(1, 'two', 3);
-    
+
     if (obj.anInt != 1) {
       errs.add('Called MyClass(1, \'two\', 3) and got an object with anInt of ${obj.anInt} \n instead of the expected value (1).');
     }
@@ -1498,7 +1496,7 @@ void main() {
   } catch (e) {
     print('Called MyClass(1, \'two\', 3) and got an exception \n of type ${e.runtimeType}.');
   }
-  
+
   if (errs.isEmpty) {
     print('Success!');
   } else {
@@ -1515,19 +1513,11 @@ void main() {
   `this.anInt`, `this.aString`, and `this.aDouble`
   as its parameters in that order.
 
-  ```dart    
+  ```dart
   MyClass(this.anInt, this.aString, this.aDouble);
   ```
 
 </details>
-
-{% comment %}
-This one seems super easy compared to previous ones.
-We've already seen it in the Exceptions example,
-and I'd already used it in a previous example.
-Move it up higher? Or make it more challenging, somehow?
-Maybe require both positional and optional named parameters (with defaults)?
-{% endcomment %}
 
 ## Initializer lists
 
@@ -1555,7 +1545,7 @@ NonNegativePoint(this.x, this.y) : assert(x >= 0), assert(y >= 0) {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Complete the `FirstTwoLetters` constructor below.
 Use an initializer list to assign the first two characters in `word` to
@@ -1563,20 +1553,6 @@ the `letterOne` and `LetterTwo` properties.
 For extra credit, add an `assert` to catch words of less than two characters.
 
 Ignore all initial errors in the DartPad.
-
-{% comment %}
-Is the assert even executed? I can't see any effect on the test,
-which makes me think asserts are ignored.
-Also, the test just checks for the presence of any exception, not for
-an AssertionError.
-
-Also, my print() wasn't visible in the Output until I fixed my code and/or
-the test. That was unexpected.
-It'd be cool if Output appeared only if you want it, like Solution does.
-
-FINALLY: Suggest using https://pub.dev/packages/characters
-if this is a user-entered string.
-{% endcomment %}
 
 ```dartpad
 class FirstTwoLetters {
@@ -1595,7 +1571,7 @@ void main() {
 
   try {
     final result = FirstTwoLetters('My String');
-    
+
     if (result.letterOne != 'M') {
       errs.add('Called FirstTwoLetters(\'My String\') and got an object with \n letterOne equal to \'${result.letterOne}\' instead of the expected value (\'M\').');
     }
@@ -1608,17 +1584,17 @@ void main() {
   }
 
   bool caughtException = false;
-  
+
   try {
     FirstTwoLetters('');
   } catch (e) {
     caughtException = true;
   }
-  
+
   if (!caughtException) {
     errs.add('Called FirstTwoLetters(\'\') and didn\'t get an exception \n from the failed assertion.');
   }
-  
+
   if (errs.isEmpty) {
     print('Success!');
   } else {
@@ -1634,7 +1610,7 @@ void main() {
   `letterOne` should be assigned `word[0]`,
   and `letterTwo` should be assigned `word[1]`.
 
-  ```dart    
+  ```dart
     FirstTwoLetters(String word)
         : assert(word.length >= 2),
           letterOne = word[0],
@@ -1644,12 +1620,6 @@ void main() {
 
 ## Named constructors
 
-{% comment %}
-Much like JavaScript, Dart doesn't support method overloads
-(two methods with the same name but different signatures).
-[ISSUE: methods & constructors aren't the same thing,
-so I deleted that. We can add it back if we can word it better.]
-{% endcomment %}
 To allow classes to have multiple constructors,
 Dart supports named constructors:
 
@@ -1671,7 +1641,7 @@ To use a named constructor, invoke it using its full name:
 final myPoint = Point.origin();
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Give the `Color` class a constructor named `Color.black`
 that sets all three properties to zero.
@@ -1683,11 +1653,10 @@ class Color {
   int red;
   int green;
   int blue;
-  
+
   Color(this.red, this.green, this.blue);
 
   // TODO: Create a named constructor called "Color.black" here:
-
 }
 
 
@@ -1697,7 +1666,7 @@ void main() {
 
   try {
     final result = Color.black();
-    
+
     if (result.red != 0) {
       errs.add('Called Color.black() and got a Color with red equal to \n ${result.red} instead of the expected value (0).');
     }
@@ -1725,14 +1694,12 @@ void main() {
 <details>
   <summary>Solution for named constructors example</summary>
 
-  The declaration for your constructor should begin with `Color.black(): `.
-  In the initializer list (after the colon), set `red`, `green`, and `blue` to `0`.
+  The declaration for your constructor should begin with `Color.black():`.
+  In the initializer list (after the colon),
+  set `red`, `green`, and `blue` to `0`.
 
-  ```dart    
-    Color.black()
-        : red = 0,
-          green = 0,
-          blue = 0;
+  ```dart
+  Color.black() : red = 0, green = 0, blue = 0;
   ```
 
 </details>
@@ -1761,7 +1728,7 @@ class Shape {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Replace the line `TODO();` in the factory constructor
 named `IntegerHolder.fromList` to return the following:
@@ -1779,7 +1746,7 @@ If you succeed, the console should display `Success!`.
 ```dartpad
 class IntegerHolder {
   IntegerHolder();
-  
+
   // Implement this factory constructor.
   factory IntegerHolder.fromList(List<int> list) {
     TODO();
@@ -1811,7 +1778,7 @@ class IntegerTriple extends IntegerHolder {
 void main() {
   final errs = <String>[];
 
-  // Run 5 tests to see which values have valid integer holders
+  // Run 5 tests to see which values have valid integer holders.
   for (var tests = 0; tests < 5; tests++) {
     if (!testNumberOfArgs(errs, tests)) return;
   }
@@ -1820,7 +1787,7 @@ void main() {
   // but have errors with values 0 and 4.
   // The testNumberOfArgs method adds to the errs array if
   // the values 1 to 3 have an error and
-  // the values 0 and 4 don't have an error
+  // the values 0 and 4 don't have an error.
   if (errs.isEmpty) {
     print('Success!');
   } else {
@@ -1874,13 +1841,12 @@ void testValues(List<String> errs, List<int> expectedValues, IntegerHolder obj,
 
     if (found != expectedValues[i]) {
       errs.add(
-          "Called $callText and got a ${obj.runtimeType} " + 
+          "Called $callText and got a ${obj.runtimeType} " +
           "with a property at index $i value of $found " +
           "instead of the expected (${expectedValues[i]}).");
     }
   }
 }
-
 ```
 
 <details>
@@ -1932,7 +1898,7 @@ class Automobile {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Remember the `Color` class from above? Create a named constructor called
 `black`, but rather than manually assigning the properties, redirect it to the
@@ -1945,7 +1911,7 @@ class Color {
   int red;
   int green;
   int blue;
-  
+
   Color(this.red, this.green, this.blue);
 
   // TODO: Create a named constructor called "black" here
@@ -1959,7 +1925,7 @@ void main() {
 
   try {
     final result = Color.black();
-    
+
     if (result.red != 0) {
       errs.add('Called Color.black() and got a Color with red equal to \n ${result.red} instead of the expected value (0).');
     }
@@ -1990,16 +1956,17 @@ void main() {
   Your constructor should redirect to `this(0, 0, 0)`.
 
   ```dart
-    Color.black() : this(0, 0, 0);
+  Color.black() : this(0, 0, 0);
   ```
 
 </details>
 
 ## Const constructors
 
-If your class produces objects that never change, you can make these objects compile-time constants. To
-do this, define a `const` constructor and make sure that all instance variables
-are final.
+If your class produces objects that never change,
+you can make these objects compile-time constants.
+To do this, define a `const` constructor and
+make sure that all instance variables are final.
 
 <?code-excerpt "misc/lib/cheatsheet/redirecting_constructors.dart (const-constructors)"?>
 ```dart
@@ -2013,7 +1980,7 @@ class ImmutablePoint {
 }
 ```
 
-### Code example {:.no_toc}
+### Exercise {:.no_toc}
 
 Modify the `Recipe` class so its instances can be constants,
 and create a constant constructor that does the following:
@@ -2033,7 +2000,7 @@ class Recipe {
   int calories;
   double milligramsOfSodium;
 
-  // TODO: Create a const constructor here"
+  // TODO: Create a const constructor here.
 
 }
 
@@ -2044,15 +2011,15 @@ void main() {
 
   try {
     const obj = Recipe(['1 egg', 'Pat of butter', 'Pinch salt'], 120, 200);
-    
+
     if (obj.ingredients.length != 3) {
       errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) \n and got an object with ingredient list of length ${obj.ingredients.length} rather than the expected length (3).');
     }
-    
+
     if (obj.calories != 120) {
       errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) \n and got an object with a calorie value of ${obj.calories} rather than the expected value (120).');
     }
-    
+
     if (obj.milligramsOfSodium != 200) {
       errs.add('Called Recipe([\'1 egg\', \'Pat of butter\', \'Pinch salt\'], 120, 200) \n and got an object with a milligramsOfSodium value of ${obj.milligramsOfSodium} rather than the expected value (200).');
     }


### PR DESCRIPTION
- Changes the "Code example" headings to "Exercise" as suggested by @antfitch in https://github.com/dart-lang/site-www/pull/6532#issuecomment-2816322491.
- Fix the format of a few comments in code snippets
- Removes unnecessary spaces and extra new lines throughout the docs and code snippets.
- Removes some outdated author comments.
- Some other minor cleanup :)