### PR TITLE
Update lints and clean up ignores in examples

### DIFF
--- a/examples/analysis/lib/strict_modes.dart
+++ b/examples/analysis/lib/strict_modes.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: dead_code
-// ignore_for_file: unused_local_variable
-
 import 'dart:convert';
 
 import 'package:examples_util/ellipsis.dart';

--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -21,6 +21,7 @@ linter:
     - prefer_single_quotes
     - sort_child_properties_last
     - sort_unnamed_constructors_first
+    - specify_nonobvious_property_types
     - strict_top_level_inference
     - test_types_in_equals
     - throw_in_finally
@@ -32,3 +33,4 @@ linter:
     - unnecessary_underscores
     - use_enums
     - use_truncating_division
+    - use_null_aware_elements

--- a/examples/async_await/lib/practice_errors/test.dart
+++ b/examples/async_await/lib/practice_errors/test.dart
@@ -2,7 +2,7 @@ import 'package:examples_util/codelabs.dart';
 
 import 'solution.dart';
 
-const _result = result;
+const void Function(bool success, [List<String> messages]) _result = result;
 
 // #docregion
 List<String> messages = [];

--- a/examples/async_await/lib/practice_using/test.dart
+++ b/examples/async_await/lib/practice_using/test.dart
@@ -2,7 +2,7 @@ import 'package:examples_util/codelabs.dart';
 
 import 'solution.dart';
 
-const _result = result;
+const void Function(bool success, [List<String> messages]) _result = result;
 
 // #docregion
 const role = 'administrator';

--- a/examples/async_await/lib/putting_together/test.dart
+++ b/examples/async_await/lib/putting_together/test.dart
@@ -2,7 +2,7 @@ import 'package:examples_util/codelabs.dart';
 
 import 'solution.dart';
 
-const _result = result;
+const void Function(bool success, [List<String> messages]) _result = result;
 
 // #docregion
 List<String> messages = [];

--- a/examples/concurrency/lib/basic_ports_example/parse_json.dart
+++ b/examples/concurrency/lib/basic_ports_example/parse_json.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unused_field
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';

--- a/examples/concurrency/lib/basic_ports_example/spawn.dart
+++ b/examples/concurrency/lib/basic_ports_example/spawn.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unused_field
-
 import 'dart:async';
 import 'dart:isolate';
 

--- a/examples/concurrency/lib/basic_ports_example/start.dart
+++ b/examples/concurrency/lib/basic_ports_example/start.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field, unused_element
+// ignore_for_file: unused_element
 import 'dart:isolate';
 
 // #docregion worker

--- a/examples/concurrency/lib/basic_ports_example/start_remote_isolate.dart
+++ b/examples/concurrency/lib/basic_ports_example/start_remote_isolate.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unused_field
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';

--- a/examples/concurrency/lib/robust_ports_example/complete.dart
+++ b/examples/concurrency/lib/robust_ports_example/complete.dart
@@ -32,7 +32,7 @@ class Worker {
   }
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/examples/concurrency/lib/robust_ports_example/spawn_2.dart
+++ b/examples/concurrency/lib/robust_ports_example/spawn_2.dart
@@ -9,7 +9,7 @@ class Worker {
   final ReceivePort _responses;
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/examples/concurrency/lib/robust_ports_example/step_4.dart
+++ b/examples/concurrency/lib/robust_ports_example/step_4.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field, body_might_complete_normally_nullable, unused_element
+// ignore_for_file: body_might_complete_normally_nullable
 
 import 'dart:async';
 import 'dart:convert';
@@ -11,7 +11,7 @@ class Worker {
   // #enddocregion constructor
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/examples/concurrency/lib/robust_ports_example/step_5_add_completers.dart
+++ b/examples/concurrency/lib/robust_ports_example/step_5_add_completers.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unused_field, body_might_complete_normally_nullable, unused_element
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
@@ -13,7 +11,7 @@ class Worker {
   // #enddocregion vars
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/examples/concurrency/lib/robust_ports_example/step_6_close_ports.dart
+++ b/examples/concurrency/lib/robust_ports_example/step_6_close_ports.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: unused_field, body_might_complete_normally_nullable, unused_element
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
@@ -14,7 +13,7 @@ class Worker {
   int _idCounter = 0;
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/examples/futures/lib/simple.dart
+++ b/examples/futures/lib/simple.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: dead_code, invalid_return_type_for_catch_error, one_member_abstracts
+// ignore_for_file: dead_code, invalid_return_type_for_catch_error
 
 import 'dart:async';
 

--- a/examples/misc/bin/try_dart/collection_literals.dart
+++ b/examples/misc/bin/try_dart/collection_literals.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type_annotate_public_apis
 // A list literal.
 const lostNumbers = [4, 8, 15, 16, 23, 42];
 

--- a/examples/misc/lib/effective_dart/design_bad.dart
+++ b/examples/misc/lib/effective_dart/design_bad.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: close_sinks, type_annotate_public_apis, unused_element, unused_local_variable, avoid_types_as_parameter_names
 // ignore_for_file: type_init_formals, unused_field, always_declare_return_types, strict_raw_type, prefer_typing_uninitialized_variables
-// ignore_for_file: use_function_type_syntax_for_parameters, prefer_generic_function_type_aliases, avoid_null_checks_in_equality_operators
+// ignore_for_file: use_function_type_syntax_for_parameters, prefer_generic_function_type_aliases, specify_nonobvious_property_types
 // ignore_for_file: non_nullable_equals_parameter
 
 import 'dart:async';
@@ -271,7 +271,6 @@ class Person1 {
   // #enddocregion eq-dont-check-for-null
   Person1(this.name);
   int get hashCode => ellipsis();
-  // ignore_for_file: unnecessary_null_comparison
   // #docregion eq-dont-check-for-null
 
   bool operator ==(Object? other) =>

--- a/examples/misc/lib/effective_dart/design_good.dart
+++ b/examples/misc/lib/effective_dart/design_good.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: close_sinks, type_annotate_public_apis, unused_element
+// ignore_for_file: close_sinks, unused_element
 // ignore_for_file: unused_local_variable, strict_raw_type, use_function_type_syntax_for_parameters
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 

--- a/examples/misc/lib/effective_dart/docs_bad.dart
+++ b/examples/misc/lib/effective_dart/docs_bad.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, unused_element
+// ignore_for_file: unused_element
 import 'package:examples_util/ellipsis.dart';
 
 void miscDeclAnalyzedButNotTested() {

--- a/examples/misc/lib/effective_dart/docs_good.dart
+++ b/examples/misc/lib/effective_dart/docs_good.dart
@@ -1,5 +1,4 @@
-// ignore_for_file: type_annotate_public_apis, unused_element, strict_raw_type
-// ignore_for_file: no_leading_underscores_for_local_identifiers, use_function_type_syntax_for_parameters
+// ignore_for_file: unused_element, strict_raw_type, no_leading_underscores_for_local_identifiers
 
 // #docregion library-doc
 /// A really great test library.

--- a/examples/misc/lib/effective_dart/style_bad.dart
+++ b/examples/misc/lib/effective_dart/style_bad.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names, type_annotate_public_apis, curly_braces_in_flow_control_structures
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, curly_braces_in_flow_control_structures
 import 'dart:math';
 
 // #docregion const-names

--- a/examples/misc/lib/effective_dart/style_good.dart
+++ b/examples/misc/lib/effective_dart/style_good.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: annotate_overrides, type_annotate_public_apis, unused_element, unused_local_variable, sdk_version_extension_methods
+// ignore_for_file: unused_element, unused_local_variable, sdk_version_extension_methods
 import 'dart:io';
 import 'dart:math';
 

--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -1,11 +1,10 @@
-// ignore_for_file: avoid_init_to_null, empty_constructor_bodies, final_not_initialized_constructor_1
-// ignore_for_file: type_annotate_public_apis, type_init_formals, unnecessary_brace_in_string_interps
-// ignore_for_file: unnecessary_getters_setters, unused_element, unused_local_variable, prefer_equal_for_default_values
+// ignore_for_file: avoid_init_to_null, empty_constructor_bodies, unnecessary_brace_in_string_interps
+// ignore_for_file: unnecessary_getters_setters, unused_element, unused_local_variable
 // ignore_for_file: use_rethrow_when_possible, prefer_is_empty, prefer_iterable_wheretype, prefer_initializing_formals
-// ignore_for_file: prefer_typing_uninitialized_variables, prefer_collection_literals, unnecessary_cast, strict_raw_type
+// ignore_for_file: prefer_collection_literals, strict_raw_type
 // ignore_for_file: avoid_function_literals_in_foreach_calls, prefer_function_declarations_over_variables
 // ignore_for_file: prefer_adjacent_string_concatenation, prefer_is_not_empty, prefer_interpolation_to_compose_strings
-// ignore_for_file: unnecessary_this, always_declare_return_types, no_leading_underscores_for_local_identifiers
+// ignore_for_file: unnecessary_this, no_leading_underscores_for_local_identifiers
 // ignore_for_file: unchecked_use_of_nullable_value, unnecessary_library_directive, unnecessary_library_name
 
 // #docregion library-dir

--- a/examples/misc/lib/effective_dart/usage_good.dart
+++ b/examples/misc/lib/effective_dart/usage_good.dart
@@ -1,7 +1,5 @@
-// ignore_for_file: type_annotate_public_apis, unused_element, unused_local_variable
-// ignore_for_file: prefer_function_declarations_over_variables, strict_raw_type,
-// ignore_for_file: prefer_initializing_formals, prefer_typing_uninitialized_variables
-// ignore_for_file: use_super_parameters, dead_code
+// ignore_for_file:  unused_element, unused_local_variable, specify_nonobvious_property_types
+// ignore_for_file: strict_raw_type, prefer_initializing_formals, use_super_parameters, dead_code
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
@@ -80,7 +78,6 @@ void miscDeclAnalyzedButNotTested() {
   {
     var command = 'c';
     var options = ['a'];
-    // ignore: unnecessary_cast
     var modeFlags = ['b'] as List<String>?;
     var filePaths = ['p'];
     String removeExtension(String path) => path;

--- a/examples/misc/lib/language_tour/async.dart
+++ b/examples/misc/lib/language_tour/async.dart
@@ -78,7 +78,6 @@ Future<void> miscDeclAnalyzedButNotTested() async {
 
   <varOrType>(Stream<varOrType> expression) async {
     // #docregion await-for
-    // ignore: prefer_final_in_for_each
     await for (varOrType identifier in expression) {
       // Executes each time the stream emits a value.
     }

--- a/examples/misc/lib/language_tour/callable_objects.dart
+++ b/examples/misc/lib/language_tour/callable_objects.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: type_annotate_public_apis
+// ignore_for_file: type_annotate_public_apis, specify_nonobvious_property_types
 class WannabeFunction {
   String call(String a, String b, String c) => '$a $b $c!';
 }

--- a/examples/misc/lib/language_tour/classes/employee.dart
+++ b/examples/misc/lib/language_tour/classes/employee.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unnecessary_cast, strict_raw_type, use_super_parameters
+// ignore_for_file: strict_raw_type, use_super_parameters
 
 Map fetchDefaultData() => {}; // stub
 

--- a/examples/misc/lib/language_tour/classes/misc.dart
+++ b/examples/misc/lib/language_tour/classes/misc.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: annotate_overrides, one_member_abstracts
+// ignore_for_file: one_member_abstracts
 // #docregion abstract
 // This class is declared abstract and thus
 // can't be instantiated.
@@ -21,7 +21,7 @@ class Point implements Comparable, Location {
 
 // #docregion static-field
 class Queue {
-  static const initialCapacity = 16; // ignore: type_annotate_public_apis
+  static const initialCapacity = 16;
   // #enddocregion static-field
   // #docregion static-field
 }

--- a/examples/misc/lib/language_tour/classes/point_alt.dart
+++ b/examples/misc/lib/language_tour/classes/point_alt.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: prefer_initializing_formals
 /// Example of:
 ///
 /// - A constructor initializing fields in the body "the long way"

--- a/examples/misc/lib/language_tour/functions.dart
+++ b/examples/misc/lib/language_tour/functions.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_element, type_annotate_public_apis, always_declare_return_types
+// ignore_for_file: unused_element, always_declare_return_types
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
 void miscDeclAnalyzedButNotTested() {

--- a/examples/misc/lib/library_tour/async/future.dart
+++ b/examples/misc/lib/library_tour/async/future.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_element, type_annotate_public_apis, strict_raw_type
+// ignore_for_file: unused_element, strict_raw_type
 // #docregion import
 import 'dart:async';
 // #enddocregion import

--- a/examples/misc/lib/library_tour/core/collections.dart
+++ b/examples/misc/lib/library_tour/core/collections.dart
@@ -1,7 +1,7 @@
 void miscDeclAnalyzedButNotTested() {
   var fruits = <String>[];
   // #docregion list-of-string
-  // ignore: argument_type_not_assignable, unused_local_variable
+  // ignore: argument_type_not_assignable
   fruits.add(5); // Error: 'int' can't be assigned to 'String'
   // #enddocregion list-of-string
 }

--- a/examples/misc/lib/tutorial/stream_interface.dart
+++ b/examples/misc/lib/tutorial/stream_interface.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: annotate_overrides, type_annotate_public_apis, strict_raw_type
+// ignore_for_file: annotate_overrides, strict_raw_type
 import 'dart:async';
 
 abstract class MyStream<T> implements Stream<T> {

--- a/examples/misc/test/cheatsheet/null_aware_test.dart
+++ b/examples/misc/test/cheatsheet/null_aware_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, unnecessary_null_in_if_null_operators, dead_null_aware_expression, unnecessary_null_comparison
+// ignore_for_file: unnecessary_null_in_if_null_operators, dead_null_aware_expression, unnecessary_null_comparison
 
 import 'package:test/test.dart';
 

--- a/examples/misc/test/language_tour/async_test.dart
+++ b/examples/misc/test/language_tour/async_test.dart
@@ -1,4 +1,5 @@
-// ignore_for_file: type_annotate_public_apis, curly_braces_in_flow_control_structures
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/basic_test.dart
+++ b/examples/misc/test/language_tour/basic_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type_annotate_public_apis
 import 'package:test/test.dart';
 import 'package:examples_util/print_matcher.dart' as m;
 

--- a/examples/misc/test/language_tour/built_in_types_test.dart
+++ b/examples/misc/test/language_tour/built_in_types_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: prefer_single_quotes, prefer_typing_uninitialized_variables, prefer_adjacent_string_concatenation, avoid_init_to_null
+// ignore_for_file: prefer_single_quotes, prefer_adjacent_string_concatenation, avoid_init_to_null
 
 import 'package:test/test.dart';
 

--- a/examples/misc/test/language_tour/collections/if_case_operator_in_collection_e.dart
+++ b/examples/misc/test/language_tour/collections/if_case_operator_in_collection_e.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: dead_code
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/collections/if_case_operator_in_collection_g.dart
+++ b/examples/misc/test/language_tour/collections/if_case_operator_in_collection_g.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: dead_code
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/collections/if_case_operator_in_collection_h.dart
+++ b/examples/misc/test/language_tour/collections/if_case_operator_in_collection_h.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: dead_code
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/exceptions_test.dart
+++ b/examples/misc/test/language_tour/exceptions_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: assignment_to_final, unused_local_variable
 import 'package:test/test.dart';
 
 void main() {

--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_element, type_annotate_public_apis, prefer_function_declarations_over_variables, avoid_function_literals_in_foreach_calls
+// ignore_for_file: unused_element, prefer_function_declarations_over_variables, avoid_function_literals_in_foreach_calls
 // ignore_for_file: always_declare_return_types
 
 import 'package:examples/language_tour/function_equality.dart'

--- a/examples/misc/test/language_tour/generics_test.dart
+++ b/examples/misc/test/language_tour/generics_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type_annotate_public_apis
 import 'dart:collection';
 
 import 'package:examples/language_tour/generics/base_class.dart';
@@ -82,6 +81,6 @@ class A implements Comparable<A> {
   int compareTo(A other) => /*...implementation...*/ 0;
 }
 
-var useIt = compareAndOffset(A(), A());
+int useIt = compareAndOffset(A(), A());
 
 // #enddocregion f-bound

--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -1,4 +1,5 @@
-// ignore_for_file: type_annotate_public_apis, prefer_collection_literals, avoid_function_literals_in_foreach_calls
+// ignore_for_file: prefer_collection_literals, avoid_function_literals_in_foreach_calls
+
 import 'package:test/test.dart';
 
 import 'package:examples/library_tour/core/comparable.dart' as comparable;

--- a/examples/misc/test/library_tour/io_test.dart
+++ b/examples/misc/test/library_tour/io_test.dart
@@ -11,7 +11,7 @@ import 'package:examples/library_tour/io/http_server.dart' as http_server;
 import 'package:examples_util/print_matcher.dart' as m;
 
 void main() {
-  test('readAsString, readAsLines', () async {
+  test('readAsString, readAsLines', () {
     // #docregion read-as-string
     void main() async {
       var config = File('test_data/config.txt');
@@ -115,7 +115,7 @@ void main() {
     expect(main, prints(contains('Found file')));
   });
 
-  test('client-server', () async {
+  test('client-server', () {
     // #docregion client
     Future<void> main() async {
       var url = Uri.parse('http://localhost:8888/dart');

--- a/examples/misc/test/tutorial/streams_test.dart
+++ b/examples/misc/test/tutorial/streams_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type_annotate_public_apis
 import 'package:test/test.dart';
 import 'package:examples/tutorial/sum_stream.dart' as sum_stream;
 import 'package:examples/tutorial/sum_stream_with_catch.dart'

--- a/examples/non_promotion/lib/non_promotion.dart
+++ b/examples/non_promotion/lib/non_promotion.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: expected_executable, missing_statement
 // ignore_for_file: unused_local_variable, unused_element
 // ignore_for_file: prefer_function_declarations_over_variables
 // ignore_for_file: prefer_if_null_operators

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -26,4 +26,4 @@ workspace:
   - vector_victor
 
 dev_dependencies:
-  lints: ^5.1.1
+  lints: ^6.0.0

--- a/examples/type_system/lib/common_fixes_analysis.dart
+++ b/examples/type_system/lib/common_fixes_analysis.dart
@@ -1,6 +1,6 @@
 // NOTE: Declarations in this file are analyzed but not tested.
 // ignore_for_file: unused_element, unused_local_variable, one_member_abstracts, use_super_parameters
-// ignore_for_file: prefer_function_declarations_over_variables, unused_field, strict_raw_type
+// ignore_for_file: unused_field, strict_raw_type
 
 import 'package:web/web.dart';
 
@@ -143,7 +143,7 @@ void funcCast() {
 void infNull() {
   // #docregion type-inf-null
   var ints = [1, 2, 3];
-  // ignore: non_bool_operand, undefined_operator, return_of_invalid_type_from_closure
+  // ignore: undefined_operator, return_of_invalid_type_from_closure
   var maximumOrNull = ints.fold(null, (a, b) => a == null || a < b ? b : a);
   // #enddocregion type-inf-null
 }

--- a/examples/type_system/lib/strong_analysis.dart
+++ b/examples/type_system/lib/strong_analysis.dart
@@ -131,7 +131,7 @@ void _miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion MaineCoon-Cat-err
-    // ignore: stable, beta, dev, invalid_cast_new_expr, invalid_assignment
+    // ignore: stable, beta, dev, invalid_assignment
     MaineCoon c = Cat();
     // #enddocregion MaineCoon-Cat-err
   }

--- a/src/content/language/generics.md
+++ b/src/content/language/generics.md
@@ -216,7 +216,7 @@ class A implements Comparable<A> {
   int compareTo(A other) => /*...implementation...*/ 0;
 }
 
-var useIt = compareAndOffset(A(), A());
+int useIt = compareAndOffset(A(), A());
 ```
 
 The F-bound `T extends Comparable<T>` means `T` must be comparable to itself.

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -664,7 +664,7 @@ class Worker {
   final ReceivePort _responses;
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {
@@ -1019,7 +1019,7 @@ class Worker {
   }
 
   static Future<Worker> spawn() async {
-    // Create a receive port and add its initial message handler
+    // Create a receive port and add its initial message handler.
     final initPort = RawReceivePort();
     final connection = Completer<(ReceivePort, SendPort)>.sync();
     initPort.handler = (initialMessage) {

--- a/src/content/tools/pub/dependencies.md
+++ b/src/content/tools/pub/dependencies.md
@@ -499,7 +499,7 @@ resemble the following:
 ```yaml
 dev_dependencies:
   build_runner: ^2.4.15
-  lints: ^5.1.1
+  lints: ^6.0.0
   test: ^1.25.15
 ```
 


### PR DESCRIPTION
- Update site-shared to pull in `package:lints` v6.0.0
- Enable and fix `specify_nonobvious_property_types` and `use_null_aware_elements` in `/examples`
- Temporarily enable experimental `unnecessary_ignore` lint to identify and remove various unused or incorrect ignores.