### PR TITLE
Clarify `elementAt` complexity and alternative

### DIFF
--- a/examples/iterables/test/iterables_test.dart
+++ b/examples/iterables/test/iterables_test.dart
@@ -152,7 +152,7 @@ void main() {
       final hundredthItem = items[99];
       final thousandthItem = items[999];
       final lastItem = items.last;
-      // #docregion iterable-to-list
+      // #enddocregion iterable-to-list
       expect(tenthItem, 9);
       expect(hundredthItem, 99);
       expect(thousandthItem, 999);

--- a/examples/iterables/test/iterables_test.dart
+++ b/examples/iterables/test/iterables_test.dart
@@ -140,6 +140,25 @@ void main() {
       expect(value, 2);
     });
 
+    test('iterable-to-list', () {
+      Iterable<int> veryLargeIterable() {
+        return [for (var i = 0; i < 10000; i++) i];
+      }
+
+      // #docregion iterable-to-list
+      final items = veryLargeIterable().toList();
+
+      final tenthItem = items[9];
+      final hundredthItem = items[99];
+      final thousandthItem = items[999];
+      final lastItem = items.last;
+      // #docregion iterable-to-list
+      expect(tenthItem, 9);
+      expect(hundredthItem, 99);
+      expect(thousandthItem, 999);
+      expect(lastItem, 9999);
+    });
+
     test('map_int_example', () {
       final numbers = [1, 2, 3];
       // #docregion map-int

--- a/firebase.json
+++ b/firebase.json
@@ -102,6 +102,7 @@
       { "source": "/codelabs", "destination": "/tutorials", "type": 301 },
       { "source": "/codelabs/async-await", "destination": "/libraries/async/async-await", "type": 301 },
       { "source": "/codelabs/dart-cheatsheet", "destination": "/resources/dart-cheatsheet", "type": 301 },
+      { "source": "/codelabs/iterables", "destination": "/libraries/collections/iterables", "type": 301 },
       { "source": "/codelabs/null-safety{,/**}", "destination": "/null-safety/understanding-null-safety", "type": 301 },
       { "source": "/codelabs/server{,/**}", "destination": "/tutorials/server/httpserver", "type": 301 },
       { "source": "/code-of-conduct", "destination": "/community/code-of-conduct", "type": 301 },

--- a/src/content/libraries/collections/iterables.md
+++ b/src/content/libraries/collections/iterables.md
@@ -105,13 +105,29 @@ isn't defined for the class `Iterable`,
 which means that you can't use `[index]` in this case.
 
 You can instead read elements with `elementAt()`,
-which steps through the elements of the iterable until
-it reaches that position.
+which can step through the items of the iterable until
+it reaches the item at that position.
 
 <?code-excerpt "iterables/test/iterables_test.dart (iterable-elementat)"?>
 ```dart
 Iterable<int> iterable = [1, 2, 3];
 int value = iterable.elementAt(1);
+```
+
+Depending on the iterable implementation and number of items,
+`elementAt` can have a linear complexity and be expensive.
+If you plan to access specific items repeatedly, then consider
+calling `.toList()` on the iterable to convert it to a list once,
+then use the `[]` operator.
+
+<?code-excerpt "iterables/test/iterables_test.dart (iterable-to-list)"?>
+```dart
+final items = veryLargeIterable().toList();
+
+final tenthItem = items[9];
+final hundredthItem = items[99];
+final thousandthItem = items[999];
+final lastItem = items.last;
 ```
 
 Continue to the next section to learn more about


### PR DESCRIPTION
Also adds a missing redirect for the old location of the iterables codelab.

Fixes https://github.com/dart-lang/site-www/issues/5618
