### PR TITLE
Fix leading margin in blockquotes

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -136,8 +136,14 @@ blockquote {
   margin: 0;
   margin-block-end: 1rem;
 
-  p:last-child {
-    margin-bottom: 0;
+  > p, > li, > ul, > ol {
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Removes the leading(top) margin from the first child of a blockquote, to avoid it having unsymmetrical padding.

---

**Before:**

<img width="768" alt="Blockquote before fix" src="https://github.com/user-attachments/assets/057b1870-71fb-4aed-aa3a-aabdd4820347" />


**After:**

<img width="768" alt="Blockquote after fix" src="https://github.com/user-attachments/assets/77467d98-4892-4b59-a051-4cf675bdced5" />

