### PR TITLE
Fix broken link for Glossary card on resources page

### DIFF
--- a/src/content/resources/index.md
+++ b/src/content/resources/index.md
@@ -7,7 +7,7 @@ toc: false
 Check out the following Dart language resources:
 
 <div class="card-grid">
-  {% card "Glossary", "/resources/breaking-changes" %}
+  {% card "Glossary", "/resources/glossary" %}
     Terminology used by Dart documentation and developers.
   {% endcard %}
   {% card "Breaking changes", "/resources/breaking-changes" %}


### PR DESCRIPTION
The "Glossary" card on the /resources page was incorrectly linking to `/resources/breaking-changes`. This PR updates the link to point to the correct glossary location at` /resources/glossary`