### PR TITLE
Fix missing "Learn more" buttons on diagnostic index page

### DIFF
--- a/site/lib/src/pages/diagnostic_index.dart
+++ b/site/lib/src/pages/diagnostic_index.dart
@@ -88,8 +88,8 @@ class _DiagnosticCard extends StatelessComponent {
 extension type _DiagnosticInfo._(Map<String, Object?> info) {
   String get id => info['id'] as String;
   String get description => info['description'] as String;
-  bool get hasDocumentation => info['hasDocumentation'] == 'true';
-  bool get fromLint => info['fromLint'] == 'true';
+  bool get hasDocumentation => info['hasDocumentation'] as bool? ?? false;
+  bool get fromLint => info['fromLint'] as bool? ?? false;
   List<String> get previousNames =>
       (info['previousNames'] as List<Object?>).cast<String>();
 }

--- a/src/content/tools/diagnostics/deprecated_mixin.md
+++ b/src/content/tools/diagnostics/deprecated_mixin.md
@@ -1,0 +1,45 @@
+---
+title: deprecated_mixin
+description: >-
+  Details about the deprecated_mixin
+  diagnostic produced by the Dart analyzer.
+underscore_breaker_titles: true
+bodyClass: highlight-diagnostics
+---
+
+_Mixing in '{0}' is deprecated._
+
+## Description
+
+The analyzer produces this diagnostic when a mixin class annotated with
+`@Deprecated.mixin` is used in the `with` clause of a class or enum
+declaration. This annotation indicates that the ability for classes
+to mixin the annotated mixin class is deprecated, and will soon be
+removed, perhaps by removing the `mixin` class modifier.
+
+## Example
+
+If the library `p` defines a class annotated with `@Deprecated.mixin`:
+
+```dart
+@Deprecated.mixin()
+mixin class C {}
+```
+
+Then, the following code, when in a library other than `p`, produces this
+diagnostic:
+
+```dart
+import 'package:p/p.dart';
+
+class D with [!C!] {}
+```
+
+## Common fixes
+
+Follow any directions found in the `Deprecation.mixin` annotation, or
+just remove the mixin class name from the `with` clause.
+
+```dart
+class D {}
+```

--- a/src/content/tools/diagnostics/invalid_deprecated_mixin_annotation.md
+++ b/src/content/tools/diagnostics/invalid_deprecated_mixin_annotation.md
@@ -1,0 +1,33 @@
+---
+title: invalid_deprecated_mixin_annotation
+description: >-
+  Details about the invalid_deprecated_mixin_annotation
+  diagnostic produced by the Dart analyzer.
+underscore_breaker_titles: true
+bodyClass: highlight-diagnostics
+---
+
+_The annotation '@Deprecated.mixin' can only be applied to classes._
+
+## Description
+
+The analyzer produces this diagnostic when anything other than a
+mixin class is annotated with Deprecated.mixin.
+
+## Example
+
+The following code produces this diagnostic because the annotation is on a
+non-mixin class:
+
+```dart
+@[!Deprecated.mixin!]()
+class C {}
+```
+
+## Common fixes
+
+Remove the annotation:
+
+```dart
+class C {}
+```

--- a/src/data/diagnostics.json
+++ b/src/data/diagnostics.json
@@ -1257,6 +1257,13 @@
     "previousNames": []
   },
   {
+    "id": "deprecated_mixin",
+    "description": "_Mixing in '{0}' is deprecated._",
+    "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "deprecated_new_in_comment_reference",
     "description": "_Using the 'new' keyword in a comment reference is deprecated._",
     "hasDocumentation": true,
@@ -3121,6 +3128,13 @@
   {
     "id": "invalid_deprecated_instantiate_annotation",
     "description": "_The annotation '@Deprecated.instantiate' can only be applied to classes._",
+    "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "invalid_deprecated_mixin_annotation",
+    "description": "_The annotation '@Deprecated.mixin' can only be applied to classes._",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []


### PR DESCRIPTION
Fixes the "Learn more" link buttons not being added to Diagnostic cards on the diagnostic index page.

The `_DiagnosticInfo` extension type assumed the values were strings instead of booleans, causing the "Learn more" buttons not to be rendered even if the `hasDocumentation` value was set to `true`.

Fixes https://github.com/dart-lang/site-www/issues/6851

**Staged:** https://dart-dev--pr6852-fix-6851-2lf4ba4i.web.app/tools/diagnostics#diagnostic-index