### PR TITLE
Update Jaspr to fix incorrect include directory handling

### DIFF
--- a/site/lib/main.dart
+++ b/site/lib/main.dart
@@ -45,13 +45,7 @@ Component get _dartDevSite => ContentApp.custom(
     ],
     templateEngine: LiquidTemplateEngine(
       includesPath: path.canonicalize(
-        path.join(
-          siteSrcDirectoryPath,
-          // TODO(https://github.com/schultek/jaspr/pull/545):
-          //  Remove duplicated segment once linked fix has been released.
-          '_includes',
-          '_includes',
-        ),
+        path.join(siteSrcDirectoryPath, '_includes'),
       ),
     ),
     parsers: const [

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -43,22 +43,22 @@ dependency_overrides:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr
-      ref: 4fc382d4f5f41c6eb6c62a7bd8d905877731298a
+      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
   jaspr_builder:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_builder
-      ref: 4fc382d4f5f41c6eb6c62a7bd8d905877731298a
+      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
   jaspr_content:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_content
-      ref: 4fc382d4f5f41c6eb6c62a7bd8d905877731298a
+      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
   jaspr_router:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_router
-      ref: 4fc382d4f5f41c6eb6c62a7bd8d905877731298a
+      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
 
 jaspr:
   mode: static

--- a/tool/dart_site/lib/src/utils.dart
+++ b/tool/dart_site/lib/src/utils.dart
@@ -49,7 +49,7 @@ int installJasprCliIfNecessary() {
     'git',
     'https://github.com/schultek/jaspr.git',
     '--git-path=packages/jaspr_cli',
-    '--git-ref=4fc382d4f5f41c6eb6c62a7bd8d905877731298a',
+    '--git-ref=4a475a603552b6491845bbc9be035c57b9ba3632',
   ]);
 
   if (activateOutput.exitCode != 0) {


### PR DESCRIPTION
Remove the double `_includes` workaround in the path to our partial file directory as I landed a fix to the issue that necessitated it in https://github.com/schultek/jaspr/pull/545.
