### PR TITLE
Break up Language > Syntax basics for improved learning order

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -3,20 +3,13 @@
   children:
     - title: Introduction
       permalink: /language
-    - title: Syntax basics
-      children:
-        - title: Variables
-          permalink: /language/variables
-        - title: Operators
-          permalink: /language/operators
-        - title: Comments
-          permalink: /language/comments
-        - title: Metadata
-          permalink: /language/metadata
-        - title: Libraries & imports
-          permalink: /language/libraries
-        - title: Keywords
-          permalink: /language/keywords
+    - title: Variables
+      permalink: /language/variables
+    - title: Operators
+      permalink: /language/operators
+    - title: Comments
+      permalink: /language/comments
+    - divider
     - title: Types
       children:
         - title: Built-in types
@@ -39,8 +32,6 @@
           permalink: /language/pattern-types
         - title: Applied tutorial
           permalink: https://codelabs.developers.google.com/codelabs/dart-patterns-records
-    - title: Functions
-      permalink: /language/functions
     - title: Control flow
       children:
       - title: Loops
@@ -49,6 +40,12 @@
         permalink: /language/branches
       - title: Error handling
         permalink: /language/error-handling
+    - title: Functions
+      permalink: /language/functions
+    - title: Metadata
+      permalink: /language/metadata
+    - title: Libraries & imports
+      permalink: /language/libraries
     - title: Classes & objects
       children:
         - title: Classes
@@ -85,6 +82,7 @@
           permalink: /language/async
         - title: Isolates
           permalink: /language/isolates
+    - divider
     - title: Null safety
       expanded: false
       children:
@@ -98,6 +96,8 @@
           permalink: /null-safety/unsound-null-safety
         - title: FAQ
           permalink: /null-safety/faq
+    - title: Keywords
+      permalink: /language/keywords
 
 - title: Core libraries
   expanded: false

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -2,8 +2,8 @@
 title: Built-in types
 description: Information on the types Dart supports.
 prevpage:
-  url: /language/keywords
-  title: Keywords
+  url: /language/comments
+  title: Comments
 nextpage:
   url: /language/records
   title: Records

--- a/src/content/language/comments.md
+++ b/src/content/language/comments.md
@@ -5,8 +5,8 @@ prevpage:
   url: /language/operators
   title: Operators
 nextpage:
-  url: /language/metadata
-  title: Metadata
+  url: /language/built-in-types
+  title: Built-in types
 ---
 
 Dart supports single-line comments, multi-line comments, and

--- a/src/content/language/error-handling.md
+++ b/src/content/language/error-handling.md
@@ -5,8 +5,8 @@ prevpage:
   url: /language/branches
   title: Branches
 nextpage:
-  url: /language/classes
-  title: Classes
+  url: /language/functions
+  title: Functions
 ---
 
 ## Exceptions

--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -3,11 +3,11 @@ title: Functions
 description: Everything about functions in Dart.
 js: [{url: '/assets/js/inject_dartpad.js', defer: true}]
 prevpage:
-  url: /language/pattern-types
-  title: Pattern types
+  url: /language/error-handling
+  title: Error handling
 nextpage:
-  url: /language/loops
-  title: Loops
+  url: /language/metadata
+  title: Metadata
 ---
 
 Dart is a true object-oriented language, so even functions are objects

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -8,7 +8,7 @@ prevpage:
   title: Asynchronous support
 nextpage:
   url: /null-safety
-  title: Sound Null Safety
+  title: Sound null safety
 ---
 
 <?code-excerpt path-base="concurrency"?>

--- a/src/content/language/keywords.md
+++ b/src/content/language/keywords.md
@@ -2,12 +2,6 @@
 title: Keywords
 description: Keywords in Dart.
 toc: false
-prevpage:
-  url: /language/libraries
-  title: Libraries
-nextpage:
-  url: /language/built-in-types
-  title: Built-in types
 ---
 
 {% assign ckw = '&nbsp;<sup>1</sup>' %}

--- a/src/content/language/libraries.md
+++ b/src/content/language/libraries.md
@@ -6,8 +6,8 @@ prevpage:
   url: /language/metadata
   title: Metadata
 nextpage:
-  url: /language/keywords
-  title: Keywords
+  url: /language/classes
+  title: Classes
 ---
 
 The `import` and `library` directives can help you create a

--- a/src/content/language/loops.md
+++ b/src/content/language/loops.md
@@ -2,8 +2,8 @@
 title: Loops 
 description: Learn how to use loops to control the flow of your Dart code.
 prevpage:
-  url: /language/functions
-  title: Functions
+  url: /language/pattern-types
+  title: Pattern types
 nextpage:
   url: /language/branches
   title: Branches

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -3,11 +3,11 @@ title: Metadata
 description: Metadata and annotations in Dart.
 toc: false
 prevpage:
-  url: /language/comments
-  title: Comments
+  url: /language/functions
+  title: Functions
 nextpage:
   url: /language/libraries
-  title: Libraries
+  title: Libraries & imports
 ---
 
 

--- a/src/content/language/pattern-types.md
+++ b/src/content/language/pattern-types.md
@@ -5,8 +5,8 @@ prevpage:
   url: /language/patterns
   title: Patterns
 nextpage:
-  url: /language/functions
-  title: Functions
+  url: /language/loops
+  title: Loops
 ---
 
 This page is a reference for the different kinds of patterns.

--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -3,7 +3,7 @@ title: Variables
 description: Learn about variables in Dart.
 prevpage:
   url: /language
-  title: Basics
+  title: Introduction
 nextpage:
   url: /language/operators
   title: Operators


### PR DESCRIPTION
Reorganizes the **Language >** section of the sidenav by breaking up the **Syntax basics** section. The category was a sort of catch all and didn't all represent syntax. Beyond that, some of the contents didn't make sense in that order, particularly **Libraries & imports** and **Metadata** which make much more sense after having learned at least functions. Then **Keywords** is a separate reference/index, so place it at the end of the sidenav category.

Fixes https://github.com/dart-lang/site-www/issues/4654