### PR TITLE
Remove reference of Maven from jnigen documentation page

### DIFF
--- a/src/content/interop/java-interop.md
+++ b/src/content/interop/java-interop.md
@@ -36,9 +36,6 @@ that uses `package:jnigen` to generate bindings for a simple class.
 ### Prerequisites
 
 - JDK
-- [Maven][]
-
-[Maven]: https://maven.apache.org/
 
 ### Configure `jnigen`
 


### PR DESCRIPTION
Maven has been removed as a dependency from the underlying library(jni/jnigen). Updating documentation to match.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
