### PR TITLE
Remove requirement for Insiders channel for GCA Agent Mode

### DIFF
--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -124,11 +124,6 @@ documentation for [setting up MCP servers][].
 
 ### Gemini Code Assist in VS Code
 
-:::note
-This requires the "Insiders" channel of Gemini Code Assist.
-Follow the [instructions][] to enable this build.
-:::
-
 [Gemini Code Assist][]'s [Agent mode][] integrates the
 Gemini CLI to provide a powerful AI agent directly in your IDE.
 To configure Gemini Code Assist to use the Dart MCP server,


### PR DESCRIPTION
As of 1st August, Gemini Code Assist Agent Mode (VS Code) preview is now available to all users in the default channel.

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
