### PR TITLE
Adjust documentation of extension types: Cast/match does not run cons…

### DIFF
--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -476,8 +476,8 @@ still refers to the same object, and `v` refers to the same object as `i`, and
 nothing has changed about this object. It is only the static type that changeed
 (and hence the methods that we can call on this object). In particular, the
 change of type does not involve an invocation of a constructor. If you wish to
-execute a constructor (e.g., to perform some kind of validation) then it is
-necessary to write an explicit constructor invocation (such as `NumberE(i)`).
+execute a constructor (for example, to perform some kind of validation) then it
+is necessary to write an explicit constructor invocation (such as `NumberE(i)`).
 
 It's important to be aware of this behavior when using extension types.
 Always keep in mind that an extension type exists and matters at compile time,

--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -477,7 +477,7 @@ nothing has changed about this object. It is only the static type that changeed
 (and hence the methods that we can call on this object). In particular, the
 change of type does not involve an invocation of a constructor. If you wish to
 execute a constructor (e.g., to perform some kind of validation) then it is
-necessary to write an explicit constructor invocation (such as `NumberE(1)`).
+necessary to write an explicit constructor invocation (such as `NumberE(i)`).
 
 It's important to be aware of this behavior when using extension types.
 Always keep in mind that an extension type exists and matters at compile time,

--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -473,7 +473,7 @@ void main() {
 
 When `i` gets the static type `NumberE` based on a cast or a pattern match, `i`
 still refers to the same object, and `v` refers to the same object as `i`, and
-nothing has changed about this object. It is only the static type that changeed
+nothing has changed about this object. It is only the static type that changed
 (and hence the methods that we can call on this object). In particular, the
 change of type does not involve an invocation of a constructor. If you wish to
 execute a constructor (for example, to perform some kind of validation) then it

--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -473,7 +473,7 @@ void main() {
 
 When `i` gets the static type `NumberE` based on a cast or a pattern match, `i`
 still refers to the same object, and `v` refers to the same object as `i`, and
-nothing has changed about this object. It is only the static type that changed
+the object itself remains unchanged. It is only the static type that changed
 (and hence the methods that we can call on this object). In particular, the
 change of type does not involve an invocation of a constructor. If you wish to
 execute a constructor (for example, to perform some kind of validation) then it

--- a/src/content/language/extension-types.md
+++ b/src/content/language/extension-types.md
@@ -446,8 +446,8 @@ and when testing against an extension type (`case MyExtensionType(): ... `).
 void main() {
   var n = NumberE(1);
 
-  // Run-time type of 'n' is representation type 'int'.
-  if (n is int) print(n.value); // Prints 1.
+  // The run-time type of 'n' is the representation type 'int'.
+  if (n is int) print(n); // Prints 1.
 
   // Can use 'int' methods on 'n' at run time.
   if (n case int x) print(x.toRadixString(10)); // Prints 1.
@@ -471,13 +471,21 @@ void main() {
 }
 ```
 
-It's important to be aware of this quality when using extension types.
+When `i` gets the static type `NumberE` based on a cast or a pattern match, `i`
+still refers to the same object, and `v` refers to the same object as `i`, and
+nothing has changed about this object. It is only the static type that changeed
+(and hence the methods that we can call on this object). In particular, the
+change of type does not involve an invocation of a constructor. If you wish to
+execute a constructor (e.g., to perform some kind of validation) then it is
+necessary to write an explicit constructor invocation (such as `NumberE(1)`).
+
+It's important to be aware of this behavior when using extension types.
 Always keep in mind that an extension type exists and matters at compile time,
-but gets erased _during_ compilation.
+but gets _erased_ during compilation.
 
 For example, consider an expression `e` whose static type is the
-extension type `E`, and the representation type of `E` is `R`.
-Then, the run-time type of the value of `e` is a subtype of `R`.
+extension type `E`. Assume that the representation type of `E` is `R`.
+The run-time type of the value of `e` is then a subtype of `R`.
 Even the type itself is erased;
 `List<E>` is exactly the same thing as `List<R>` at run time.
 


### PR DESCRIPTION
This PR extends the description of 'Type Considerations' in the section about extension types, in order to make it more explicit that type casts and pattern matching operations won't invoke a constructor, it just changes the static type based on the representation type of said extension type.

Written in response to https://github.com/dart-lang/sdk/issues/61343#issuecomment-3197242069.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
