### PR TITLE
Add glossary entry for bottom type

### DIFF
--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -107,7 +107,7 @@
     Since `fail` never returns, it has type `Never`, which can be assigned to any other type.
 
   related_links:
-    - text: "Builtin types"
+    - text: "Built-in types"
       link: "/language/built-in-types"
       type: "doc"
     - text: "Never for unreachable code"

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -85,14 +85,17 @@
   short_description: |-
     A type that has no values and is a subtype of all other types.
   long_description: |-
-    The **bottom type** in Dart is the type that has **no values** and is considered a **subtype of every other type**.
+    The **bottom type** in Dart is the type that has **no values** and is considered a [**subtype**](/resources/glossary#subtype) of every other type.
 
     In Dart, the bottom type is represented by the `Never` type.
 
     This means a value of type `Never` can be used anywhere, because such a value can never actually exist. 
-    It's most often used to represent functions or expressions that **never return**, such as those that throw exceptions or loop forever.
+    It's most often used as the **return type** of functions to indicate they **never return**,  
+    such as for those that throw exceptions or loop forever.
 
     Example:
+
+    The `fail` function below always throws an exception, so it’s declared with return type `Never` to indicate that it never returns.
 
     ```dart
     Never fail(String message) {
@@ -104,7 +107,7 @@
     }
     ```
 
-    Since `fail` never returns, it has type `Never`, which can be assigned to any other type.
+    Since `fail` returns Never, assigning it to a String is allowed    
 
   related_links:
     - text: "Built-in types"

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -81,6 +81,44 @@
     - "language"
     - "type system"
 
+- term: "Bottom type"
+  short_description: |-
+    A type that has no values and is a subtype of all other types.
+  long_description: |-
+    The **bottom type** in Dart is the type that has **no values** and is considered a **subtype of every other type**.
+
+    In Dart, the bottom type is represented by the `Never` type.
+
+    This means a value of type `Never` can be used anywhere, because such a value can never actually exist. 
+    It's most often used to represent functions or expressions that **never return**, such as those that throw exceptions or loop forever.
+
+    Example:
+
+    ```dart
+    Never fail(String message) {
+      throw Exception(message);
+    }
+    
+    void main() {
+      String result = fail('Oooops'); // OK: Never is a subtype of String
+    }
+    ```
+
+    Since `fail` never returns, it has type `Never`, which can be assigned to any other type.
+
+  related_links:
+    - text: "Builtin types"
+      link: "/language/built-in-types"
+      type: "doc"
+    - text: "Never for unreachable code"
+      link: "/null-safety/understanding-null-safety#never-for-unreachable-code"
+      type: "doc"
+  labels:
+    - "type system"
+    - "language"
+  alternate:
+    - "Never"
+
 - term: "Constant context"
   short_description: |-
     A region of code where the const keyword is implied and

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -85,29 +85,32 @@
   short_description: |-
     A type that has no values and is a subtype of all other types.
   long_description: |-
-    The **bottom type** in Dart is the type that has **no values** and is considered a [**subtype**](/resources/glossary#subtype) of every other type.
+    The **bottom type** in Dart is the type that has **no values** and is
+    considered a [**subtype**](/resources/glossary#subtype) of every other type.
 
     In Dart, the bottom type is represented by the `Never` type.
 
-    This means a value of type `Never` can be used anywhere, because such a value can never actually exist. 
-    It's most often used as the **return type** of functions to indicate they **never return**,  
-    such as for those that throw exceptions or loop forever.
+    This means a value of type `Never` can be used anywhere,
+    because such a value can never actually exist.
+    It's most often used as the **return type** of functions to
+    indicate they **never return**, such as for those that
+    throw exceptions or loop forever.
 
-    Example:
-
-    The `fail` function below always throws an exception, so it’s declared with return type `Never` to indicate that it never returns.
+    For example, the following `fail` function always throws an exception,
+    so it's declared with a return type of `Never` to
+    indicate that it never returns:
 
     ```dart
     Never fail(String message) {
       throw Exception(message);
     }
-    
+
     void main() {
-      String result = fail('Oooops'); // OK: Never is a subtype of String
+      String result = fail('Oops'); // OK: Never is a subtype of String.
     }
     ```
 
-    Since `fail` returns Never, assigning it to a String is allowed    
+    Since `fail` never returns, assigning it to a `String` is allowed.
 
   related_links:
     - text: "Built-in types"


### PR DESCRIPTION
Adds  "Bottom type" term to glossary.

Contributes to https://github.com/dart-lang/site-www/issues/6461

Preview: https://dart-dev--pr6721-main-ejjxss0q.web.app/resources/glossary#bottom-type