### PR TITLE
[dart 3.9.0] Add Dart MCP Server guide.

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -261,7 +261,7 @@
     permalink: /tools
   - title: AI
     children:
-        - title: Dart Tooling MCP Server
+        - title: Dart MCP Server
           permalink: /tools/mcp-server
   - title: Editors & debuggers
     children:

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -259,6 +259,10 @@
   children:
   - title: Overview
     permalink: /tools
+  - title: AI
+    children:
+        - title: Dart Tooling MCP Server
+          permalink: /tools/mcp-server
   - title: Editors & debuggers
     children:
       - title: IntelliJ & Android Studio

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -33,7 +33,7 @@ Dart 3.9.0-163.0.dev or later.
 ## Set up your MCP client
 
 The server is run with the `dart mcp-server` command, which will
-have to be configured in your preferred client. 
+have to be configured in your preferred client.
 
 This section provides instructions for setting up the
 Dart MCP server with popular tools like Gemini CLI,
@@ -177,40 +177,14 @@ documentation for [enabling MCP support][].
 [VS Code MCP API]: https://code.visualstudio.com/api/extension-guides/mcp
 [enabling MCP support]: https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code
 
-## Tools for Dart
+## Available Tools
 
-| Tool Name | Title | Description |
-| --- | --- | --- |
-| `connect_dart_tooling_daemon` | Connect to DTD | Connects to the Dart Tooling Daemon. You should get the uri either from available tools or the user, do not just make up a random URI to pass. When asking the user for the uri, you should suggest the "Copy DTD Uri to clipboard" action. When reconnecting after losing a connection, always request a new uri first. |
-| `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Dart application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `get_active_location` | Get Active Editor Location | Retrieves the current active location (e.g., cursor position) in the connected editor. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `pub_dev_search` | pub.dev search | Searches pub.dev for packages relevant to a given search query. The response will describe each result with its download count, package description, topics, license, and publisher. |
-| `remove_roots` | Remove roots | Removes one or more project roots previously added via the add_roots tool. |
-| `add_roots` | Add roots | Adds one or more project roots. Tools are only allowed to run under these roots, so you must call this function before passing any roots to any other tools. |
-| `dart_fix` | Dart fix | Runs `dart fix --apply` for the given project roots. |
-| `dart_format` | Dart format | Runs `dart format .` for the given project roots. |
-| `run_tests` | Run tests | Run Dart tests with an agent centric UX. ALWAYS use instead of `dart test` shell commands. |
-| `create_project` | Create project | Creates a new Dart project. |
-| `pub` | pub | Runs a pub command for the given project roots, like `dart pub get`. |
-| `analyze_files` | Analyze projects | Analyzes the entire project for errors. |
-| `resolve_workspace_symbol` | Project search | Look up a symbol or symbols in all workspaces by name. Can be used to validate that a symbol exists or discover small spelling mistakes, since the search is fuzzy. |
-| `signature_help` | Signature help | Get signature help for an API being used at a given cursor position in a file. |
-| `hover` | Hover information | Get hover information at a given cursor position in a file. This can include documentation, type information, etc for the text at that position. |
+For an update to date list of the available tools and any
+other functionality, see the [README.md][MCP Readme] file.
 
-{:.table .table-striped .nowrap}
+Note that MCP tools are not intended to be invoked by normal
+code, only by LLMs based on their description. This means we
+do not consider it a breaking change to add, remove, or
+modify the behavior of tools at any time.
 
-## Tools for Flutter
-
-| Tool Name | Title | Description |
-| --- | --- | --- |
-| `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `hot_reload` | Hot reload | Performs a hot reload of the active Flutter application. This is to apply the latest code changes to the running application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `get_widget_tree` | Get widget tree | Retrieves the widget tree from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `get_selected_widget` | Get selected widget | Retrieves the selected widget from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `set_widget_selection_mode` | Set Widget Selection Mode | Enables or disables widget selection mode in the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `run_tests` | Run tests | Run Flutter tests with an agent centric UX. ALWAYS use instead of `flutter test` shell commands. |
-| `create_project` | Create project | Creates a new Flutter project. |
-| `pub` | pub | Runs a pub command for the given project roots, like `flutter pub add`. |
-
-{:.table .table-striped .nowrap}
-
+[MCP Readme]: https://github.com/dart-lang/ai/blob/main/pkgs/dart_mcp_server/README.md#tools

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -101,7 +101,7 @@ documentation for [using agent mode][].
 [instructions]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer#before-you-begin
 [Gemini Code Assist]: https://codeassist.google/
 [Agent mode]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer
-[configure the Gemini]: #gemini-cli
+[configure the Gemini CLI]: #gemini-cli
 [using agent mode]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer#before-you-begin
 
 ### Cursor

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -32,6 +32,9 @@ Dart 3.9.0-163.0.dev or later.
 
 ## Set up your MCP client
 
+The server is run with the `dart mcp-server` command, which will
+have to be configured in your preferred client. 
+
 This section provides instructions for setting up the
 Dart MCP server with popular tools like Gemini CLI,
 Gemini Code Assist, Cursor, and GitHub Copilot.

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -18,20 +18,6 @@ but does not actually set them, pass
 `--force-roots-fallback` which will instead enable tools
 for managing the roots.
 
-:::note
-This package is still experimental and is likely to
-evolve quickly.
-
-All of the following set up instructions require
-Dart 3.9.0-163.0.dev or later.
-:::
-
-[Tools]: https://modelcontextprotocol.io/docs/concepts/tools
-[Resources]: https://modelcontextprotocol.io/docs/concepts/resources
-[Roots]: https://modelcontextprotocol.io/docs/concepts/roots
-
-### What can the Dart MCP Server do for you?
-
 The Dart MCP Server provides a growing list of tools that
 grant AI assistants deep insights into your project.
 Here is an overivew of a few things it can do:
@@ -43,6 +29,18 @@ Here is an overivew of a few things it can do:
 *  Search pub.dev for the best package for your use case.
 *  Manage package dependencies in your pubspec.yaml.
 *  Run tests and analyze the results.
+
+:::note
+This package is still experimental and is likely to
+evolve quickly.
+
+All of the following set up instructions require
+Dart 3.9.0-163.0.dev or later.
+:::
+
+[Tools]: https://modelcontextprotocol.io/docs/concepts/tools
+[Resources]: https://modelcontextprotocol.io/docs/concepts/resources
+[Roots]: https://modelcontextprotocol.io/docs/concepts/roots
 
 ## Set up your MCP client
 

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -8,22 +8,20 @@ description: >-
 ---
 
 The Dart MCP server exposes Dart (and Flutter)
-development tool actions to compatible AI-assistant
-clients.
+development tool actions to compatible AI-assistant clients.
 
 ## Overview
 
 The [Dart MCP server][] can work with any MCP client that
 supports standard I/O (stdio) as the transport medium.
-To access all the features of the Dart MCP server, an
-MCP client must support [Tools][] and [Resources][].
-For the best development experience with the Dart MCP
-server, an MCP client should also support [Roots][].
+To access all the features of the Dart MCP server,
+an MCP client must support [Tools][] and [Resources][].
+For the best development experience with the Dart MCP server,
+an MCP client should also support [Roots][].
 
-If you are using a client that claims it supports roots
-but does not actually set them, pass
-`--force-roots-fallback` which will instead enable tools
-for managing the roots.
+If you are using a client that claims it
+supports roots but doesn't actually set them,
+pass `--force-roots-fallback` to enable tools for managing the roots.
 
 The Dart MCP server provides a growing list of tools that
 grant AI assistants deep insights into your project.
@@ -33,12 +31,12 @@ Here is an overview of a few things it can do:
 *  Introspect and interact with your running application
    (such as trigger a hot reload, get the selected widget,
    fetch runtime errors).
-*  Search pub.dev for the best package for your use case.
+*  Search the [pub.dev site]({{site.pub}}) for the best package for a use case.
 *  Manage package dependencies in your `pubspec.yaml`.
 *  Run tests and analyze the results.
 
 :::note Experimental
-This package is still experimental and is likely to evolve quickly.
+This tool is still experimental and is likely to evolve quickly.
 The following setup and usage instructions
 require Dart `3.9.0-163.0.dev` or later.
 :::
@@ -93,10 +91,9 @@ Follow the [instructions][] to enable this build.
 :::
 
 [Gemini Code Assist][]'s [Agent mode][] integrates the
-Gemini CLI to provide a powerful AI agent
-directly in your IDE. To configure Gemini Code Assist to
-use the Dart MCP server, follow the instructions to
-[configure the Gemini CLI][].
+Gemini CLI to provide a powerful AI agent directly in your IDE.
+To configure Gemini Code Assist to use the Dart MCP server,
+follow the instructions to [configure the Gemini CLI][].
 
 You can verify the MCP server has been configured
 properly by typing `/mcp` in the chat window in Agent mode.
@@ -119,30 +116,28 @@ Cursor is by clicking the **Add to Cursor** button:
 
 Alternatively, you can configure the server manually:
 
-1.  Go to **Cursor > Settings > Cursor Settings > Tools
-    & Integrations**.
+1.  Go to **Cursor > Settings > Cursor Settings > Tools & Integrations**.
 1.  Click **Add Custom MCP** or **New MCP Server**
-    depending on whether you already have other MCP
-    servers configured.
-1.  Edit the `.cursor/mcp.json` file in your local
-    project (configuration will only apply to this
-    project) or edit the global `~/.cursor/mcp.json`
-    file in your home directory (configuration will apply
-    for all projects) to configure the Dart MCP server:
+    depending on whether you already have other MCP servers configured.
+1.  Edit the `.cursor/mcp.json` file in your local project
+    (configuration will only apply to this project) or
+    edit the global `~/.cursor/mcp.json` file in your home directory
+    (configuration will apply for all projects) to
+    configure the Dart MCP server:
 
-```json
-{
-  "mcpServers": {
-    "dart": {
-      "command": "dart",
-      "args": [
-        "mcp-server",
-        "--force-roots-fallback"
-      ]
+    ```json title=".cursor/mcp.json"
+    {
+      "mcpServers": {
+        "dart": {
+          "command": "dart",
+          "args": [
+            "mcp-server",
+            "--force-roots-fallback"
+          ]
+        }
+      }
     }
-  }
-}
-```
+    ```
 
 For more information, see the official Cursor
 documentation for [installing MCP servers][].
@@ -162,8 +157,7 @@ Daemon. This automatically enables it for any tool (such as
 Copilot) which uses these APIs for MCP configuration.
 
 You explicitly enable or disable the Dart MCP server by
-configuring the `dart.mcpServer` setting your VS Code
-settings files.
+configuring the `dart.mcpServer` setting in your VS Code settings.
 
 To change this globally, update your user settings:
 
@@ -200,8 +194,8 @@ documentation for [enabling MCP support][].
 Once you've set up the Dart MCP server with a client,
 the Dart MCP server enables the client to not only reason
 about your project's context but also to take action with tools.
-The Large Language Model (LLM) decides which tools to use and
-when, so you can focus on describing your goal in natural language.
+The Large Language Model (LLM) decides which tools to use and when,
+so you can focus on describing your goal in natural language.
 Let's see this in action with a couple of examples using
 GitHub Copilot's Agent mode in VS Code.
 
@@ -222,15 +216,15 @@ Behind the scenes, the AI agent uses the Dart MCP server's tools to:
    from the running application.
 *  Inspect the UI: It accesses the Flutter widget tree to understand
    the layout that is causing the overflow.
-*  Apply a fix: Armed with this context, it applies a fix and checks
-   once more for any remaining errors.
+*  Apply a fix: Armed with this context, it applies a fix and
+   checks once more for any remaining errors.
 
 You can then keep or undo the code changes.
 
 ### Add new functionality with package search
 
-Imagine you need to add a chart to your app. Which package
-should you use? How do you add it and write the boilerplate?
+Imagine you need to add a chart to your app.
+Which package should you use? How do you add it and write the boilerplate?
 The Dart MCP server can streamline this entire process with
 a prompt similar to the following:
 
@@ -243,12 +237,11 @@ The AI agent now acts as a true assistant:
    find popular and highly-rated charting libraries.
 *  Manage dependencies: After you confirm its choice (for
    example, `syncfusion_flutter_charts`), it uses a tool to
-   add the package to your `pubspec.yaml` file and runs
-   `pub get`.
-*  Generate the code: It generates the new widget code, complete
-   with boilerplate for a line chart that it places in the UI.
-   It even self-corrects syntax errors introduced during the
-   process. You can customize further from there.
+   add the package to your `pubspec.yaml` file and runs `dart pub get`.
+*  Generate the code: It generates the new widget code,
+   complete with boilerplate for a line chart that it places in the UI.
+   It even self-corrects syntax errors introduced during the process.
+   You can customize further from there.
 
 What used to be a multi-step process of research,
 reading documentation, editing `pubspec.yaml`, and

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -6,7 +6,7 @@ clients.
 
 ## Overview
 
-The Dart MCP server can work with any MCP client that
+The [Dart MCP server][] can work with any MCP client that
 supports standard I/O (stdio) as the transport medium.
 To access all the features of the Dart MCP server, an
 MCP client must support [Tools][] and [Resources][].
@@ -41,6 +41,7 @@ Dart 3.9.0-163.0.dev or later.
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
 [Resources]: https://modelcontextprotocol.io/docs/concepts/resources
 [Roots]: https://modelcontextprotocol.io/docs/concepts/roots
+[Dart MCP server]: {{site.repo.dart.org}}/ai/blob/main/pkgs/dart_mcp_server
 
 ## Set up your MCP client
 
@@ -190,10 +191,10 @@ documentation for [enabling MCP support][].
 [VS Code MCP API]: https://code.visualstudio.com/api/extension-guides/mcp
 [enabling MCP support]: https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code
 
-### The  Dart MCP Server in action
+## Use your MCP client
 
-The true power of the Dart MCP Server is how it enables
-AI assistants and agents to not only reason about your
+Once you've set up the Dart MCP server with a client,
+Dart MCP Server enables the client to not only reason about your
 project’s context, but take action with tools. The 
 Large Language Model (LLM) decides which tools to use and when,
 so you can focus on describing your goal in natural language.
@@ -250,15 +251,3 @@ The AI agent now acts as a true assistant:
 What used to be a multi-step process of research, reading documentation,
 editing pubspec.yaml, and writing the appropriate code in your app, is now a single
 request.
-
-## Available Tools
-
-For an update to date list of the available tools and any
-other functionality, see the [README.md][MCP Readme] file.
-
-Note that MCP tools are not intended to be invoked by normal
-code, only by LLMs based on their description. This means we
-do not consider it a breaking change to add, remove, or
-modify the behavior of tools at any time.
-
-[MCP Readme]: https://github.com/dart-lang/ai/blob/main/pkgs/dart_mcp_server/README.md#tools

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -135,13 +135,21 @@ documentation for [installing MCP servers][].
 ### GitHub Copilot in VS Code
 
 :::note
-This requires Dart-Code VS Code extension v3.114 or
+This requires Dart-Code VS Code extension v3.116 or
 later.
 :::
 
-To globally configure the Dart MCP server with Copilot or
-any other AI agent that supports the [VS Code MCP API][],
-add the following to your VS Code user settings as follows:
+By default, the Dart-Code extension uses the
+[VS Code MCP API][] to register the Dart MCP server, as well
+as a tool to provide the URI for the active Dart Tooling
+Daemon. This automatically enables it for any tool (such as
+Copilot) which uses these APIs for MCP configuration.
+
+You explicitly enable or disable the Dart MCP server by
+configuring the `dart.mcpServer` setting your VS Code
+settings files.
+
+To change this globally, update your user settings:
 
 1. In VS Code, click **View > Command Palette Preferences:
    Open User Settings (JSON)**.
@@ -153,8 +161,7 @@ add the following to your VS Code user settings as follows:
     ```
 
 If you'd like this setting to apply only to a specific
-workspace, add the entry to your workspace settings as
-follows:
+workspace, add the entry to your workspace settings:
 
 1. In VS Code, click **View > Command Palette > Preferences:
    Open Workplace Settings (JSON)**.
@@ -164,12 +171,6 @@ follows:
     ```json
     "dart.mcpServer": true
     ```
-
-By adding this setting, the Dart VS Code extension
-registers the Dart MCP Server configuration with VS Code
-so that you don't have to manually configure the server.
-Copilot will then automatically configure the Dart MCP
-server on your behalf.
 
 For more information, see the official VS Code
 documentation for [enabling MCP support][].

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -206,9 +206,8 @@ GitHub Copilot's Agent mode in VS Code.
 We’ve all been there: you build a beautiful UI, run the app,
 and are greeted by the infamous yellow-and-black stripes of
 a RenderFlex overflow error. Instead of manually debugging the
-widget tree, you can now ask your AI assistant for help.
-
-[screencast]
+widget tree, you can now ask your AI assistant for help with a
+prompt similar to the following:
 
 **Prompt**: *"Check for and fix static and runtime analysis issues.
 Check for and fix any layout issues."* (Note: For brevity, parts of
@@ -228,10 +227,8 @@ You can then keep or undo the code changes.
 ### Add new functionality with package search
 
 Imagine you need to add a chart to your app. Which package should you use?
-How do you add it and write the boilerplate? The Dart MCP Server streamlines
-this entire process.
-
-[screencast]
+How do you add it and write the boilerplate? The Dart MCP Server can streamline
+this entire process with a prompt similar to the following:
 
 **Prompt**: *"Find a suitable package to add a line chart that maps the number
 of button presses over time."* (Note: For brevity, parts of this recording

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -72,7 +72,7 @@ to this project) or edit the global
     "dart": {
       "command": "dart",
       "args": [
-        "mcp-server",
+        "mcp-server"
       ]
     }
   }
@@ -138,7 +138,7 @@ Alternatively, you can configure the server manually:
       "command": "dart",
       "args": [
         "mcp-server",
-        "--force-roots-fallback" // Workaround for a Cursor issue with Roots support
+        "--force-roots-fallback"
       ]
     }
   }

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -210,8 +210,7 @@ widget tree, you can now ask your AI assistant for help with a
 prompt similar to the following:
 
 **Prompt**: *"Check for and fix static and runtime analysis issues.
-Check for and fix any layout issues."* (Note: For brevity, parts of
-this recording have been sped up.)
+Check for and fix any layout issues."*
 
 Behind the scenes, the AI agent uses the Dart MCP Server's tools to:
 
@@ -231,8 +230,7 @@ How do you add it and write the boilerplate? The Dart MCP Server can streamline
 this entire process with a prompt similar to the following:
 
 **Prompt**: *"Find a suitable package to add a line chart that maps the number
-of button presses over time."* (Note: For brevity, parts of this recording
-have been sped up.)
+of button presses over time."*
 
 The AI agent now acts as a true assistant:
 

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -1,0 +1,214 @@
+# Dart MCP Server
+
+The Dart MCP Server exposes Dart (and Flutter)
+development tool actions to compatible AI-assistant
+clients.
+
+## Overview
+
+The Dart MCP server can work with any MCP client that
+supports standard I/O (stdio) as the transport medium.
+To access all the features of the Dart MCP server, an
+MCP client must support [Tools][] and [Resources][].
+For the best development experience with the Dart MCP
+server, an MCP client should also support [Roots][].
+
+If you are using a client that claims it supports roots
+but does not actually set them, pass
+`--force-roots-fallback` which will instead enable tools
+for managing the roots.
+
+:::note
+This package is still experimental and is likely to
+evolve quickly.
+
+All of the following set up instructions require
+Dart 3.9.0-163.0.dev or later.
+:::
+
+[Tools]: https://modelcontextprotocol.io/docs/concepts/tools
+[Resources]: https://modelcontextprotocol.io/docs/concepts/resources
+[Roots]: https://modelcontextprotocol.io/docs/concepts/roots
+
+## Set up your MCP client
+
+This section provides instructions for setting up the
+Dart MCP server with popular tools like Gemini CLI,
+Gemini Code Assist, Cursor, and GitHub Copilot.
+
+### Gemini CLI
+
+To configure the [Gemini CLI][] to use
+the Dart MCP server, edit the `.gemini/settings.json`
+file in your local project (configuration will only apply
+to this project) or edit the global
+`~/.gemini/settings.json` file in your home directory
+(configuration will apply for all projects).
+
+```json
+{
+  "mcpServers": {
+    "dart": {
+      "command": "dart",
+      "args": [
+        "mcp-server",
+        "--experimental-mcp-server",
+        // Can be removed for Dart 3.9.0 or later.
+      ]
+    }
+  }
+}
+```
+
+For more information, see the official Gemini CLI
+documentation for [setting up MCP servers][].
+
+[Gemini CLI]: https://github.com/google-gemini/gemini-cli
+[setting up MCP servers]: https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#how-to-set-up-your-mcp-server
+
+### Gemini Code Assist in VS Code
+
+:::note
+This requires the "Insiders" channel.
+Follow [instructions][] to enable this build.
+:::
+
+[Gemini Code Assist][]'s [Agent mode][] integrates the
+Gemini CLI to provide a powerful AI agent
+directly in your IDE. To configure Gemini Code Assist to
+use the Dart MCP server, follow the instructions to
+[configure the Gemini][] CLI above.
+
+You can verify the MCP server has been configured
+properly by typing `/mcp` in the chat window in Agent
+mode.
+
+For more information see the official Gemini Code Assist
+documentation for [using agent mode][].
+
+[instructions]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer#before-you-begin
+[Gemini Code Assist]: https://codeassist.google/
+[Agent mode]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer
+[configure the Gemini]: #gemini-cli
+[using agent mode]: https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer#before-you-begin
+
+### Cursor
+
+The easiest way to configure the Dart MCP server with
+Cursor is by clicking the **Add to Cursor** button:
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=dart&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoiZGFydCBtY3Atc2VydmVyIC0tZXhwZXJpbWVudGFsLW1jcC1zZXJ2ZXIgLS1mb3JjZS1yb290cy1mYWxsYmFjayJ9)
+
+Alternatively, you can configure the server manually:
+
+1.  Go to **Cursor > Settings > Cursor Settings > Tools
+    & Integrations**.
+1.  Click **Add Custom MCP** or **New MCP Server**
+    depending on whether you already have other MCP
+    servers configured.
+1.  Edit the `.cursor/mcp.json` file in your local
+    project (configuration will only apply to this
+    project) or edit the global `~/.cursor/mcp.json`
+    file in your home directory (configuration will apply
+    for all projects) to configure the Dart MCP server:
+
+```json
+{
+  "mcpServers": {
+    "dart": {
+      "command": "dart",
+      "args": [
+        "mcp-server",
+        "--experimental-mcp-server",
+        // Can be removed for Dart 3.9.0 or later
+        "--force-roots-fallback" // Workaround for a
+                                   // Cursor issue with
+                                   // Roots support
+      ]
+    }
+  }
+}
+```
+
+For more information, see the official Cursor
+documentation for [installing MCP servers][].
+
+[installing MCP servers]: https://docs.cursor.com/context/model-context-protocol#installing-mcp-servers
+
+### GitHub Copilot in VS Code
+
+:::note
+This requires Dart-Code VS Code extension v3.114 or
+later.
+:::
+
+To globally configure the Dart MCP server with Copilot or
+any other AI agent that supports the [VS Code MCP API][],
+add the following to your VS Code user settings as follows:
+
+1. In VS Code, click **View > Command Palette Preferences:
+   Open User Settings (JSON)**.
+
+1. Add the following setting:
+
+    ```json
+    "dart.mcpServer": true
+    ```
+
+If you'd like this setting to apply only to a specific
+workspace, add the entry to your workspace settings as
+follows:
+
+1. In VS Code, click **View > Command Palette > Preferences:
+   Open Workplace Settings (JSON)**.
+
+1. Add the following setting:
+
+    ```json
+    "dart.mcpServer": true
+    ```
+
+By adding this setting, the Dart VS Code extension
+registers the Dart MCP Server configuration with VS Code
+so that you don't have to manually configure the server.
+Copilot will then automatically configure the Dart MCP
+server on your behalf.
+
+For more information, see the official VS Code
+documentation for [enabling MCP support][].
+
+[VS Code MCP API]: https://code.visualstudio.com/api/extension-guides/mcp
+[enabling MCP support]: https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code
+
+## Tools for Dart
+
+| Tool Name | Title | Description |
+| --- | --- | --- |
+| `connect_dart_tooling_daemon` | Connect to DTD | Connects to the Dart Tooling Daemon. You should get the uri either from available tools or the user, do not just make up a random URI to pass. When asking the user for the uri, you should suggest the "Copy DTD Uri to clipboard" action. When reconnecting after losing a connection, always request a new uri first. |
+| `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Dart application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `get_active_location` | Get Active Editor Location | Retrieves the current active location (e.g., cursor position) in the connected editor. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `pub_dev_search` | pub.dev search | Searches pub.dev for packages relevant to a given search query. The response will describe each result with its download count, package description, topics, license, and publisher. |
+| `remove_roots` | Remove roots | Removes one or more project roots previously added via the add_roots tool. |
+| `add_roots` | Add roots | Adds one or more project roots. Tools are only allowed to run under these roots, so you must call this function before passing any roots to any other tools. |
+| `dart_fix` | Dart fix | Runs `dart fix --apply` for the given project roots. |
+| `dart_format` | Dart format | Runs `dart format .` for the given project roots. |
+| `run_tests` | Run tests | Run Dart tests with an agent centric UX. ALWAYS use instead of `dart test` shell commands. |
+| `create_project` | Create project | Creates a new Dart project. |
+| `pub` | pub | Runs a pub command for the given project roots, like `dart pub get`. |
+| `analyze_files` | Analyze projects | Analyzes the entire project for errors. |
+| `resolve_workspace_symbol` | Project search | Look up a symbol or symbols in all workspaces by name. Can be used to validate that a symbol exists or discover small spelling mistakes, since the search is fuzzy. |
+| `signature_help` | Signature help | Get signature help for an API being used at a given cursor position in a file. |
+| `hover` | Hover information | Get hover information at a given cursor position in a file. This can include documentation, type information, etc for the text at that position. |
+
+## Tools for Flutter
+
+| Tool Name                  | Feature Group    | Description |
+| :------------------------- | :--------------- | :---------- |
+| `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `hot_reload` | Hot reload | Performs a hot reload of the active Flutter application. This is to apply the latest code changes to the running application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `get_widget_tree` | Get widget tree | Retrieves the widget tree from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `get_selected_widget` | Get selected widget | Retrieves the selected widget from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `set_widget_selection_mode` | Set Widget Selection Mode | Enables or disables widget selection mode in the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `run_tests` | Run tests | Run Flutter tests with an agent centric UX. ALWAYS use instead of `flutter test` shell commands. |
+| `create_project` | Create project | Creates a new Flutter project. |
+| `pub` | pub | Runs a pub command for the given project roots, like `flutter pub add`. |

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -1,6 +1,6 @@
 # Dart MCP Server
 
-The Dart MCP Server exposes Dart (and Flutter)
+The Dart MCP server exposes Dart (and Flutter)
 development tool actions to compatible AI-assistant
 clients.
 
@@ -18,24 +18,22 @@ but does not actually set them, pass
 `--force-roots-fallback` which will instead enable tools
 for managing the roots.
 
-The Dart MCP Server provides a growing list of tools that
+The Dart MCP server provides a growing list of tools that
 grant AI assistants deep insights into your project.
-Here is an overivew of a few things it can do:
+Here is an overview of a few things it can do:
 
 *  Analyze and fix errors in your project's code.
 *  Introspect and interact with your running application
    (such as trigger a hot reload, get the selected widget,
    fetch runtime errors).
 *  Search pub.dev for the best package for your use case.
-*  Manage package dependencies in your pubspec.yaml.
+*  Manage package dependencies in your `pubspec.yaml`.
 *  Run tests and analyze the results.
 
 :::note
 This package is still experimental and is likely to
-evolve quickly.
-
-All of the following set up instructions require
-Dart 3.9.0-163.0.dev or later.
+evolve quickly. All of the following setup instructions
+require Dart 3.9.0-163.0.dev or later.
 :::
 
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
@@ -91,7 +89,7 @@ Follow [instructions][] to enable this build.
 Gemini CLI to provide a powerful AI agent
 directly in your IDE. To configure Gemini Code Assist to
 use the Dart MCP server, follow the instructions to
-[configure the Gemini][] CLI above.
+[configure the Gemini CLI][].
 
 You can verify the MCP server has been configured
 properly by typing `/mcp` in the chat window in Agent
@@ -164,8 +162,8 @@ settings files.
 
 To change this globally, update your user settings:
 
-1. In VS Code, click **View > Command Palette Preferences:
-   Open User Settings (JSON)**.
+1. In VS Code, click **View > Command Palette** and then
+   search for **Preferences: Open User Settings (JSON)**.
 
 1. Add the following setting:
 
@@ -176,8 +174,8 @@ To change this globally, update your user settings:
 If you'd like this setting to apply only to a specific
 workspace, add the entry to your workspace settings:
 
-1. In VS Code, click **View > Command Palette > Preferences:
-   Open Workplace Settings (JSON)**.
+1. In VS Code, click **View > Command Palette** and then
+   search for **Preferences: Open User Settings (JSON)**.
 
 1. Add the following setting:
 
@@ -194,10 +192,10 @@ documentation for [enabling MCP support][].
 ## Use your MCP client
 
 Once you've set up the Dart MCP server with a client,
-Dart MCP Server enables the client to not only reason about your
-project’s context, but take action with tools. The 
-Large Language Model (LLM) decides which tools to use and when,
-so you can focus on describing your goal in natural language.
+the Dart MCP server enables the client to not only reason
+about your project’s context but also to take action with tools.
+The Large Language Model (LLM) decides which tools to use and
+when, so you can focus on describing your goal in natural language.
 Let's see this in action with a couple of examples using
 GitHub Copilot's Agent mode in VS Code.
 
@@ -212,37 +210,40 @@ prompt similar to the following:
 **Prompt**: *"Check for and fix static and runtime analysis issues.
 Check for and fix any layout issues."*
 
-Behind the scenes, the AI agent uses the Dart MCP Server's tools to:
+Behind the scenes, the AI agent uses the Dart MCP server's tools to:
 
 *  See the error: It uses a tool to get the current runtime errors
    from the running application.
 *  Inspect the UI: It accesses the Flutter widget tree to understand
    the layout that is causing the overflow.
-*  Applies a fix: Armed with this context, it applies a fix and checks
+*  Apply a fix: Armed with this context, it applies a fix and checks
    once more for any remaining errors.
 
 You can then keep or undo the code changes.
 
 ### Add new functionality with package search
 
-Imagine you need to add a chart to your app. Which package should you use?
-How do you add it and write the boilerplate? The Dart MCP Server can streamline
-this entire process with a prompt similar to the following:
+Imagine you need to add a chart to your app. Which package
+should you use? How do you add it and write the boilerplate?
+The Dart MCP server can streamline this entire process with
+a prompt similar to the following:
 
-**Prompt**: *"Find a suitable package to add a line chart that maps the number
-of button presses over time."*
+**Prompt**: *"Find a suitable package to add a line chart that
+maps the number of button presses over time."*
 
 The AI agent now acts as a true assistant:
 
-*  Find the right tool: It uses the pub_dev_search tool to find popular and
-   highly-rated charting libraries.
-*  Manage dependencies: After you confirm its choice (for example,
-   syncfusion_flutter_charts), it uses a tool to add the package to your
-   pubspec.yaml and runs pub get.
-*  Generate the code: It generates the new widget code, complete with boilerplate
-   or a line chart that it places in the UI. It even self-corrects syntax errors
-   introduced during the process. You can customize further from there.
+*  Find the right tool: It uses the `pub_dev_search` tool to
+   find popular and highly-rated charting libraries.
+*  Manage dependencies: After you confirm its choice (for
+   example, `syncfusion_flutter_charts`), it uses a tool to
+   add the package to your `pubspec.yaml` file and runs
+   `pub get`.
+*  Generate the code: It generates the new widget code, complete
+   with boilerplate for a line chart that it places in the UI.
+   It even self-corrects syntax errors introduced during the
+   process. You can customize further from there.
 
-What used to be a multi-step process of research, reading documentation,
-editing pubspec.yaml, and writing the appropriate code in your app, is now a single
-request.
+What used to be a multi-step process of research, reading
+documentation, editing `pubspec.yaml`, and writing the appropriate
+code in your app, is now a single request.

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -30,6 +30,20 @@ Dart 3.9.0-163.0.dev or later.
 [Resources]: https://modelcontextprotocol.io/docs/concepts/resources
 [Roots]: https://modelcontextprotocol.io/docs/concepts/roots
 
+### What can the Dart MCP Server do for you?
+
+The Dart MCP Server provides a growing list of tools that
+grant AI assistants deep insights into your project.
+Here is an overivew of a few things it can do:
+
+*  Analyze and fix errors in your project's code.
+*  Introspect and interact with your running application
+   (such as trigger a hot reload, get the selected widget,
+   fetch runtime errors).
+*  Search pub.dev for the best package for your use case.
+*  Manage package dependencies in your pubspec.yaml.
+*  Run tests and analyze the results.
+
 ## Set up your MCP client
 
 The server is run with the `dart mcp-server` command, which will
@@ -177,6 +191,67 @@ documentation for [enabling MCP support][].
 
 [VS Code MCP API]: https://code.visualstudio.com/api/extension-guides/mcp
 [enabling MCP support]: https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code
+
+### The  Dart MCP Server in action
+
+The true power of the Dart MCP Server is how it enables
+AI assistants and agents to not only reason about your
+project’s context, but take action with tools. The 
+Large Language Model (LLM) decides which tools to use and when,
+so you can focus on describing your goal in natural language.
+Let's see this in action with a couple of examples using
+GitHub Copilot's Agent mode in VS Code.
+
+### Fix a runtime layout error
+
+We’ve all been there: you build a beautiful UI, run the app,
+and are greeted by the infamous yellow-and-black stripes of
+a RenderFlex overflow error. Instead of manually debugging the
+widget tree, you can now ask your AI assistant for help.
+
+[screencast]
+
+**Prompt**: *"Check for and fix static and runtime analysis issues.
+Check for and fix any layout issues."* (Note: For brevity, parts of
+this recording have been sped up.)
+
+Behind the scenes, the AI agent uses the Dart MCP Server's tools to:
+
+*  See the error: It uses a tool to get the current runtime errors
+   from the running application.
+*  Inspect the UI: It accesses the Flutter widget tree to understand
+   the layout that is causing the overflow.
+*  Applies a fix: Armed with this context, it applies a fix and checks
+   once more for any remaining errors.
+
+You can then keep or undo the code changes.
+
+### Add new functionality with package search
+
+Imagine you need to add a chart to your app. Which package should you use?
+How do you add it and write the boilerplate? The Dart MCP Server streamlines
+this entire process.
+
+[screencast]
+
+**Prompt**: *"Find a suitable package to add a line chart that maps the number
+of button presses over time."* (Note: For brevity, parts of this recording
+have been sped up.)
+
+The AI agent now acts as a true assistant:
+
+*  Find the right tool: It uses the pub_dev_search tool to find popular and
+   highly-rated charting libraries.
+*  Manage dependencies: After you confirm its choice (for example,
+   syncfusion_flutter_charts), it uses a tool to add the package to your
+   pubspec.yaml and runs pub get.
+*  Generate the code: It generates the new widget code, complete with boilerplate
+   or a line chart that it places in the UI. It even self-corrects syntax errors
+   introduced during the process. You can customize further from there.
+
+What used to be a multi-step process of research, reading documentation,
+editing pubspec.yaml, and writing the appropriate code in your app, is now a single
+request.
 
 ## Available Tools
 

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -52,8 +52,6 @@ to this project) or edit the global
       "command": "dart",
       "args": [
         "mcp-server",
-        "--experimental-mcp-server",
-        // Can be removed for Dart 3.9.0 or later.
       ]
     }
   }
@@ -119,11 +117,7 @@ Alternatively, you can configure the server manually:
       "command": "dart",
       "args": [
         "mcp-server",
-        "--experimental-mcp-server",
-        // Can be removed for Dart 3.9.0 or later
-        "--force-roots-fallback" // Workaround for a
-                                   // Cursor issue with
-                                   // Roots support
+        "--force-roots-fallback" // Workaround for a Cursor issue with Roots support
       ]
     }
   }
@@ -202,8 +196,8 @@ documentation for [enabling MCP support][].
 
 ## Tools for Flutter
 
-| Tool Name                  | Feature Group    | Description |
-| :------------------------- | :--------------- | :---------- |
+| Tool Name | Title | Description |
+| --- | --- | --- |
 | `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
 | `hot_reload` | Hot reload | Performs a hot reload of the active Flutter application. This is to apply the latest code changes to the running application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
 | `get_widget_tree` | Get widget tree | Retrieves the widget tree from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -37,10 +37,10 @@ Here is an overview of a few things it can do:
 *  Manage package dependencies in your `pubspec.yaml`.
 *  Run tests and analyze the results.
 
-:::note
-This package is still experimental and is likely to
-evolve quickly. All of the following setup instructions
-require Dart 3.9.0-163.0.dev or later.
+:::note Experimental
+This package is still experimental and is likely to evolve quickly.
+The following setup and usage instructions
+require Dart `3.9.0-163.0.dev` or later.
 :::
 
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
@@ -66,7 +66,7 @@ to this project) or edit the global
 `~/.gemini/settings.json` file in your home directory
 (configuration will apply for all projects).
 
-```json
+```json title=".gemini/settings.json"
 {
   "mcpServers": {
     "dart": {
@@ -88,8 +88,8 @@ documentation for [setting up MCP servers][].
 ### Gemini Code Assist in VS Code
 
 :::note
-This requires the "Insiders" channel.
-Follow [instructions][] to enable this build.
+This requires the "Insiders" channel of Gemini Code Assist.
+Follow the [instructions][] to enable this build.
 :::
 
 [Gemini Code Assist][]'s [Agent mode][] integrates the
@@ -99,8 +99,7 @@ use the Dart MCP server, follow the instructions to
 [configure the Gemini CLI][].
 
 You can verify the MCP server has been configured
-properly by typing `/mcp` in the chat window in Agent
-mode.
+properly by typing `/mcp` in the chat window in Agent mode.
 
 For more information see the official Gemini Code Assist
 documentation for [using agent mode][].
@@ -153,8 +152,7 @@ documentation for [installing MCP servers][].
 ### GitHub Copilot in VS Code
 
 :::note
-This requires Dart-Code VS Code extension v3.116 or
-later.
+This requires v3.116 or later of the [Dart Code extension][] for VS Code.
 :::
 
 By default, the Dart-Code extension uses the
@@ -193,6 +191,7 @@ workspace, add the entry to your workspace settings:
 For more information, see the official VS Code
 documentation for [enabling MCP support][].
 
+[Dart Code extension]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code
 [VS Code MCP API]: https://code.visualstudio.com/api/extension-guides/mcp
 [enabling MCP support]: https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code
 
@@ -200,15 +199,15 @@ documentation for [enabling MCP support][].
 
 Once you've set up the Dart MCP server with a client,
 the Dart MCP server enables the client to not only reason
-about your project’s context but also to take action with tools.
+about your project's context but also to take action with tools.
 The Large Language Model (LLM) decides which tools to use and
 when, so you can focus on describing your goal in natural language.
 Let's see this in action with a couple of examples using
 GitHub Copilot's Agent mode in VS Code.
 
-### Fix a runtime layout error
+### Fix a runtime layout error in a Flutter app
 
-We’ve all been there: you build a beautiful UI, run the app,
+We've all been there: you build a beautiful UI, run the app,
 and are greeted by the infamous yellow-and-black stripes of
 a RenderFlex overflow error. Instead of manually debugging the
 widget tree, you can now ask your AI assistant for help with a
@@ -251,6 +250,7 @@ The AI agent now acts as a true assistant:
    It even self-corrects syntax errors introduced during the
    process. You can customize further from there.
 
-What used to be a multi-step process of research, reading
-documentation, editing `pubspec.yaml`, and writing the appropriate
-code in your app, is now a single request.
+What used to be a multi-step process of research,
+reading documentation, editing `pubspec.yaml`, and
+writing the appropriate code in your app,
+is now a single request.

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -194,6 +194,8 @@ documentation for [enabling MCP support][].
 | `signature_help` | Signature help | Get signature help for an API being used at a given cursor position in a file. |
 | `hover` | Hover information | Get hover information at a given cursor position in a file. This can include documentation, type information, etc for the text at that position. |
 
+{:.table .table-striped .nowrap}
+
 ## Tools for Flutter
 
 | Tool Name | Title | Description |
@@ -206,3 +208,6 @@ documentation for [enabling MCP support][].
 | `run_tests` | Run tests | Run Flutter tests with an agent centric UX. ALWAYS use instead of `flutter test` shell commands. |
 | `create_project` | Create project | Creates a new Flutter project. |
 | `pub` | pub | Runs a pub command for the given project roots, like `flutter pub add`. |
+
+{:.table .table-striped .nowrap}
+

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -1,4 +1,11 @@
-# Dart MCP Server
+---
+title: Dart MCP server
+short-title: MCP server
+description: >-
+  Learn about the Dart MCP server tool that
+  exposes Dart and Flutter tools to compatible
+  AI-assistant clients and agents.
+---
 
 The Dart MCP server exposes Dart (and Flutter)
 development tool actions to compatible AI-assistant


### PR DESCRIPTION
Adds a guide for Dart's MPC server.

Fixes #6686 

Preview: https://dart-dev--pr6729-dart-mcp-docs-d20u7wz7.web.app/tools/mcp-server

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
