### PR TITLE
Fix ECMA typos in faq.md

### DIFF
--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -16,7 +16,7 @@ This page collects some of the top questions from the community.
 
 ### Q. Is there a specification for Dart?
 
-Yes. [EMCA-408][emca408] covers the Dart Programming Language Specification.
+Yes. [ECMA-408][ecma408] covers the Dart Programming Language Specification.
 
 Five versions have been published.
 The latest in-progress version covers to Dart 2.13-dev.
@@ -45,7 +45,7 @@ Google engineers also work in the public repository, making visible changes.
 The project has received many external patches
 and welcomes distributed committers.
 
-[emca408]: https://ecma-international.org/publications-and-standards/standards/ecma-408/
+[ecma408]: https://ecma-international.org/publications-and-standards/standards/ecma-408/
 [1st-ed]: {{ecma-pdf}}/ECMA-408_1st_edition_june_2014.pdf
 [2nd-ed]: {{ecma-pdf}}/ECMA-408_2nd_edition_december_2014.pdf
 [3rd-ed]: {{ecma-pdf}}/ECMA-408_3rd_edition_june_2015.pdf


### PR DESCRIPTION
This fixes ECMA being typoed as EMCA in a few places.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
