### PR TITLE
Include Flutter CLI instructions for Dart experiment flags

### DIFF
--- a/src/content/tools/experiment-flags.md
+++ b/src/content/tools/experiment-flags.md
@@ -20,17 +20,28 @@ pass the corresponding flag to the tool.
 
 For example, to enable the experiments
 `super-mixins` and `no-slow-checks`,
-add those flags to the `dart` command:
+add those flags to the
+`dart` or `flutter` command:
+
+{% tabs "experiment-flags-tabs" %}
+
+{% tab "Dart command" %}
 
 ```console
 $ dart run --enable-experiment=super-mixins,no-slow-checks bin/main.dart
 ```
 
-Or for the `flutter` command:
+{% endtab %}
+
+{% tab "Flutter command" %}
 
 ```console
 $ flutter run --enable-experiment=super-mixins,no-slow-checks
 ```
+
+{% endtab %}
+
+{% endtabs %}
 
 ## Using experiment flags with the Dart analyzer (command-line and IDE)
 

--- a/src/content/tools/experiment-flags.md
+++ b/src/content/tools/experiment-flags.md
@@ -20,28 +20,17 @@ pass the corresponding flag to the tool.
 
 For example, to enable the experiments
 `super-mixins` and `no-slow-checks`,
-add those flags to the
-`dart` or `flutter` command:
-
-{% tabs "experiment-flags-tabs" %}
-
-{% tab "Dart command" %}
+add those flags to the `dart` command:
 
 ```console
 $ dart run --enable-experiment=super-mixins,no-slow-checks bin/main.dart
 ```
 
-{% endtab %}
-
-{% tab "Flutter command" %}
+Or to the `flutter` command:
 
 ```console
 $ flutter run --enable-experiment=super-mixins,no-slow-checks
 ```
-
-{% endtab %}
-
-{% endtabs %}
 
 ## Using experiment flags with the Dart analyzer (command-line and IDE)
 

--- a/src/content/tools/experiment-flags.md
+++ b/src/content/tools/experiment-flags.md
@@ -17,6 +17,7 @@ without notice.
 
 To use an experiment with Dart SDK [command line tools](/tools/sdk),
 pass the corresponding flag to the tool.
+
 For example, to enable the experiments
 `super-mixins` and `no-slow-checks`,
 add those flags to the `dart` command:
@@ -25,6 +26,11 @@ add those flags to the `dart` command:
 $ dart run --enable-experiment=super-mixins,no-slow-checks bin/main.dart
 ```
 
+Or for the `flutter` command:
+
+```console
+$ flutter run --enable-experiment=super-mixins,no-slow-checks
+```
 
 ## Using experiment flags with the Dart analyzer (command-line and IDE)
 


### PR DESCRIPTION
Explain how you can turn on a Dart experiment when running a Flutter app.

Here's prior art where we explain how a Dart feature can be used on Flutter's tooling: https://dart.dev/libraries/core/environment-declarations#flutter

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
