### PR TITLE
Collections > Null-aware element (3.8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: stable
+          sdk: beta
       - name: Fetch Dart packages
         run: dart pub get
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - sdk: beta
             experimental: false
           - sdk: stable
-            experimental: false
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           submodules: recursive
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: stable
+          sdk: beta
       - name: Fetch Dart packages
         run: dart pub get
       - name: Check if excerpts are up to date
@@ -88,7 +88,7 @@ jobs:
           submodules: recursive
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: stable
+          sdk: beta
       - name: Fetch Dart packages
         run: dart pub get
       - name: Check if text can be replaced with site variables
@@ -103,7 +103,7 @@ jobs:
           submodules: recursive
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: stable
+          sdk: beta
       - name: Fetch Dart packages
         run: dart pub get
       - name: Validate the firebase.json file

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -3,7 +3,7 @@ description: dart.dev example code.
 
 resolution: workspace
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0-0
 
 dependencies:
   args: ^2.7.0

--- a/examples/misc/test/language_tour/collections/if_case_operator_in_collection_d.dart
+++ b/examples/misc/test/language_tour/collections/if_case_operator_in_collection_d.dart
@@ -5,7 +5,7 @@ void main() {
   var word = 'hello';
   var items = [
     1,
-    if (word case String(length: var word_length)) word_length,
+    if (word case String(length: var wordLength)) wordLength,
     3,
   ]; // [1, 5, 3]
   // #enddocregion code_sample

--- a/examples/misc/test/language_tour/collections/null_aware_element_a.dart
+++ b/examples/misc/test/language_tour/collections/null_aware_element_a.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+void main() {
+  // #docregion code_sample
+  int? a = null;
+  int? b = 3;
+  int? c = null;
+  var items = [1, ?a, ?b, c, 5]; // [1, 3, null, 5]
+  // #enddocregion code_sample
+
+  print(items);
+  expect(items, equals([1, 3, null, 5]));
+}

--- a/examples/misc/test/language_tour/collections/null_aware_element_a.dart
+++ b/examples/misc/test/language_tour/collections/null_aware_element_a.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_init_to_null, invalid_null_aware_operator
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/collections/null_aware_element_b.dart
+++ b/examples/misc/test/language_tour/collections/null_aware_element_b.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_init_to_null, invalid_null_aware_operator
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/collections/null_aware_element_b.dart
+++ b/examples/misc/test/language_tour/collections/null_aware_element_b.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+
+void main() {
+  // #docregion code_sample
+  String? itemX = 'Apple';
+  String? itemY = null;
+  
+  int? quantityX = 3;
+  int? quantityY = null;
+  
+  var inventoryA = {itemX: quantityY}; // {Apple: null}
+  var inventoryB = {itemX: ?quantityY}; // {}
+  
+  var inventoryC = {itemY: quantityX}; // {null: 3}
+  var inventoryD = {?itemY: quantityX}; // {}
+  
+  var inventoryE = {itemY: quantityY}; // {null: null}
+  var inventoryF = {?itemY: ?quantityY}; // {}
+  // #enddocregion code_sample
+
+  print(inventoryA);
+  print(inventoryB);
+  print(inventoryC);
+  print(inventoryD);
+  print(inventoryE);
+  print(inventoryF);
+  expect(inventoryA, equals({'Apple': null}));
+  expect(inventoryB, equals({}));
+  expect(inventoryC, equals({null: 3}));
+  expect(inventoryD, equals({}));
+  expect(inventoryE, equals({null: null}));
+  expect(inventoryF, equals({}));
+}

--- a/src/content/effective-dart/usage.md
+++ b/src/content/effective-dart/usage.md
@@ -436,7 +436,7 @@ class UploadException {
 [final]: /effective-dart/design#prefer-making-fields-and-top-level-variables-final
 [null-check pattern]: /language/pattern-types#null-check
 [`final`]: /effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables
-[use `!`]: /null-safety/understanding-null-safety#non-null-assertion-operator
+[use `!`]: /null-safety/understanding-null-safety#not-null-assertion-operator
 
 ## Strings
 

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -590,7 +590,7 @@ var typeInfo = [
 var word = 'hello';
 var items = [
   1,
-  if (word case String(length: var word_length)) word_length,
+  if (word case String(length: var wordLength)) wordLength,
   3,
 ]; // [1, 5, 3]
 ```

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -328,6 +328,72 @@ A map entry element has this syntax in a collection:
 <key_expression>: <value_expression>
 ```
 
+### Null-aware elements {: #null-aware-element }
+
+The null-aware element checks if a value is not null
+and inserts the resulting value into the surrounding
+collection. Null-aware elements can only be used with
+leaf elements and can't be nested.
+
+A null-aware element has the following syntax in an
+expression element:
+
+```dart
+?<expression>
+```
+
+A null-aware element has the following syntax in a
+map entry element:
+
+```dart
+// key is a null-aware element
+?<key_expression>: <value_expression>
+```
+
+```dart
+// value is a null-aware element
+<key_expression>: ?<value_expression>
+```
+
+```dart
+// key and value are null-aware elements
+?<key_expression>: ?<value_expression>
+```
+
+In the following example, the result for the
+null-aware element `?a` is not added to a list called
+`items` because `a` is `null`:
+
+<?code-excerpt "misc/test/language_tour/collections/null_aware_element_a.dart (code_sample)"?>
+```dart
+int? a = null;
+int? b = 3;
+int? c = null;
+var items = [1, ?a, ?b, c, 5]; // [1, 3, null, 5]
+```
+
+The following example illustrates various ways that
+you can use null-aware elements inside of
+map entry elements:
+
+<?code-excerpt "misc/test/language_tour/collections/null_aware_element_b.dart (code_sample)"?>
+```dart
+String? itemX = 'Apple';
+String? itemY = null;
+
+int? quantityX = 3;
+int? quantityY = null;
+
+var inventoryA = {itemX: quantityY}; // {Apple: null}
+var inventoryB = {itemX: ?quantityY}; // {}
+
+var inventoryC = {itemY: quantityX}; // {null: 3}
+var inventoryD = {?itemY: quantityX}; // {}
+
+var inventoryE = {itemY: quantityY}; // {null: null}
+var inventoryF = {?itemY: ?quantityY}; // {}
+```
+
 ### Spread elements {: #spread-element }
 
 The spread element iterates over a given sequence and

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -536,7 +536,7 @@ You've seen most of the remaining operators in other examples:
 | `?[]`    | Conditional subscript access | Like `[]`, but the leftmost operand can be null; example: `fooList?[1]` passes the int `1` to `fooList` to access the element at index `1` unless `fooList` is null (in which case the expression evaluates to null)                                    |
 | `.`      | Member access                | Refers to a property of an expression; example: `foo.bar` selects property `bar` from expression `foo`                                                                                                                                                  |
 | `?.`     | Conditional member access    | Like `.`, but the leftmost operand can be null; example: `foo?.bar` selects property `bar` from expression `foo` unless `foo` is null (in which case the value of `foo?.bar` is null)                                                                   |
-| `!`      | Non-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null in which case a runtime exception is thrown |
+| `!`      | Not-null assertion operator  | Casts an expression to its underlying non-nullable type, throwing a runtime exception if the cast fails; example: `foo!.bar` asserts `foo` is non-null and selects the property `bar`, unless `foo` is null (in which case a runtime exception is thrown) |
 
 {:.table .table-striped}
 

--- a/src/content/null-safety/faq.md
+++ b/src/content/null-safety/faq.md
@@ -216,8 +216,8 @@ The
 on Map (`[]`) by default returns a nullable type. There's no way to signal to
 the language that the value is guaranteed to be there.
 
-In this case, you should use the bang operator (`!`) to cast the value back to
-V:
+In this case, you should use the not-null assertion operator (`!`) to
+cast the value back to `V`:
 
 ```dart
 return blockTypes[key]!;
@@ -339,12 +339,13 @@ seem less than their native targets.
 
 A few notes that are worth highlighting:
 
-* The production JavaScript compiler generates `!` null assertions. You might
-  not notice them when comparing the output of the compiler before and
-  after adding null assertions. That's because the compiler already
+* The production JavaScript compiler generates `!` not-null assertions.
+  You might not notice them when comparing the output of the compiler
+  before and after adding not-null assertions.
+  That's because the compiler already
   generated null checks in programs that weren't null safe.
 
-* The compiler generates these null assertions regardless of the
+* The compiler generates these not-null assertions regardless of the
   soundness of null safety or optimization level. In fact, the compiler
   doesn't remove `!` when using `-O3` or `--omit-implicit-checks`.
 

--- a/src/content/null-safety/understanding-null-safety.md
+++ b/src/content/null-safety/understanding-null-safety.md
@@ -698,7 +698,7 @@ String makeCommand(String executable, [List<String>? arguments]) {
 The language is also smarter about what kinds of expressions cause promotion. An
 explicit `== null` or `!= null` of course works. But explicit casts using `as`,
 or assignments, or the postfix `!` operator
-(which we'll cover [later on](#non-null-assertion-operator)) also cause
+(which we'll cover [later on](#not-null-assertion-operator)) also cause
 promotion. The general goal is that if the code is dynamically correct and it's
 reasonable to figure that out statically, the analysis should be clever enough
 to do so.
@@ -879,8 +879,10 @@ There isn't a null-aware function call operator, but you can write:
 function?.call(arg1, arg2);
 ```
 
-<a id="null-assertion-operator"></a>
-### Non-null assertion operator
+<a id="null-assertion-operator" aria-hidden="true"></a>
+<a id="non-null-assertion-operator" aria-hidden="true"></a>
+
+### Not-null assertion operator
 
 The great thing about using flow analysis to move a nullable variable to the
 non-nullable side of the world is that doing so is provably safe. You get to
@@ -991,8 +993,8 @@ it has a conservative rule that non-nullable fields have to be initialized
 either at their declaration (or in the constructor initialization list for
 instance fields). So Dart reports a compile error on this class.
 
-You can fix the error by making the field nullable and then using null assertion
-operators on the uses:
+You can fix the error by making the field nullable and then
+using not-null assertion operators on the uses:
 
 ```dart
 // Using null safety:
@@ -1026,11 +1028,13 @@ class Coffee {
 }
 ```
 
-Note that the `_temperature` field has a non-nullable type, but is not
-initialized. Also, there's no explicit null assertion when it's used. There are
-a few models you can apply to the semantics of `late`, but I think of it like
-this: The `late` modifier means "enforce this variable's constraints at runtime
-instead of at compile time". It's almost like the word "late" describes *when*
+Note that the `_temperature` field has a non-nullable type,
+but is not initialized.
+Also, there's no explicit not-null assertion when it's used.
+There are a few models you can apply to the semantics of `late`,
+but I think of it like this: The `late` modifier means
+"enforce this variable's constraints at runtime instead of at compile time".
+It's almost like the word "late" describes *when*
 it enforces the variable's guarantees.
 
 In this case, since the field is not definitely initialized, every time the
@@ -1537,7 +1541,7 @@ The core points to take away are:
 
 *   Method chains after null-aware operators short circuit if the receiver is
     `null`. There are new null-aware cascade (`?..`) and index (`?[]`)
-    operators. The postfix null assertion "bang" operator (`!`) casts its
+    operators. The postfix not-null assertion "bang" operator (`!`) casts its
     nullable operand to the underlying non-nullable type.
 
 *   Flow analysis lets you safely turn nullable local variables and parameters

--- a/src/content/resources/whats-new.md
+++ b/src/content/resources/whats-new.md
@@ -727,7 +727,7 @@ we made the following changes to this site:
     as the underlying compilers of tools like
     [`dart compile js`][] and [`webdev`][].
 * Increased documentation coverage of null safety:
-  * Documented the non-null assertion operator (`!`) as part of
+  * Documented the not-null assertion operator (`!`) as part of
     the [Other operators][] section of the language tour.
   * Migrated the [Low-level HTML tutorials][] to support null safety
     and discuss how to interact with web APIs while using it.


### PR DESCRIPTION
This add the null-aware element to our [collections documentation](https://dart.dev/language/collections).

Notes:
- This is behind a beta feature flag right now.

Fixes [6458](https://github.com/dart-lang/site-www/issues/6458)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
