### PR TITLE
Create directory for in-progress FWE content

### DIFF
--- a/src/_includes/navigation-main.html
+++ b/src/_includes/navigation-main.html
@@ -23,9 +23,15 @@
       <a href="/community" class="nav-link
         {%- if page_url_path contains '/*/community/' %} active {%- endif -%}">Community</a>
     </li>
+    {%- if page_url_path contains '/*/get-started/' -%}
+    <li>
+      <a href="/get-started" class="nav-link active">Learn</a>
+    </li>
+    {%- else -%}
     <li>
       <a href="/#try-dart" class="nav-link">Try Dart</a>
     </li>
+    {% endif -%}
     <li>
       <a href="/get-dart" class="nav-link
         {%- if page_url_path contains '/*/get-dart/' %} active {%- endif -%}">Get Dart</a>

--- a/src/_sass/_site.scss
+++ b/src/_sass/_site.scss
@@ -37,6 +37,7 @@
 
 @use 'pages/dash';
 @use 'pages/error';
+@use 'pages/tutorial';
 
 // Must be imported last to ensure that
 // the print overrides take priority over earlier defined styles.

--- a/src/_sass/pages/_tutorial.scss
+++ b/src/_sass/pages/_tutorial.scss
@@ -1,0 +1,11 @@
+body.tutorial {
+  &:not(.open_menu) {
+    #sidenav {
+      display: none;
+    }
+  }
+
+  #site-banner {
+    display: none;
+  }
+}

--- a/src/content/get-started/get-started.11tydata.json
+++ b/src/content/get-started/get-started.11tydata.json
@@ -1,0 +1,7 @@
+{
+  "sitemap": false,
+  "noindex": true,
+  "show_breadcrumbs": true,
+  "toc": false,
+  "body_class": "tutorial"
+}

--- a/src/content/get-started/index.md
+++ b/src/content/get-started/index.md
@@ -1,0 +1,38 @@
+---
+title: Learn Dart
+short-title: Learn
+breadcrumb: Tutorial
+description: >-
+  Begin your Dart learning journey by building an interactive CLI app.
+nextpage:
+  url: /get-started/first-program
+  title: Build your first app
+---
+
+:::warning Work in progress
+**These getting-started documents are in progress.**
+They shouldn't be considered a reliable source of information or
+a representation of their final state.
+
+If you are looking to learn Dart,
+check out the [Dart language documentation][], [Dart API docs][], or
+try out one of the topic-specific [Dart tutorials][].
+
+[Dart language documentation]: /language
+[Dart API docs]: {{site.dart-api}}
+[Dart tutorials]: /tutorials
+:::
+
+## Set up Dart {: #set-up }
+
+These lessons assume you're using the latest, stable version of Dart.
+
+To learn how to install or update Dart,
+follow the instructions on how to [Get the Dart SDK][].
+
+[Get the Dart SDK]: /get-dart
+
+## In progress lessons {: #lessons }
+
+1. [Build your first app](/get-started)
+2. [Add interactivity to your app](/get-started)


### PR DESCRIPTION
This prepares a `/get-started` directory that hides its child pages from the sitemap and asks search engines to not index them. In-progress FWE content can be placed here. Eventually custom tutorial functionality and styles will be applied within the directory as well.

The content is a placeholder so there's something clarifying there, feel free to change it as needed in other PRs.

**Staged:** https://dart-dev--pr6636-feat-hidden-fwe-directory-m2cikzvz.web.app/get-started