### PR TITLE
[Dart 3.8] Introduce documentation for doc imports

### DIFF
--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -131,7 +131,7 @@ example, 'dart:', 'package:', and relative paths). They can't contain the
 `deferred` keyword or configurations. Doc imports currently can't contain `as`,
 `show`, or `hide`.
 
-[regular doc imports]: /language/libraries#using-libraries
+[regular Dart imports]: /language/libraries#using-libraries
 
 :::version-note
 Support for doc imports was introduced in Dart 3.8.

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -60,12 +60,14 @@ link is created.
 
 ## What can be referenced
 
-Most library members can be referenced in a doc comment, including classes,
-constants, enums, named extensions, extension types, functions, mixins, and
-type aliases. This includes all in-scope library members, either declared
-locally, or imported, or [imported with a doc import](#doc-imports). Library
-members that are imported with an import prefix can be referenced with the
-prefix. For example:
+Most library members can be referenced in a doc comment, including
+classes, constants, enums, named extensions, extension types,
+functions, mixins, and type aliases.
+This includes all in-scope library members, either
+declared locally, imported, or [imported with a doc import](#doc-imports).
+Library members that are imported with an import prefix can
+be referenced with the prefix.
+For example:
 
 ```dart
 import 'dart:math' as math;
@@ -77,7 +79,7 @@ int x = 7;
 
 Most members of a class, an enum, an extension, an extension type, and a mixin
 can also be referenced. A reference to a member that is not in scope must be
-qualified (prefixed) with its container's name. For example the `wait` static
+qualified (prefixed) with its container's name. For example, the `wait` static
 method on the `Future` class can be referenced in a doc comment with
 `[Future.wait]`. This is true for instance members as well; the `add` method
 and the `length` property on the `List` class can be referenced with
@@ -113,9 +115,11 @@ scope.
 
 ## Doc imports
 
-Dart provides a `@docImport` documentation tag, which enables external elements
-to be referenced in doc comments without actually importing them. This tag can be
-specified in a doc comment above a `library` directive. For example:
+Dart provides a `@docImport` documentation tag,
+which enables external elements to be referenced in
+doc comments without actually importing them.
+This tag can be specified in a doc comment above a `library` directive.
+For example:
 
 ```dart
 /// @docImport 'dart:async';
@@ -126,10 +130,10 @@ library;
 class Foo {}
 ```
 
-Doc imports support all of the same URI styles as [regular Dart imports][] (for
-example, 'dart:', 'package:', and relative paths). They can't contain the
-`deferred` keyword or configurations. Doc imports currently can't contain `as`,
-`show`, or `hide`.
+Doc imports support the same URI styles as [regular Dart imports][]
+(for example, 'dart:', 'package:', and relative paths).
+They can't contain the `deferred` keyword or configurations.
+Doc imports currently can't contain `as`, `show`, or `hide`.
 
 [regular Dart imports]: /language/libraries#using-libraries
 

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -131,5 +131,5 @@ keyword or configurations. Doc imports currently can't contain `as`, `show`,
 or `hide`.
 
 :::version-note
-Doc imports were introduced in Dart 3.8.
+Support for doc imports was introduced in Dart 3.8.
 :::

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -130,10 +130,9 @@ library;
 class Foo {}
 ```
 
-Doc imports support the same URI styles as [regular Dart imports][]
-(for example, 'dart:', 'package:', and relative paths).
-They can't contain the `deferred` keyword or configurations.
-Doc imports currently can't contain `as`, `show`, or `hide`.
+Doc imports support the same URI styles as [regular Dart imports][],
+including the `dart:` and `package:` schemes as well as relative paths.
+However, they can't be deferred or configured with `as`, `show`, or `hide`.
 
 [regular Dart imports]: /language/libraries#using-libraries
 

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -110,7 +110,7 @@ The doc comment for a type alias that aliases a class, enum, extension type, or
 mixin can't reference any of the aliased type's members as if they were in
 scope.
 
-## Documentation imports
+## Doc imports
 
 Dart provides a "documentation imports" feature which enables external elements
 to be referenced in doc comments without actually importing them via a Dart

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -115,13 +115,13 @@ scope.
 
 ## Doc imports
 
-Dart provides a `@docImport` documentation tag,
+Dart supports a `@docImport` documentation tag,
 which enables external elements to be referenced in
-doc comments without actually importing them.
+documentation comments without actually importing them.
 This tag can be specified in a doc comment above a `library` directive.
 For example:
 
-```dart
+```dart highlightLines=1
 /// @docImport 'dart:async';
 library;
 

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -125,8 +125,9 @@ For example:
 /// @docImport 'dart:async';
 library;
 
-/// We can now reference elements like [Future] and [Future.value] from
-/// `dart:async`, even if the library is not imported with an actual import.
+/// Doc comments can now reference elements like
+/// [Future] and [Future.value] from `dart:async`,
+/// even if the library is not imported with an actual import.
 class Foo {}
 ```
 

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -112,10 +112,9 @@ scope.
 
 ## Doc imports
 
-Dart provides a "documentation imports" feature which enables external elements
-to be referenced in doc comments without actually importing them via a Dart
-import directive. Doc imports are specified in a doc comment on a `library`
-directive. For example:
+Dart provides a `@docImport` documentation tag, which enables external elements
+to be referenced in doc comments without actually importing them. This tag can be
+specified in a doc comment above a `library` directive. For example:
 
 ```dart
 /// @docImport 'dart:async';

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -128,7 +128,7 @@ class Foo {}
 
 Doc imports support all of the same URI styles as regular Dart imports (for example,
 'dart:', 'package:', and relative paths). They can't contain the `deferred`
-keyword, or configurations. Doc imports currently can't contain `as`, `show`,
+keyword or configurations. Doc imports currently can't contain `as`, `show`,
 or `hide`.
 
 :::version-note

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -131,7 +131,7 @@ example, 'dart:', 'package:', and relative paths). They can't contain the
 `deferred` keyword or configurations. Doc imports currently can't contain `as`,
 `show`, or `hide`.
 
-[regular doc imports]: https://dart.dev/language/libraries#using-libraries
+[regular doc imports]: /language/libraries#using-libraries
 
 :::version-note
 Support for doc imports was introduced in Dart 3.8.

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -126,7 +126,7 @@ library;
 class Foo {}
 ```
 
-Doc imports support all of the same URI styles as regular Dart imports (e.g.
+Doc imports support all of the same URI styles as regular Dart imports (for example,
 'dart:', 'package:', and relative paths). They can't contain the `deferred`
 keyword, or configurations. Doc imports currently can't contain `as`, `show`,
 or `hide`.

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -121,7 +121,7 @@ specified in a doc comment above a `library` directive. For example:
 library;
 
 /// We can now reference elements like [Future] and [Future.value] from
-/// dart:async, even if the library is not imported with an actual import.
+/// `dart:async`, even if the library is not imported with an actual import.
 class Foo {}
 ```
 

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -109,3 +109,28 @@ within a doc comment on that element or on one of its members.
 The doc comment for a type alias that aliases a class, enum, extension type, or
 mixin can't reference any of the aliased type's members as if they were in
 scope.
+
+## Documentation imports
+
+Dart provides a "documentation imports" feature which enables external elements
+to be referenced in doc comments without actually importing them via a Dart
+import directive. Doc imports are specified in a doc comment on a `library`
+directive. For example:
+
+```dart
+/// @docImport 'dart:async';
+library;
+
+/// We can now reference elements like [Future] and [Future.value] from
+/// dart:async, even if the library is not imported with an actual import.
+class Foo {}
+```
+
+Doc imports support all of the same URI styles as regular Dart imports (e.g.
+'dart:', 'package:', and relative paths). They can't contain the `deferred`
+keyword, or configurations. Doc imports currently can't contain `as`, `show`,
+or `hide`.
+
+:::version-note
+Doc imports were introduced in Dart 3.8.
+:::

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -63,8 +63,9 @@ link is created.
 Most library members can be referenced in a doc comment, including classes,
 constants, enums, named extensions, extension types, functions, mixins, and
 type aliases. This includes all in-scope library members, either declared
-locally, or imported. Library members that are imported with an import prefix
-can be referenced with the prefix. For example:
+locally, or imported, or [imported with a doc import](#doc-imports). Library
+members that are imported with an import prefix can be referenced with the
+prefix. For example:
 
 ```dart
 import 'dart:math' as math;

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -125,10 +125,12 @@ library;
 class Foo {}
 ```
 
-Doc imports support all of the same URI styles as regular Dart imports (for example,
-'dart:', 'package:', and relative paths). They can't contain the `deferred`
-keyword or configurations. Doc imports currently can't contain `as`, `show`,
-or `hide`.
+Doc imports support all of the same URI styles as [regular Dart imports][] (for
+example, 'dart:', 'package:', and relative paths). They can't contain the
+`deferred` keyword or configurations. Doc imports currently can't contain `as`,
+`show`, or `hide`.
+
+[regular doc imports]: https://dart.dev/language/libraries#using-libraries
 
 :::version-note
 Support for doc imports was introduced in Dart 3.8.


### PR DESCRIPTION
## Task

Add Documentation imports section to Documentation comment references guide.

## Preview

https://dart-dev--pr6538-doc-imports-bbvfn6a4.web.app/tools/doc-comments/references

## Other

Fixes https://github.com/dart-lang/site-www/issues/6140

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
