### PR TITLE
Clarify rectangle property calculation

### DIFF
--- a/examples/misc/lib/language_tour/classes/rectangle.dart
+++ b/examples/misc/lib/language_tour/classes/rectangle.dart
@@ -1,3 +1,5 @@
+/// A rectangle in a screen coordinate system,
+/// where the origin `(0, 0)` is in the top-left corner.
 class Rectangle {
   double left, top, width, height;
 

--- a/src/content/language/methods.md
+++ b/src/content/language/methods.md
@@ -110,7 +110,7 @@ additional properties by implementing getters and setters, using the
 <?code-excerpt "misc/lib/language_tour/classes/rectangle.dart"?>
 ```dart highlightLines=8-12
 /// A rectangle in a screen coordinate system,
-/// where the origin `(0, 0)` is the top-left corner.
+/// where the origin `(0, 0)` is in the top-left corner.
 class Rectangle {
   double left, top, width, height;
 

--- a/src/content/language/methods.md
+++ b/src/content/language/methods.md
@@ -108,7 +108,9 @@ additional properties by implementing getters and setters, using the
 `get` and `set` keywords:
 
 <?code-excerpt "misc/lib/language_tour/classes/rectangle.dart"?>
-```dart
+```dart highlightLines=8-12
+/// A rectangle in a screen coordinate system,
+/// where the origin `(0, 0)` is the top-left corner.
 class Rectangle {
   double left, top, width, height;
 
@@ -133,7 +135,7 @@ With getters and setters, you can start with instance variables, later
 wrapping them with methods, all without changing client code.
 
 :::note
-Operators such as increment (++) work in the expected way, whether or
+Operators such as increment (`++`) work in the expected way, whether or
 not a getter is explicitly defined. To avoid any unexpected side
 effects, the operator calls the getter exactly once, saving its value
 in a temporary variable.


### PR DESCRIPTION
https://github.com/dart-lang/site-www/issues/6798 reported the calculation as wrong, but I believe it's right since we tend to document screen-space where `(0, 0)` is in the upper left and y grows down. To avoid any future misunderstandings, I've added a doc comment to the class to clarify this. I've also highlighted the import lines of the code snippet.

Closes https://github.com/dart-lang/site-www/issues/6798

**Staged:** https://dart-dev--pr6827-fix-6798-hwzhhasy.web.app/language/methods#getters-and-setters

