### PR TITLE
typeInfo consists only: 'Data is an integer: 123'

### DIFF
--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -597,7 +597,7 @@ var typeInfo = [
   if (data case String s) 'Data is a string: $s',
   if (data case bool b) 'Data is a boolean: $b',
   if (data case double d) 'Data is a double: $d',
-]; // [Data is an integer: 123, Data is a double: 123]
+]; // [Data is an integer: 123]
 ```
 
 <?code-excerpt "misc/test/language_tour/collections/if_case_operator_in_collection_d.dart (code_sample)"?>


### PR DESCRIPTION

<img width="1052" height="740" alt="Screenshot from 2025-07-18 11-55-08" src="https://github.com/user-attachments/assets/b81573ea-4986-41e2-840a-eefe39c06b71" />

Running on Dart SDK version: 3.8.1 there is no 'Data is a double: 123' in the variable typeInfo  after running the example.

 
