### PR TITLE
[native assets] Graduate to preview

### DIFF
--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -260,22 +260,22 @@ use the [`package:ffigen`][ffigen] binding generator.
 ## Build and bundle native assets {:#native-assets}
 
 :::note
-The native assets are in **preview**,
-and [in active development]({{site.repo.dart.sdk}}/issues/50565).
+The dart build hooks support is in **preview**.
 :::
 
-The _Native Assets_ feature should resolve a number of issues associated with
+The _Build Hooks_ (formerly known as _Native Assets_) feature should
+resolve a number of issues associated with
 the distribution of Dart packages that depend on native code.
 It does so by providing uniform hooks for integrating with various
 build systems involved in building Flutter and standalone Dart applications.
 
 This feature should simplify how Dart packages depend on and use native code.
-Native Assets should provide the following benefits:
+Build hooks should provide the following benefits:
 
 * Build the native code or obtains the binaries
   using a package's `hook/build.dart` build hook.
 * Bundle the native [`Asset`][] that the `build.dart` build hook reports.
-* Make native assets available at runtime through
+* Make native code assets available at runtime through
   declarative `@Native<>() extern` functions using the [`assetId`][].
 
 When you [opt in](#opt-in-to-the-experiment) to the native experiment,
@@ -315,7 +315,7 @@ The [`native_add_app`][] example showcases a use of `native_add_library`.
 
 API documentation can be found for the following packages:
 
-* To learn about native assets in Dart FFI,
+* To learn about native code assets in Dart FFI,
   consult the `dart:ffi` API reference for [`Native`][] and [`DefaultAsset`][].
 * To learn about the `hook/build.dart` build hook,
   consult the [`package:hooks` API reference][].

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -43,7 +43,7 @@ previous section.
 The `hello_world` example has the following files:
 
 | **Source file**                  | **Description**                                                                |
-|----------------------------------|--------------------------------------------------------------------------------|
+| -------------------------------- | ------------------------------------------------------------------------------ |
 | [`hello.dart`]                   | A Dart file that uses the `hello_world()` function from a C library.           |
 | [`pubspec.yaml`]                 | The Dart [pubspec](/tools/pub/pubspec) file, with an SDK lower bound of 3.4.   |
 | [`hello_library/hello.h`]        | Declares the `hello_world()` function.                                         |
@@ -191,12 +191,12 @@ They or their subtypes _can_ be instantiated in Dart code.
 {{site.dart-api}}/dart-ffi
 {%- endcapture %}
 
-| **Dart type**   | **Description**                                                  |
-| --------------- | ---------------------------------------------------------------- |
-| [Array][]       | A fixed-sized array of items. Supertype of type specific arrays. |
-| [Pointer][]     | Represents a pointer into native C memory.                       |
-| [Struct][]      | The supertype of all FFI struct types.                           |
-| [Union][]       | The supertype of all FFI union types.                            |
+| **Dart type** | **Description**                                                  |
+| ------------- | ---------------------------------------------------------------- |
+| [Array][]     | A fixed-sized array of items. Supertype of type specific arrays. |
+| [Pointer][]   | Represents a pointer into native C memory.                       |
+| [Struct][]    | The supertype of all FFI struct types.                           |
+| [Union][]     | The supertype of all FFI union types.                            |
 
 {:.table .table-striped }
 
@@ -230,23 +230,23 @@ that extend [AbiSpecificInteger][].
 To learn how these types map on specific platforms,
 consult the API documentation linked in the following table.
 
-| **Dart type**            | **Description**                                    |
-| -------------------------| -------------------------------------------------- |
-| [AbiSpecificInteger][]   | The supertype of all ABI-specific integer types.   |
-| [Int][]                  | Represents the `int` type in C.                    |
-| [IntPtr][]               | Represents the `intptr_t` type in C.               |
-| [Long][]                 | Represents the `long int` (`long`) type in C.      |
-| [LongLong][]             | Represents the `long long` type in C.              |
-| [Short][]                | Represents the `short` type in C.                  |
-| [SignedChar][]           | Represents the `signed char` type in C.            |
-| [Size][]                 | Represents the `size_t` type in C.                 |
-| [UintPtr][]              | Represents the `uintptr_t` type in C.              |
-| [UnsignedChar][]         | Represents the `unsigned char` type in C.          |
-| [UnsignedInt][]          | Represents the `unsigned int` type in C.           |
-| [UnsignedLong][]         | Represents the `unsigned long int` type in C.      |
-| [UnsignedLongLong][]     | Represents the `unsigned long long` type in C.     |
-| [UnsignedShort][]        | Represents the `unsigned short` type in C.         |
-| [WChar][]                | Represents the `wchar_t` type in C.                |
+| **Dart type**          | **Description**                                  |
+| ---------------------- | ------------------------------------------------ |
+| [AbiSpecificInteger][] | The supertype of all ABI-specific integer types. |
+| [Int][]                | Represents the `int` type in C.                  |
+| [IntPtr][]             | Represents the `intptr_t` type in C.             |
+| [Long][]               | Represents the `long int` (`long`) type in C.    |
+| [LongLong][]           | Represents the `long long` type in C.            |
+| [Short][]              | Represents the `short` type in C.                |
+| [SignedChar][]         | Represents the `signed char` type in C.          |
+| [Size][]               | Represents the `size_t` type in C.               |
+| [UintPtr][]            | Represents the `uintptr_t` type in C.            |
+| [UnsignedChar][]       | Represents the `unsigned char` type in C.        |
+| [UnsignedInt][]        | Represents the `unsigned int` type in C.         |
+| [UnsignedLong][]       | Represents the `unsigned long int` type in C.    |
+| [UnsignedLongLong][]   | Represents the `unsigned long long` type in C.   |
+| [UnsignedShort][]      | Represents the `unsigned short` type in C.       |
+| [WChar][]              | Represents the `wchar_t` type in C.              |
 
 {:.table .table-striped }
 
@@ -272,9 +272,9 @@ This feature simplifies how Dart packages depend on and use native code:
 
 * Build the native code or obtain the binaries using a package's build hook
 (`hook/build.dart`).
-* Dart and Flutter bundle the native code [`Asset`][]s that the build hook
+* Dart and Flutter bundle the [`CodeAsset`][]s that the build hook
   reports.
-* Access the native code assets at runtime through declarative
+* Access the code assets at runtime through declarative
   `@Native<>() extern` functions using the [`assetId`][].
 
 Flutter and standalone Dart automatically bundle the native code of all packages
@@ -293,11 +293,11 @@ The example includes the following files:
 {%- endcapture %}
 
 | **Source file**                         | **Description**                                                                                                                                                                |
-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [`src/native_add_library.c`][]          | The C file containing the code for `add`.                                                                                                                                      |
 | [`lib/native_add_library.dart`][]       | The Dart file that invokes the C function `add` in asset `package:native_add_library/native_add_library.dart` through FFI. (Note that _asset id_ defaults to the library uri.) |
 | [`test/native_add_library_test.dart`][] | A Dart test using the native code.                                                                                                                                             |
-| [`hook/build.dart`][]                   | A build hook for compiling `src/native_add_library.c` and declaring the compiled asset with  id `package:native_add_library/native_add_library.dart`.                              |
+| [`hook/build.dart`][]                   | A build hook for compiling `src/native_add_library.c` and declaring the compiled asset with  id `package:native_add_library/native_add_library.dart`.                          |
 
 {:.table .table-striped }
 
@@ -326,7 +326,7 @@ To provide feedback, consult these tracking issues:
 * [Dart native assets]({{site.repo.dart.sdk}}/issues/50565)
 * [Flutter native assets](https://github.com/flutter/flutter/issues/129757)
 
-[`Asset`]: {{site.pub-api}}/hooks/latest/hooks/Asset-class.html
+[`CodeAsset`]: {{site.pub-api}}/code_assets/latest/code_assets/CodeAsset-class.html
 [`assetId`]: {{site.dart-api}}/dart-ffi/Native/assetId.html
 [`DefaultAsset`]: {{site.dart-api}}/dart-ffi/DefaultAsset-class.html
 [`native_add_app`]: {{site.repo.dart.org}}/native/tree/main/pkgs/hooks/example/build/native_add_app

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -260,18 +260,19 @@ use the [`package:ffigen`][ffigen] binding generator.
 ## Dart packages containing native code {:#native-assets}
 
 :::note
-The dart build hooks support is in **preview** and can be used in Dart & Flutter main channel.
+Support for build hooks is in **preview** and
+can be used on the `main` channel.
 :::
 
-The _Build Hooks_ (formerly known as _Native Assets_) feature enables Dart
-packages to contain more than just Dart source code. Dart packages can now
-contain native code assets that will be transparently built, bundled and made
-available at runtime.
+Dart _build hooks_ (formerly known as _native assets_) enable
+packages to contain more than just Dart source code.
+Packages can now contain native code assets that are
+transparently built, bundled, and made available at runtime.
 
 This feature simplifies how Dart packages depend on and use native code:
 
-* Build the native code or obtain the binaries using a package's build hook
-(`hook/build.dart`).
+* Build the native code or obtain the binaries using a
+  package's build hook in `hook/build.dart`.
 * Dart and Flutter bundle the [`CodeAsset`][]s that the build hook
   reports.
 * Access the code assets at runtime through declarative

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -257,7 +257,9 @@ to write the Dart bindings that integrate with the C code.
 To have Dart create FFI wrappers from C header files,
 use the [`package:ffigen`][ffigen] binding generator.
 
-## Dart packages containing native code {:#native-assets}
+<a id="native-assets" aria-hidden="true"></a>
+
+## Dart packages containing native code {: #build-hooks }
 
 :::note
 Support for build hooks is in **preview** and

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -257,30 +257,29 @@ to write the Dart bindings that integrate with the C code.
 To have Dart create FFI wrappers from C header files,
 use the [`package:ffigen`][ffigen] binding generator.
 
-## Build and bundle native assets {:#native-assets}
+## Dart packages containing native code {:#native-assets}
 
 :::note
-The dart build hooks support is in **preview**.
+The dart build hooks support is in **preview** and can be used in Dart & Flutter main channel.
 :::
 
-The _Build Hooks_ (formerly known as _Native Assets_) feature should
-resolve a number of issues associated with
-the distribution of Dart packages that depend on native code.
-It does so by providing uniform hooks for integrating with various
-build systems involved in building Flutter and standalone Dart applications.
+The _Build Hooks_ (formerly known as _Native Assets_) feature enables Dart
+packages to contain more than just Dart source code. Dart packages can now
+contain native code assets that will be transparently built, bundled and made
+available at runtime.
 
-This feature should simplify how Dart packages depend on and use native code.
-Build hooks should provide the following benefits:
+This feature simplifies how Dart packages depend on and use native code:
 
-* Build the native code or obtains the binaries
-  using a package's `hook/build.dart` build hook.
-* Bundle the native [`Asset`][] that the `build.dart` build hook reports.
-* Make native code assets available at runtime through
-  declarative `@Native<>() extern` functions using the [`assetId`][].
+* Build the native code or obtain the binaries using a package's build hook
+(`hook/build.dart`).
+* Dart and Flutter bundle the native code [`Asset`][]s that the build hook
+  reports.
+* Access the native code assets at runtime through declarative
+  `@Native<>() extern` functions using the [`assetId`][].
 
-When you [opt in](#opt-in-to-the-experiment) to the native experiment,
-The `flutter (run|build)` and `dart (run|build)` commands
-build and bundle native code with the Dart code.
+Flutter and standalone Dart automatically bundle the native code of all packages
+used by the app and makes them available at runtime. This works for `flutter
+(run|build)` as well as `dart (run|build)` .
 
 ### Review the `native_add_library` example
 

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -319,10 +319,9 @@ API documentation can be found for the following packages:
 * To learn about the `hook/build.dart` build hook,
   consult the [`package:hooks` API reference][].
 
-### Opt-in to the experiment
+### Provide feedback
 
-To learn how to enable the experiment and provide feedback,
-consult these tracking issues:
+To provide feedback, consult these tracking issues:
 
 * [Dart native assets]({{site.repo.dart.sdk}}/issues/50565)
 * [Flutter native assets](https://github.com/flutter/flutter/issues/129757)

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -280,9 +280,9 @@ This feature simplifies how Dart packages depend on and use native code:
 * Access the code assets at runtime through declarative
   `@Native<>() extern` functions using the [`assetId`][].
 
-Flutter and standalone Dart automatically bundle the native code of all packages
-used by the app and makes them available at runtime. This works for `flutter
-(run|build)` as well as `dart (run|build)` .
+Flutter and standalone Dart automatically bundle the
+native code of all packages used by the app and make it available at runtime.
+This works for `flutter (run|build)` as well as `dart (run|build)`.
 
 ### Review the `native_add_library` example
 

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -260,7 +260,7 @@ use the [`package:ffigen`][ffigen] binding generator.
 ## Build and bundle native assets {:#native-assets}
 
 :::note
-The native assets are **experimental**,
+The native assets are in **preview**,
 and [in active development]({{site.repo.dart.sdk}}/issues/50565).
 :::
 


### PR DESCRIPTION
Accompanying Dart CL: https://dart-review.googlesource.com/c/sdk/+/429920

Preview: https://dart-dev--pr6612-graduate-native-assets-o7fy5603.web.app/interop/c-interop

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
