### PR TITLE
[dart 3.9.0] Add @awaitNotRequired annotation to docs

### DIFF
--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -16,10 +16,27 @@ annotation begins with the character `@`, followed by either a reference
 to a compile-time constant (such as `deprecated`) or a call to a
 constant constructor.
 
-Four annotations are available to all Dart code: 
-[`@Deprecated`][], [`@deprecated`][], [`@override`][], and [`@pragma`][]. 
-For examples of using `@override`,
-see [Extending a class][].
+Metadata can appear before a library, class, typedef, type parameter,
+constructor, factory, function, field, parameter, or variable
+declaration and before an import or export directive.
+
+## Built-in annotations
+
+The following annotations are available to all Dart code: 
+
+*   [`@awaitNotRequired`][]: Suppress `unawaited_futures` and
+    `discarded_futures` lint diagnostics at call sites.
+*   [`@Deprecated`][]: Mark a part of your code as no longer
+    recommended. Optionally [provide a deprecation message][].
+*   [`@deprecated`][]: Mark a part of your code as no longer
+    recommended.
+*   [`@override`][]: Mark a method as an override for a
+    method with the same name from a parent class or
+    interface. For examples of using `@override`, see
+    [Extending a class][].
+*   [`@pragma`][]: Provide specific instructions or hints to
+    Dart tools, like the compiler or analyzer.
+
 Here's an example of using the `@Deprecated` annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/television.dart (deprecated)" replace="/@Deprecated.*/[!$&!]/g"?>
@@ -39,9 +56,7 @@ class Television {
 }
 ```
 
-You can use `@deprecated` if you don't want to specify a message.
-However, we [recommend][dep-lint] always
-specifying a message with `@Deprecated`.
+## Custom annotations
 
 You can define your own metadata annotations. Here's an example of
 defining a `@Todo` annotation that takes two arguments:
@@ -66,13 +81,10 @@ void doSomething() {
 }
 ```
 
-Metadata can appear before a library, class, typedef, type parameter,
-constructor, factory, function, field, parameter, or variable
-declaration and before an import or export directive.
-
+[`@awaitNotRequired`]: {{site.dart-api}}/dart-core/awaitNotRequired-class.html
 [`@Deprecated`]: {{site.dart-api}}/dart-core/Deprecated-class.html
 [`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
 [`@override`]: {{site.dart-api}}/dart-core/override-constant.html
 [`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
-[dep-lint]: /tools/linter-rules/provide_deprecation_message
+[provide a deprecation message]: /tools/linter-rules/provide_deprecation_message
 [Extending a class]: /language/extend


### PR DESCRIPTION
Adds `@awaitNotRequired` to the metadata docs.

Fixes #6687 

Notes:

@srawlins go ahead and review this first. Please feel free to update the files directly with your edits. Check the link I added for the new annotation, as I'm not sure it's correct. @parlough, once we have Sam's okay, this will be ready for you to review.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.