### PR TITLE
Update Dart Frog URL in index.md

### DIFF
--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -39,7 +39,7 @@ Server-side frameworks written in Dart include:
 : A scalable app server that supports code generation,
   authentication, real-time communication, databases, and caching.
 
-[Dart Frog](https://dartfrog.vgv.dev/)
+[Dart Frog](https://dart-frog.dev/)
 : A fast, minimalistic backend framework for Dart.
 
 More tools


### PR DESCRIPTION
The current dart frog URL points to an invalid link.

The PR updates the broken link for Dart Frog on [CLI & Server Docs](https://dart.dev/server#frameworks)

Fixes #6779

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
