### PR TITLE
Fix broken link in glossary

### DIFF
--- a/src/_data/glossary.yml
+++ b/src/_data/glossary.yml
@@ -779,7 +779,7 @@
     [`pub get`]: /tools/pub/cmd/pub-get
     [`pub upgrade`]: /tools/pub/cmd/pub-upgrade
     [`pub downgrade`]: /tools/pub/cmd/pub-downgrade
-    [application package]: #application-packages
+    [application package]: #application-package
     [content hash]: #pub-content-hash
   related_links:
     - text: "pub get"


### PR DESCRIPTION
https://github.com/dart-lang/site-www/pull/6804 was landed with a broken link.