### PR TITLE
Add support for a dark mode

### DIFF
--- a/src/_11ty/plugins/highlight.ts
+++ b/src/_11ty/plugins/highlight.ts
@@ -1,4 +1,5 @@
 import {getSingletonHighlighter, Highlighter} from 'shiki';
+import dashDarkTheme from '../syntax/dark-dark.js';
 import dashLightTheme from '../syntax/dash-light.js';
 import MarkdownIt from 'markdown-it';
 import * as hast from 'hast';
@@ -44,7 +45,7 @@ export async function configureHighlighting(markdown: MarkdownIt): Promise<void>
       'cmd',
       'plaintext',
     ],
-    themes: [dashLightTheme],
+    themes: [dashLightTheme, dashDarkTheme],
   });
 
   markdown.renderer.rules.fence = function (tokens, index) {
@@ -135,7 +136,10 @@ function _highlight(
 
   return highlighter.codeToHtml(content, {
     lang: language,
-    theme: 'dash-light',
+    themes: {
+      light: 'dash-light',
+      dark: 'dash-dark',
+    },
     transformers: [
       {
         pre(preElement) {

--- a/src/_11ty/syntax/dark-dark.ts
+++ b/src/_11ty/syntax/dark-dark.ts
@@ -1,0 +1,140 @@
+// This is the dark mode version of the
+// syntax highlighting theme for code blocks on the website.
+// It's imported and used by `src/_11ty/plugins/highlight.ts`.
+export default {
+    name: 'dash-dark',
+    colors: {
+        'editor.background': '#242b32',
+        'editor.foreground': '#dcdcdc',
+    },
+    tokenColors: [
+        {
+            settings: {
+                background: '#242b32',
+                foreground: '#dcdcdc',
+            },
+        },
+        {
+            scope: 'emphasis',
+            settings: {
+                fontStyle: 'italic',
+            },
+        },
+        {
+            scope: 'strong',
+            settings: {
+                fontStyle: 'bold',
+            },
+        },
+        {
+            scope: [
+                'punctuation',
+                'punctuation.separator.inheritance-clause',
+                'storage.modifier.package.java',
+            ],
+            settings: {
+                foreground: '#dcdcdc',
+            },
+        },
+        {
+            scope: ['comment', 'punctuation.definition.comment'],
+            settings: {
+                foreground: '#8B95A7',
+            },
+        },
+        {
+            scope: 'constant',
+            settings: {
+                foreground: '#1CDAC5',
+            },
+        },
+        {
+            scope: [
+                'keyword',
+                'storage.modifier',
+                'storage.type',
+                'variable.language',
+            ],
+            settings: {
+                foreground: '#FF897E',
+            },
+        },
+        {
+            scope: [
+                'keyword.operator',
+                'string.interpolated.expression',
+                'constant.character.escape',
+            ],
+            settings: {
+                foreground: '#E1E2EC',
+            },
+        },
+        {
+            scope: ['string', 'string.interpolated', 'punctuation.definition.string'],
+            settings: {
+                foreground: '#1CDAC5',
+            },
+        },
+        {
+            scope: [
+                'entity.name.function',
+                'support.function',
+                'entity.other.attribute-name',
+            ],
+            settings: {
+                foreground: '#B581FF',
+            },
+        },
+        {
+            scope: [
+                'entity.name.class',
+                'entity.name.type',
+                'entity.name.type.class',
+                'entity.name.type.enum',
+                'entity.name.type.protocol',
+                'support.class',
+                'support.type',
+                'entity.name.tag',
+            ],
+            settings: {
+                foreground: '#6bb1ff',
+            },
+        },
+        {
+            scope: ['variable', 'variable.other'],
+            settings: {
+                foreground: '#E1E2EC',
+            },
+        },
+        {
+            scope: 'markup.underline',
+            settings: {
+                fontStyle: 'underline',
+            },
+        },
+        {
+            scope: 'markup.bold',
+            settings: {
+                fontStyle: 'bold',
+            },
+        },
+        {
+            scope: 'markup.heading',
+            settings: {
+                fontStyle: 'bold',
+            },
+        },
+        {
+            scope: 'markup.italic',
+            settings: {
+                fontStyle: 'italic',
+            },
+        },
+        {
+            scope: 'markup.strikethrough',
+            settings: {
+                fontStyle: 'strikethrough',
+            },
+        },
+    ],
+};

--- a/src/_11ty/syntax/dash-light.ts
+++ b/src/_11ty/syntax/dash-light.ts
@@ -4,14 +4,14 @@
 export default {
   name: 'dash-light',
   colors: {
-    'editor.background': '#F8F9FA',
-    'editor.foreground': '#222222',
+    'editor.background': '#ECEDF7',
+    'editor.foreground': '#191C22',
   },
   tokenColors: [
     {
       settings: {
-        background: '#F8F9FA',
-        foreground: '#222222',
+        background: '#ECEDF7',
+        foreground: '#191C22',
       },
     },
     {
@@ -33,19 +33,19 @@ export default {
         'storage.modifier.package.java',
       ],
       settings: {
-        foreground: '#222222',
+        foreground: '#191C22',
       },
     },
     {
       scope: ['comment', 'punctuation.definition.comment'],
       settings: {
-        foreground: '#6E6E70',
+        foreground: '#59616E',
       },
     },
     {
       scope: 'constant',
       settings: {
-        foreground: '#11796D',
+        foreground: '#0C7064',
       },
     },
     {
@@ -56,7 +56,7 @@ export default {
         'variable.language',
       ],
       settings: {
-        foreground: '#D43324',
+        foreground: '#BD2314',
       },
     },
     {
@@ -66,13 +66,13 @@ export default {
         'constant.character.escape',
       ],
       settings: {
-        foreground: '#222222',
+        foreground: '#191C22',
       },
     },
     {
       scope: ['string', 'string.interpolated', 'punctuation.definition.string'],
       settings: {
-        foreground: '#11796D',
+        foreground: '#0C7064',
       },
     },
     {
@@ -97,13 +97,13 @@ export default {
         'entity.name.tag',
       ],
       settings: {
-        foreground: '#0468D7',
+        foreground: '#146BCD',
       },
     },
     {
       scope: ['variable', 'variable.other'],
       settings: {
-        foreground: '#222222',
+        foreground: '#191C22',
       },
     },
     {

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -33,7 +33,7 @@ yt:
   watch: 'https://www.youtube.com/watch'
   playlist: 'https://www.youtube.com/playlist?list='
 
-showBanner: true
+showBanner: false
 
 # Increment this global og:image URL version number (used as a query parameter)
 # when you update any og:image file. (Also increment the corresponding number

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,4 +1,4 @@
-{% assign cache_bust = '?v=3' %}
+{% assign cache_bust = '?v=4' %}
 
 <head>
   <meta charset="utf-8">

--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -1,7 +1,6 @@
 {% assign page_url_path = page.url | regexReplace: '/index$|/index\.html$|\.html$|/$' | prepend: '/*' | append: '/' -%}
 
-<nav id="mainnav">
-  <div id="menu-toggle"><span class="material-symbols" title="Toggle side navigation menu." aria-label="Toggle side navigation menu." type="button">menu</span></div>
+<nav id="mainnav" class="always-dark-mode">
   <a href="/" class="brand" title="{{site.title}}">
     <img src="/assets/img/logo/logo-white-text.svg" alt="{{site.title}}">
   </a>
@@ -13,7 +12,7 @@
       <a href="/overview" class="nav-link
         {%- if page_url_path contains '/*/overview/' %} active {%- endif -%}">Overview</a>
     </li>
-    <li class="mainnav__get-started">
+    <li>
       <a href="/docs" class="nav-link
         {%- if page_url_path contains '/*/docs/' or page_url_path contains '/*/language/' or page_url_path contains '/*/resources/' or page_url_path contains '/*/codelabs/' or page_url_path contains '/*/deprecated/' or page_url_path contains '/*/tools/' or page_url_path contains '/*/tutorials/' or page_url_path contains '/*/server/' or page_url_path contains '/*/web/' or page_url_path contains '/*/effective-dart/' or page_url_path contains '/*/libraries/' %} active {%- endif -%}">
         <span>Docs</span>
@@ -30,14 +29,58 @@
       <a href="/get-dart" class="nav-link
         {%- if page_url_path contains '/*/get-dart/' %} active {%- endif -%}">Get Dart</a>
     </li>
-    <li class="searchfield">
-      <form action="/search" class="site-header-search form-inline" id="cse-search-box">
-        <input type="hidden" name="cx" value="011220921317074318178:_yy-tmb5t_i">
-        <input type="hidden" name="ie" value="UTF-8">
-        <input type="hidden" name="hl" value="en">
-        <input class="site-header-searchfield form-control search-field" type="search" name="q"
-          id="search-main" autocomplete="off" placeholder="Search" aria-label="Search">
-      </form>
-    </li>
   </ul>
+  <div class="navbar-contents">
+    <form action="/search/" class="site-header-search" id="cse-search-box">
+      <input type="hidden" name="cx" value="011220921317074318178:_yy-tmb5t_i">
+      <input type="hidden" name="ie" value="UTF-8">
+      <input type="hidden" name="hl" value="en">
+      <input
+          class="site-header-searchfield search-field"
+          type="search" name="q" id="search-main" autocomplete="off"
+          placeholder="Search" aria-label="Search">
+    </form>
+    <a href="/search" id="fallback-search-button" class="icon-button" aria-label="Navigate to the docs search page." title="Navigate to the docs search page.">
+      <span class="material-symbols" aria-hidden="true">search</span>
+    </a>
+    <div id="theme-switcher" class="dropdown">
+      <button class="dropdown-button icon-button" title="Select a theme" aria-label="Select a theme" aria-expanded="false" aria-controls="site-switcher-menu">
+        <span class="material-symbols" aria-hidden="true">routine</span>
+      </button>
+      <div class="dropdown-content" id="theme-menu">
+        <div class="dropdown-menu">
+          <ul role="listbox">
+            <li>
+              <button data-theme="light" title="Switch to light mode" aria-label="Switch to light mode" aria-selected="false">
+                <span class="material-symbols" aria-hidden="true">light_mode</span>
+                <span>Light</span>
+              </button>
+            </li>
+            <li>
+              <button data-theme="dark" title="Switch to dark mode" aria-label="Switch to dark mode" aria-selected="false">
+                <span class="material-symbols" aria-hidden="true">dark_mode</span>
+                <span>Dark</span>
+              </button>
+            </li>
+            <li>
+              <button data-theme="auto" title="Follow the device theme" aria-label="Follow the device theme" aria-selected="false">
+                <span class="material-symbols" aria-hidden="true">night_sight_auto</span>
+                <span>Automatic</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <button
+        id="menu-toggle"
+        class="icon-button"
+        type="button"
+        aria-controls="sidenav"
+        aria-label="Toggle side navigation menu."
+        title="Toggle side navigation menu.">
+      <span class="material-symbols" aria-hidden="true">menu</span>
+      <span class="material-symbols" aria-hidden="true">close</span>
+    </button>
+  </div>
 </nav>

--- a/src/_includes/navigation-side.html
+++ b/src/_includes/navigation-side.html
@@ -1,6 +1,6 @@
 <div id="sidenav">
   <form action="/search/" class="site-header-search form-inline">
-    <input class="site-header-searchfield form-control search-field" type="search" name="q"
+    <input class="site-header-searchfield search-field" type="search" name="q"
            id="search-side" autocomplete="off" placeholder="Search" aria-label="Search">
   </form>
 

--- a/src/_sass/_site.scss
+++ b/src/_sass/_site.scss
@@ -21,6 +21,7 @@
 @use 'components/code';
 @use 'components/content';
 @use 'components/diagnostics';
+@use 'components/dropdown';
 @use 'components/filter-search';
 @use 'components/cookie-notice';
 @use 'components/footer';
@@ -33,6 +34,7 @@
 @use 'components/sidenav';
 @use 'components/tabs';
 @use 'components/tags';
+@use 'components/theming';
 @use 'components/toc';
 
 @use 'pages/dash';

--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -5,6 +5,7 @@ body {
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
+  background-color: var(--site-base-bgColor);
   color: var(--site-base-fgColor);
 
   overflow-x: hidden;
@@ -115,6 +116,12 @@ ul {
 img {
   max-width: 100%;
   height: auto;
+
+  &.diagram-wrap {
+    background-color: var(--site-diagram-wrap-bgColor);
+    padding: 1rem;
+    border-radius: 1rem;
+  }
 }
 
 dd {
@@ -123,10 +130,15 @@ dd {
 }
 
 blockquote {
-  border: solid #b3b3b3;
-  border-width: 1px 0;
-  margin: 20px;
-  padding: 10px 20px 0 20px;
+  background-color: var(--site-inset-bgColor-translucent);
+  padding: 0.75rem 1rem;
+  border-left: solid 5px var(--site-inset-borderColor);
+  margin: 0;
+  margin-block-end: 1rem;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 details {

--- a/src/_sass/base/_layout.scss
+++ b/src/_sass/base/_layout.scss
@@ -22,7 +22,11 @@
 
     > .content {
       min-width: 8rem;
-      padding: 2rem;
+      padding: 1.5rem;
+
+      @media (min-width: 576px) {
+        padding: 2rem;
+      }
     }
   }
 }

--- a/src/_sass/base/_root.scss
+++ b/src/_sass/base/_root.scss
@@ -11,7 +11,7 @@ body {
   --site-icon-fontFamily: 'Material Symbols Outlined', 'Material Symbols', 'Material Icons';
 
   // Site layout sizes.
-  --site-header-height: 3.25rem; // TODO(parlough): Make 4 when adding toc.
+  --site-header-height: 3.25rem;
   --site-subheader-height: 2.5rem;
 
   // Site visual hierarchy levels.
@@ -25,7 +25,7 @@ body {
   --site-z-top: 1000;
 
   // Misc site styles.
-  --site-radius: 0.35rem;
+  --site-radius: 0.45rem;
 }
 
 body {
@@ -72,9 +72,10 @@ body {
   --site-wordmark-fgColor: #4a4a4a;
 
   --site-chrome-bgColor: #1c2834;
+  --site-chrome-borderColor: #394c60;
   --site-chrome-fgColor: #F3F4F6;
 
-  --site-banner-bgColor: linear-gradient(139deg, #{$base_primary_color}, #833ef2);
+  --site-banner-bgColor: linear-gradient(139deg, #134386, #1959b3);
   --site-banner-fgColor: #fff;
 
   --site-card-borderColor: var(--site-outline);
@@ -98,7 +99,7 @@ body {
     display: none !important;
   }
 
-  &.dark-mode {
+  &.dark-mode, .always-dark-mode {
     color-scheme: dark;
     --site-outline: rgba(95, 100, 119, .75);
     --site-outline-variant: #252834;
@@ -141,6 +142,7 @@ body {
     --site-wordmark-fgColor: #fff;
 
     --site-chrome-bgColor: #1c2834;
+    --site-chrome-borderColor: #394c60;
     --site-chrome-fgColor: #F3F4F6;
 
     --site-banner-bgColor: linear-gradient(139deg, #165399, #5b0fd7);
@@ -155,7 +157,7 @@ body {
 
     --site-code-highlight-bgColor: rgba(164, 158, 62, 0.15);
 
-    --site-diagram-wrap-bgColor: #e1e6ea;
+    --site-diagram-wrap-bgColor: #c2cdd6;
 
     --site-alert-info-color: #439bff;
     --site-alert-tip-color: #25c04b;

--- a/src/_sass/components/_alert.scss
+++ b/src/_sass/components/_alert.scss
@@ -1,17 +1,11 @@
 aside.alert {
-  --alert-info-fgColor: #2058b7;
-  --alert-tip-fgColor: #0c7927;
-  --alert-important-fgColor: #7953bf;
-  --alert-warning-fgColor: #955d00;
-  --alert-error-fgColor: #c43131;
-
-  --alert-title-color: var(--site-base-fgColor);
-
   padding: 0.75rem;
   margin-block-start: 1rem;
   margin-block-end: 1rem;
-  border-left: solid 0.25rem var(--alert-border-color, var(--alert-title-color, var(--site-outline-variant)));
-  background-color: var(--site-inset-bgColor);
+  border-left: solid 0.25rem var(--site-inset-borderColor);
+  background-color: var(--site-inset-bgColor-translucent);
+  color: var(--site-inset-fgColor);
+  --alert-title-color: var(--site-base-fgColor);
 
   .alert-header {
     display: flex;
@@ -25,7 +19,7 @@ aside.alert {
     color: var(--alert-title-color);
 
     .material-symbols {
-      font-size: 22px;
+      font-size: 1.25em;
       user-select: none;
     }
   }
@@ -49,26 +43,32 @@ aside.alert {
   }
 
   &.alert-success {
-    --alert-title-color: var(--alert-tip-fgColor);
+    border-color: var(--site-alert-tip-color);
+    --alert-title-color: var(--site-alert-tip-color);
   }
 
   &.alert-important {
-    --alert-title-color: var(--alert-important-fgColor);
+    border-color: var(--site-alert-important-color);
+    --alert-title-color: var(--site-alert-important-color);
   }
 
   &.alert-warning {
-    --alert-title-color: var(--alert-warning-fgColor);
+    border-color: var(--site-alert-warning-color);
+    --alert-title-color: var(--site-alert-warning-color);
   }
 
   &.alert-info {
-    --alert-title-color: var(--alert-info-fgColor);
+    border-color: var(--site-alert-info-color);
+    --alert-title-color: var(--site-alert-info-color);
   }
 
   &.alert-secondary {
-    --alert-border-color: var(--site-outline-variant);
+    border-color: var(--site-inset-borderColor);
+    --alert-title-color: var(--site-base-fgColor);
   }
 
   &.alert-error {
-    --alert-title-color: var(--alert-error-fgColor);
+    border-color: var(--site-alert-error-color);
+    --alert-title-color: var(--site-alert-error-color);
   }
 }

--- a/src/_sass/components/_banner.scss
+++ b/src/_sass/components/_banner.scss
@@ -4,26 +4,35 @@
   justify-content: center;
   align-items: center;
   font-family: var(--site-ui-fontFamily);
+  font-weight: 500;
   font-size: 1rem;
 
   gap: 0.5rem;
   padding: 0.75rem;
   text-align: center;
-  background-color: #121a26;
-  color: #fff;
+  background: var(--site-banner-bgColor);
+  color: var(--site-banner-fgColor);
+  z-index: var(--site-z-floating);
 
   p {
     overflow-wrap: anywhere;
     word-break: normal;
     margin: 0;
     flex-grow: 1;
+    text-wrap: balance;
   }
 
   a, button {
-    color: var(--site-altLink-fgColor);
+    white-space: nowrap;
+    color: var(--site-onPrimary-color);
+    font-family: var(--site-ui-fontFamily);
+
+    &:hover {
+      color: var(--site-onPrimary-color-light);
+    }
 
     &:active {
-      color: var(--site-altLink-fgColor-active);
+      color: var(--site-onPrimary-color-lighter);
     }
   }
 }

--- a/src/_sass/components/_buttons.scss
+++ b/src/_sass/components/_buttons.scss
@@ -18,7 +18,7 @@ a, button {
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    border-radius: 20px;
+    border-radius: var(--site-radius);
     width: fit-content;
     white-space: nowrap;
     font-family: var(--site-ui-fontFamily);
@@ -57,12 +57,13 @@ a, button {
   }
 
   &.filled-button {
-    background-color: #06599C;
+    background-color: var(--site-filledButton-bgColor);
+    color: var(--site-filledButton-fgColor);
     outline-offset: 2px;
 
     // Ensure color takes precedence over other anchor styling.
     &, &:hover, &:focus, &:active {
-      color: #fff;
+      color: var(--site-filledButton-fgColor);
     }
 
     span.material-symbols {
@@ -72,25 +73,36 @@ a, button {
   }
 
   &.icon-button {
-    height: 2rem;
-    width: 2rem;
+    border-radius: 2rem;
+    padding: 0.25rem;
+    color: var(--site-base-fgColor-alt);
+    text-decoration: none;
 
-    padding: 0.2rem;
-    color: #3a3a3a;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    background: none;
 
-    span {
-      font-size: 22px;
+    > span {
+      font-size: 1.5rem;
+    }
+
+    &:hover {
+      color: var(--site-base-fgColor);
     }
   }
 
   &.text-button, &.outlined-button {
     // Ensure color takes precedence over other anchor styling.
     &, &:hover, &:active, &:focus {
-      color: #3a3a3a;
+      // TODO(parlough): Should this be primary color instead?
+      color: var(--site-base-fgColor-lighter);
     }
   }
 
   &.outlined-button {
-    border: 1px solid rgba(0, 0, 0, .125);
+    border: 1px solid var(--site-outline);
   }
 }

--- a/src/_sass/components/_card.scss
+++ b/src/_sass/components/_card.scss
@@ -27,7 +27,7 @@
     border-radius: 0.5rem;
     padding: 0.75rem;
     gap: 0.5rem;
-    background-color: var(--card-container-color, rgb(242, 245, 255));
+    background-color: var(--card-container-color, var(--site-filledCard-bgColor, rgb(242, 245, 255)));
     height: auto;
 
     scroll-margin: 4rem;
@@ -37,7 +37,7 @@
     }
 
     &.outlined-card {
-      border: 1px solid var(--card-border-color, rgba(0, 0, 0, .125));
+      border: 1px solid var(--card-border-color, var(--site-card-borderColor));
     }
 
     .card-header {
@@ -86,7 +86,7 @@
     text-decoration: none;
 
     .card-header {
-      --card-title-color: #1967D2;
+      --card-title-color: var(--site-link-fgColor);
     }
 
     &:hover {

--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -3,9 +3,8 @@
   font-size: 0.9em;
   line-height: 1.25em;
   padding: 0.1rem 0.25rem;
-  background-color: var(--site-outline-variant);
-  background-color: color-mix(in srgb, var(--site-outline-variant) 35%, transparent);
-  border: 1px solid rgb(195, 201, 214);
+  background-color: var(--site-inset-bgColor-translucent);
+  border: 1px solid var(--site-inset-borderColor);
   border-radius: 0.25rem;
   word-wrap: break-word;
   white-space: nowrap;
@@ -146,11 +145,11 @@ pre {
   left: 6px;
 
   .tag-good &, .tag-passes-sa &, .tag-runtime-success & {
-    color: #155723;
+    color: var(--site-alert-tip-color);
   }
 
   .tag-bad &, .tag-fails-sa &, .tag-runtime-fail & {
-    color: #cb1425;
+    color: var(--site-alert-error-color);
   }
 }
 
@@ -182,13 +181,14 @@ pre {
       }
     }
 
-    &.tag-good, &.tag-passes-sa, &.tag-runtime-success {
-      background-color: #f1fbf9;
-    }
-
-    &.tag-bad, &.tag-fails-sa, &.tag-runtime-fail {
-      background-color: #fef3f6;
-    }
+    // TODO(parlough): Consider bringing some background highlighting back.
+    //&.tag-good, &.tag-passes-sa, &.tag-runtime-success {
+    //  background-color: #f1fbf9;
+    //}
+    //
+    //&.tag-bad, &.tag-fails-sa, &.tag-runtime-fail {
+    //  background-color: #fef3f6;
+    //}
   }
 
   &:has(:focus-visible) {

--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -7,10 +7,10 @@ article {
 
     thead {
       vertical-align: bottom;
+      background-color: var(--site-raised-bgColor);
 
       th {
         border-top: 1px solid var(--site-outline-variant);
-        border-bottom: 2px solid var(--site-outline-variant);
         text-align: start;
       }
     }
@@ -20,13 +20,14 @@ article {
         vertical-align: top;
 
         &:nth-of-type(odd) {
-          background-color: rgba(0, 0, 0, 0.05);
+          background-color: rgb(var(--site-interaction-base-values) / 3%)
         }
       }
     }
 
     td, th {
       border: none;
+      border-top: 1px solid var(--site-inset-borderColor);
       padding: .75rem;
     }
   }
@@ -85,7 +86,7 @@ article {
       line-height: 1;
       @include mixins.transition(.1s);
       overflow: hidden;
-      color: #4a4a4a;
+      color: var(--site-base-fgColor-alt);
       opacity: 0;
       text-decoration: none;
 

--- a/src/_sass/components/_diagnostics.scss
+++ b/src/_sass/components/_diagnostics.scss
@@ -1,20 +1,18 @@
 @use '../base/mixins' as *;
 
 body.diagnostics {
-  --chip-container-color: transparent;
-  --chip-border-color: rgba(0, 0, 0, .35);
-  --chip-selected-container-color: rgb(194 229 255);
-  --chip-text-color: #3a3a3a;
+  --chip-border-color: var(--site-outline);
+  --chip-selected-container-color: var(--site-secondaryContainer-bgColor);
+  --chip-text-color: var(--site-base-fgColor);
 
-  --menu-border-color: rgba(0, 0, 0, .35);
-  --menu-container-color: #ffffff;
+  --menu-border-color: var(--site-inset-borderColor);
+  --menu-container-color: var(--site-inset-bgColor);
   --menu-item-container-color: transparent;
-  --menu-item-selected-container-color: rgb(194 229 255);
-  --menu-item-text-color: #3a3a3a;
+  --menu-item-selected-container-color: var(--site-secondaryContainer-bgColor);
+  --menu-item-text-color: var(--site-base-fgColor);
 
   // Overrides of existing variables.
   --card-min-width: 19rem;
-  --card-text-color: #3a3a3a;
 
   .filter-group {
     display: flex;
@@ -45,7 +43,7 @@ body.diagnostics {
           user-select: none;
 
           span {
-            color: var(--card-text-color);
+            color: var(--site-base-fgColor-alt);
             font-size: 20px;
             font-variation-settings: 'FILL' 1;
           }

--- a/src/_sass/components/_dropdown.scss
+++ b/src/_sass/components/_dropdown.scss
@@ -1,0 +1,61 @@
+@use '../base/mixins';
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: var(--site-chrome-bgColor);
+  color: var(--site-chrome-fgColor);
+  box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.2);
+  border-radius: calc(var(--site-radius) * 1.25);
+  width: max-content;
+  border: var(--site-chrome-borderColor) 1px solid;
+  z-index: var(--site-z-dropdown);
+
+  &.show {
+    display: block;
+  }
+
+  .dropdown-divider {
+    background-color: var(--site-outline-variant);
+    border-radius: 0.5rem;
+    height: 0.125rem;
+    margin: 0.25rem;
+    padding: 0 !important;
+  }
+
+  .dropdown-menu {
+    padding: 0.2rem;
+
+    ul {
+      display: flex;
+      flex-direction: column;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      li {
+        padding: 0.25rem;
+
+        a, button {
+          display: flex;
+          align-items: center;
+          flex-direction: row;
+          width: 100%;
+          gap: 0.4rem;
+          padding: 0.2rem 0.4rem;
+          border-radius: var(--site-radius);
+
+          text-decoration: none;
+
+          &:hover {
+            @include mixins.interaction-style(4%);
+          }
+
+          &:active {
+            @include mixins.interaction-style(6%);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/_sass/components/_filter-search.scss
+++ b/src/_sass/components/_filter-search.scss
@@ -23,7 +23,7 @@
       align-items: center;
       width: 100%;
 
-      border: 1px solid rgba(0, 0, 0, .25);
+      border: 1px solid var(--site-outline);
       border-radius: 1rem;
       height: 3rem;
       padding: 0 .5rem;

--- a/src/_sass/components/_footer.scss
+++ b/src/_sass/components/_footer.scss
@@ -52,6 +52,8 @@
   .footer-social-links {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1rem;
     margin-top: 1.5rem;
 

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -1,30 +1,17 @@
 #site-header {
-  background-color: #fff;
+  background-color: var(--site-chrome-bgColor);
+  color: var(--site-chrome-fgColor);
   font-family: var(--site-ui-fontFamily);
   position: sticky;
   top: 0;
   z-index: 1000;
 
-  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.1);
+  @media (min-width: 1200px) {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .05);
+    border-bottom: none;
+  }
 
   .navbar {
-    font-size: 1.25rem;
-    min-height: var(--site-header-height);
-
-    @media (min-width: 768px) {
-      font-size: 1rem;
-    }
-
-    .navbar-toggler {
-      color: var(--site-base-fgColor);
-      margin-right: 1rem;
-      padding: 0;
-
-      .material-symbols {
-        font-size: 28px;
-      }
-    }
-
     .navbar-brand {
       margin-right: auto;
     }
@@ -60,61 +47,30 @@
     }
   }
 
-  .site-header-search {
-    position: relative;
-
-    &::before {
-      content: 'search';
-      font: 24px / 1 var(--site-icon-fontFamily);
-      pointer-events: none;
-      position: absolute;
-      left: 0.25rem;
-    }
-
-    @media (min-width: 768px) {
-      margin-left: 1rem;
-    }
-  }
-
-  .site-header-searchfield {
-    border: 0;
-    padding-left: 2rem;
-    font-size: 1.25rem;
-    height: 3rem;
-    width: 100%;
-
-    @media (min-width: 768px) {
-      font-size: 0.875rem;
-      height: unset;
-      transition: width .35s ease-in-out;
-      width: 24px !important;
-
-      &:focus {
-        width: 220px !important;
-      }
-    }
-  }
-
   #mainnav {
-    background-color: var(--site-chrome-bgColor);
-    color: var(--site-chrome-fgColor);
     display: flex;
     align-items: center;
+    min-height: var(--site-header-height);
 
-    ul {
-      margin: 0 0 0 auto;
+    ul.navbar {
       padding: 0;
+      margin: 0;
       list-style: none;
 
-      display: flex;
+      display: none;
+      flex-grow: 1;
       flex-wrap: wrap;
-      justify-content: center;
+      justify-content: right;
       align-items: center;
 
-      li {
+      @media (min-width: 1024px) {
+        display: flex;
+      }
+
+      > li {
         padding: 0 0.75rem;
 
-        a {
+        > a {
           color: var(--site-chrome-fgColor);
           display: inline-block;
           padding: 0 6px;
@@ -130,29 +86,79 @@
             color: var(--site-altLink-fgColor-active);
           }
         }
+      }
+    }
 
-        &.searchfield {
-          position: relative;
+    .navbar-contents {
+      margin-left: auto;
+      margin-right: 0.75rem;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: .5rem;
 
-          form {
-            display: flex;
-            align-items: center;
-          }
+      .icon-button {
+        > .material-symbols {
+          font-size: 1.625rem;
+        }
+      }
+
+      .site-header-search {
+        display: none;
+        position: relative;
+        align-items: center;
+        vertical-align: middle;
+        margin-left: 1rem;
+
+        @media (min-width: 768px) {
+          display: flex;
         }
 
-        // TODO(parlough): Reverse and simplify these media queries.
-        @media(max-width: 960px) {
+        &::before {
+          content: 'search';
+          color: var(--site-base-fgColor-alt);
+          font: 26px / 1 var(--site-icon-fontFamily);
+          pointer-events: none;
+          position: absolute;
+          left: .75rem;
+        }
+
+        &:hover::before {
+          color: var(--site-base-fgColor);
+        }
+      }
+
+      .site-header-searchfield {
+        border: 0;
+        font-size: 1rem;
+        height: 2.25rem;
+        transition: width .35s ease-in-out;
+        width: 24px;
+        cursor: pointer;
+        border-radius: 24px;
+        padding: 0.25rem 0.5rem 0.25rem 2.5rem;
+        background: none;
+        color: var(--site-chrome-fgColor);
+
+        &:focus {
+          width: 14rem;
+          cursor: auto;
+        }
+
+        &::-webkit-search-cancel-button {
           display: none;
+        }
+      }
 
-          &.searchfield {
-            display: block;
-          }
+      #fallback-search-button {
+        display: none;
+
+        @media (min-width: 320px) {
+          display: flex;
         }
 
-        @media(max-width: 479px) {
-          &.searchfield {
-            display: none;
-          }
+        @media (min-width: 768px) {
+          display: none;
         }
       }
     }
@@ -167,26 +173,29 @@
   }
 
   #menu-toggle {
-    display: none;
-    align-items: center;
-    line-height: var(--site-header-height);
-    margin-left: 20px;
-    padding-right: 10px;
-    cursor: pointer;
-    z-index: 100;
-    user-select: none;
-
-    span {
-      font-size: 32px;
+    @media (min-width: 1024px) {
+      display: none;
     }
 
-    // TODO(parlough): Reverse and simplify these media queries.
-    @media(max-width: 479px) {
-      order: 2;
-    }
+    // Toggle between menu and close buttons if sidenav is open or not.
+    span.material-symbols {
+      &:first-child {
+        display: inline;
+      }
 
-    @media(max-width: 1024px) {
-      display: flex;
+      &:last-child {
+        display: none;
+      }
+
+      @at-root body.open_menu & {
+        &:first-child {
+          display: none;
+        }
+
+        &:last-child {
+          display: inline;
+        }
+      }
     }
   }
 }

--- a/src/_sass/components/_search.scss
+++ b/src/_sass/components/_search.scss
@@ -1,72 +1,19 @@
 @use '../base/mixins';
 
 .site-header-search {
-  &::before {
-    color: var(--site-outline-variant);
-    z-index: 1;
-  }
-
   display: flex;
   align-items: center;
 
-  #mainnav & {
-    // Override of _header.scss
-    border: 0;
-
-    .open_menu & {
-      visibility: hidden;
-    }
-  }
-
   #sidenav & {
     display: none;
-    flex-shrink: 0;
-    margin: 0;
-    padding: 0 1.25rem;
-    order: -1;
+    margin: 0 0.5rem 0.5rem;
 
-    // Override of _header.scss
-    &::before {
-      left: 1.5rem;
-    }
-  }
-}
-
-.site-header-searchfield {
-  border: 0;
-  box-shadow: none;
-  background-color: transparent;
-
-  #mainnav & {
-    background-color: var(--site-chrome-bgColor);
-    color: var(--site-chrome-fgColor);
-    font-size: inherit;
-    height: inherit;
-    width: 24px;
-
-    &:focus {
-      width: 220px;
-    }
-
-    @media (min-width: 768px) {
-      font-size: 1rem;
-      height: unset;
-      width: unset;
-    }
-  }
-
-  #sidenav & {
-    font-size: 1.25rem;
-    height: 3rem;
-    width: 100%;
-
-    // Override of _header.scss.
-    @media (min-width: 768px) {
-      width: 100% !important;
-
-      &:focus {
-        width: 100% !important;
-      }
+    .site-header-searchfield {
+      font-size: 1.25rem;
+      height: 3rem;
+      width: 100%;
+      background-color: var(--site-raised-bgColor);
+      border-radius: var(--site-radius);
     }
   }
 }

--- a/src/_sass/components/_sidenav.scss
+++ b/src/_sass/components/_sidenav.scss
@@ -15,7 +15,7 @@ $sidenav-wide-layout: 1024px;
 
   display: none;
   width: 100%;
-  background: #fff;
+  background-color: var(--site-base-bgColor);
   z-index: 100;
 
   @at-root body.open_menu {
@@ -146,7 +146,7 @@ $sidenav-wide-layout: 1024px;
       }
 
       &.active {
-        background-color: rgb(245, 245, 246);
+        background-color: rgb(var(--site-interaction-base-values) / 4%);
 
         &:not(.collapsible) {
           color: var(--site-link-fgColor);

--- a/src/_sass/components/_tags.scss
+++ b/src/_sass/components/_tags.scss
@@ -12,18 +12,22 @@
 
 .language-versioned-tag {
   background-color: #13B9FD;
+  color: #212121;
 }
 
 .deprecated-tag {
   background-color: #F2AA3A;
+  color: #212121;
 }
 
 .removed-tag {
   background-color: #F3655B;
+  color: #212121;
 }
 
 .experimental-tag {
   background-color: #DADCE0;
+  color: #212121;
 }
 
 .tags {
@@ -37,6 +41,7 @@
     flex-direction: row;
     align-items: center;
     background-color: rgb(194 229 255);
+    color: #212121;
     gap: 0.25rem;
     font-size: 1rem;
     padding: 0.1rem 0.4rem;
@@ -67,7 +72,6 @@
 
   a.tag-label {
     text-decoration: none;
-    color: inherit;
 
     &:hover {
       @include mixins.interaction-style(6%);

--- a/src/_sass/components/_theming.scss
+++ b/src/_sass/components/_theming.scss
@@ -1,0 +1,33 @@
+#theme-switcher {
+  position: relative;
+
+  //.icon-button span {
+  //  font-size: 1.5rem;
+  //}
+
+  > .dropdown-content {
+    right: -0.5rem;
+
+    .material-symbols {
+      font-size: 20px;
+    }
+  }
+
+  @at-root body:not(.dark-mode):not(.auto-mode) & {
+    button[data-theme="light"] {
+      background-color: var(--site-primary-color-highlight);
+    }
+  }
+
+  @at-root body.dark-mode:not(.auto-mode) & {
+    button[data-theme="dark"] {
+      background-color: var(--site-primary-color-highlight);
+    }
+  }
+
+  @at-root body.auto-mode & {
+    button[data-theme="auto"] {
+      background-color: var(--site-primary-color-highlight);
+    }
+  }
+}

--- a/src/_sass/components/_toc.scss
+++ b/src/_sass/components/_toc.scss
@@ -70,7 +70,7 @@
 }
 
 #site-toc--inline {
-  background: #f5f5f7;
+  background: var(--site-inset-bgColor);
   padding: 1rem 1.5rem;
   margin-block-start: 1rem;
   margin-block-end: 1rem;

--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -1,3 +1,110 @@
+const _prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
+function setupTheme() {
+  const storedTheme = window.localStorage.getItem('theme') ?? 'light-mode';
+  if (storedTheme === 'auto-mode') {
+    document.body.classList.add(
+        'auto-mode',
+        _prefersDarkMode.matches ? 'dark-mode' : 'light-mode',
+    );
+  } else {
+    document.body.classList.add(storedTheme);
+  }
+
+  const themeMenu = document.getElementById('theme-menu');
+  if (themeMenu) {
+    const themeButtons = themeMenu.querySelectorAll('button');
+
+    function updateButtonSelectedState() {
+      const theme =
+          document.body.classList.contains('auto-mode') ? 'auto' :
+              document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+
+      themeButtons.forEach((button) => {
+        button.ariaSelected = button.dataset.theme === theme ? 'true' : 'false';
+      });
+    }
+
+    themeButtons.forEach((button) => {
+      button.addEventListener('click', (_) => {
+        const newMode = `${button.dataset.theme}-mode`;
+
+        document.body.classList.remove('auto-mode', 'dark-mode', 'light-mode');
+        document.body.classList.add(newMode);
+
+        window.localStorage.setItem('theme', newMode);
+        _switchToPreferenceIfAuto();
+
+        updateButtonSelectedState();
+      });
+    });
+
+    updateButtonSelectedState();
+  }
+
+  _prefersDarkMode.addEventListener('change', _switchToPreferenceIfAuto);
+}
+
+function _switchToPreferenceIfAuto() {
+  if (document.body.classList.contains('auto-mode')) {
+    if (_prefersDarkMode.matches) {
+      document.body.classList.remove('light-mode');
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+      document.body.classList.add('light-mode');
+    }
+  }
+}
+
+function setupThemeSwitcher() {
+  const themeSwitcher = document.getElementById('theme-switcher');
+  if (!themeSwitcher) {
+    return;
+  }
+
+  const themeSwitcherButton = themeSwitcher.querySelector('.dropdown-button');
+  const themeSwitcherMenu = themeSwitcher.querySelector('#theme-menu');
+  if (!themeSwitcherButton || !themeSwitcherMenu) {
+    return;
+  }
+
+  function _closeMenusAndToggle() {
+    themeSwitcherMenu.classList.remove('show');
+    themeSwitcherButton.ariaExpanded = 'false';
+  }
+
+  themeSwitcherButton.addEventListener('click', (_) => {
+    if (themeSwitcherMenu.classList.contains('show')) {
+      _closeMenusAndToggle();
+    } else {
+      themeSwitcherMenu.classList.add('show');
+      themeSwitcherButton.ariaExpanded = 'true';
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    // If pressing the `esc` key in the menu area, close the menu.
+    if (event.key === 'Escape' && event.target.closest('#theme-switcher')) {
+      _closeMenusAndToggle();
+    }
+  });
+
+  themeSwitcher.addEventListener('focusout', (e) => {
+    // If focus leaves the theme-switcher, hide the menu.
+    if (e.relatedTarget && !e.relatedTarget.closest('#theme-switcher')) {
+      _closeMenusAndToggle();
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    // If not clicking inside the theme switcher, close the menu.
+    if (!event.target.closest('#theme-switcher')) {
+      _closeMenusAndToggle();
+    }
+  })
+}
+
 function handleSearchShortcut(event) {
   const activeElement = document.activeElement;
   if (activeElement instanceof HTMLInputElement ||
@@ -189,9 +296,11 @@ function setupExpandableCards() {
 }
 
 function _setupSite() {
+  setupTheme();
   setupSidenav();
   initCookieNotice();
   setupTabs();
+  setupThemeSwitcher();
 
   // Set up collapse and expand for sidenav buttons.
   const toggles = document.querySelectorAll('.nav-link.collapsible');

--- a/src/content/language/concurrency.md
+++ b/src/content/language/concurrency.md
@@ -14,12 +14,6 @@ nextpage:
 
 <?code-excerpt path-base="concurrency"?>
 
-<style>
-  article img {
-    padding: 15px 0;
-  }
-</style>
-
 This page contains a conceptual overview of how concurrent programming works in
 Dart. It explains the event-loop, async language features, and isolates from
 a high-level. For more practical code examples of using concurrency in Dart,
@@ -50,8 +44,7 @@ to user taps and keystrokes, to I/O from the disk.
 Because your app can’t predict what order events will happen,
 the event loop processes events in the order they're queued, one at a time.
 
-![A figure showing events being fed, one by one, into the
-event loop](/assets/img/language/concurrency/event-loop.png)
+![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/event-loop.png){:.diagram-wrap}
 
 The way the event loop functions resembles this code:
 
@@ -85,9 +78,7 @@ It also tells the event loop to hold onto the callback in the `then()` clause
 until the HTTP request resolves. When that happens, it should
 execute that callback, passing the result of the request as an argument.
 
-![Figure showing async events being added to an event loop and
-holding onto a callback to execute later
-.](/assets/img/language/concurrency/async-event-loop.png)
+![Figure showing async events being added to an event loop and holding onto a callback to execute later .](/assets/img/language/concurrency/async-event-loop.png){:.diagram-wrap}
 
 This same model is generally how the event loop handles all other
 asynchronous events in Dart, such as [`Stream`][] objects.
@@ -188,8 +179,7 @@ As the following figure shows, the Dart code pauses while `readAsString()`
 executes non-Dart code, in either the Dart runtime or the operating system. 
 Once `readAsString()` returns a value, Dart code execution resumes.
 
-![Flowchart-like figure showing app code executing from start to exit, waiting
-for native I/O in between](/assets/img/language/concurrency/basics-await.png)
+![Flowchart-like figure showing app code executing from start to exit, waiting for native I/O in between](/assets/img/language/concurrency/basics-await.png){:.diagram-wrap}
 
 ### Streams
 
@@ -268,8 +258,7 @@ In most cases, you don't need to think about isolates at all. Dart programs run
 in the main isolate by default. It’s the thread where a program starts to run
 and execute, as shown in the following figure:
 
-![A figure showing a main isolate, which runs `main()`, responds to events,
-and then exits](/assets/img/language/concurrency/basics-main-isolate.png)
+![A figure showing a main isolate, which runs `main()`, responds to events, and then exits](/assets/img/language/concurrency/basics-main-isolate.png){:.diagram-wrap}
 
 Even single-isolate programs can execute smoothly. Before continuing to the next
 line of code, these apps use [async-await][] to wait for asynchronous operations to
@@ -290,7 +279,7 @@ When the isolate's initial function returns,
 the isolate stays around if it needs to handle events.
 After handling the events, the isolate exits.
 
-![A more general figure showing that any isolate runs some code, optionally responds to events, and then exits](/assets/img/language/concurrency/basics-isolate.png)
+![A more general figure showing that any isolate runs some code, optionally responds to events, and then exits](/assets/img/language/concurrency/basics-isolate.png){:.diagram-wrap}
 
 ### Event handling
 
@@ -299,7 +288,7 @@ and notifications of tap and other UI events. For example, the following figure
 shows a repaint event, followed by a tap event, followed by two repaint events.
 The event loop takes events from the queue in first in, first out order.
 
-![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/event-loop.png)
+![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/event-loop.png){:.diagram-wrap}
 
 Event handling happens on the main isolate after `main()` exits. In the
 following figure, after `main()` exits, the main isolate handles the first
@@ -311,7 +300,7 @@ unresponsive. In the following figure, the tap-handling code takes too long, so
 subsequent events are handled too late. The app might appear to freeze, and any
 animation it performs might be jerky.
 
-![A figure showing a tap handler with a too-long execution time](/assets/img/language/concurrency/event-jank.png)
+![A figure showing a tap handler with a too-long execution time](/assets/img/language/concurrency/event-jank.png){:.diagram-wrap}
 
 In client apps, the result of a too-lengthy synchronous operation is often
 [janky (non-smooth) UI animation][jank]. Worse, the UI might become completely
@@ -330,7 +319,7 @@ its result in a message when it exits.
 
 [json]: {{site.flutter-docs}}/cookbook/networking/background-parsing
 
-![A figure showing a main isolate and a simple worker isolate](/assets/img/language/concurrency/isolate-bg-worker.png)
+![A figure showing a main isolate and a simple worker isolate](/assets/img/language/concurrency/isolate-bg-worker.png){:.diagram-wrap}
 
 A worker isolate can perform I/O
 (reading and writing files, for example), set timers, and more. It has its own

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -13,12 +13,6 @@ nextpage:
 
 <?code-excerpt path-base="concurrency"?>
 
-<style>
-  article img {
-    padding: 15px 0;
-  }
-</style>
-
 This page discusses some examples that use the `Isolate` API to implement 
 isolates.
 
@@ -236,10 +230,10 @@ now both sides have an open channel to send and receive messages.
 The diagrams in this section are high-level and intended to convey the 
 _concept_ of using ports for isolates. Actual implementation requires 
 a bit more code, which you will find 
-[later on this page](#basic-ports-example).  
+[later on this page](#basic-ports-example).
 :::
 
-![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/ports-setup.png)
+![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/ports-setup.png){:.diagram-wrap}
 
 1. Create a `ReceivePort` in the main isolate. The `SendPort` is created
    automatically as a property on the `ReceivePort`.
@@ -254,7 +248,7 @@ Along with creating the ports and setting up communication, you’ll also need
 to tell the ports what to do when they receive messages. This is done using
 the `listen` method on each respective `ReceivePort`.
 
-![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/ports-passing-messages.png)
+![A figure showing events being fed, one by one, into the event loop](/assets/img/language/concurrency/ports-passing-messages.png){:.diagram-wrap}
 
 1. Send a message via the main isolate’s reference to the worker isolate's
    `SendPort`.

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -126,7 +126,7 @@ Here are some of the less obvious rules:
 Let's see these rules in detail, with examples that use the following
 type hierarchy:
 
-<img src="/assets/img/language/type-hierarchy.png" alt="a hierarchy of animals where the supertype is Animal and the subtypes are Alligator, Cat, and HoneyBadger. Cat has the subtypes of Lion and MaineCoon">
+<img src="/assets/img/language/type-hierarchy.png" class="diagram-wrap" alt="a hierarchy of animals where the supertype is Animal and the subtypes are Alligator, Cat, and HoneyBadger. Cat has the subtypes of Lion and MaineCoon">
 
 <a name="use-proper-return-types"></a>
 ### Use sound return types when overriding methods
@@ -518,7 +518,7 @@ or a producer.
 
 Consider the following type hierarchy:
 
-<img src="/assets/img/language/type-hierarchy.png" alt="a hierarchy of animals where the supertype is Animal and the subtypes are Alligator, Cat, and HoneyBadger. Cat has the subtypes of Lion and MaineCoon">
+<img src="/assets/img/language/type-hierarchy.png" class="diagram-wrap" alt="a hierarchy of animals where the supertype is Animal and the subtypes are Alligator, Cat, and HoneyBadger. Cat has the subtypes of Lion and MaineCoon">
 
 Consider the following simple assignment where `Cat c` is a _consumer_
 and `Cat()` is a _producer_:
@@ -562,7 +562,7 @@ Are the rules the same for generic types? Yes. Consider the hierarchy
 of lists of animals—a `List` of `Cat` is a subtype of a `List` of
 `Animal`, and a supertype of a `List` of `MaineCoon`:
 
-<img src="/assets/img/language/type-hierarchy-generics.png" alt="List<Animal> -> List<Cat> -> List<MaineCoon>">
+<img src="/assets/img/language/type-hierarchy-generics.png" class="diagram-wrap" alt="List<Animal> -> List<Cat> -> List<MaineCoon>">
 
 In the following example, 
 you can assign a `MaineCoon` list to `myCats`
@@ -604,7 +604,7 @@ depending on the actual type of the list being cast (`myAnimals`).
 When overriding a method, the producer and consumer rules still apply.
 For example:
 
-<img src="/assets/img/language/consumer-producer-methods.png" alt="Animal class showing the chase method as the consumer and the parent getter as the producer">
+<img src="/assets/img/language/consumer-producer-methods.png" class="diagram-wrap" alt="Animal class showing the chase method as the consumer and the parent getter as the producer">
 
 For a consumer (such as the `chase(Animal)` method), you can replace
 the parameter type with a supertype. For a producer (such as

--- a/src/content/overview.md
+++ b/src/content/overview.md
@@ -4,10 +4,17 @@ description: A short introduction to Dart.
 js: [{url: '/assets/js/inject_dartpad.js', defer: true}]
 ---
 
-<img 
+<img
+  class="light-mode-visible"
   style="padding: 30px; float: right; width: 300px" 
   src="/assets/img/logo_lockup_dart_horizontal.png" 
   alt="Dart product logo">
+<img
+  class="dark-mode-visible"
+  style="padding: 30px; float: right; width: 300px"
+  src="/assets/img/logo/logo-white-text.svg"
+  alt="Dart product logo">
+
 
 Dart is a client-optimized language for developing fast apps on any platform.
 Its goal is to offer the most productive programming language for

--- a/src/content/resources/dart-cheatsheet.md
+++ b/src/content/resources/dart-cheatsheet.md
@@ -44,7 +44,7 @@ The following function takes two integers as parameters.
 Make it return a string containing both integers separated by a space.
 For example, `stringify(2, 3)` should return `'2 3'`.
 
-```dartpad
+```dartpad theme="dark"
 String stringify(int x, int y) {
   TODO('Return a formatted string here');
 }
@@ -119,7 +119,7 @@ Declare two variables in this DartPad:
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 // TODO: Declare the two variables here
 
 
@@ -187,7 +187,7 @@ to implement the described behavior in the following snippet.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 String? foo = 'a string';
 String? bar; // = null
 
@@ -275,7 +275,7 @@ The following function takes a nullable string as a parameter.
 Try using conditional property access to make it
 return the uppercase version of `str`, or `null` if `str` is `null`.
 
-```dartpad
+```dartpad theme="dark"
 String? upperCaseIt(String? str) {
   // TODO: Try conditionally accessing the `toUpperCase` method here.
 }
@@ -361,7 +361,7 @@ final aListOfBaseType = <BaseType>[SubType(), SubType()];
 
 Try setting the following variables to the indicated values. Replace the existing null values.
 
-```dartpad
+```dartpad theme="dark"
 // Assign this a list containing 'a', 'b', and 'c' in that order:
 final aListOfStrings = null;
 
@@ -491,7 +491,7 @@ bool hasEmpty = aListOfStrings.any((s) => s.isEmpty);
 
 Try finishing the following statements, which use arrow syntax.
 
-```dartpad
+```dartpad theme="dark"
 class MyClass {
   int value1 = 2;
   int value2 = 3;
@@ -643,7 +643,7 @@ sets the `anInt`, `aString`, and `aList` properties of a `BigObject`
 to `1`, `'String!'`, and `[3.0]` (respectively)
 and then calls `allDone()`.
 
-```dartpad
+```dartpad theme="dark"
 class BigObject {
   int anInt = 0;
   String aString = '';
@@ -780,7 +780,7 @@ Add the following:
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class InvalidPriceException {}
 
 class ShoppingCart {
@@ -937,7 +937,7 @@ Here are some examples of function calls and returned values:
 
 <br>
 
-```dartpad
+```dartpad theme="dark"
 String joinWithCommas(int a, [int? b, int? c, int? d, int? e]) {
   return TODO();
 }
@@ -1079,7 +1079,7 @@ then copy its value into `anInt`.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class MyDataObject {
   final int anInt;
   final String aString;
@@ -1271,7 +1271,7 @@ then do the following:
 * After everything's caught and handled, call `logger.doneLogging`
   (try using `finally`).
 
-```dartpad
+```dartpad theme="dark"
 typedef VoidFunction = void Function();
 
 class ExceptionWithMessage {
@@ -1465,7 +1465,7 @@ all three properties of the class.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class MyClass {
   final int anInt;
   final String aString;
@@ -1554,7 +1554,7 @@ For extra credit, add an `assert` to catch words of less than two characters.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class FirstTwoLetters {
   final String letterOne;
   final String letterTwo;
@@ -1648,7 +1648,7 @@ that sets all three properties to zero.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class Color {
   int red;
   int green;
@@ -1743,7 +1743,7 @@ named `IntegerHolder.fromList` to return the following:
 
 If you succeed, the console should display `Success!`.
 
-```dartpad
+```dartpad theme="dark"
 class IntegerHolder {
   IntegerHolder();
 
@@ -1906,7 +1906,7 @@ default constructor with zeros as the arguments.
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class Color {
   int red;
   int green;
@@ -1994,7 +1994,7 @@ and create a constant constructor that does the following:
 
 Ignore all initial errors in the DartPad.
 
-```dartpad
+```dartpad theme="dark"
 class Recipe {
   List<String> ingredients;
   int calories;

--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -131,8 +131,9 @@ If no file is available, the analyzer defaults to standard checks.
 
 Consider the following directory structure for a large project:
 
-<img 
+<img
   src="/assets/img/guides/analysis-options-directory-structure.png"
+  class="diagram-wrap"
   alt="project root contains analysis_options.yaml (#1) and 3 packages, one of which (my_package) contains an analysis_options.yaml file (#2).">
 
 The analyzer uses file #1 to analyze the code in `my_other_package`

--- a/src/content/tools/pub/create-packages.md
+++ b/src/content/tools/pub/create-packages.md
@@ -22,8 +22,9 @@ $ dart create -t package <PACKAGE_NAME>
 
 The following diagram shows the simplest layout of a package:
 
-<img 
-  src="/assets/img/libraries/simple-lib2.png" 
+<img
+  src="/assets/img/libraries/simple-lib2.png"
+  class="diagram-wrap"
   alt="root directory contains pubspec.yaml and lib/file.dart">
 
 The minimal requirements for a library are:
@@ -78,8 +79,9 @@ Let's look at the organization of a real-world package: shelf. The
 package provides an easy way to create web servers using Dart,
 and is laid out in a structure that is commonly used for Dart packages:
 
-<img 
+<img
   src="/assets/img/libraries/shelf.png"
+  class="diagram-wrap"
   alt="shelf root directory contains example, lib, test, and tool subdirectories">
 
 Directly under lib, the main library file,
@@ -134,8 +136,9 @@ Use `package:` when the imported file is in lib and the importer is outside.
 The following graphic shows how
 to import `lib/foo/a.dart` from both lib and web.
 
-<img 
+<img
   src="/assets/img/libraries/import-lib-rules.png"
+  class="diagram-wrap"
   alt="lib/bar/b.dart uses a relative import; web/main.dart uses a package import">
 
 

--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -281,7 +281,7 @@ the entire dependency graph of the containing app.
 Package authors must define package constraints with care.
 Consider the following scenario:
 
-<img src="/assets/img/tools/pub/PubExportedConstraints.png" alt="dependency graph">
+<img src="/assets/img/tools/pub/PubExportedConstraints.png" alt="dependency graph" class="diagram-wrap">
 
 The `bookshelf` package depends on `widgets`.
 The `widgets` package, currently at 1.2.0, exports

--- a/src/content/tools/pub/writing-package-pages.md
+++ b/src/content/tools/pub/writing-package-pages.md
@@ -7,8 +7,8 @@ description: Learn how to write a good package page.
   .screenshot, .screenshot-narrow {
     border-style: solid;
     border-width: 1px;
-    border-color: lightgray;
-    margin: 0px 20px;
+    border-color: var(--site-outline);
+    margin: 0 20px;
     padding: 10px;
     width: 90%;
   }
@@ -27,7 +27,7 @@ in the following screenshot:
 <img 
   src="/assets/img/libraries/package-page-sections.png"
   alt="package page contains sections like package layout, flutter favorite, package scoring, verified publishers, pubspec file" 
-  class="screenshot">
+  class="screenshot diagram-wrap">
 
 For details about other parts of the package page,
 follow these links:

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -253,7 +253,7 @@ Then, the result of parsing command-line arguments is stored in `argResults`.
 The following diagram shows how the `dcat` command line used above
 is parsed into an `ArgResults` object.
 
-![Run dcat from the command-line](/assets/img/tutorials/server/dcat-dart-run.svg){:width="350"}
+![Run dcat from the command-line](/assets/img/tutorials/server/dcat-dart-run.svg){:width="350" .diagram-wrap}
 
 You can access flags and options by name,
 treating an `ArgResults` like a `Map`.

--- a/src/content/web/index.md
+++ b/src/content/web/index.md
@@ -26,7 +26,7 @@ and other web frameworks for Dart are powered by the Dart web platform.
 <div class="side-by-side">
 <div class="centered-rows">
 <p class="">
-  <a href="/web/get-started" class="filled-button">Build a web app with Dart</a>
+  <a href="/web/get-started" class="filled-button large-button">Build a web app with Dart</a>
 </p>
 </div>
 <div class="centered-rows">


### PR DESCRIPTION
Generally migrated from the docs.flutter.dev implementation, with adjustments for Dart-site specifics, such as its navbar, tagged code blocks, lint and glossary cards, etc. Also fixes a few accessibility issues

Resolves https://github.com/dart-lang/site-www/issues/2625
Contributes to https://github.com/dart-lang/site-www/issues/5251

**Staged:** https://dart-dev--pr6635-feat-dark-mode-3jiovcyx.web.app/docs