### PR TITLE
Update build_runner tools docs

### DIFF
--- a/src/content/tools/build_runner.md
+++ b/src/content/tools/build_runner.md
@@ -80,8 +80,8 @@ watch
 
 ## More information
 
-* [webdev][webdev] guide (use if you're working on web-specific code)
-* [build_runner][webdev] guide
+* [webdev][] guide (use if you're working on web-specific code)
+* [build_runner][] guide
 * [packages with the `build_runner` dependency][]
 * [packages with the `build` dependency][]
 
@@ -89,7 +89,6 @@ watch
 [build_runner]: {{site.pub-pkg}}/build_runner
 [built_value_generator]: {{site.pub-pkg}}/built_value_generator
 [dev dependency]: /tools/pub/dependencies#dev-dependencies
-[Build_runner documentation.]: {{site.pub-pkg}}/build_runner
 [json_serializable]: {{site.pub-pkg}}/json_serializable
 [packages with the `build` dependency]: {{site.pub-pkg}}?q=dependency%3Abuild
 [packages with the `build_runner` dependency]: {{site.pub-pkg}}?q=dependency%3Abuild_runner


### PR DESCRIPTION
These pages are gone due to https://github.com/dart-lang/build/pull/4129

Preview: https://dart-dev--pr6837-patch-1-8lua4imh.web.app/tools/build_runner

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
