### PR TITLE
Rename `package:native_assets_cli` to `package_hooks`

### DIFF
--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -290,7 +290,7 @@ build and bundle C code in a Dart package.
 The example includes the following files:
 
 {% capture native-assets -%}
-{{site.repo.dart.org}}/native/blob/main/pkgs/native_assets_cli/example/build/native_add_library
+{{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library
 {%- endcapture %}
 
 | **Source file**                         | **Description**                                                                                                                                                                |
@@ -318,7 +318,7 @@ API documentation can be found for the following packages:
 * To learn about native assets in Dart FFI,
   consult the `dart:ffi` API reference for [`Native`][] and [`DefaultAsset`][].
 * To learn about the `hook/build.dart` build hook,
-  consult the [`package:native_assets_cli` API reference][].
+  consult the [`package:hooks` API reference][].
 
 ### Opt-in to the experiment
 
@@ -328,14 +328,14 @@ consult these tracking issues:
 * [Dart native assets]({{site.repo.dart.sdk}}/issues/50565)
 * [Flutter native assets](https://github.com/flutter/flutter/issues/129757)
 
-[`Asset`]: {{site.pub-api}}/native_assets_cli/latest/native_assets_cli/Asset-class.html
+[`Asset`]: {{site.pub-api}}/hooks/latest/hooks/Asset-class.html
 [`assetId`]: {{site.dart-api}}/dart-ffi/Native/assetId.html
 [`DefaultAsset`]: {{site.dart-api}}/dart-ffi/DefaultAsset-class.html
-[`native_add_app`]: {{site.repo.dart.org}}/native/tree/main/pkgs/native_assets_cli/example/build/native_add_app
+[`native_add_app`]: {{site.repo.dart.org}}/native/tree/main/pkgs/hooks/example/build/native_add_app
 [`native_add_library`]: {{native-assets}}
 [`Native`]: {{site.dart-api}}/dart-ffi/Native-class.html
 [`NativeType`]: {{dart-ffi}}/NativeType-class.html
-[`package:native_assets_cli` API reference]: {{site.pub-api}}/native_assets_cli/latest/
+[`package:hooks` API reference]: {{site.pub-api}}/hooks/latest/
 [ABI]: {{dart-ffi}}/Abi-class.html
 [AbiSpecificInteger]: {{dart-ffi}}/AbiSpecificInteger-class.html
 [android]: {{site.flutter-docs}}/development/platform-integration/android/c-interop


### PR DESCRIPTION
Fixes broken links and outdated names.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
