### PR TITLE
Restructure dart create page with clearer template section and cross link

### DIFF
--- a/src/content/tools/dart-create.md
+++ b/src/content/tools/dart-create.md
@@ -4,6 +4,8 @@ description: Command-line tool for creating Dart projects.
 toc: false
 ---
 
+## Overview
+
 The `dart create` command creates a Dart project,
 using one of several supported templates.
 The same functionality is available in IDEs.
@@ -13,6 +15,8 @@ The same functionality is available in IDEs.
 When you run `dart create`, it first creates a directory with the project files. 
 Then it gets package dependencies (unless you specify the `--no-pub` flag).
 
+## Basic usage
+
 Here's an example of using `dart create` to create a directory named `my_cli` 
 that contains a simple console app (the default template):
 
@@ -20,18 +24,24 @@ that contains a simple console app (the default template):
 $ dart create my_cli
 ```
 
-To use a different template, such as `web`, add a template argument:
+## Specifying a template
+
+To use a different template, use the `-t` (or `--template`) flag followed by the template name:
 
 ```console
 $ dart create -t web my_web_app
 ```
 
-The following table shows the templates you can use:
+The `-t` flag allows you to specify which type of Dart project you want to create. If you don't specify a template, `dart create` uses the `console` template by default.
+
+## Available templates
+
+The following table shows the templates you can use with the `-t` flag:
 
 | Template       | Description                                                                                           |
 |----------------|-------------------------------------------------------------------------------------------------------|
 | `cli`          | A command-line application with basic argument parsing using [`package:args`]({{site.pub-pkg}}/args). |
-| `console`      | A command-line application.                                                                           |
+| `console`      | A command-line application (default template).                                                       |
 | `package`      | A package containing shared Dart libraries.                                                           |
 | `server-shelf` | A server built using [shelf][].                                                                       |
 | `web`          | A web app built using core Dart libraries.                                                            |
@@ -43,12 +53,18 @@ The following table shows the templates you can use:
 These templates result in a file structure that follows
 [package layout conventions](/tools/pub/package-layout).
 
+## Additional options
+
+### Force project creation
+
 If the specified directory already exists, `dart create` fails. 
 You can force project generation with the `--force` flag:
 
 ```console
 $ dart create --force <DIRECTORY>
 ```
+
+### Getting help
 
 For further information on command-line options, use the `--help` flag:
 
@@ -59,16 +75,13 @@ $ dart create --help
 {% comment %}
 ```
 Create a new Dart project.
-
 Usage: dart create [arguments] <directory>
 -h, --help                       Print this usage information.
 -t, --template                   The project template to use.
-
           [console] (default)    A command-line application.
           [package]              A package containing shared Dart libraries.
           [server-shelf]         A server app using `package:shelf`
           [web]                  A web app that uses only core Dart libraries.
-
     --[no-]pub                   Whether to run 'pub get' after the project has been created.
                                  (defaults to on)
     --force                      Force project generation, even if the target directory already exists.

--- a/src/content/tools/pub/create-packages.md
+++ b/src/content/tools/pub/create-packages.md
@@ -18,6 +18,9 @@ and the `package` template:
 $ dart create -t package <PACKAGE_NAME>
 ```
 
+To learn more about available templates and how to use the `-t` flag, 
+see the [dart create documentation](/tools/dart-create#available-templates).
+
 ## What makes a package
 
 The following diagram shows the simplest layout of a package:


### PR DESCRIPTION
Clarify `dart create` template usage and improve documentation structure

This improves the [`/tools/dart-create` ](https://dart.dev/tools/dart-create) page by:

- Adding a clear section on using the `-t` / `--template` flag
- Introducing section headers to improve readability

Related to: #6730