### PR TITLE
Add type alias term

### DIFF
--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -786,7 +786,8 @@
   long_description: |-
     A **type alias** is an alternative name that refers to another type.
 
-    It can be used to simplify complex type definitions, improve readability, or create semantic meaning in code.
+    They can be used to simplify complex type definitions,
+    improve readability, or create semantic meaning in code.
 
     Dart supports type aliases using the `typedef` keyword. You can alias functions, classes, and even generic types.
 

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -782,7 +782,7 @@
 
 - term: "Type alias"
   short_description: |-
-    A name that refers to another type.
+    A user-defined name for an existing type
   long_description: |-
     A **type alias** is an alternative name that refers to another type.
 

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -780,6 +780,47 @@
     - "subtyping"
     - "subtype polymorphism"
 
+- term: "Type alias"
+  short_description: |-
+    A name that refers to another type.
+  long_description: |-
+    A **type alias** is an alternative name that refers to another type.
+
+    It can be used to simplify complex type definitions, improve readability, or create semantic meaning in code.
+
+    Dart supports type aliases using the `typedef` keyword. You can alias functions, classes, and even generic types.
+
+    ### Examples
+
+    #### Function type alias:
+
+    ```dart
+    typedef StringTransformer = String Function(String);
+    ```
+
+    #### Class alias (since Dart 2.13):
+
+    ```dart
+    class HttpClient {}
+
+    typedef Client = HttpClient;
+
+    Client client = HttpClient();
+    ```
+
+    Type aliases don’t create new types — they just provide alternate names.
+
+  related_links:
+    - text: "`typedef` keyword"
+      link: "/language/typedefs"
+      type: "doc"
+  labels:
+    - "language"
+    - "type system"
+  alternate:
+    - "typedef"
+    - "alias"
+
 - term: "Variance and variance positions"
   id: "variance"
   short_description: |-

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -798,6 +798,14 @@
 
     ```dart
     typedef StringTransformer = String Function(String);
+
+    void printTransformed(String input, StringTransformer transformer) {
+      print(transformer(input));
+    }
+
+    void main() {
+      printTransformed('hello', (str) => str.toUpperCase()); // Output: HELLO
+    }
     ```
 
     #### Class alias

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -794,7 +794,7 @@
 
     ### Examples
 
-    #### Function type alias:
+    #### Function type alias
 
     ```dart
     typedef StringTransformer = String Function(String);

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -789,7 +789,8 @@
     They can be used to simplify complex type definitions,
     improve readability, or create semantic meaning in code.
 
-    Dart supports type aliases using the `typedef` keyword. You can alias functions, classes, and even generic types.
+    Dart supports defining type aliases using the `typedef` keyword.
+    You can alias functions, classes, and even generic types.
 
     ### Examples
 

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -808,7 +808,7 @@
     Client client = HttpClient();
     ```
 
-    Type aliases don’t create new types — they just provide alternate names.
+    Type aliases don’t create new types, they just provide alternate names.
 
   related_links:
     - text: "`typedef` keyword"

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -800,7 +800,7 @@
     typedef StringTransformer = String Function(String);
     ```
 
-    #### Class alias (since Dart 2.13):
+    #### Class alias
 
     ```dart
     class HttpClient {}

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -782,7 +782,7 @@
 
 - term: "Type alias"
   short_description: |-
-    A user-defined name for an existing type
+    A user-defined name for an existing type.
   long_description: |-
     A **type alias** is an alternative name that refers to another type.
 

--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -818,8 +818,7 @@
     Client client = HttpClient();
     ```
 
-    Type aliases don’t create new types, they just provide alternate names.
-
+    Type aliases don't create new types, they just provide alternate names.
   related_links:
     - text: "`typedef` keyword"
       link: "/language/typedefs"


### PR DESCRIPTION
Adds the term "type alias" to the glossary.

Contributes to #6461 
