### PR TITLE
Remove most Liquid usages from c-interop page

### DIFF
--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -14,6 +14,7 @@ repo:
     org: https://github.com/dart-lang
     sdk: https://github.com/dart-lang/sdk
     lang: https://github.com/dart-lang/language
+    samples: https://github.com/dart-lang/samples
 branch: main
 
 flutter: https://flutter.dev

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -51,14 +51,14 @@ previous section.
 
 The `hello_world` example has the following files:
 
-| **Source file**                  | **Description**                                                                |
-| -------------------------------- | ------------------------------------------------------------------------------ |
-| [`hello.dart`]                   | A Dart file that uses the `hello_world()` function from a C library.           |
-| [`pubspec.yaml`]                 | The Dart [pubspec](/tools/pub/pubspec) file, with an SDK lower bound of 3.4.   |
-| [`hello_library/hello.h`]        | Declares the `hello_world()` function.                                         |
-| [`hello_library/hello.c`]        | A C file that imports `hello.h` and defines the `hello_world()` function.      |
-| [`hello_library/hello.def`]      | A module-definition file which specifies information used when building a DLL. |
-| [`hello_library/CMakeLists.txt`] | A CMake build file for compiling the C code into a dynamic library.            |
+| **Source file**                    | **Description**                                                                |
+|------------------------------------|--------------------------------------------------------------------------------|
+| [`hello.dart`][]                   | A Dart file that uses the `hello_world()` function from a C library.           |
+| [`pubspec.yaml`][]                 | The Dart [pubspec](/tools/pub/pubspec) file, with an SDK lower bound of 3.4.   |
+| [`hello_library/hello.h`][]        | Declares the `hello_world()` function.                                         |
+| [`hello_library/hello.c`][]        | A C file that imports `hello.h` and defines the `hello_world()` function.      |
+| [`hello_library/hello.def`][]      | A module-definition file which specifies information used when building a DLL. |
+| [`hello_library/CMakeLists.txt`][] | A CMake build file for compiling the C code into a dynamic library.            |
 
 {: .table .table-striped }
 
@@ -104,7 +104,7 @@ consult Apple's [Code Signing Guide.][codesign]
 #### Leverage dart:ffi
 
 To learn how to call a C function using the `dart:ffi` library,
-review the [`hello.dart` file]({{hw}}/hello.dart).
+review the [`hello.dart` file][`hello.dart`].
 This section explains the contents of this file.
 
 1. Import `dart:ffi`.
@@ -210,16 +210,12 @@ The `dart:ffi` library provides multiple types that implement [`NativeType`][]
 and represent native types in C. You can instantiate some native types.
 Some other native types can be used only as markers in type signatures.
 
-[`NativeType`]: {{dart-ffi}}/NativeType-class.html
+[`NativeType`]: {{site.dart-api}}/dart-ffi/NativeType-class.html
 
 ### Can instantiate these type signature markers
 
 The following native types can be used as markers in type signatures.
 They or their subtypes _can_ be instantiated in Dart code.
-
-{% capture dart-ffi -%}
-{{site.dart-api}}/dart-ffi
-{%- endcapture %}
 
 | **Dart type** | **Description**                                                  |
 | ------------- | ---------------------------------------------------------------- |
@@ -230,10 +226,10 @@ They or their subtypes _can_ be instantiated in Dart code.
 
 {: .table .table-striped }
 
-[Array]: {{dart-ffi}}/Array-class.html
-[Pointer]: {{dart-ffi}}/Pointer-class.html
-[Struct]: {{dart-ffi}}/Struct-class.html
-[Union]: {{dart-ffi}}/Union-class.html
+[Array]: {{site.dart-api}}/dart-ffi/Array-class.html
+[Pointer]: {{site.dart-api}}/dart-ffi/Pointer-class.html
+[Struct]: {{site.dart-api}}/dart-ffi/Struct-class.html
+[Union]: {{site.dart-api}}/dart-ffi/Union-class.html
 
 ### Serve as type signature markers only
 
@@ -285,37 +281,37 @@ consult the API documentation linked in the following table.
 
 {: .table .table-striped }
 
-[Bool]: {{dart-ffi}}/Bool-class.html
-[Double]: {{dart-ffi}}/Double-class.html
-[Float]: {{dart-ffi}}/Float-class.html
-[Int8]: {{dart-ffi}}/Int8-class.html
-[Int16]: {{dart-ffi}}/Int16-class.html
-[Int32]: {{dart-ffi}}/Int32-class.html
-[Int64]: {{dart-ffi}}/Int64-class.html
-[NativeFunction]: {{dart-ffi}}/NativeFunction-class.html
-[Opaque]: {{dart-ffi}}/Opaque-class.html
-[Uint16]: {{dart-ffi}}/Uint16-class.html
-[Uint32]: {{dart-ffi}}/Uint32-class.html
-[Uint64]: {{dart-ffi}}/Uint64-class.html
-[Uint8]: {{dart-ffi}}/Uint8-class.html
-[Void]: {{dart-ffi}}/Void-class.html
+[Bool]: {{site.dart-api}}/dart-ffi/Bool-class.html
+[Double]: {{site.dart-api}}/dart-ffi/Double-class.html
+[Float]: {{site.dart-api}}/dart-ffi/Float-class.html
+[Int8]: {{site.dart-api}}/dart-ffi/Int8-class.html
+[Int16]: {{site.dart-api}}/dart-ffi/Int16-class.html
+[Int32]: {{site.dart-api}}/dart-ffi/Int32-class.html
+[Int64]: {{site.dart-api}}/dart-ffi/Int64-class.html
+[NativeFunction]: {{site.dart-api}}/dart-ffi/NativeFunction-class.html
+[Opaque]: {{site.dart-api}}/dart-ffi/Opaque-class.html
+[Uint16]: {{site.dart-api}}/dart-ffi/Uint16-class.html
+[Uint32]: {{site.dart-api}}/dart-ffi/Uint32-class.html
+[Uint64]: {{site.dart-api}}/dart-ffi/Uint64-class.html
+[Uint8]: {{site.dart-api}}/dart-ffi/Uint8-class.html
+[Void]: {{site.dart-api}}/dart-ffi/Void-class.html
 
-[ABI]: {{dart-ffi}}/Abi-class.html
-[AbiSpecificInteger]: {{dart-ffi}}/AbiSpecificInteger-class.html
-[Int]: {{dart-ffi}}/Int-class.html
-[IntPtr]: {{dart-ffi}}/IntPtr-class.html
-[Long]: {{dart-ffi}}/Long-class.html
-[LongLong]: {{dart-ffi}}/LongLong-class.html
-[Short]: {{dart-ffi}}/Short-class.html
-[SignedChar]: {{dart-ffi}}/SignedChar-class.html
-[Size]: {{dart-ffi}}/Size-class.html
-[UintPtr]: {{dart-ffi}}/UintPtr-class.html
-[UnsignedChar]: {{dart-ffi}}/UnsignedChar-class.html
-[UnsignedInt]: {{dart-ffi}}/UnsignedInt-class.html
-[UnsignedLong]: {{dart-ffi}}/UnsignedLong-class.html
-[UnsignedLongLong]: {{dart-ffi}}/UnsignedLongLong-class.html
-[UnsignedShort]: {{dart-ffi}}/UnsignedShort-class.html
-[WChar]: {{dart-ffi}}/WChar-class.html
+[ABI]: {{site.dart-api}}/dart-ffi/Abi-class.html
+[AbiSpecificInteger]: {{site.dart-api}}/dart-ffi/AbiSpecificInteger-class.html
+[Int]: {{site.dart-api}}/dart-ffi/Int-class.html
+[IntPtr]: {{site.dart-api}}/dart-ffi/IntPtr-class.html
+[Long]: {{site.dart-api}}/dart-ffi/Long-class.html
+[LongLong]: {{site.dart-api}}/dart-ffi/LongLong-class.html
+[Short]: {{site.dart-api}}/dart-ffi/Short-class.html
+[SignedChar]: {{site.dart-api}}/dart-ffi/SignedChar-class.html
+[Size]: {{site.dart-api}}/dart-ffi/Size-class.html
+[UintPtr]: {{site.dart-api}}/dart-ffi/UintPtr-class.html
+[UnsignedChar]: {{site.dart-api}}/dart-ffi/UnsignedChar-class.html
+[UnsignedInt]: {{site.dart-api}}/dart-ffi/UnsignedInt-class.html
+[UnsignedLong]: {{site.dart-api}}/dart-ffi/UnsignedLong-class.html
+[UnsignedLongLong]: {{site.dart-api}}/dart-ffi/UnsignedLongLong-class.html
+[UnsignedShort]: {{site.dart-api}}/dart-ffi/UnsignedShort-class.html
+[WChar]: {{site.dart-api}}/dart-ffi/WChar-class.html
 
 ## Generate FFI bindings with `package:ffigen`
 

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -32,11 +32,11 @@ It includes the following examples show how to use the `dart:ffi` library:
 
 {: .table .table-striped }
 
-[ffi samples]: {{site.repo.samples}}/tree/main/ffi
-[hello_world]: {{site.repo.samples}}/tree/main/ffi/hello_world
-[primitives]: {{site.repo.samples}}/tree/main/ffi/primitives
-[structs]: {{site.repo.samples}}/tree/main/ffi/structs
-[test_utils]: {{site.repo.samples}}/tree/main/ffi/test_utils
+[ffi samples]: {{site.repo.dart.samples}}/tree/main/ffi
+[hello_world]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world
+[primitives]: {{site.repo.dart.samples}}/tree/main/ffi/primitives
+[structs]: {{site.repo.dart.samples}}/tree/main/ffi/structs
+[test_utils]: {{site.repo.dart.samples}}/tree/main/ffi/test_utils
 
 ### Review the hello_world example
 
@@ -45,7 +45,7 @@ for calling a C library.
 This example can be found in the `samples/ffi` you downloaded in the
 previous section.
 
-[hello_world]: {{site.repo.samples}}/tree/main/ffi/hello_world
+[hello_world]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world
 
 #### Files
 
@@ -62,12 +62,12 @@ The `hello_world` example has the following files:
 
 {: .table .table-striped }
 
-[`hello.dart`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello.dart
-[`pubspec.yaml`]: {{site.repo.samples}}/tree/main/ffi/hello_world/pubspec.yaml
-[`hello_library/hello.h`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.h
-[`hello_library/hello.c`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.c
-[`hello_library/hello.def`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.def
-[`hello_library/CMakeLists.txt`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/CMakeLists.txt
+[`hello.dart`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/hello.dart
+[`pubspec.yaml`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/pubspec.yaml
+[`hello_library/hello.h`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/hello_library/hello.h
+[`hello_library/hello.c`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/hello_library/hello.c
+[`hello_library/hello.def`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/hello_library/hello.def
+[`hello_library/CMakeLists.txt`]: {{site.repo.dart.samples}}/tree/main/ffi/hello_world/hello_library/CMakeLists.txt
 
 Building the C library creates several files,
 including a dynamic library file named
@@ -202,7 +202,7 @@ To learn how, consult the following pages and examples.
 [android]: {{site.flutter-docs}}/platform-integration/android/c-interop
 [ios]: {{site.flutter-docs}}/platform-integration/ios/c-interop
 [macos]: {{site.flutter-docs}}/platform-integration/macos/c-interop
-[ffi-samples]: https://github.com/dart-lang/samples/tree/main/ffi
+[ffi-samples]: {{site.repo.dart.samples}}/tree/main/ffi
 
 ## Interface with native types
 

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -1,8 +1,6 @@
 ---
 title: "C interop using dart:ffi"
 description: "To use C code in your Dart program, use the dart:ffi library."
-hw: "https://github.com/dart-lang/samples/tree/main/ffi/hello_world"
-samples: "https://github.com/dart-lang/samples/tree/main/ffi"
 ---
 
 Dart mobile, command-line, and server apps
@@ -14,12 +12,15 @@ Other terms for similar functionality include
 _native interface_ and _language bindings._
 
 API documentation is available in the
-[`dart:ffi` API reference.]({{site.dart-api}}/dart-ffi/dart-ffi-library.html)
+[`dart:ffi` API reference][dart-ffi].
+
+[FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
+[dart-ffi]: {{site.dart-api}}/dart-ffi/dart-ffi-library.html
 
 ## Download example files
 
 To work with the examples in this guide,
-download the full [ffi samples]({{samples}}) directory.
+download the full [ffi samples][] directory.
 It includes the following examples show how to use the `dart:ffi` library:
 
 | **Example**     | **Description**                                                                                         |
@@ -31,12 +32,20 @@ It includes the following examples show how to use the `dart:ffi` library:
 
 {: .table .table-striped }
 
+[ffi samples]: {{site.repo.samples}}/tree/main/ffi
+[hello_world]: {{site.repo.samples}}/tree/main/ffi/hello_world
+[primitives]: {{site.repo.samples}}/tree/main/ffi/primitives
+[structs]: {{site.repo.samples}}/tree/main/ffi/structs
+[test_utils]: {{site.repo.samples}}/tree/main/ffi/test_utils
+
 ### Review the hello_world example
 
 The [hello_world example][hello_world] has the minimum necessary code
 for calling a C library.
 This example can be found in the `samples/ffi` you downloaded in the
 previous section.
+
+[hello_world]: {{site.repo.samples}}/tree/main/ffi/hello_world
 
 #### Files
 
@@ -53,12 +62,12 @@ The `hello_world` example has the following files:
 
 {: .table .table-striped }
 
-[`hello.dart`]: {{hw}}/hello.dart
-[`pubspec.yaml`]: {{hw}}/pubspec.yaml
-[`hello_library/hello.h`]: {{hw}}/hello_library/hello.h
-[`hello_library/hello.c`]: {{hw}}/hello_library/hello.c
-[`hello_library/hello.def`]: {{hw}}/hello_library/hello.def
-[`hello_library/CMakeLists.txt`]: {{hw}}/hello_library/CMakeLists.txt
+[`hello.dart`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello.dart
+[`pubspec.yaml`]: {{site.repo.samples}}/tree/main/ffi/hello_world/pubspec.yaml
+[`hello_library/hello.h`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.h
+[`hello_library/hello.c`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.c
+[`hello_library/hello.def`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/hello.def
+[`hello_library/CMakeLists.txt`]: {{site.repo.samples}}/tree/main/ffi/hello_world/hello_library/CMakeLists.txt
 
 Building the C library creates several files,
 including a dynamic library file named
@@ -188,13 +197,20 @@ To learn how, consult the following pages and examples.
 * Flutter `dart:ffi` for [Android][android] apps
 * Flutter `dart:ffi` for [iOS][ios] apps
 * Flutter `dart:ffi` for [macOS][macos] apps
-* [`dart:ffi` examples]({{samples}})
+* [`dart:ffi` examples][ffi-samples]
+
+[android]: {{site.flutter-docs}}/platform-integration/android/c-interop
+[ios]: {{site.flutter-docs}}/platform-integration/ios/c-interop
+[macos]: {{site.flutter-docs}}/platform-integration/macos/c-interop
+[ffi-samples]: https://github.com/dart-lang/samples/tree/main/ffi
 
 ## Interface with native types
 
 The `dart:ffi` library provides multiple types that implement [`NativeType`][]
 and represent native types in C. You can instantiate some native types.
 Some other native types can be used only as markers in type signatures.
+
+[`NativeType`]: {{dart-ffi}}/NativeType-class.html
 
 ### Can instantiate these type signature markers
 
@@ -213,6 +229,11 @@ They or their subtypes _can_ be instantiated in Dart code.
 | [Union][]     | The supertype of all FFI union types.                            |
 
 {: .table .table-striped }
+
+[Array]: {{dart-ffi}}/Array-class.html
+[Pointer]: {{dart-ffi}}/Pointer-class.html
+[Struct]: {{dart-ffi}}/Struct-class.html
+[Union]: {{dart-ffi}}/Union-class.html
 
 ### Serve as type signature markers only
 
@@ -264,12 +285,46 @@ consult the API documentation linked in the following table.
 
 {: .table .table-striped }
 
+[Bool]: {{dart-ffi}}/Bool-class.html
+[Double]: {{dart-ffi}}/Double-class.html
+[Float]: {{dart-ffi}}/Float-class.html
+[Int8]: {{dart-ffi}}/Int8-class.html
+[Int16]: {{dart-ffi}}/Int16-class.html
+[Int32]: {{dart-ffi}}/Int32-class.html
+[Int64]: {{dart-ffi}}/Int64-class.html
+[NativeFunction]: {{dart-ffi}}/NativeFunction-class.html
+[Opaque]: {{dart-ffi}}/Opaque-class.html
+[Uint16]: {{dart-ffi}}/Uint16-class.html
+[Uint32]: {{dart-ffi}}/Uint32-class.html
+[Uint64]: {{dart-ffi}}/Uint64-class.html
+[Uint8]: {{dart-ffi}}/Uint8-class.html
+[Void]: {{dart-ffi}}/Void-class.html
+
+[ABI]: {{dart-ffi}}/Abi-class.html
+[AbiSpecificInteger]: {{dart-ffi}}/AbiSpecificInteger-class.html
+[Int]: {{dart-ffi}}/Int-class.html
+[IntPtr]: {{dart-ffi}}/IntPtr-class.html
+[Long]: {{dart-ffi}}/Long-class.html
+[LongLong]: {{dart-ffi}}/LongLong-class.html
+[Short]: {{dart-ffi}}/Short-class.html
+[SignedChar]: {{dart-ffi}}/SignedChar-class.html
+[Size]: {{dart-ffi}}/Size-class.html
+[UintPtr]: {{dart-ffi}}/UintPtr-class.html
+[UnsignedChar]: {{dart-ffi}}/UnsignedChar-class.html
+[UnsignedInt]: {{dart-ffi}}/UnsignedInt-class.html
+[UnsignedLong]: {{dart-ffi}}/UnsignedLong-class.html
+[UnsignedLongLong]: {{dart-ffi}}/UnsignedLongLong-class.html
+[UnsignedShort]: {{dart-ffi}}/UnsignedShort-class.html
+[WChar]: {{dart-ffi}}/WChar-class.html
+
 ## Generate FFI bindings with `package:ffigen`
 
 For large API surfaces, it can be time-consuming
 to write the Dart bindings that integrate with the C code.
 To have Dart create FFI wrappers from C header files,
 use the [`package:ffigen`][ffigen] binding generator.
+
+[ffigen]: {{site.pub-pkg}}/ffigen
 
 <a id="native-assets" aria-hidden="true"></a>
 
@@ -298,6 +353,9 @@ Flutter and standalone Dart automatically bundle the
 native code of all packages used by the app and make it available at runtime.
 This works for `flutter (run|build)` as well as `dart (run|build)`.
 
+[`CodeAsset`]: {{site.pub-api}}/code_assets/latest/code_assets/CodeAsset-class.html
+[`assetId`]: {{site.dart-api}}/dart-ffi/Native/assetId.html
+
 ### Review the `native_add_library` example
 
 The [`native_add_library`][] example includes the minimum code to
@@ -314,19 +372,18 @@ The example includes the following files:
 
 {: .table .table-striped }
 
-{% capture native-assets -%}
-{{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library
-{%- endcapture %}
-
-[`src/native_add_library.c`]: {{native-assets}}/src/native_add_library.c
-[`lib/native_add_library.dart`]: {{native-assets}}/lib/native_add_library.dart
-[`test/native_add_library_test.dart`]: {{native-assets}}/test/native_add_library_test.dart
-[`hook/build.dart`]: {{native-assets}}/hook/build.dart
+[`src/native_add_library.c`]: {{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library/src/native_add_library.c
+[`lib/native_add_library.dart`]: {{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library/lib/native_add_library.dart
+[`test/native_add_library_test.dart`]: {{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library/test/native_add_library_test.dart
+[`hook/build.dart`]: {{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library/hook/build.dart
 
 When a Dart or Flutter project depends on `package:native_add_library`,
 it invokes the `hook/build.dart` build hook when
 running the `run`, `build`, and `test` commands.
 The [`native_add_app`][] example showcases a use of `native_add_library`.
+
+[`native_add_library`]: {{site.repo.dart.org}}/native/blob/main/pkgs/hooks/example/build/native_add_library
+[`native_add_app`]: {{site.repo.dart.org}}/native/tree/main/pkgs/hooks/example/build/native_add_app
 
 ### Review build hooks API docs
 
@@ -337,61 +394,13 @@ API documentation can be found for the following packages:
 * To learn about the `hook/build.dart` build hook,
   consult the [`package:hooks` API reference][].
 
+[`Native`]: {{site.dart-api}}/dart-ffi/Native-class.html
+[`DefaultAsset`]: {{site.dart-api}}/dart-ffi/DefaultAsset-class.html
+[`package:hooks` API reference]: {{site.pub-api}}/hooks/latest/
+
 ### Provide feedback
 
 To provide feedback, consult these tracking issues:
 
 * [Dart build hooks & code assets]({{site.repo.dart.sdk}}/issues/50565)
 * [Flutter build hooks & code assets](https://github.com/flutter/flutter/issues/129757)
-
-[`CodeAsset`]: {{site.pub-api}}/code_assets/latest/code_assets/CodeAsset-class.html
-[`assetId`]: {{site.dart-api}}/dart-ffi/Native/assetId.html
-[`DefaultAsset`]: {{site.dart-api}}/dart-ffi/DefaultAsset-class.html
-[`native_add_app`]: {{site.repo.dart.org}}/native/tree/main/pkgs/hooks/example/build/native_add_app
-[`native_add_library`]: {{native-assets}}
-[`Native`]: {{site.dart-api}}/dart-ffi/Native-class.html
-[`NativeType`]: {{dart-ffi}}/NativeType-class.html
-[`package:hooks` API reference]: {{site.pub-api}}/hooks/latest/
-[ABI]: {{dart-ffi}}/Abi-class.html
-[AbiSpecificInteger]: {{dart-ffi}}/AbiSpecificInteger-class.html
-[android]: {{site.flutter-docs}}/development/platform-integration/android/c-interop
-[Bool]: {{dart-ffi}}/Bool-class.html
-[Double]: {{dart-ffi}}/Double-class.html
-[FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
-[ffigen]: {{site.pub-pkg}}/ffigen
-[Float]: {{dart-ffi}}/Float-class.html
-[hello_world]: {{hw}}
-[Int]: {{dart-ffi}}/Int-class.html
-[Int16]: {{dart-ffi}}/Int16-class.html
-[Int32]: {{dart-ffi}}/Int32-class.html
-[Int64]: {{dart-ffi}}/Int64-class.html
-[Int8]: {{dart-ffi}}/Int8-class.html
-[IntPtr]: {{dart-ffi}}/IntPtr-class.html
-[ios]: {{site.flutter-docs}}/development/platform-integration/ios/c-interop
-[Long]: {{dart-ffi}}/Long-class.html
-[LongLong]: {{dart-ffi}}/LongLong-class.html
-[macos]: {{site.flutter-docs}}/development/platform-integration/macos/c-interop
-[NativeFunction]: {{dart-ffi}}/NativeFunction-class.html
-[Opaque]: {{dart-ffi}}/Opaque-class.html
-[primitives]: {{samples}}/primitives
-[Short]: {{dart-ffi}}/Short-class.html
-[SignedChar]: {{dart-ffi}}/SignedChar-class.html
-[Size]: {{dart-ffi}}/Size-class.html
-[structs]: {{samples}}/structs
-[test_utils]: {{samples}}/test_utils
-[Uint16]: {{dart-ffi}}/Uint16-class.html
-[Uint32]: {{dart-ffi}}/Uint32-class.html
-[Uint64]: {{dart-ffi}}/Uint64-class.html
-[Uint8]: {{dart-ffi}}/Uint8-class.html
-[UintPtr]: {{dart-ffi}}/UintPtr-class.html
-[UnsignedChar]: {{dart-ffi}}/UnsignedChar-class.html
-[UnsignedInt]: {{dart-ffi}}/UnsignedInt-class.html
-[UnsignedLong]: {{dart-ffi}}/UnsignedLong-class.html
-[UnsignedLongLong]: {{dart-ffi}}/UnsignedLongLong-class.html
-[UnsignedShort]: {{dart-ffi}}/UnsignedShort-class.html
-[Void]: {{dart-ffi}}/Void-class.html
-[WChar]: {{dart-ffi}}/WChar-class.html
-[Array]: {{dart-ffi}}/Array-class.html
-[Pointer]: {{dart-ffi}}/Pointer-class.html
-[Struct]: {{dart-ffi}}/Struct-class.html
-[Union]: {{dart-ffi}}/Union-class.html

--- a/src/content/language/extension-methods.md
+++ b/src/content/language/extension-methods.md
@@ -284,4 +284,4 @@ For more information about extension methods, see the following:
 
 [specification]: {{site.repo.dart.lang}}/blob/main/accepted/2.7/static-extension-methods/feature-specification.md#dart-static-extension-methods-design
 [article]: https://medium.com/dartlang/extension-methods-2d466cd8b308
-[sample]: {{site.repo.dart.org}}/samples/tree/main/extension_methods
+[sample]: {{site.repo.dart.samples}}/tree/main/extension_methods

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -112,7 +112,7 @@ main isolate, because it's running concurrently either way.
 
 For the complete program, check out the [send_and_receive.dart][] sample.
 
-[send_and_receive.dart]: {{site.repo.dart.org}}/samples/blob/main/isolates/bin/send_and_receive.dart
+[send_and_receive.dart]: {{site.repo.dart.samples}}/blob/main/isolates/bin/send_and_receive.dart
 [background worker]: /language/concurrency#background-workers
 [main isolate]: /language/concurrency#the-main-isolate
 

--- a/src/content/null-safety/index.md
+++ b/src/content/null-safety/index.md
@@ -187,7 +187,7 @@ To learn more about null safety, check out the following resources:
 * [Null safety FAQ][]
 * [Null safety sample code][calculate_lix]
 
-[calculate_lix]: {{site.repo.dart.org}}/samples/tree/main/null_safety/calculate_lix
+[calculate_lix]: {{site.repo.dart.samples}}/tree/main/null_safety/calculate_lix
 [migration guide]: /null-safety/migration-guide
 [Null safety FAQ]: /null-safety/faq
 [Understanding null safety]: /null-safety/understanding-null-safety

--- a/src/content/resources/google-apis.md
+++ b/src/content/resources/google-apis.md
@@ -56,4 +56,4 @@ To find wrapper packages for Google client APIs, search for
 [gsheets-api-docs]: {{site.pub-api}}/gsheets/latest/gsheets/gsheets-library.html
 [gsheets-api-docs-gapi]: {{site.pub-api}}/googleapis/latest/sheets_v4/sheets_v4-library.html
 [flutter-google-apis]: {{site.flutter-docs}}/development/data-and-backend/google-apis
-[server-sample]: {{site.repo.dart.org}}/samples/tree/main/server/google_apis
+[server-sample]: {{site.repo.dart.samples}}/tree/main/server/google_apis

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -81,7 +81,7 @@ If you _want_ to use App Engine, consider using the [`appengine` package][].
 [`appengine` package]: {{site.pub-pkg}}/appengine
 [ce]: https://cloud.google.com/compute/docs/containers
 [cr]: https://cloud.google.com/run/docs/quickstarts/build-and-deploy/other
-[server examples]: {{site.repo.dart.org}}/samples/tree/main/server
+[server examples]: {{site.repo.dart.samples}}/tree/main/server
 [GKE overview]: https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview
 [Dart Functions Framework]: {{site.pub-pkg}}/functions_framework
 [CloudEvents]: https://cloudevents.io/

--- a/src/content/tools/dart-compile.md
+++ b/src/content/tools/dart-compile.md
@@ -66,7 +66,7 @@ Refer to the [native_app][] sample for a simple example of using `dart compile`
 to compile a native app, 
 followed by examples of running the app.
 
-[native_app]: {{site.repo.dart.org}}/samples/tree/main/native_app
+[native_app]: {{site.repo.dart.samples}}/tree/main/native_app
 [dart-run]: /tools/dart-run
 
 ## Subcommands

--- a/src/content/tutorials/server/cmdline.md
+++ b/src/content/tutorials/server/cmdline.md
@@ -637,7 +637,7 @@ and [`package:args`]({{argsAPI}}/args-library.html).
 For another example of a command line app, 
 check out the [`command_line`][] sample.
 
-[`command_line`]: {{site.repo.dart.org}}/samples/tree/main/command_line
+[`command_line`]: {{site.repo.dart.samples}}/tree/main/command_line
 
 ## What next?
 

--- a/src/content/tutorials/server/get-started.md
+++ b/src/content/tutorials/server/get-started.md
@@ -153,7 +153,7 @@ Check out these resources:
   * [Dart tools](/tools)
   * [IDEs](/tools#editors)
 * Other examples of natively compiled apps
-  * [native_app]({{site.repo.dart.org}}/samples/tree/main/native_app)
+  * [native_app]({{site.repo.dart.samples}}/tree/main/native_app)
 
 If you get stuck, find help at [Community and support.](/community)
 

--- a/src/content/tutorials/server/httpserver.md
+++ b/src/content/tutorials/server/httpserver.md
@@ -28,12 +28,12 @@ Dart resources for writing HTTP servers include:
     [`shelf_router`][] packages.
   * Is deployable on Cloud Run.
 
-[cloud-sample]: {{site.repo.dart.org}}/samples/tree/main/server/google_apis
+[cloud-sample]: {{site.repo.dart.samples}}/tree/main/server/google_apis
 [`googleapis`]: {{site.pub-pkg}}/googleapis
 [`googleapis_auth`]: {{site.pub-pkg}}/googleapis_auth
 [`shelf`]: {{site.pub-pkg}}/shelf
 [`shelf_router`]: {{site.pub-pkg}}/shelf_router
 [`shelf_static`]: {{site.pub-pkg}}/shelf_static
-[simple-sample]: {{site.repo.dart.org}}/samples/tree/main/server/simple
+[simple-sample]: {{site.repo.dart.samples}}/tree/main/server/simple
 [Using Google APIs]: /resources/google-apis
 [Using Google Cloud]: /server/google-cloud


### PR DESCRIPTION
This will help make https://github.com/dart-lang/site-www/pull/6702 a bit more focused.