### PR TITLE
docs: update Eclipse plugin link to dart4e

### DIFF
--- a/src/content/tools/index.md
+++ b/src/content/tools/index.md
@@ -75,7 +75,7 @@ thanks to the Dart community.
 </li>
 <li>
 <img src="/assets/img/tools/eclipse-logo.png" alt="Eclipse logo" class="list-image">
-<a href="https://github.com/eclipse/dartboard"><b>Eclipse</b></a>
+<a href="https://github.com/dart4e/dart4e"><b>Eclipse</b></a>
 </li>
 </ul>
 


### PR DESCRIPTION
The original Eclipse plugin (dartboard) was archived;
Its README now points to dart4e/dart4e as the maintained alternative
for Dart and Flutter support in Eclipse.