### PR TITLE
Minor fixes and cleanup to record.wait docs

### DIFF
--- a/src/content/libraries/dart-async.md
+++ b/src/content/libraries/dart-async.md
@@ -216,32 +216,32 @@ or with an error if any of the provided futures fail.
 
 ### Handling errors for multiple futures
 
-You can also wait for parallel operations on an [iterable]({{site.dart-api}}/dart-async/FutureIterable/wait.html)
-or [record]({{site.dart-api}}/dart-async/FutureRecord2/wait.html)
-of futures.
+You can also wait for parallel operations on
+an [iterable][iterable-futures] of futures
+or a [record][record-futures] with futures as positional fields.
 
-These extensions return a future with the resulting values of all provided
-futures. Unlike `Future.wait`, they also let you handle errors. 
+These extensions return a `Future` with the
+resulting values of all provided futures.
+Unlike `Future.wait`, they also let you handle errors.
 
-If any future in the collection completes with an error, `wait` completes with a
-[`ParallelWaitError`][]. This allows the caller to handle individual errors and
-dispose successful results if necessary.
+If any future in the collection completes with an error,
+`wait` completes with a [`ParallelWaitError`][].
+This allows the caller to handle individual errors and
+dispose of successful results if necessary.
 
-When you _don't_ need the result values from each individual future,
+When you _don't_ need the result values from each future,
 use `wait` on an _iterable_ of futures:
 
 ```dart
+Future<int> delete() async => ...;
+Future<String> copy() async => ...;
+Future<bool> errorResult() async => ...;
+
 void main() async {
-  Future<void> delete() async =>  ...
-  Future<void> copy() async =>  ...
-  Future<void> errorResult() async =>  ...
-  
   try {
     // Wait for each future in a list, returns a list of futures:
     var results = await [delete(), copy(), errorResult()].wait;
-
-    } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {
-
+  } on ParallelWaitError<List<bool?>, List<AsyncError?>> catch (e) {
     print(e.values[0]);    // Prints successful future
     print(e.values[1]);    // Prints successful future
     print(e.values[2]);    // Prints null when the result is an error
@@ -250,7 +250,6 @@ void main() async {
     print(e.errors[1]);    // Prints null when the result is successful
     print(e.errors[2]);    // Prints error
   }
-
 }
 ```
 
@@ -259,26 +258,29 @@ use `wait` on a _record_ of futures.
 This provides the additional benefit that the futures can be of different types:
 
 ```dart
+Future<int> delete() async => ...;
+Future<String> copy() async => ...;
+Future<bool> errorResult() async => ...;
+
 void main() async {
-  Future<int> delete() async =>  ...
-  Future<String> copy() async =>  ...
-  Future<bool> errorResult() async =>  ...
+  try {
+    // Wait for each future in a record.
+    // Returns a record of futures that you can destructure.
+    final (deleteInt, copyString, errorBool) =
+        await (delete(), copy(), errorResult()).wait;
 
-  try {    
-    // Wait for each future in a record, returns a record of futures:
-    (int, String, bool) result = await (delete(), copy(), errorResult()).wait;
-  
-  } on ParallelWaitError<(int?, String?, bool?),
-      (AsyncError?, AsyncError?, AsyncError?)> catch (e) {
+    // Do something with the results...
+  } on ParallelWaitError<
+    (int?, String?, bool?),
+    (AsyncError?, AsyncError?, AsyncError?)
+  > catch (e) {
     // ...
-    }
-
-  // Do something with the results:
-  var deleteInt  = result.$1;
-  var copyString = result.$2;
-  var errorBool  = result.$3;
+  }
 }
 ```
+
+[iterable-futures]: {{site.dart-api}}/dart-async/FutureIterable/wait.html
+[record-futures]: {{site.dart-api}}/dart-async/FutureRecord2/wait.html
 
 ## Stream
 


### PR DESCRIPTION
- Clarifies it only works on records with positional fields
- Fixes incorrect access to `result` variable `record.wait` outside of `try`
  - Also switches to use destructuring rather than positional access.
- Updates and simplifies formatting of snippets

Resolves https://github.com/dart-lang/site-www/issues/6078