### PR TITLE
Standardize docs on 'not-null assertion operator'

### DIFF
--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -436,7 +436,7 @@ class UploadException {
 [final]: /effective-dart/design#prefer-making-fields-and-top-level-variables-final
 [null-check pattern]: /language/pattern-types#null-check
 [`final`]: /effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables
-[use `!`]: /null-safety/understanding-null-safety#non-null-assertion-operator
+[use `!`]: /null-safety/understanding-null-safety#not-null-assertion-operator
 
 ## Strings
 

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -536,7 +536,7 @@ You've seen most of the remaining operators in other examples:
 | `?[]`    | Conditional subscript access | Like `[]`, but the leftmost operand can be null; example: `fooList?[1]` passes the int `1` to `fooList` to access the element at index `1` unless `fooList` is null (in which case the expression evaluates to null)                                    |
 | `.`      | Member access                | Refers to a property of an expression; example: `foo.bar` selects property `bar` from expression `foo`                                                                                                                                                  |
 | `?.`     | Conditional member access    | Like `.`, but the leftmost operand can be null; example: `foo?.bar` selects property `bar` from expression `foo` unless `foo` is null (in which case the value of `foo?.bar` is null)                                                                   |
-| `!`      | Not-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null in which case a runtime exception is thrown |
+| `!`      | Not-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null (in which case a runtime exception is thrown) |
 
 {:.table .table-striped}
 

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -536,7 +536,7 @@ You've seen most of the remaining operators in other examples:
 | `?[]`    | Conditional subscript access | Like `[]`, but the leftmost operand can be null; example: `fooList?[1]` passes the int `1` to `fooList` to access the element at index `1` unless `fooList` is null (in which case the expression evaluates to null)                                    |
 | `.`      | Member access                | Refers to a property of an expression; example: `foo.bar` selects property `bar` from expression `foo`                                                                                                                                                  |
 | `?.`     | Conditional member access    | Like `.`, but the leftmost operand can be null; example: `foo?.bar` selects property `bar` from expression `foo` unless `foo` is null (in which case the value of `foo?.bar` is null)                                                                   |
-| `!`      | Non-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null in which case a runtime exception is thrown |
+| `!`      | Not-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null in which case a runtime exception is thrown |
 
 {:.table .table-striped}
 

--- a/src/content/null-safety/faq.md
+++ b/src/content/null-safety/faq.md
@@ -216,8 +216,8 @@ The
 on Map (`[]`) by default returns a nullable type. There's no way to signal to
 the language that the value is guaranteed to be there.
 
-In this case, you should use the bang operator (`!`) to cast the value back to
-V:
+In this case, you should use the not-null assertion operator (`!`) to
+cast the value back to `V`:
 
 ```dart
 return blockTypes[key]!;
@@ -339,12 +339,13 @@ seem less than their native targets.
 
 A few notes that are worth highlighting:
 
-* The production JavaScript compiler generates `!` null assertions. You might
-  not notice them when comparing the output of the compiler before and
-  after adding null assertions. That's because the compiler already
+* The production JavaScript compiler generates `!` not-null assertions.
+  You might not notice them when comparing the output of the compiler
+  before and after adding not-null assertions.
+  That's because the compiler already
   generated null checks in programs that weren't null safe.
 
-* The compiler generates these null assertions regardless of the
+* The compiler generates these not-null assertions regardless of the
   soundness of null safety or optimization level. In fact, the compiler
   doesn't remove `!` when using `-O3` or `--omit-implicit-checks`.
 

--- a/src/content/null-safety/understanding-null-safety.md
+++ b/src/content/null-safety/understanding-null-safety.md
@@ -874,8 +874,10 @@ There isn't a null-aware function call operator, but you can write:
 function?.call(arg1, arg2);
 ```
 
-<a id="null-assertion-operator"></a>
-### Non-null assertion operator
+<a id="null-assertion-operator" aria-hidden="true"></a>
+<a id="non-null-assertion-operator aria-hidden="true"></a>
+
+### Not-null assertion operator
 
 The great thing about using flow analysis to move a nullable variable to the
 non-nullable side of the world is that doing so is provably safe. You get to
@@ -986,8 +988,8 @@ it has a conservative rule that non-nullable fields have to be initialized
 either at their declaration (or in the constructor initialization list for
 instance fields). So Dart reports a compile error on this class.
 
-You can fix the error by making the field nullable and then using null assertion
-operators on the uses:
+You can fix the error by making the field nullable and then
+using not-null assertion operators on the uses:
 
 ```dart
 // Using null safety:
@@ -1021,11 +1023,13 @@ class Coffee {
 }
 ```
 
-Note that the `_temperature` field has a non-nullable type, but is not
-initialized. Also, there's no explicit null assertion when it's used. There are
-a few models you can apply to the semantics of `late`, but I think of it like
-this: The `late` modifier means "enforce this variable's constraints at runtime
-instead of at compile time". It's almost like the word "late" describes *when*
+Note that the `_temperature` field has a non-nullable type,
+but is not initialized.
+Also, there's no explicit not-null assertion when it's used.
+There are a few models you can apply to the semantics of `late`,
+but I think of it like this: The `late` modifier means
+"enforce this variable's constraints at runtime instead of at compile time".
+It's almost like the word "late" describes *when*
 it enforces the variable's guarantees.
 
 In this case, since the field is not definitely initialized, every time the
@@ -1532,7 +1536,7 @@ The core points to take away are:
 
 *   Method chains after null-aware operators short circuit if the receiver is
     `null`. There are new null-aware cascade (`?..`) and index (`?[]`)
-    operators. The postfix null assertion "bang" operator (`!`) casts its
+    operators. The postfix not-null assertion "bang" operator (`!`) casts its
     nullable operand to the underlying non-nullable type.
 
 *   Flow analysis lets you safely turn nullable local variables and parameters

--- a/src/content/null-safety/understanding-null-safety.md
+++ b/src/content/null-safety/understanding-null-safety.md
@@ -698,7 +698,7 @@ String makeCommand(String executable, [List<String>? arguments]) {
 The language is also smarter about what kinds of expressions cause promotion. An
 explicit `== null` or `!= null` of course works. But explicit casts using `as`,
 or assignments, or the postfix `!` operator
-(which we'll cover [later on](#non-null-assertion-operator)) also cause
+(which we'll cover [later on](#not-null-assertion-operator)) also cause
 promotion. The general goal is that if the code is dynamically correct and it's
 reasonable to figure that out statically, the analysis should be clever enough
 to do so.
@@ -880,7 +880,7 @@ function?.call(arg1, arg2);
 ```
 
 <a id="null-assertion-operator" aria-hidden="true"></a>
-<a id="non-null-assertion-operator aria-hidden="true"></a>
+<a id="non-null-assertion-operator" aria-hidden="true"></a>
 
 ### Not-null assertion operator
 

--- a/src/content/resources/whats-new.md
+++ b/src/content/resources/whats-new.md
@@ -727,7 +727,7 @@ we made the following changes to this site:
     as the underlying compilers of tools like
     [`dart compile js`][] and [`webdev`][].
 * Increased documentation coverage of null safety:
-  * Documented the non-null assertion operator (`!`) as part of
+  * Documented the not-null assertion operator (`!`) as part of
     the [Other operators][] section of the language tour.
   * Migrated the [Low-level HTML tutorials][] to support null safety
     and discuss how to interact with web APIs while using it.


### PR DESCRIPTION
In https://github.com/dart-lang/site-www/issues/5252, no complete conclusion was came to. However, the site is currently inconsistent in how it refers to the operator which is even more harmful. I'm going to lean on what I've seen in the community and familiarity with otherwise commonly known languages:

- [TypeScript's non-null assertion operator](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-)
- [Kotlin's not-null assertion operator](https://kotlinlang.org/docs/null-safety.html#not-null-assertion-operator)

Resolves https://github.com/dart-lang/site-www/issues/5252