### PR TITLE
Update links and redirects to updated spec location

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -363,7 +363,7 @@
       { "source": "/resources/dartpad-best-practices", "destination": "https://doi.org/10.1145/3397537.3397558", "type": 301 },
       { "source": "/resources/dartpad-tutorials.pdf", "destination": "https://doi.org/10.1145/3397537.3397558", "type": 301 },
       { "source": "/resources/language/spec/versions", "destination": "/resources/language/spec", "type": 301 },
-      { "source": "/resources/language/spec/versions/DartLangSpecDraft.pdf", "destination": "https://spec.dart.dev/DartLangSpecDraft.pdf", "type": 301 },
+      { "source": "/resources/language/spec/versions/DartLangSpecDraft.pdf", "destination": "https://storage.googleapis.com/dart-specification/DartLangSpecDraft.pdf", "type": 301 },
       { "source": "/resources/language/spec/versions/DartLangSpec-v2.2.pdf", "destination": "https://github.com/dart-lang/site-www/blob/a7f170389e210adc2aef810cc9a6fdbfa78059a5/src/guides/language/specifications/DartLangSpec-v2.2.pdf", "type": 301 },
       { "source": "/samples{,/**}", "destination": "/language", "type": 301 },
       { "source": "/sdk-changelog-2.4.0", "destination": "https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#240---2019-06-27", "type": 301 },
@@ -397,6 +397,7 @@
       { "source": "/to/pubspec-overrides", "destination": "/tools/pub/dependencies#pubspec-overrides", "type": 301 },
       { "source": "/to/sdk-support-policy", "destination": "/tools/sdk#support-policy", "type": 301 },
       { "source": "/to/sdk-constraint", "destination": "/tools/pub/pubspec#sdk-constraints", "type": 301 },
+      { "source": "/to/spec-draft", "destination": "https://storage.googleapis.com/dart-specification/DartLangSpecDraft.pdf", "type": 301 },
       { "source": "/to/sdk-version-pinning", "destination": "https://github.com/dart-lang/sdk/blob/main/docs/Flutter-Pinned-Packages.md", "type": 301 },
       { "source": "/to/web-debug-extension", "destination": "https://chromewebstore.google.com/detail/dart-debug-extension/eljbmlghnomdjgdjmbdekegdkbabckhm", "type": 301 },
 

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -51,7 +51,7 @@ and welcomes distributed committers.
 [3rd-ed]: {{ecma-pdf}}/ECMA-408_3rd_edition_june_2015.pdf
 [4th-ed]: {{ecma-pdf}}/ECMA-408_4th_edition_december_2015.pdf
 [5th-ed]: /resources/language/spec/versions/DartLangSpec-v2.10.pdf
-[6th-ed]: https://spec.dart.dev/DartLangSpecDraft.pdf
+[6th-ed]: {{site.url}}/to/spec-draft
 
 ---
 

--- a/src/content/resources/language/spec/index.md
+++ b/src/content/resources/language/spec/index.md
@@ -17,7 +17,7 @@ You can find the in-progress specification in PDF format:
 * [Latest, in-progress specification][latest draft]
   (produced from a [LaTeX file][])
 
-[latest draft]: https://spec.dart.dev/DartLangSpecDraft.pdf
+[latest draft]: {{site.url}}/to/spec-draft
 [LaTeX file]: {{site.repo.dart.lang}}/blob/main/specification/dartLangSpec.tex
 
 New language features are typically described using


### PR DESCRIPTION
Adds and uses a tooling redirect [dart.dev/to/spec-draft](https://dart.dev/to/spec-draft) to point to the new spec location on Google Cloud storage.

**Staged:** https://dart-dev--pr6735-misc-update-draft-spec-destination-icix1kwq.web.app/to/spec-draft