### PR TITLE
Add a check for git merge remnants in md files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,21 @@ jobs:
       - name: Run Dart tests
         run: dart run dart_site test-dart
 
+  markdown-check:
+    name: Check Markdown content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          submodules: recursive
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+      - name: Fetch Dart packages
+        run: dart pub get
+      - name: Check Markdown for any known issues
+        run: dart run dart_site check-markdown
+
   excerpts:
     name: Check if code excerpts are up to date
     runs-on: ubuntu-latest

--- a/tool/dart_site/lib/dart_site.dart
+++ b/tool/dart_site/lib/dart_site.dart
@@ -9,6 +9,7 @@ import 'src/commands/build.dart';
 import 'src/commands/check_all.dart';
 import 'src/commands/check_link_references.dart';
 import 'src/commands/check_links.dart';
+import 'src/commands/check_markdown.dart';
 import 'src/commands/check_site_variable.dart';
 import 'src/commands/format_dart.dart';
 import 'src/commands/freshness.dart';
@@ -30,6 +31,7 @@ final class DartSiteCommandRunner extends CommandRunner<int> {
       ) {
     addCommand(CheckLinksCommand());
     addCommand(CheckLinkReferencesCommand());
+    addCommand(CheckMarkdownCommand());
     addCommand(CheckSiteVariableCommand());
     addCommand(VerifyFirebaseJsonCommand());
     addCommand(RefreshExcerptsCommand());

--- a/tool/dart_site/lib/src/commands/check_all.dart
+++ b/tool/dart_site/lib/src/commands/check_all.dart
@@ -24,6 +24,7 @@ final class CheckAllCommand extends Command<int> {
       ['test-dart'],
       ['refresh-excerpts', '--fail-on-update', '--dry-run'],
       ['verify-firebase-json'],
+      ['check-markdown'],
     ];
 
     var seenFailure = false;

--- a/tool/dart_site/lib/src/commands/check_markdown.dart
+++ b/tool/dart_site/lib/src/commands/check_markdown.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as path;
+
+import '../utils.dart';
+
+final class CheckMarkdownCommand extends Command<int> {
+  @override
+  String get description =>
+      'Scan Markdown files for any instances of known issues.';
+
+  @override
+  String get name => 'check-markdown';
+
+  @override
+  List<String> get aliases => ['check-md'];
+
+  @override
+  Future<int> run() async {
+    print('Checking for problems in Markdown files...');
+
+    try {
+      print('\nChecking for merge conflict remnants...');
+      final mergeConflictRemnants = _findMergeConflictRemnants(
+        path.join(repositoryRoot, 'src'),
+        extensionsToConsider: {'.md'},
+      );
+      if (mergeConflictRemnants.isNotEmpty) {
+        stderr.writeln(
+          'Found merge conflict remnants in the following files:\n',
+        );
+        for (final filePath in mergeConflictRemnants) {
+          stderr.writeln(' - $filePath');
+        }
+        return 1;
+      }
+      print('No merge conflict remnants found.\n');
+
+      print('No problems found in Markdown files.');
+      return 0;
+    } catch (e, stackTrace) {
+      stderr.writeln('An unexpected error occurred:');
+      stderr.writeln(e);
+      stderr.writeln(stackTrace);
+      return 1;
+    }
+  }
+}
+
+List<String> _findMergeConflictRemnants(
+  String directoryPath, {
+  Set<String> extensionsToConsider = const {'.md'},
+}) {
+  final directory = Directory(directoryPath);
+  final filesWithConflictRemnants = <String>[];
+
+  if (!directory.existsSync()) {
+    throw ArgumentError('The provided path is not a directory: $directoryPath');
+  }
+
+  final files =
+      directory.listSync(recursive: true, followLinks: false).whereType<File>();
+
+  for (final file in files) {
+    // If the file doesn't have one of the specified extensions, skip it.
+    if (!extensionsToConsider.contains(path.extension(file.path))) continue;
+
+    final content = file.readAsStringSync();
+
+    if (content.contains('<<<<<<<') ||
+        content.contains('\n=======\n') ||
+        content.contains('>>>>>>>')) {
+      filesWithConflictRemnants.add(file.path);
+    }
+  }
+
+  return filesWithConflictRemnants;
+}


### PR DESCRIPTION
This helps prevent accidentally not fully resolving a merge conflict and landing that to `main`.

The new `./dash_site check-markdown` command can be expanded in the future for other Markdown checks.

Resolves https://github.com/dart-lang/site-www/issues/4694