### PR TITLE
Dart 3.8 language evolution

### DIFF
--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -44,7 +44,7 @@ on the Dart language GitHub repo.
 
 ### Dart 3.8
 _Released 20 May 2025_
-| [Dart 3.8 announcement](https://medium.com/dartlang/...)
+| [Dart 3.8 announcement](https://medium.com/dartlang/announcing-dart-3-8-724eaaec9f47)
 
 The following language features have been added to Dart 3.8:
 
@@ -67,8 +67,8 @@ For more information about these and additional changes, see
 the [Dart 3.8 changelog][].
 
 [Null-aware elements]: /language/collections#null-aware-element
-[Dart format]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#dart-format
-[Dart 3.8 changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md##380
+[Dart format]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#380
+[Dart 3.8 changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#380
 
 ### Dart 3.7
 _Released 12 February 2025_

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -42,6 +42,35 @@ on the Dart language GitHub repo.
 
 ## Changes in each release
 
+### Dart 3.8
+_Released 20 May 2025_
+| [Dart 3.8 announcement](https://medium.com/dartlang/...)
+
+The following language features have been added to Dart 3.8:
+
+*   [Null-aware elements][]: A null-aware element evaluates
+    an expression and if the result is not null, inserts the
+    value into the surrounding collection.
+
+*   [Doc imports][]: Dart now supports a
+    `@docImport` documentation tag, which enables external
+    elements to be referenced in documentation comments
+    without actually importing them.
+
+The following support features have been added to
+Dart 3.8:
+
+*   [Cross-compile to Linux x64 and ARM64][]:
+    Cross-compilation to Linux x64 and ARM64 is supported on
+    the following 64-bit host operating systems: macOS,
+    Windows, and Linux.
+
+
+
+[Null-aware elements]: /language/collections#null-aware-element
+[Doc imports]: /tools/doc-comments/references.md
+[Cross-compilation to Linux x64 and ARM64]: /tools/dart-compile.md
+
 ### Dart 3.7
 _Released 12 February 2025_
 | [Dart 3.7 announcement](https://medium.com/dartlang/announcing-dart-3-7-bf864a1b195c)

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -70,7 +70,7 @@ Dart 3.8:
 
 [Null-aware elements]: /language/collections#null-aware-element
 [Doc imports]: /tools/doc-comments/references.md
-[Cross-compilation to Linux x64 and ARM64]: /tools/dart-compile.md
+[New cross-compilation command flags]: /tools/dart-compile.md
 
 ### Dart 3.7
 _Released 12 February 2025_

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -48,9 +48,9 @@ _Released 20 May 2025_
 
 The following language features have been added to Dart 3.8:
 
-*   [Null-aware elements][]: A null-aware element evaluates
-    an expression and if the result is not null, inserts the
-    value into the surrounding collection.
+*   [Null-aware elements][]: A null-aware collection element evaluates
+    an expression in a collection literal and if the result is not `null`,
+    inserts the value into the resulting collection.
 
 *   [Doc imports][]: Dart now supports a
     `@docImport` documentation tag, which enables external

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -68,7 +68,7 @@ the [Dart 3.8 changelog][].
 
 [Null-aware elements]: /language/collections#null-aware-element
 [Dart format]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#dart-format
-[Dart 3.8 changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#dart-format
+[Dart 3.8 changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md##380
 
 ### Dart 3.7
 _Released 12 February 2025_

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -69,8 +69,8 @@ Dart 3.8:
     * `--target-arch=arm64`
 
 [Null-aware elements]: /language/collections#null-aware-element
-[Doc imports]: /tools/doc-comments/references.md
-[New cross-compilation command flags]: /tools/dart-compile.md
+[Doc imports]: /tools/doc-comments/references
+[New cross-compilation command flags]: /tools/dart-compile
 
 ### Dart 3.7
 _Released 12 February 2025_

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -48,29 +48,27 @@ _Released 20 May 2025_
 
 The following language features have been added to Dart 3.8:
 
-*   [Null-aware elements][]: A null-aware collection element evaluates
-    an expression in a collection literal and if the result is not `null`,
-    inserts the value into the resulting collection.
+*   [Null-aware elements][]: A null-aware element evaluates
+    an expression in a collection literal and if the result
+    is not `null`, inserts the value into the surrounding
+    collection.
 
-*   [Doc imports][]: Dart now supports a
-    `@docImport` documentation tag, which enables external
-    elements to be referenced in documentation comments
-    without actually importing them.
+The following supporting features have been updated:
 
-The following support features have been added to
-Dart 3.8:
-
-*   [New cross-compilation command flags][]:
-    Cross-compilation flags for Linux x64 and ARM64 have
-    been added for the `dart compile` command. These are:
-
-    * `--target-os=linux`
-    * `--target-arch=x64`
-    * `--target-arch=arm64`
+*   [Dart format][]: Dart 3.8's formatter builds on the
+    previous release's rewrite, incorporating feedback,
+    bug fixes, and further enhancements. It now
+    intelligently automates trailing comma placement,
+    deciding whether to split constructs rather than forcing
+    them. The update also includes style changes to tighten
+    and improve code output.
+    
+For more information about these and additional changes, see
+the [Dart 3.8 changelog][].
 
 [Null-aware elements]: /language/collections#null-aware-element
-[Doc imports]: /tools/doc-comments/references#doc-imports
-[New cross-compilation command flags]: /tools/dart-compile#cross-compilation-exe
+[Dart format]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#dart-format
+[Dart 3.8 changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md#dart-format
 
 ### Dart 3.7
 _Released 12 February 2025_

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -60,12 +60,13 @@ The following language features have been added to Dart 3.8:
 The following support features have been added to
 Dart 3.8:
 
-*   [Cross-compile to Linux x64 and ARM64][]:
-    Cross-compilation to Linux x64 and ARM64 is supported on
-    the following 64-bit host operating systems: macOS,
-    Windows, and Linux.
+*   [New cross-compilation command flags][]:
+    Cross-compilation flags for Linux x64 and ARM64 have
+    been added for the `dart compile` command. These are:
 
-
+    * `--target-os=linux`
+    * `--target-arch=x64`
+    * `--target-arch=arm64`
 
 [Null-aware elements]: /language/collections#null-aware-element
 [Doc imports]: /tools/doc-comments/references.md

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -69,8 +69,8 @@ Dart 3.8:
     * `--target-arch=arm64`
 
 [Null-aware elements]: /language/collections#null-aware-element
-[Doc imports]: /tools/doc-comments/references
-[New cross-compilation command flags]: /tools/dart-compile
+[Doc imports]: /tools/doc-comments/references#doc-imports
+[New cross-compilation command flags]: /tools/dart-compile#cross-compilation-exe
 
 ### Dart 3.7
 _Released 12 February 2025_


### PR DESCRIPTION
This adds new features that are available in Dart 3.8. Links are pending.

Preview:

https://dart-dev--pr6589-dart-lang-evolution-3-8-45am495n.web.app/resources/language/evolution#dart-3-8

Todo list:

- [ ]  Update blog post link.