### PR TITLE
Migrate site switcher from flutter docs site

### DIFF
--- a/site/lib/_sass/_site.scss
+++ b/site/lib/_sass/_site.scss
@@ -32,6 +32,7 @@
 @use 'components/next-prev-nav';
 @use 'components/search';
 @use 'components/sidenav';
+@use 'components/site-switcher';
 @use 'components/tabs';
 @use 'components/tags';
 @use 'components/theming';

--- a/site/lib/_sass/components/_header.scss
+++ b/site/lib/_sass/components/_header.scss
@@ -4,198 +4,185 @@
   font-family: var(--site-ui-fontFamily);
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: var(--site-z-header);
 
-  @media (min-width: 1200px) {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, .05);
-    border-bottom: none;
-  }
-
-  .navbar {
-    .navbar-brand {
-      margin-right: auto;
-    }
-
-    .nav-link {
-      color: var(--site-base-fgColor-alt);
-      padding: 1.25rem 0;
-      position: relative;
-      text-decoration: none;
-
-      @media (min-width: 768px) {
-        padding: 0 1rem;
-      }
-
-      &.active {
-        color: var(--site-base-fgColor);
-        font-weight: 500;
-
-        @media (min-width: 768px) {
-          &:after {
-            $nav-active-marker-thickness: 3px;
-            background-color: var(--site-altLink-fgColor);
-            content: '';
-            display: block;
-            height: $nav-active-marker-thickness;
-            left: 0;
-            position: absolute;
-            top: calc(50% + (var(--site-header-height) / 2) - #{$nav-active-marker-thickness});
-            width: 100%;
-          }
-        }
-      }
-    }
-  }
-
-  #mainnav {
+  > nav.navbar {
+    position: relative;
     display: flex;
+    flex-wrap: nowrap;
     align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 1rem;
+
     min-height: var(--site-header-height);
 
-    ul.navbar {
-      padding: 0;
-      margin: 0;
-      list-style: none;
-
-      display: none;
-      flex-grow: 1;
-      flex-wrap: wrap;
-      justify-content: right;
-      align-items: center;
-
+    #menu-toggle {
       @media (min-width: 1024px) {
-        display: flex;
-      }
-
-      > li {
-        padding: 0 0.75rem;
-
-        > a {
-          color: var(--site-chrome-fgColor);
-          display: inline-block;
-          padding: 0 6px;
-          font-size: 1rem;
-          font-weight: 500;
-          font-family: var(--site-ui-fontFamily);
-
-          &:hover {
-            color: var(--site-altLink-fgColor);
-          }
-
-          &:active {
-            color: var(--site-altLink-fgColor-active);
-          }
-        }
+        display: none;
       }
     }
 
     .navbar-contents {
-      margin-left: auto;
-      margin-right: 0.75rem;
       display: flex;
       flex-direction: row;
       align-items: center;
       gap: .5rem;
+    }
 
-      .icon-button {
-        > .material-symbols {
-          font-size: 1.625rem;
-        }
-      }
+    ul.nav-items {
+      display: none;
+      padding: 0;
+      margin: 0 0 0 auto;
+      gap: 1rem;
+      flex-direction: row;
+      list-style-type: none;
 
-      .site-header-search {
-        display: none;
-        position: relative;
-        align-items: center;
-        vertical-align: middle;
-        margin-left: 1rem;
-
-        @media (min-width: 768px) {
-          display: flex;
-        }
-
-        &::before {
-          content: 'search';
-          color: var(--site-base-fgColor-alt);
-          font: 26px / 1 var(--site-icon-fontFamily);
-          pointer-events: none;
-          position: absolute;
-          left: .75rem;
-        }
-
-        &:hover::before {
-          color: var(--site-base-fgColor);
-        }
-      }
-
-      .site-header-searchfield {
-        border: 0;
-        font-size: 1rem;
-        height: 2.25rem;
-        transition: width .35s ease-in-out;
-        width: 24px;
-        cursor: pointer;
-        border-radius: 24px;
-        padding: 0.25rem 0.5rem 0.25rem 2.5rem;
-        background: none;
-        color: var(--site-chrome-fgColor);
-
-        &:focus {
-          width: 14rem;
-          cursor: auto;
-        }
-
-        &::-webkit-search-cancel-button {
-          display: none;
-        }
-      }
-
-      #fallback-search-button {
-        display: none;
-
-        @media (min-width: 320px) {
-          display: flex;
-        }
-
-        @media (min-width: 768px) {
-          display: none;
-        }
+      @media (min-width: 1024px) {
+        display: flex;
       }
     }
 
-    .brand {
-      display: flex;
-      width: 5.5rem;
-      overflow: hidden;
-      margin-left: 1.25rem;
-      align-items: center;
+    .nav-link {
+      color: var(--site-chrome-fgColor);
+      font-weight: 500;
+      padding: 0.25rem .5rem;
+      position: relative;
+      text-decoration: none;
+
+      &:hover {
+        color: var(--site-altLink-fgColor);
+      }
+
+      &.active::after {
+        background-color: var(--site-altLink-fgColor);
+        content: "";
+        display: block;
+        height: 3px;
+        left: 0;
+        position: absolute;
+        top: calc(50% + var(--site-header-height) / 2 - 3px);
+        width: 100%;
+      }
     }
   }
 
-  #menu-toggle {
+  .icon-button > .material-symbols {
+    font-size: 1.75rem;
+  }
+
+  #call-to-action {
+    padding: 0.5rem 1rem;
+    display: none;
+
     @media (min-width: 1024px) {
+      display: unset;
+    }
+  }
+
+  #header-search {
+    display: none;
+    position: relative;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 1rem;
+
+    @media (min-width: 576px) {
+      display: flex;
+    }
+
+    &::before {
+      content: 'search';
+      color: var(--site-base-fgColor-alt);
+      font: 28px/1 var(--site-icon-fontFamily);
+      pointer-events: none;
+      position: absolute;
+      left: 1rem;
+    }
+
+    &:hover::before {
+      color: var(--site-base-fgColor);
+    }
+
+    input {
+      border: 0;
+      font-size: 1rem;
+      transition: width .35s ease-in-out;
+      width: 24px;
+      cursor: pointer;
+      border-radius: 24px;
+      padding: 0.5rem 0.5rem 0.5rem 3rem;
+      background: none;
+
+      &:focus {
+        width: 220px;
+        cursor: auto;
+      }
+    }
+  }
+
+  #fallback-search-button {
+    display: none;
+
+    @media (min-width: 320px) {
+      display: flex;
+    }
+
+    @media (min-width: 576px) {
       display: none;
     }
+  }
 
-    // Toggle between menu and close buttons if sidenav is open or not.
-    span.material-symbols {
-      &:first-child {
-        display: inline;
-      }
+  #site-primary-logo {
+    text-decoration: none;
+    border-radius: 0.25rem;
+    padding: 0;
 
-      &:last-child {
+    > img {
+      width: 2.25rem;
+      margin-right: 0;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    > span {
+      &.name {
         display: none;
+
+        @media (min-width: 200px) {
+          display: unset;
+        }
       }
 
-      @at-root body.open_menu & {
-        &:first-child {
-          display: none;
-        }
+      &.subtype {
+        margin-left: 0;
 
-        &:last-child {
-          display: inline;
+        @media (min-width: 420px) {
+          margin-left: 0.4rem;
         }
       }
     }
+  }
+}
+
+// Toggle between menu and close buttons if sidenav is open or not.
+#menu-toggle span.material-symbols {
+  &:first-child {
+    display: inline;
+  }
+
+  &:last-child {
+    display: none;
+  }
+}
+
+body.open_menu #menu-toggle span.material-symbols {
+  &:first-child {
+    display: none;
+  }
+
+  &:last-child {
+    display: inline;
   }
 }

--- a/site/lib/_sass/components/_misc.scss
+++ b/site/lib/_sass/components/_misc.scss
@@ -131,18 +131,18 @@
   }
 }
 
-body.obsolete {
-  #site-header {
-    .alert {
-      background-color: #fcf8e3;
+#obsolete-banner {
+  position: fixed;
+  z-index: var(--site-z-floating);
+  top: calc(var(--site-header-height) + 1rem);
+  right: 1rem;
+  margin-left: 1rem;
 
-      padding: 0.5rem;
-      margin: 0;
+  background-color: var(--site-raised-bgColor);
+  padding: 0.5rem;
+  max-width: 16rem;
+  font-weight: 500;
 
-      h4 {
-        margin-bottom: 0;
-        margin-top: 0;
-      }
-    }
-  }
+  border: 2px solid var(--site-alert-warning-color);
+  border-radius: var(--site-radius);
 }

--- a/site/lib/_sass/components/_sidenav.scss
+++ b/site/lib/_sass/components/_sidenav.scss
@@ -16,7 +16,7 @@ $sidenav-wide-layout: 1024px;
   display: none;
   width: 100%;
   background-color: var(--site-base-bgColor);
-  z-index: 100;
+  z-index: var(--site-z-side);
 
   @at-root body.open_menu {
     #sidenav {

--- a/site/lib/_sass/components/_site-switcher.scss
+++ b/site/lib/_sass/components/_site-switcher.scss
@@ -1,0 +1,57 @@
+@use '../base/mixins';
+
+#site-switcher {
+  position: relative;
+
+  display: none;
+
+  @media (min-width: 320px) {
+    display: block;
+  }
+
+  .dropdown-content {
+    right: -0.5rem;
+  }
+}
+
+#site-primary-logo, #site-switcher .site-wordmark {
+  padding: 0.4rem 0.6rem;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+  gap: 0;
+
+  font-variant-ligatures: none;
+  font-size: 1.75rem;
+  line-height: 1.25em;
+  font-family: 'Google Sans', sans-serif;
+  user-select: none;
+
+  > img {
+    width: 2rem;
+  }
+
+  &.current-site {
+    background-color: var(--site-primary-color-highlight);
+  }
+
+  span {
+    color: var(--site-wordmark-fgColor);
+
+    &.name {
+      margin-left: 0.5rem;
+    }
+
+    &.subtype {
+      padding: 0 0.3rem;
+      font-size: 1.25rem;
+      font-weight: 500;
+      line-height: 1.3;
+      border-radius: 0.25rem;
+      background-color: var(--site-secondaryContainer-bgColor);
+      margin-left: 0.4rem;
+      letter-spacing: normal;
+    }
+  }
+}

--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -6,7 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
-import 'banner.dart';
+import 'material_icon.dart';
 
 /// The site-wide top navigation bar.
 class DashHeader extends StatelessComponent {
@@ -14,132 +14,187 @@ class DashHeader extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    final page = context.page;
-    final pageUrlPath = page.url;
-    final pageData = page.data.page;
-    final siteData = page.data.site;
-    final siteTitle = siteData['title'] as String;
-    final obsolete = pageData['obsolete'] == true;
+    final pageUrlPath = context.page.url;
     final activeEntry = _activeNavEntry(pageUrlPath);
 
-    return Component.fragment(
-      [
-        if (siteData['showBanner'] != false && pageData['showBanner'] != false)
-          DashBanner(
-            BannerContent.fromMap(page.data['banner'] as Map<String, Object?>),
-          ),
-        header(id: 'site-header', [
-          nav(id: 'mainnav', classes: 'always-dark-mode', [
+    return header(id: 'site-header', classes: 'always-dark-mode', [
+      nav(classes: 'navbar', [
+        a(
+          id: 'site-primary-logo',
+          classes: 'site-wordmark',
+          href: '/',
+          attributes: {
+            'aria-label': 'Go to the Dart homepage',
+            'title': 'Go to the Dart homepage',
+          },
+          [
+            img(
+              src: '/assets/img/logo/dart-192.svg',
+              alt: 'Dart logo',
+              attributes: {'width': '192'},
+            ),
+            span(
+              classes: 'name',
+              attributes: {'translate': 'no'},
+              [text('Dart')],
+            ),
+          ],
+        ),
+
+        ul(classes: 'nav-items', [
+          li([
             a(
-              href: '/',
-              classes: 'brand',
-              attributes: {'title': siteTitle},
+              href: '/overview',
+              classes: [
+                'nav-link',
+                if (activeEntry == _ActiveNavEntry.overview) 'active',
+              ].join(' '),
+              [text('Overview')],
+            ),
+          ]),
+          li([
+            a(
+              href: '/docs',
+              classes: [
+                'nav-link',
+                if (activeEntry == _ActiveNavEntry.docs) 'active',
+              ].join(' '),
               [
-                img(
-                  src: '/assets/img/logo/logo-white-text.svg',
-                  alt: siteTitle,
+                span([text('Docs')]),
+              ],
+            ),
+          ]),
+          li([
+            a(
+              href: '/community',
+              classes: [
+                'nav-link',
+                if (activeEntry == _ActiveNavEntry.community) 'active',
+              ].join(' '),
+              [text('Community')],
+            ),
+          ]),
+          li([
+            if (activeEntry == _ActiveNavEntry.learn)
+              a(href: '/get-started', classes: 'nav-link active', [
+                text('Learn'),
+              ])
+            else
+              a(href: '/#try-dart', classes: 'nav-link', [
+                text('Try Dart'),
+              ]),
+          ]),
+          li([
+            a(
+              href: '/get-dart',
+              classes: [
+                'nav-link',
+                if (activeEntry == _ActiveNavEntry.getDart) 'active',
+              ].join(' '),
+              [text('Get Dart')],
+            ),
+          ]),
+        ]),
+
+        div(
+          classes: 'navbar-contents',
+          [
+            form(
+              action: '/search/',
+              id: 'header-search',
+              [
+                input(
+                  classes: 'search-field',
+                  type: InputType.search,
+                  name: 'q',
+                  id: 'q',
+                  attributes: {
+                    'autocomplete': 'off',
+                    'placeholder': 'Search',
+                    'aria-label': 'Search',
+                  },
                 ),
               ],
             ),
-
-            ul(classes: 'navbar', [
-              li([
-                a(
-                  href: '/overview',
-                  classes: [
-                    'nav-link',
-                    if (activeEntry == _ActiveNavEntry.overview) 'active',
-                  ].join(' '),
-                  [text('Overview')],
-                ),
-              ]),
-              li([
-                a(
-                  href: '/docs',
-                  classes: [
-                    'nav-link',
-                    if (activeEntry == _ActiveNavEntry.docs) 'active',
-                  ].join(' '),
-                  [
-                    span([text('Docs')]),
-                  ],
-                ),
-              ]),
-              li([
-                a(
-                  href: '/community',
-                  classes: [
-                    'nav-link',
-                    if (activeEntry == _ActiveNavEntry.community) 'active',
-                  ].join(' '),
-                  [text('Community')],
-                ),
-              ]),
-              li([
-                if (activeEntry == _ActiveNavEntry.learn)
-                  a(href: '/get-started', classes: 'nav-link active', [
-                    text('Learn'),
-                  ])
-                else
-                  a(href: '/#try-dart', classes: 'nav-link', [
-                    text('Try Dart'),
-                  ]),
-              ]),
-              li([
-                a(
-                  href: '/get-dart',
-                  classes: [
-                    'nav-link',
-                    if (activeEntry == _ActiveNavEntry.getDart) 'active',
-                  ].join(' '),
-                  [text('Get Dart')],
-                ),
+            a(
+              id: 'fallback-search-button',
+              classes: 'icon-button',
+              href: '/search',
+              attributes: {
+                'aria-label': 'Navigate to the dart.dev search page.',
+                'title': 'Navigate to the dart.dev search page.',
+              },
+              const [
+                MaterialIcon('search'),
+              ],
+            ),
+            div(id: 'theme-switcher', classes: 'dropdown', [
+              button(
+                classes: 'dropdown-button icon-button',
+                attributes: {
+                  'title': 'Select a theme',
+                  'aria-label': 'Select a theme',
+                  'aria-expanded': 'false',
+                  'aria-controls': 'theme-menu',
+                },
+                const [MaterialIcon('routine')],
+              ),
+              div(classes: 'dropdown-content', id: 'theme-menu', [
+                div(classes: 'dropdown-menu', [
+                  ul(
+                    attributes: {'role': 'listbox'},
+                    [
+                      li([
+                        button(
+                          attributes: {
+                            'data-theme': 'light',
+                            'title': 'Switch to light mode',
+                            'aria-label': 'Switch to light mode',
+                            'aria-selected': 'false',
+                          },
+                          [
+                            const MaterialIcon('light_mode'),
+                            span([text('Light')]),
+                          ],
+                        ),
+                      ]),
+                      li([
+                        button(
+                          attributes: {
+                            'data-theme': 'dark',
+                            'title': 'Switch to dark mode',
+                            'aria-label': 'Switch to dark mode',
+                            'aria-selected': 'false',
+                          },
+                          [
+                            const MaterialIcon('dark_mode'),
+                            span([text('Dark')]),
+                          ],
+                        ),
+                      ]),
+                      li([
+                        button(
+                          attributes: {
+                            'data-theme': 'auto',
+                            'title': 'Follow the device theme',
+                            'aria-label': 'Follow the device theme',
+                            'aria-selected': 'false',
+                          },
+                          [
+                            const MaterialIcon('night_sight_auto'),
+                            span([text('Automatic')]),
+                          ],
+                        ),
+                      ]),
+                    ],
+                  ),
+                ]),
               ]),
             ]),
-            div(classes: 'navbar-contents', [
-              form(
-                action: '/search/',
-                classes: 'site-header-search',
-                id: 'cse-search-box',
-                [
-                  input(
-                    type: InputType.hidden,
-                    name: 'cx',
-                    value: '011220921317074318178:_yy-tmb5t_i',
-                  ),
-                  input(type: InputType.hidden, name: 'ie', value: 'UTF-8'),
-                  input(type: InputType.hidden, name: 'hl', value: 'en'),
-                  input(
-                    type: InputType.search,
-                    name: 'q',
-                    id: 'search-main',
-                    classes: 'site-header-searchfield search-field',
-                    attributes: {
-                      'autocomplete': 'off',
-                      'placeholder': 'Search',
-                      'aria-label': 'Search',
-                    },
-                  ),
-                ],
-              ),
-
-              a(
-                href: '/search',
-                id: 'fallback-search-button',
-                classes: 'icon-button',
-                attributes: {
-                  'aria-label': 'Navigate to the docs search page.',
-                  'title': 'Navigate to the docs search page.',
-                },
-                [
-                  span(
-                    classes: 'material-symbols',
-                    attributes: {'aria-hidden': 'true'},
-                    [text('search')],
-                  ),
-                ],
-              ),
-              div(id: 'theme-switcher', classes: 'dropdown', [
+            div(
+              id: 'site-switcher',
+              classes: 'dropdown',
+              [
                 button(
                   classes: 'dropdown-button icon-button',
                   attributes: {
@@ -148,147 +203,151 @@ class DashHeader extends StatelessComponent {
                     'aria-expanded': 'false',
                     'aria-controls': 'site-switcher-menu',
                   },
+                  const [MaterialIcon('apps')],
+                ),
+
+                div(
+                  id: 'site-switcher-menu',
+                  classes: 'dropdown-content',
                   [
-                    span(
-                      classes: 'material-symbols',
-                      attributes: {'aria-hidden': 'true'},
-                      [text('routine')],
+                    nav(
+                      classes: 'dropdown-menu',
+                      attributes: {
+                        'role': 'menu',
+                      },
+                      [
+                        ul(
+                          const [
+                            _SiteWordMarkListEntry(
+                              name: 'Dart',
+                              href: '/',
+                              current: true,
+                            ),
+                            _SiteWordMarkListEntry(
+                              name: 'Dart',
+                              subtype: 'API',
+                              href: 'https://api.dart.dev',
+                            ),
+                            _SiteWordMarkListEntry(
+                              name: 'DartPad',
+                              href: 'https://dartpad.dev',
+                            ),
+                            _SiteWordMarkListEntry(
+                              name: 'pub.dev',
+                              href: 'https://pub.dev',
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
                   ],
                 ),
-                div(classes: 'dropdown-content', id: 'theme-menu', [
-                  div(classes: 'dropdown-menu', [
-                    ul(
-                      attributes: {'role': 'listbox'},
-                      [
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'light',
-                              'title': 'Switch to light mode',
-                              'aria-label': 'Switch to light mode',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              span(
-                                classes: 'material-symbols',
-                                attributes: {'aria-hidden': 'true'},
-                                [text('light_mode')],
-                              ),
-                              span([text('Light')]),
-                            ],
-                          ),
-                        ]),
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'dark',
-                              'title': 'Switch to dark mode',
-                              'aria-label': 'Switch to dark mode',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              span(
-                                classes: 'material-symbols',
-                                attributes: {'aria-hidden': 'true'},
-                                [text('dark_mode')],
-                              ),
-                              span([text('Dark')]),
-                            ],
-                          ),
-                        ]),
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'auto',
-                              'title': 'Follow the device theme',
-                              'aria-label': 'Follow the device theme',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              span(
-                                classes: 'material-symbols',
-                                attributes: {'aria-hidden': 'true'},
-                                [text('night_sight_auto')],
-                              ),
-                              span([text('Automatic')]),
-                            ],
-                          ),
-                        ]),
-                      ],
-                    ),
-                  ]),
-                ]),
-              ]),
-              button(
-                id: 'menu-toggle',
-                classes: 'icon-button',
-                type: ButtonType.button,
-                attributes: {
-                  'aria-controls': 'sidenav',
-                  'aria-label': 'Toggle side navigation menu.',
-                  'title': 'Toggle side navigation menu.',
-                },
-                [
-                  span(
-                    classes: 'material-symbols',
-                    attributes: {'aria-hidden': 'true'},
-                    [text('menu')],
-                  ),
-                  span(
-                    classes: 'material-symbols',
-                    attributes: {'aria-hidden': 'true'},
-                    [text('close')],
-                  ),
-                ],
+              ],
+            ),
+            button(
+              id: 'menu-toggle',
+              classes: 'icon-button',
+              type: ButtonType.button,
+              attributes: {
+                'aria-controls': 'sidenav',
+                'aria-label': 'Open navigation menu.',
+                'title': 'Open navigation menu.',
+              },
+              const [
+                MaterialIcon('menu'),
+                MaterialIcon('close'),
+              ],
+            ),
+          ],
+        ),
+      ]),
+    ]);
+  }
+}
+
+class _SiteWordMarkListEntry extends StatelessComponent {
+  const _SiteWordMarkListEntry({
+    required this.href,
+    required this.name,
+    this.subtype,
+    this.current = false,
+  });
+
+  final String href;
+  final String name;
+  final String? subtype;
+  final bool current;
+
+  String get _combinedName => '$name${subtype != null ? ' $subtype' : ''}';
+
+  @override
+  Component build(BuildContext context) {
+    return li(
+      attributes: {'role': 'presentation'},
+      [
+        a(
+          href: '/',
+          classes: ['site-wordmark', if (current) 'current-site'].join(' '),
+          attributes: {
+            'role': 'menuitem',
+            'title': 'Navigate to the $_combinedName website.',
+            'aria-label': 'Navigate to the $_combinedName website.',
+          },
+          [
+            img(
+              src: '/assets/img/logo/dart-192.svg',
+              alt: 'Dart logo',
+              width: 28,
+              height: 28,
+            ),
+            span(
+              classes: 'name',
+              attributes: {
+                'translate': 'no',
+              },
+              [text(name)],
+            ),
+            if (subtype case final subtype?)
+              span(
+                classes: 'subtype',
+                [text(subtype)],
               ),
-            ]),
-          ]),
-          if (obsolete)
-            div(classes: 'alert alert-warning', [
-              h4(classes: 'text-center', [
-                text('Some of the content of this page might be out of date.'),
-              ]),
-            ]),
-        ]),
+          ],
+        ),
       ],
     );
   }
+}
 
-  static _ActiveNavEntry? _activeNavEntry(String pageUrlPath) {
-    final firstFragment = pageUrlPath
-        .split('/')
-        .where((fragment) => fragment.isNotEmpty)
-        .firstOrNull
-        ?.trim()
-        .toLowerCase();
+_ActiveNavEntry? _activeNavEntry(String pageUrlPath) {
+  final firstFragment = pageUrlPath
+      .split('/')
+      .where((fragment) => fragment.isNotEmpty)
+      .firstOrNull
+      ?.trim()
+      .toLowerCase();
 
-    return switch (firstFragment) {
-      'overview' => _ActiveNavEntry.overview,
-      'community' => _ActiveNavEntry.community,
-      'get-started' => _ActiveNavEntry.learn,
-      'get-dart' => _ActiveNavEntry.getDart,
-      _
-          when const {
-            'deprecated',
-            'docs',
-            'effective-dart',
-            'get-started',
-            'interop',
-            'language',
-            'libraries',
-            'null-safety',
-            'resources',
-            'server',
-            'tools',
-            'tutorials',
-            'web',
-            'multiplatform-apps',
-          }.contains(firstFragment) =>
-        _ActiveNavEntry.docs,
-      _ => null,
-    };
-  }
+  return switch (firstFragment) {
+    'overview' => _ActiveNavEntry.overview,
+    'community' => _ActiveNavEntry.community,
+    'get-started' => _ActiveNavEntry.learn,
+    'get-dart' => _ActiveNavEntry.getDart,
+    'deprecated' ||
+    'docs' ||
+    'effective-dart' ||
+    'get-started' ||
+    'interop' ||
+    'language' ||
+    'libraries' ||
+    'null-safety' ||
+    'resources' ||
+    'server' ||
+    'tools' ||
+    'tutorials' ||
+    'web' ||
+    'multiplatform-apps' => _ActiveNavEntry.docs,
+    _ => null,
+  };
 }
 
 enum _ActiveNavEntry {

--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -286,7 +286,7 @@ class _SiteWordMarkListEntry extends StatelessComponent {
       attributes: {'role': 'presentation'},
       [
         a(
-          href: '/',
+          href: href,
           classes: ['site-wordmark', if (current) 'current-site'].join(' '),
           attributes: {
             'role': 'menuitem',

--- a/site/lib/src/components/material_icon.dart
+++ b/site/lib/src/components/material_icon.dart
@@ -25,6 +25,7 @@ class MaterialIcon extends StatelessComponent {
       attributes: {
         'title': ?title,
         'aria-label': ?(label ?? title),
+        'translate': 'no',
       },
       [text(id)],
     );

--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -166,6 +166,7 @@ ga('send', 'pageview');
       ),
       _ => null,
     };
+    final obsolete = pageData['obsolete'] == true;
 
     return Component.fragment(
       [
@@ -196,6 +197,12 @@ ga('send', 'pageview');
               ].join(' '),
               [child],
             ),
+            if (obsolete)
+              div(id: 'obsolete-banner', [
+                div(classes: 'text-center', [
+                  text('Some content on this page might be out of date.'),
+                ]),
+              ]),
           ]),
           const DashFooter(),
         ]),

--- a/site/web/assets/img/logo/dart-192.svg
+++ b/site/web/assets/img/logo/dart-192.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="192px" height="192px" viewBox="0 0 192 192" enable-background="new 0 0 192 192" xml:space="preserve">
+<g>
+	<rect x="0" fill="none" width="192" height="192"/>
+	<path fill="#01579B" d="M51,141l-26-26c-3.08-3.17-5-7.63-5-12c0-2.02,1.14-5.18,2-7l24-50L51,141z"/>
+	<path fill="#40C4FF" d="M140,51l-26-26c-2.27-2.28-7-5-11-5c-3.44,0-6.81,0.69-9,2L46,46L140,51z"/>
+	<polygon fill="#40C4FF" points="82,172 145,172 145,145 98,130 55,145 	"/>
+	<path fill="#29B6F6" d="M46,127c0,8.02,1.01,9.99,5,14l4,4h90l-44-50L46,46V127z"/>
+	<path fill="#01579B" d="M126,46H46l99,99h27V83l-32-32C135.51,46.49,131.51,46,126,46z"/>
+	<path opacity="0.2" fill="#FFFFFF" d="M52,142c-4-4.02-5-7.97-5-15V47l-1-1v81C46,134.03,46,135.98,52,142l3,3l0,0L52,142z"/>
+	<polygon opacity="0.2" fill="#263238" points="171,82 171,144 144,144 145,145 172,145 172,83 	"/>
+	<path opacity="0.2" fill="#FFFFFF" d="M140,51c-4.96-4.96-9.02-5-15-5H46l1,1h78C127.99,47,135.52,46.5,140,51L140,51z"/>
+	<radialGradient id="SVGID_1_" cx="96" cy="96" r="76" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0.1"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path opacity="0.2" fill="url(#SVGID_1_)" d="M171,82l-31-31l-26-26c-2.27-2.28-7-5-11-5c-3.44,0-6.81,0.69-9,2L46,46L22,96
+		c-0.86,1.82-2,4.98-2,7c0,4.37,1.92,8.83,5,12l23.96,23.79c0.57,0.7,1.25,1.42,2.04,2.21l1,1l3,3l26,26l1,1h62h1v-27h27v-0.07V83
+		L171,82z"/>
+</g>
+</svg>

--- a/site/web/assets/js/main.js
+++ b/site/web/assets/js/main.js
@@ -105,6 +105,55 @@ function setupThemeSwitcher() {
   })
 }
 
+function setupSiteSwitcher() {
+  const siteSwitcher = document.getElementById('site-switcher');
+
+  if (!siteSwitcher) {
+    return;
+  }
+
+  const siteSwitcherButton = siteSwitcher.querySelector('.dropdown-button');
+  const siteSwitcherMenu = siteSwitcher.querySelector('#site-switcher-menu');
+  if (!siteSwitcherButton || !siteSwitcherMenu) {
+    return;
+  }
+
+  function _closeMenusAndToggle() {
+    siteSwitcherMenu.classList.remove('show');
+    siteSwitcherButton.ariaExpanded = 'false';
+  }
+
+  siteSwitcherButton.addEventListener('click', (_) => {
+    if (siteSwitcherMenu.classList.contains('show')) {
+      _closeMenusAndToggle();
+    } else {
+      siteSwitcherMenu.classList.add('show');
+      siteSwitcherButton.ariaExpanded = 'true';
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    // If pressing the `esc` key in the menu area, close the menu.
+    if (event.key === 'Escape' && event.target.closest('#site-switcher')) {
+      _closeMenusAndToggle();
+    }
+  });
+
+  siteSwitcher.addEventListener('focusout', (e) => {
+    // If focus leaves the site-switcher, hide the menu.
+    if (e.relatedTarget && !e.relatedTarget.closest('#site-switcher')) {
+      _closeMenusAndToggle();
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    // If not clicking inside the site switcher, close the menu.
+    if (!event.target.closest('#site-switcher')) {
+      _closeMenusAndToggle();
+    }
+  });
+}
+
 function handleSearchShortcut(event) {
   const activeElement = document.activeElement;
   if (activeElement instanceof HTMLInputElement ||
@@ -125,7 +174,7 @@ function handleSearchShortcut(event) {
       parentElement = bodySearch;
     } else {
       // Otherwise, fallback to the top navbar search field.
-      parentElement = document.getElementById('cse-search-box');
+      parentElement = document.getElementById('header-search');
     }
   }
 
@@ -325,6 +374,7 @@ function _setupSite() {
   initCookieNotice();
   setupTabs();
   setupThemeSwitcher();
+  setupSiteSwitcher();
 
   // Set up collapse and expand for sidenav buttons.
   const toggles = document.querySelectorAll('.nav-link.collapsible');


### PR DESCRIPTION
Migrates the site switcher from docs.flutter.dev as well as its updated header styles. This allows users to quickly navigate to the API docs, DartPad, as well as pub.dev from the global site header.

**Site switcher preview:**
<img width="200" alt="Screenshot of the site switcher open on the site homepage." src="https://github.com/user-attachments/assets/fb668cf5-70aa-4fe2-b43b-910b9c492cfa" />

---

This implementation does not use Jaspr for the interactivity yet as I wasn't to keep the PR mostly a direct migration from the Flutter docs site. I will migrate the interactivity alongside other components.

Contributes to https://github.com/dart-lang/site-www/issues/6838 as the new TOC is based on this updated header style existing.
Contributes to https://github.com/flutter/website/issues/12405 as the Flutter docs will need this migration as well.
