### PR TITLE
Switch CSP to report only for now

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -21,7 +21,7 @@
       {
         "source": "**",
         "headers": [
-          { "key": "Content-Security-Policy", "value": "script-src 'self'"},
+          { "key": "Content-Security-Policy-Report-Only", "value": "script-src 'self'"},
           { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
           { "key": "X-Content-Type-Options", "value": "nosniff"},
           { "key": "X-Frame-Options", "value": "DENY"},


### PR DESCRIPTION
The CSP introduced in https://github.com/dart-lang/site-www/pull/6728 breaks various functionality on the site, including the SDK archive, embedded videos, inline analytics, etc. as it isn't configured for the scripts those rely on. Until someone gets a chance to do so, we should disable the policy or switch it to report only for now. This PR switches it to report only for now which will log violations in the browser console.