### PR TITLE
Use actually `dynamic` example in `.cast` guideline

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -132,7 +132,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion cast-map
     var stuff = <dynamic>[1, 2];
-    var reciprocals = stuff.map((n) => 1 / (n as int)).cast<double>();
+    var reciprocals = stuff.map((n) => n * 2).cast<double>();
     // #enddocregion cast-map
   }
 

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -114,7 +114,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion cast-map
     var stuff = <dynamic>[1, 2];
-    var reciprocals = stuff.map<double>((n) => 1 / (n as int));
+    var reciprocals = stuff.map<double>((n) => (n as int) * 2);
     // #enddocregion cast-map
   }
 

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -749,13 +749,13 @@ to be explicit.
 <?code-excerpt "usage_good.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 ```dart tag=good
 var stuff = <dynamic>[1, 2];
-var reciprocals = stuff.map<double>((n) => 1 / n);
+var reciprocals = stuff.map<double>((n) => n * 2);
 ```
 
 <?code-excerpt "usage_bad.dart (cast-map)" replace="/\(n as int\)/n/g"?>
 ```dart tag=bad
 var stuff = <dynamic>[1, 2];
-var reciprocals = stuff.map((n) => 1 / n).cast<double>();
+var reciprocals = stuff.map((n) => n * 2).cast<double>();
 ```
 
 


### PR DESCRIPTION
Applies suggestion from munificent in https://github.com/dart-lang/site-www/issues/4312#issuecomment-1533807697

Fixes https://github.com/dart-lang/site-www/issues/4312