### PR TITLE
Fix build failure due to tsx changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "node": ">=22.11.0",
     "pnpm": ">=10.4.1"
   },
-  "packageManager": "pnpm@10.11.1",
+  "packageManager": "pnpm@10.12.1",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.1",
-    "@swc/html": "^1.11.31",
+    "@swc/html": "^1.12.0",
     "@types/hast": "^3.0.4",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.15.31",
@@ -37,6 +37,6 @@
     "markdown-it-deflist": "^3.0.0",
     "sass": "^1.89.2",
     "shiki": "^3.6.0",
-    "tsx": "^4.19.4"
+    "tsx": "4.19.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       '@swc/html':
-        specifier: ^1.11.31
-        version: 1.11.31
+        specifier: ^1.12.0
+        version: 1.12.0
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -63,7 +63,7 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       tsx:
-        specifier: ^4.19.4
+        specifier: 4.19.4
         version: 4.19.4
 
 packages:
@@ -389,68 +389,68 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/html-darwin-arm64@1.11.31':
-    resolution: {integrity: sha512-/BZ7KLfkua568iNNnLAlxa88P7gBiouZ+aW7LFcqfv62ueCpjLY7YSUXcVcb8bAoGwDcB+fO2xMYz5ABHcaFZg==}
+  '@swc/html-darwin-arm64@1.12.0':
+    resolution: {integrity: sha512-okpx8G7xGSPiSekxS4FQu3aR8k+q8nZJCfVKzanQxdZUaCm7YDVUci2Unqp9TvpgZJRA0GOWs1U3QMu2vdr0sQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/html-darwin-x64@1.11.31':
-    resolution: {integrity: sha512-J/gRwto/pxeKm4+fpS/ynn748dhRzsOrJKFHoFkDE79WRwxgbTkQUwLwn1AC336ssE9Bx0XvyJZI93hjs7JNyA==}
+  '@swc/html-darwin-x64@1.12.0':
+    resolution: {integrity: sha512-OWvHTNcnfIbrLWMq7JMmPRQh/Dx23+CX3WaRubotlBuXfKZf9cHKbbeOmW5t0h6gTQGGX3q4vEC8LQb7g6++Cg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/html-linux-arm-gnueabihf@1.11.31':
-    resolution: {integrity: sha512-cQo3snjtWnPl1AdC8JA6vANsO01ksCE81jNKxxJxnlkN/iP9F4nWG41/UboKsRK+sdyyFUoSJqz2HGy6aU4izA==}
+  '@swc/html-linux-arm-gnueabihf@1.12.0':
+    resolution: {integrity: sha512-l+gvFFgqFUlsHH1zoaYPjpNi2/6MSGmdsQfeC7juW1h7G+UhnKGyZKUxkXL2imV/+VQjN875S8G/gv2Z4tBg+g==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/html-linux-arm64-gnu@1.11.31':
-    resolution: {integrity: sha512-3rbfgMDGeLx52iFOCGaeeK8IEj1fT7gsvTWfXACJ4ns7MPupz6v3dVoGCIuzh0yHGAZPY0QL1iVAYjPLg8TrWw==}
+  '@swc/html-linux-arm64-gnu@1.12.0':
+    resolution: {integrity: sha512-ImZLbghifCPqQhwbEprv2zojieD0j/RGJ+tkNpJ6DyGqcf5qVFfPgGDe/WDPEHCMbJlAodvp1iKTdLSAdTfaLg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/html-linux-arm64-musl@1.11.31':
-    resolution: {integrity: sha512-vUKGadmgQaN5WtEHoXsihWKKeiTNxQ/hv4W7FejPNnV3EOBG0pcxKqMXqlXfzEP8ij2bnqy+JauW4RRX3PnV4g==}
+  '@swc/html-linux-arm64-musl@1.12.0':
+    resolution: {integrity: sha512-9TzNRjcRQWUSt2LX0MR5seibGimgGhXfHcPNH6w1ysa6N0Idu7Jpl3LB7B1K584LXjmZ47wFq5IOs6QHdKshXw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/html-linux-x64-gnu@1.11.31':
-    resolution: {integrity: sha512-6w9yZ1W23y17Y8NLTqy+efaAHjnqumSdn8PdCmBvMxwFRwjo9dNkkcDJsTZ5EERBMH+DnDbVR+HkuNypd0Y7Gw==}
+  '@swc/html-linux-x64-gnu@1.12.0':
+    resolution: {integrity: sha512-IVFXgsyn0/8e9nfVrQXAdGDFboom0nls7KSOJ/+oXMmdK917wrnYLDt7M4DyRT2c+xJmMxgR6tyaTW8KLAl02w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/html-linux-x64-musl@1.11.31':
-    resolution: {integrity: sha512-P/OSc/JlbCVfpZWg1eDhFJRC0iP3/PfP77MM/e01WFtM1QhriPBpYAOIXSdfWsPNGXa8keFP4vzm8BBNYyVKvw==}
+  '@swc/html-linux-x64-musl@1.12.0':
+    resolution: {integrity: sha512-QWNaGWES553AuGr46CXHLyfBBktnRWv32D87alvn3IBb/iJNHOqmcN2tUSFWiGCgWoylZWSa5OBWGj2ulk6AHg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/html-win32-arm64-msvc@1.11.31':
-    resolution: {integrity: sha512-/dlryiXq3SsXgV9FcG3klAE9kVVT7dW4eaiRpsW31GErlnVdTQ46rU6v2t+kqROmyW+LUpqo80ZGyynyeDS8Ag==}
+  '@swc/html-win32-arm64-msvc@1.12.0':
+    resolution: {integrity: sha512-MUmXWGnbngXeO/kARz26MLKxqLe5VYo+1EmkvxTfBajlcVnjdSZW1oFtP7d6eqxQSmVqU4mTtM9gELe2BnAbIQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/html-win32-ia32-msvc@1.11.31':
-    resolution: {integrity: sha512-PEqJca+mFz0wvmmODEgrcuoNyV7Oz5Tl6ttHOrk54dv4q8nErw/oH3xUdap2CL0uDeWV2Xbd2OXFXAMc3keK2g==}
+  '@swc/html-win32-ia32-msvc@1.12.0':
+    resolution: {integrity: sha512-k9pRORyAaL5fbMR2Isn3y2v+9tYElZ1XZp/Ff2RGNlKj/Y2IgDp+i4eUNPQzrcslAZKs7lTG1Rdax49uC8Wqzw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/html-win32-x64-msvc@1.11.31':
-    resolution: {integrity: sha512-TngLrcUJCA+U0P3YKe/8Tx7/MGeD45rDK4gY390ELIP3pNtUIW1dkfYasEexvG9NYb5u+hzJAg/Wf2ahztTIIQ==}
+  '@swc/html-win32-x64-msvc@1.12.0':
+    resolution: {integrity: sha512-vBFdG6x8A+NrPv+f2d01kBkUuD1O1bcoOLtwBegYK2W1lvRQCjUIwfM9eumPqUpaXsImZ1UMTW0n5tLJY7IoAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/html@1.11.31':
-    resolution: {integrity: sha512-KNgCP+wF+38piQj6Rv5tZyHBkEavtm7UxEgS/fU3T6wavj0Cj3NnOGVgOMJoN9YqpE2+wMWQARz3xZnUfXdXzg==}
+  '@swc/html@1.12.0':
+    resolution: {integrity: sha512-DBQ9bnNexbVUYkjpSkFA+t+QXmG7N0x8Xuv3fiNRGuEsCgtS1y3BZuoy9wTCettd2LL0d8QWCXXHnCxNl6WSvw==}
     engines: {node: '>=14'}
 
   '@types/hast@3.0.4':
@@ -484,8 +484,8 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.14.1:
-    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -537,8 +537,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -666,8 +666,8 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
-  entities@6.0.0:
-    resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   errno@1.0.0:
@@ -706,8 +706,8 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
-  fdir@6.4.5:
-    resolution: {integrity: sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==}
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -798,8 +798,8 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  immutable@5.1.2:
-    resolution: {integrity: sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==}
+  immutable@5.1.3:
+    resolution: {integrity: sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1143,6 +1143,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -1150,8 +1154,8 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  terser@5.40.0:
-    resolution: {integrity: sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==}
+  terser@5.42.0:
+    resolution: {integrity: sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1241,7 +1245,7 @@ snapshots:
   '@11ty/dependency-tree-esm@2.0.0':
     dependencies:
       '@11ty/eleventy-utils': 2.0.7
-      acorn: 8.14.1
+      acorn: 8.15.0
       dependency-graph: 1.0.0
       normalize-path: 3.0.0
 
@@ -1294,7 +1298,7 @@ snapshots:
       chokidar: 3.6.0
       debug: 4.4.1
       dependency-graph: 1.0.0
-      entities: 6.0.0
+      entities: 6.0.1
       filesize: 10.1.6
       gray-matter: 4.0.3
       iso-639-1: 3.1.5
@@ -1537,50 +1541,50 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/html-darwin-arm64@1.11.31':
+  '@swc/html-darwin-arm64@1.12.0':
     optional: true
 
-  '@swc/html-darwin-x64@1.11.31':
+  '@swc/html-darwin-x64@1.12.0':
     optional: true
 
-  '@swc/html-linux-arm-gnueabihf@1.11.31':
+  '@swc/html-linux-arm-gnueabihf@1.12.0':
     optional: true
 
-  '@swc/html-linux-arm64-gnu@1.11.31':
+  '@swc/html-linux-arm64-gnu@1.12.0':
     optional: true
 
-  '@swc/html-linux-arm64-musl@1.11.31':
+  '@swc/html-linux-arm64-musl@1.12.0':
     optional: true
 
-  '@swc/html-linux-x64-gnu@1.11.31':
+  '@swc/html-linux-x64-gnu@1.12.0':
     optional: true
 
-  '@swc/html-linux-x64-musl@1.11.31':
+  '@swc/html-linux-x64-musl@1.12.0':
     optional: true
 
-  '@swc/html-win32-arm64-msvc@1.11.31':
+  '@swc/html-win32-arm64-msvc@1.12.0':
     optional: true
 
-  '@swc/html-win32-ia32-msvc@1.11.31':
+  '@swc/html-win32-ia32-msvc@1.12.0':
     optional: true
 
-  '@swc/html-win32-x64-msvc@1.11.31':
+  '@swc/html-win32-x64-msvc@1.12.0':
     optional: true
 
-  '@swc/html@1.11.31':
+  '@swc/html@1.12.0':
     dependencies:
       '@swc/counter': 0.1.3
     optionalDependencies:
-      '@swc/html-darwin-arm64': 1.11.31
-      '@swc/html-darwin-x64': 1.11.31
-      '@swc/html-linux-arm-gnueabihf': 1.11.31
-      '@swc/html-linux-arm64-gnu': 1.11.31
-      '@swc/html-linux-arm64-musl': 1.11.31
-      '@swc/html-linux-x64-gnu': 1.11.31
-      '@swc/html-linux-x64-musl': 1.11.31
-      '@swc/html-win32-arm64-msvc': 1.11.31
-      '@swc/html-win32-ia32-msvc': 1.11.31
-      '@swc/html-win32-x64-msvc': 1.11.31
+      '@swc/html-darwin-arm64': 1.12.0
+      '@swc/html-darwin-x64': 1.12.0
+      '@swc/html-linux-arm-gnueabihf': 1.12.0
+      '@swc/html-linux-arm64-gnu': 1.12.0
+      '@swc/html-linux-arm64-musl': 1.12.0
+      '@swc/html-linux-x64-gnu': 1.12.0
+      '@swc/html-linux-x64-musl': 1.12.0
+      '@swc/html-win32-arm64-msvc': 1.12.0
+      '@swc/html-win32-ia32-msvc': 1.12.0
+      '@swc/html-win32-x64-msvc': 1.12.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1611,9 +1615,9 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
 
-  acorn@8.14.1: {}
+  acorn@8.15.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -1657,7 +1661,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -1767,7 +1771,7 @@ snapshots:
 
   entities@4.5.0: {}
 
-  entities@6.0.0: {}
+  entities@6.0.1: {}
 
   errno@1.0.0:
     dependencies:
@@ -1807,7 +1811,7 @@ snapshots:
 
   esm-import-transformer@3.0.3:
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
 
   esprima@4.0.1: {}
 
@@ -1819,7 +1823,7 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
-  fdir@6.4.5(picomatch@4.0.2):
+  fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -1956,7 +1960,7 @@ snapshots:
       entities: 4.5.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.40.0
+      terser: 5.42.0
 
   html-void-elements@3.0.0: {}
 
@@ -1977,7 +1981,7 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  immutable@5.1.2: {}
+  immutable@5.1.3: {}
 
   inherits@2.0.4: {}
 
@@ -2115,7 +2119,7 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
 
@@ -2139,7 +2143,7 @@ snapshots:
 
   node-retrieve-globals@6.0.1:
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
       acorn-walk: 8.3.4
       esm-import-transformer: 3.0.3
 
@@ -2178,7 +2182,7 @@ snapshots:
 
   parse5@7.3.0:
     dependencies:
-      entities: 6.0.0
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -2243,7 +2247,7 @@ snapshots:
   sass@1.89.2:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.2
+      immutable: 5.1.3
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.1
@@ -2269,7 +2273,7 @@ snapshots:
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2309,6 +2313,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -2316,16 +2322,16 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  terser@5.40.0:
+  terser@5.42.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.1
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.5(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
   to-regex-range@5.0.1:


### PR DESCRIPTION
Limit `tsx` to the previous release and upgrade other npm deps.