### PR TITLE
Cross link to doc comment references docs

### DIFF
--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -93,6 +93,7 @@ void miscDeclAnalyzedButNotTested() {
     /// Throws a [StateError] if ...
     /// similar to [anotherMethod()], but ...
     // #enddocregion identifiers
+    void method0() {}
 
     // #docregion member
     /// Similar to [Duration.inDays], but handles fractional days.

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -91,7 +91,8 @@ void miscDeclAnalyzedButNotTested() {
 
     // #docregion identifiers
     /// Throws a [StateError] if ...
-    /// similar to [anotherMethod()], but ...
+    ///
+    /// Similar to [anotherMethod()], but ...
     // #enddocregion identifiers
     void method0() {}
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -382,13 +382,16 @@ makes an API easier to learn.
 
 If you surround things like variable, method, or type names in square brackets,
 then `dart doc` looks up the name and links to the relevant API docs.
-Parentheses are optional,
-but can make it clearer when you're referring to a method or constructor.
+Parentheses are optional but can
+clarify you're referring to a function or constructor.
+The following partial doc comments illustrate a few cases
+where these comment references can be helpful:
 
 <?code-excerpt "docs_good.dart (identifiers)"?>
 ```dart tag=good
 /// Throws a [StateError] if ...
-/// similar to [anotherMethod()], but ...
+///
+/// Similar to [anotherMethod()], but ...
 ```
 
 To link to a member of a specific class, use the class name and member name,

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -407,6 +407,12 @@ constructor, use `.new` after the class name:
 /// To create a point, call [Point.new] or use [Point.polar] to ...
 ```
 
+To learn more about the references that
+the analyzer and `dart doc` support in doc comments,
+check out [Documentation comment references][].
+
+[Documentation comment references]: /tools/doc-comments/references
+
 ### DO use prose to explain parameters, return values, and exceptions
 
 Other languages use verbose tags and sections to describe what the parameters


### PR DESCRIPTION
Cross link Effective Dart guideline suggesting doc comment references to the new docs about them.

Also clarify that the included examples are not full doc comments and just meant to illustrate the guideline at hand. Resolves https://github.com/dart-lang/site-www/issues/3317 