### PR TITLE
Overhaul the metadata and annotation language docs

### DIFF
--- a/examples/misc/lib/language_tour/metadata/television.dart
+++ b/examples/misc/lib/language_tour/metadata/television.dart
@@ -10,13 +10,13 @@ class Television {
 
   /// Turns the TV's power on.
   void turnOn() {
-    /*...*/
+    // ···
   }
   // #enddocregion deprecated
 
   // #docregion override
   set contrast(int value) {
-    /*...*/
+    // ···
   }
   // #docregion deprecated
 }
@@ -25,7 +25,7 @@ class Television {
 class SmartTelevision extends Television {
   @override
   set contrast(num value) {
-    /*...*/
+    // ···
   }
   // #enddocregion override
   // #docregion override

--- a/examples/misc/lib/language_tour/metadata/todo.dart
+++ b/examples/misc/lib/language_tour/metadata/todo.dart
@@ -1,6 +1,15 @@
+// #docregion target-kinds
+import 'package:meta/meta_meta.dart';
+
+@Target({TargetKind.function, TargetKind.method})
+// #docregion definition
 class Todo {
+  // #enddocregion target-kinds
   final String who;
   final String what;
 
   const Todo(this.who, this.what);
+  // #docregion target-kinds
 }
+
+// #enddocregion definition, target-kinds

--- a/examples/misc/pubspec.yaml
+++ b/examples/misc/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   characters: ^1.3.0
   examples_util: { path: ../util }
   http: ^1.4.0
+  meta: ^1.17.0
   web: ^1.1.0
 
 dev_dependencies:

--- a/src/content/language/extend.md
+++ b/src/content/language/extend.md
@@ -48,14 +48,14 @@ intentionally overriding a member:
 class Television {
   // ···
   set contrast(int value) {
-    ...
+    // ···
   }
 }
 
 class SmartTelevision extends Television {
   [!@override!]
   set contrast(num value) {
-    ...
+    // ···
   }
   // ···
 }

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -127,11 +127,15 @@ void doSomething() {
 }
 ```
 
-To indicate the type of elements that should be annotated with your annotation,
-you can use the [`@Target`][] annotation from [`package:meta`][].
+### Specifying supported targets {:.no_toc}
 
-For example, if you wanted the above `@Todo` annotation to
-only be allowed on functions, you'd add the following annotation:
+To indicate the type of language constructs that
+should be annotated with your annotation,
+use the [`@Target`][] annotation from [`package:meta`][].
+
+For example, if you wanted the earlier `@Todo` annotation to
+only be allowed on functions and methods,
+you'd add the following annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/todo.dart (target-kinds)"?>
 ```dart highlightLines=3

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -71,6 +71,37 @@ members annotated with `@deprecated` or `@Deprecated`.
 [Extend a class]: /language/extend
 [Dart analyzer]: /tools/analysis
 
+## Analyzer-supported annotations
+
+Beyond providing support and analysis for the [built-in annotations][],
+the [Dart analyzer][] provides additional support and diagnostics for
+a variety of annotations from [`package:meta`][].
+Some commonly used annotations the package provides include:
+
+[`@visibleForTesting`][]
+: Marks a public member of a package as only public so
+  that the package can write tests for it.
+  The analyzer hides the member from autocompletion suggestions
+  and warns if it's used from another package.
+
+[`@awaitNotRequired`][]
+: Marks variables that have a `Future` type or functions that return a `Future`
+  as not requiring the caller to await the `Future`.
+  This stops the analyzer from warning callers that don't await the `Future`
+  due to the [`discarded_futures`][] or [`unawaited_futures`][] lints.
+
+To learn more about these and the other annotations the package provides,
+what they indicate, what functionality they enable, and how to use them,
+check out the [`package:meta/meta.dart` API docs][meta-api].
+
+[built-in annotations]: #built-in-annotations
+[Dart analyzer]: /tools/analysis
+[`@visibleForTesting`]: {{site.pub-api}}/meta/latest/meta/visibleForTesting-constant.html
+[`@awaitNotRequired`]: {{site.pub-api}}/meta/latest/meta/awaitNotRequired-constant.html
+[`discarded_futures`]: /tools/linter-rules/discarded_futures
+[`unawaited_futures`]: /tools/linter-rules/unawaited_futures
+[meta-api]: {{site.pub-api}}/meta/latest/meta/meta-library.html
+
 ## Custom annotations
 
 You can define your own metadata annotations. Here's an example of
@@ -117,34 +148,3 @@ an annotation on any declaration besides a top-level function or method.
 
 [`@Target`]: {{site.pub-api}}/meta/latest/meta_meta/Target-class.html
 [`package:meta`]: {{site.pub-pkg}}/meta
-
-## Analyzer supported annotations
-
-Beyond providing support and analysis for the [built-in annotations][],
-the [Dart analyzer][] provides additional support and diagnostics for
-a variety of annotations from [`package:meta`][].
-Some commonly used annotations the package provides include:
-
-[`@visibleForTesting`][]
-: Marks a public member of a package as only public so
-  that the package can write tests for it.
-  The analyzer hides the member from autocompletion suggestions
-  and warns if it's used from another package.
-
-[`@awaitNotRequired`][]
-:  Marks variables that have a `Future` type or functions that return a `Future`
-  as not requiring the caller to await the `Future`.
-  This stops the analyzer from warning callers that don't await the `Future`
-  due to the [`discarded_futures`][] or [`unawaited_futures`][] lints.
-
-To learn more about these and the other annotations the package provides,
-what they indicate, what functionality they enable, and how to use them,
-check out the [`package:meta/meta.dart` API docs][meta-api].
-
-[built-in annotations]: #built-in-annotations
-[Dart analyzer]: /tools/analysis
-[`@visibleForTesting`]: {{site.pub-api}}/meta/latest/meta/visibleForTesting-constant.html
-[`@awaitNotRequired`]: {{site.pub-api}}/meta/latest/meta/awaitNotRequired-constant.html
-[`discarded_futures`]: /tools/linter-rules/discarded_futures
-[`unawaited_futures`]: /tools/linter-rules/unawaited_futures
-[meta-api]: {{site.pub-api}}/meta/latest/meta/meta-library.html

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -24,8 +24,6 @@ declaration and before an import or export directive.
 
 The following annotations are available to all Dart code: 
 
-*   [`@awaitNotRequired`][]: Suppress `unawaited_futures` and
-    `discarded_futures` lint diagnostics at call sites.
 *   [`@Deprecated`][]: Mark a part of your code as no longer
     recommended. Optionally [provide a deprecation message][].
 *   [`@deprecated`][]: Mark a part of your code as no longer
@@ -39,29 +37,41 @@ The following annotations are available to all Dart code:
 
 Here's an example of using the `@Deprecated` annotation:
 
-<?code-excerpt "misc/lib/language_tour/metadata/television.dart (deprecated)" replace="/@Deprecated.*/[!$&!]/g"?>
-```dart
+<?code-excerpt "misc/lib/language_tour/metadata/television.dart (deprecated)"?>
+```dart highlightLines=3
 class Television {
   /// Use [turnOn] to turn the power on instead.
-  [!@Deprecated('Use turnOn instead')!]
+  @Deprecated('Use turnOn instead')
   void activate() {
     turnOn();
   }
 
   /// Turns the TV's power on.
   void turnOn() {
-    ...
+    // ···
   }
   // ···
 }
 ```
+
+The [Dart analyzer][] provides feedback as diagnostics if
+the `@override` annotation is needed and when using
+members annotated with `@deprecated` or `@Deprecated`.
+
+[`@Deprecated`]: {{site.dart-api}}/dart-core/Deprecated-class.html
+[`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
+[`@override`]: {{site.dart-api}}/dart-core/override-constant.html
+[`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
+[provide a deprecation message]: /tools/linter-rules/provide_deprecation_message
+[Extending a class]: /language/extend
+[Dart analyzer]: /tools/analysis
 
 ## Custom annotations
 
 You can define your own metadata annotations. Here's an example of
 defining a `@Todo` annotation that takes two arguments:
 
-<?code-excerpt "misc/lib/language_tour/metadata/todo.dart"?>
+<?code-excerpt "misc/lib/language_tour/metadata/todo.dart (definition)"?>
 ```dart
 class Todo {
   final String who;
@@ -81,10 +91,48 @@ void doSomething() {
 }
 ```
 
-[`@awaitNotRequired`]: {{site.dart-api}}/dart-core/awaitNotRequired-class.html
-[`@Deprecated`]: {{site.dart-api}}/dart-core/Deprecated-class.html
-[`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
-[`@override`]: {{site.dart-api}}/dart-core/override-constant.html
-[`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
-[provide a deprecation message]: /tools/linter-rules/provide_deprecation_message
-[Extending a class]: /language/extend
+To indicate the type of elements that should be annotated with your annotation,
+you can use the [`@Target`][] annotation from [`package:meta`][].
+
+For example, if you wanted the above `@Todo` annotation to
+only be allowed on functions, you'd add the following annotation:
+
+<?code-excerpt "misc/lib/language_tour/metadata/todo.dart (target-kinds)"?>
+```dart highlightLines=3
+import 'package:meta/meta_meta.dart';
+
+@Target({TargetKind.function, TargetKind.method})
+class Todo {
+  // ···
+}
+```
+
+With this configuration, the analyzer will warn if `Todo` is used as
+an annotation on any declaration besides a top-level function or method.
+
+[`@Target`]: {{site.pub-api}}/meta/latest/meta_meta/Target-class.html
+[`package:meta`]: {{site.pub-pkg}}/meta
+
+## Analyzer supported annotations
+
+Beyond providing support and analysis for the [built-in annotations][],
+the [Dart analyzer][] provides additional support and diagnostics for
+a variety of annotations from [`package:meta`][].
+Some of the most commonly used annotations it provides include:
+
+*   [`@visibleForTesting`][]: Mark a public member of a package as
+    only public for that package to write tests for it.
+    The analyzer hides the member from autocompletion suggestions
+    and warns if it's used from another package.
+*   [`@awaitNotRequired`][]: Suppress `unawaited_futures` and
+    `discarded_futures` lint diagnostics at call sites.
+
+To learn more about these and the other annotations the package provides,
+what elements they can be applied to, what they do, and how to use them,
+check out the [`package:meta/meta.dart` API docs][meta-api].
+
+[built-in annotations]: #built-in-annotations
+[Dart analyzer]: /tools/analysis
+[`@visibleForTesting`]: {{site.pub-api}}/meta/latest/meta/visibleForTesting-constant.html
+[`@awaitNotRequired`]: {{site.pub-api}}/meta/latest/meta/awaitNotRequired-constant.html
+[meta-api]: {{site.pub-api}}/meta/latest/meta/meta-library.html

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -10,14 +10,13 @@ nextpage:
 ---
 
 
-Use metadata to give additional information about your code. A metadata
-annotation begins with the character `@`, followed by either a reference
-to a compile-time constant (such as `deprecated`) or a call to a
-constant constructor.
+Use metadata to provide additional static information about your code.
+A metadata annotation begins with the character `@`, followed by either
+a reference to a compile-time constant (such as `deprecated`) or
+a call to a constant constructor.
 
-Metadata can appear before a library, class, typedef, type parameter,
-constructor, factory, function, field, parameter, or variable
-declaration and before an import or export directive.
+Metadata can be attached to most Dart program constructs by
+adding annotations before the construct's declaration or directive.
 
 ## Built-in annotations
 

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -16,10 +16,27 @@ annotation begins with the character `@`, followed by either a reference
 to a compile-time constant (such as `deprecated`) or a call to a
 constant constructor.
 
-Four annotations are available to all Dart code: 
-[`@Deprecated`][], [`@deprecated`][], [`@override`][], and [`@pragma`][]. 
-For examples of using `@override`,
-see [Extending a class][].
+Metadata can appear before a library, class, typedef, type parameter,
+constructor, factory, function, field, parameter, or variable
+declaration and before an import or export directive.
+
+## Built-in annotations
+
+The following annotations are available to all Dart code: 
+
+*   [`@awaitNotRequired`][]: Suppress `unawaited_futures` and
+    `discarded_futures` lint diagnostics at call sites.
+*   [`@Deprecated`][]: Mark a part of your code as no longer
+    recommended. Optionally [provide a deprecation message][].
+*   [`@deprecated`][]: Mark a part of your code as no longer
+    recommended.
+*   [`@override`][]: Mark a method as an override for a
+    method with the same name from a parent class or
+    interface. For examples of using `@override`, see
+    [Extending a class][].
+*   [`@pragma`][]: Provide specific instructions or hints to
+    Dart tools, like the compiler or analyzer.
+
 Here's an example of using the `@Deprecated` annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/television.dart (deprecated)" replace="/@Deprecated.*/[!$&!]/g"?>
@@ -39,9 +56,7 @@ class Television {
 }
 ```
 
-You can use `@deprecated` if you don't want to specify a message.
-However, we [recommend][dep-lint] always
-specifying a message with `@Deprecated`.
+## Custom annotations
 
 You can define your own metadata annotations. Here's an example of
 defining a `@Todo` annotation that takes two arguments:
@@ -66,13 +81,10 @@ void doSomething() {
 }
 ```
 
-Metadata can appear before a library, class, typedef, type parameter,
-constructor, factory, function, field, parameter, or variable
-declaration and before an import or export directive.
-
+[`@awaitNotRequired`]: {{site.dart-api}}/dart-core/awaitNotRequired-class.html
 [`@Deprecated`]: {{site.dart-api}}/dart-core/Deprecated-class.html
 [`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
 [`@override`]: {{site.dart-api}}/dart-core/override-constant.html
 [`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
-[dep-lint]: /tools/linter-rules/provide_deprecation_message
+[provide a deprecation message]: /tools/linter-rules/provide_deprecation_message
 [Extending a class]: /language/extend

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -1,7 +1,6 @@
 ---
 title: Metadata
 description: Metadata and annotations in Dart.
-toc: false
 prevpage:
   url: /language/functions
   title: Functions
@@ -22,18 +21,25 @@ declaration and before an import or export directive.
 
 ## Built-in annotations
 
-The following annotations are available to all Dart code: 
+The following annotations are available to all Dart code:
 
-*   [`@Deprecated`][]: Mark a part of your code as no longer
-    recommended. Optionally [provide a deprecation message][].
-*   [`@deprecated`][]: Mark a part of your code as no longer
-    recommended.
-*   [`@override`][]: Mark a method as an override for a
-    method with the same name from a parent class or
-    interface. For examples of using `@override`, see
-    [Extending a class][].
-*   [`@pragma`][]: Provide specific instructions or hints to
-    Dart tools, like the compiler or analyzer.
+[`@Deprecated`][]
+: Marks a declaration as deprecated,
+  indicating it should be migrated away from,
+  with a message explaining the replacement and potential removal date.
+
+[`@deprecated`][]
+: Marks a declaration as deprecated until an unspecified future release.
+  Prefer using `@Deprecated` and [providing a deprecation message][].
+
+[`@override`][]
+: Marks an instance member as an override or implementation of
+  a member with the same name from a parent class or interface.
+  For examples of using `@override`, check out [Extend a class][].
+
+[`@pragma`][]
+: Provides specific instructions or hints about a declaration to
+  Dart tools, such as the compiler or analyzer.
 
 Here's an example of using the `@Deprecated` annotation:
 
@@ -62,8 +68,8 @@ members annotated with `@deprecated` or `@Deprecated`.
 [`@deprecated`]: {{site.dart-api}}/dart-core/deprecated-constant.html
 [`@override`]: {{site.dart-api}}/dart-core/override-constant.html
 [`@pragma`]: {{site.dart-api}}/dart-core/pragma-class.html
-[provide a deprecation message]: /tools/linter-rules/provide_deprecation_message
-[Extending a class]: /language/extend
+[providing a deprecation message]: /tools/linter-rules/provide_deprecation_message
+[Extend a class]: /language/extend
 [Dart analyzer]: /tools/analysis
 
 ## Custom annotations
@@ -84,7 +90,7 @@ class Todo {
 And here's an example of using that `@Todo` annotation:
 
 <?code-excerpt "misc/lib/language_tour/metadata/misc.dart (usage)"?>
-```dart
+```dart highlightLines=1
 @Todo('Dash', 'Implement this function')
 void doSomething() {
   print('Do something');
@@ -118,21 +124,28 @@ an annotation on any declaration besides a top-level function or method.
 Beyond providing support and analysis for the [built-in annotations][],
 the [Dart analyzer][] provides additional support and diagnostics for
 a variety of annotations from [`package:meta`][].
-Some of the most commonly used annotations it provides include:
+Some commonly used annotations the package provides include:
 
-*   [`@visibleForTesting`][]: Mark a public member of a package as
-    only public for that package to write tests for it.
-    The analyzer hides the member from autocompletion suggestions
-    and warns if it's used from another package.
-*   [`@awaitNotRequired`][]: Suppress `unawaited_futures` and
-    `discarded_futures` lint diagnostics at call sites.
+[`@visibleForTesting`][]
+: Marks a public member of a package as only public so
+  that the package can write tests for it.
+  The analyzer hides the member from autocompletion suggestions
+  and warns if it's used from another package.
+
+[`@awaitNotRequired`][]
+:  Marks variables that have a `Future` type or functions that return a `Future`
+  as not requiring the caller to await the `Future`.
+  This stops the analyzer from warning callers that don't await the `Future`
+  due to the [`discarded_futures`][] or [`unawaited_futures`][] lints.
 
 To learn more about these and the other annotations the package provides,
-what elements they can be applied to, what they do, and how to use them,
+what they indicate, what functionality they enable, and how to use them,
 check out the [`package:meta/meta.dart` API docs][meta-api].
 
 [built-in annotations]: #built-in-annotations
 [Dart analyzer]: /tools/analysis
 [`@visibleForTesting`]: {{site.pub-api}}/meta/latest/meta/visibleForTesting-constant.html
 [`@awaitNotRequired`]: {{site.pub-api}}/meta/latest/meta/awaitNotRequired-constant.html
+[`discarded_futures`]: /tools/linter-rules/discarded_futures
+[`unawaited_futures`]: /tools/linter-rules/unawaited_futures
 [meta-api]: {{site.pub-api}}/meta/latest/meta/meta-library.html

--- a/src/content/language/metadata.md
+++ b/src/content/language/metadata.md
@@ -79,8 +79,8 @@ a variety of annotations from [`package:meta`][].
 Some commonly used annotations the package provides include:
 
 [`@visibleForTesting`][]
-: Marks a public member of a package as only public so
-  that the package can write tests for it.
+: Marks a member of a package as only public so that
+  the member can be accessed from the package's tests.
   The analyzer hides the member from autocompletion suggestions
   and warns if it's used from another package.
 


### PR DESCRIPTION
Overhaul the metadata page of the language docs, with a primary goal of including some mention of `package:meta`. I know technically `package:meta` isn't technically part of the language, but for developers reading these docs, the distinction isn't important enough to document this somewhere completely different. However, I did still try to clarify that the support around it is provided "by the Dart analyzer" rather than "by Dart".

- Integrate @antfitch's idea from https://github.com/dart-lang/site-www/pull/6731 of adding sections, particularly one focused on the built-in annotations.
- As began in https://github.com/dart-lang/site-www/pull/6731 by @antfitch, include a short definition and relative links about each of the built-in (`dart:core`) annotations.
- Document how to configure the supported targets of custom annotations using `package:meta/meta_meta.dart`.
- Add a new section on the (analyzer supported) annotations provided by `package:meta`, include some examples, and otherwise link to its (quite thorough) API docs.
- Take advantage of the ability to highlight relevant lines in example code blocks.

Resolves https://github.com/dart-lang/site-www/issues/6687

**Staged:** http://dart-dev--pr6758-feat-metadata-package-meta-325c4pbv.web.app/language/metadata