### PR TITLE
Migrate youtube embed optimization from flutter docs

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -87,5 +87,7 @@
   {% endfor -%}
   {% endif -%}
 
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.8.2/lite-youtube.js" integrity="sha256-Jy0j0fUMJ2T3WxSEs2WjHLrS+3DlO7S9DItQtP55FII=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
   {% render 'analytics.html' -%}
  </head>

--- a/src/_sass/components/_card.scss
+++ b/src/_sass/components/_card.scss
@@ -7,6 +7,9 @@
   gap: var(--card-grid-gap, 1rem);
   margin: 0 0 1rem;
   justify-content: center;
+
+  // Disable lite-youtube shadow for videos in cards.
+  --lite-youtube-frame-shadow-visible: false;
 }
 
 .card-list {

--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -132,10 +132,20 @@ article {
     }
   }
 
-  .content > p {
-    > i.material-symbols, > span.material-symbols {
-      vertical-align: bottom;
-      user-select: none;
+  .content {
+    > p {
+      > i.material-symbols, > span.material-symbols {
+        vertical-align: bottom;
+        user-select: none;
+      }
     }
+
+    > lite-youtube {
+      margin-block-end: 1rem;
+    }
+  }
+
+  lite-youtube:not(.full-width) {
+    max-width: 560px;
   }
 }

--- a/src/content/resources/videos.md
+++ b/src/content/resources/videos.md
@@ -18,10 +18,10 @@ A playlist of Google-produced videos on Dart's capabilities.
 These range from 5-minute talks on Dart asynchrony support
 to the Dart session from Google I/O 2019.
 
-{% ytEmbed "PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J", "Dart videos from Google", "series" %}
+{% ytEmbed "TF-TBsgIErY", "Dart videos from Google", "PLjxrf2q8roU0Net_g1NT5_vOO3s_FR02J" %}
 
 ## Dart training course in Brazilian Portuguese
 
 Nesta série de vídeos estudaremos juntos a linguagem Dart.
 
-{% ytEmbed "PLK5FPzMuRKlyiWZUUqea2Hmszhy9vUixJ", "Dart Curso Completo", "series" %}
+{% ytEmbed "Vz11rFFewkM", "Dart Curso Completo", "PLK5FPzMuRKlyiWZUUqea2Hmszhy9vUixJ" %}


### PR DESCRIPTION
Uses [lite-youtube](https://github.com/justinribeiro/lite-youtube) to properly lazily load youtube embeds. This PR migrates the implementation from flutter/website which has been using it for a while.