### PR TITLE
Add version note and redirect for cross compilation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -373,6 +373,7 @@
       { "source": "/support/faq", "destination": "/resources/faq", "type": 301 },
       { "source": "/support{,/**}", "destination": "/community", "type": 301 },
 
+      { "source": "/to/cross-compilation", "destination": "/tools/dart-compile#cross-compilation", "type": 301 },
       { "source": "/to/doc-comment-references", "destination": "/tools/doc-comments/references", "type": 301 },
       { "source": "/to/downgrade-testing", "destination": "/tools/pub/dependencies#test-with-downgraded-dependencies", "type": 301 },
       { "source": "/to/enforce-lockfile", "destination": "/tools/pub/packages#get-dependencies-for-production", "type": 301 },

--- a/src/content/tools/dart-compile.md
+++ b/src/content/tools/dart-compile.md
@@ -169,22 +169,27 @@ Run your compiled app from the `/tmp` directory:
 $ ./tmp/myapp
 ```
 
+<a id="cross-compilation" aria-hidden="true"></a>
+
 #### Cross-compilation {: #cross-compilation-exe }
 
+:::version-note
+Support for cross-compilation was introduced in Dart 3.8.
+:::
+
 Cross-compilation to Linux x64 and ARM64 is supported on the
-following 64-bit host operating systems: macOS, Windows,
-and Linux.
+following 64-bit host operating systems: macOS, Windows, and Linux.
 
 To use cross-compilation, include the following flags:
 
-*   `--target-os=linux`: The target operating system
-    for the compiled executable. The Linux operating system
-    is supported at this time.
+`--target-os=linux`
+: The target operating system for the compiled executable.
+  The Linux operating system is supported at this time.
 
-*   `--target-arch=value`: The target
-    architecture for the compiled executable. The value
-    for this flag can be `arm64` (64-bit ARM processor)
-    or `x64` (64-bit processor).
+`--target-arch=value`
+: The target architecture for the compiled executable.
+  The value for this flag can be `arm64` (64-bit ARM processor)
+  or `x64` (x86-64 processor).
 
 The following command demonstrates how to cross-compile a
 standalone executable for a 64-bit Linux system:
@@ -196,9 +201,10 @@ dart compile exe \
   hello.dart
 ```
 
-Internally, this command downloads additional Dart SDK
-binaries and caches them in the `~/.dart` directory. Here's
-a sample output with the `--verbose` flag included with
+Internally, this command downloads additional Dart SDK binaries and
+caches them in the `~/.dart` directory.
+
+Here's a sample output with the `--verbose` flag specified with
 the command:
 
 ```console
@@ -233,11 +239,10 @@ The `exe` subcommand has the following known limitations:
 
 * No support for `dart:mirrors` and `dart:developer`.
   For a complete list of the core libraries you can use,
-  see the [Multi-platform][] and [Native platform][] library
-  tables.
+  reference the [Multi-platform][] and [Native platform][] library tables.
 
-* Cross-compilation is supported, but the target is limited
-  to Linux. For more information, see [Cross-compilation][].
+* Cross-compilation is supported, but the target OS is limited to Linux.
+  To learn more, check out [Cross-compilation][].
 
 [Multi-platform]: /libraries#multi-platform-libraries
 [Native platform]: /libraries#native-platform-libraries
@@ -282,7 +287,7 @@ To learn more, see the
 #### Cross-compilation {: #cross-compilation-aot }
 
 Cross-compilation support for the `aot-snapshot` subcommand
-is the same as what is available for the `exe` subcommand.
+is the same as what's available for the `exe` subcommand.
 For more information, see
 [Self-contained executables (exe)][cross-compile-exe].
 
@@ -290,7 +295,7 @@ For more information, see
 
 #### Known limitations {: #known-limitations-aot }
 
-The `aot-snapshot` subcommand has the the same limitations
+The `aot-snapshot` subcommand has the same limitations
 as the `exe` subcommand. For more information, see
 [Self-contained executables (exe)][known-limitations-exe]
 
@@ -379,10 +384,10 @@ improve JavaScript performance:
   you pass into each function or method.
 
 :::tip
-Don't worry about the size of your app's included libraries. 
+Don't worry about the size of your app's included libraries.
 The production compiler performs tree shaking to omit
 unused classes, functions, methods, and so on.
-Import the libraries you think you'll need, 
+Import the libraries you think you'll need,
 and let the compiler get rid of what it doesn't need.
 :::
 


### PR DESCRIPTION
- Add version note to cross compilation support
- Add `cross-compilation` anchor to use for new `/to/cross-compilation` tooling redirect
- Fix case of double "the"
- Minor formatting changes