### PR TITLE
Update Jaspr for analyzer v8 support

### DIFF
--- a/examples/build_runner_usage/pubspec.yaml
+++ b/examples/build_runner_usage/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
 
 dev_dependencies:
   args: ^2.7.0
-  build_runner: ^2.7.0
-  build_test: ^3.3.0
+  build_runner: ^2.7.1
+  build_test: ^3.3.3

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -33,9 +33,8 @@ dev_dependencies:
   build_runner: ^2.7.1
   build_web_compilers: ^4.2.3
   jaspr_builder: ^0.21.0-dev.1
-  lints: ^6.0.0
-  sass: ^1.92.0
-  sass_builder: ^2.2.1
+  sass: ^1.92.1
+  sass_builder: ^2.3.1
 
 dependency_overrides:
   # Remove once the next stable release of Jaspr has been published.
@@ -43,22 +42,22 @@ dependency_overrides:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr
-      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
+      ref: b7a8b00e2dd4c4d907fb6377739269d29bac6849
   jaspr_builder:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_builder
-      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
+      ref: b7a8b00e2dd4c4d907fb6377739269d29bac6849
   jaspr_content:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_content
-      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
+      ref: b7a8b00e2dd4c4d907fb6377739269d29bac6849
   jaspr_router:
     git:
       url: https://github.com/schultek/jaspr.git
       path: packages/jaspr_router
-      ref: 4a475a603552b6491845bbc9be035c57b9ba3632
+      ref: b7a8b00e2dd4c4d907fb6377739269d29bac6849
 
 jaspr:
   mode: static

--- a/src/content/tools/build_runner.md
+++ b/src/content/tools/build_runner.md
@@ -38,8 +38,8 @@ to your app's pubspec:
 ```yaml
 dev_dependencies:
   # ···
-  build_runner: ^2.7.0
-  build_test: ^3.3.0
+  build_runner: ^2.7.1
+  build_test: ^3.3.3
 ```
 
 Depending on **build_test** is optional; do it if you'll be testing your code.

--- a/src/content/tools/pub/dependencies.md
+++ b/src/content/tools/pub/dependencies.md
@@ -525,7 +525,7 @@ resemble the following:
 
 ```yaml
 dev_dependencies:
-  build_runner: ^2.7.0
+  build_runner: ^2.7.1
   lints: ^6.0.0
   test: ^1.25.15
 ```

--- a/src/content/tools/webdev.md
+++ b/src/content/tools/webdev.md
@@ -44,9 +44,9 @@ your app's `pubspec.yaml` file:
 ```yaml
   dev_dependencies:
     # ···
-    build_runner: ^2.7.0
-    build_test: ^3.3.0
-    build_web_compilers: ^4.2.2
+    build_runner: ^2.7.1
+    build_test: ^3.3.3
+    build_web_compilers: ^4.2.3
 ```
 
 As usual after `pubspec.yaml` changes, run `dart pub get` or 

--- a/tool/dash_site/lib/src/utils.dart
+++ b/tool/dash_site/lib/src/utils.dart
@@ -52,7 +52,7 @@ int installJasprCliIfNecessary() {
     'git',
     'https://github.com/schultek/jaspr.git',
     '--git-path=packages/jaspr_cli',
-    '--git-ref=4a475a603552b6491845bbc9be035c57b9ba3632',
+    '--git-ref=b7a8b00e2dd4c4d907fb6377739269d29bac6849',
   ]);
 
   if (activateOutput.exitCode != 0) {


### PR DESCRIPTION
Updates Jaspr to a commit that supports the latest analyzer releases. No immediate functional change, but unblocks future dependency updates.