### PR TITLE
Rename 'short-title' page metadata to 'shortTitle'

### DIFF
--- a/site/lib/_sass/components/_breadcrumbs.scss
+++ b/site/lib/_sass/components/_breadcrumbs.scss
@@ -39,7 +39,7 @@ nav.breadcrumbs {
       }
     }
 
-    .child-icon {
+    .material-symbols {
       user-select: none;
     }
   }

--- a/site/lib/src/components/breadcrumbs.dart
+++ b/site/lib/src/components/breadcrumbs.dart
@@ -6,6 +6,8 @@ import 'package:collection/collection.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
+import 'material_icon.dart';
+
 /// Breadcrumbs navigation component that
 /// follows ARIA guidelines and includes RDFa markup.
 ///
@@ -162,12 +164,7 @@ final class _BreadcrumbItemComponent extends StatelessComponent {
         ],
       ),
       meta(attributes: {'property': 'position', 'content': index.toString()}),
-      if (!isLast)
-        span(
-          classes: 'material-symbols child-icon',
-          attributes: {'aria-hidden': 'true'},
-          [text('chevron_right')],
-        ),
+      if (!isLast) const MaterialIcon('chevron_right'),
     ],
   );
 }

--- a/site/lib/src/components/breadcrumbs.dart
+++ b/site/lib/src/components/breadcrumbs.dart
@@ -49,18 +49,15 @@ class PageBreadcrumbs extends StatelessComponent {
   /// Extract breadcrumbs from page data.
   ///
   /// Uses page metadata to generate breadcrumb titles with fallbacks:
-  /// breadcrumb >short-title > title.
+  /// `breadcrumb` > `shortTitle` > `title`.
   List<_BreadcrumbItem>? _breadcrumbsForPage(List<Page> pages, Page page) {
     final pageUrl = page.url;
 
     // Only show breadcrumbs if the URL isn't empty.
     if (pageUrl.isEmpty || pageUrl == '/') return null;
 
-    final pageData = page.data.page;
-
-    final displayTitle =
-        pageData['breadcrumb'] ?? pageData['short-title'] ?? pageData['title'];
-    if (displayTitle is! String || displayTitle.isEmpty) {
+    final pageBreadcrumb = page.breadcrumb;
+    if (pageBreadcrumb == null) {
       return null;
     }
 
@@ -85,15 +82,10 @@ class PageBreadcrumbs extends StatelessComponent {
       // Skip if no index page found.
       if (indexPage == null) continue;
 
-      final indexPageData = indexPage.data.page;
-      final indexTitle =
-          indexPageData['breadcrumb'] ??
-          indexPageData['short-title'] ??
-          indexPageData['title'];
-      if (indexTitle is String && indexTitle.isNotEmpty) {
+      if (indexPage.breadcrumb case final indexBreadcrumb?) {
         breadcrumbs.add(
           _BreadcrumbItem(
-            title: indexTitle,
+            title: indexBreadcrumb,
             url: indexPage.url,
           ),
         );
@@ -109,12 +101,25 @@ class PageBreadcrumbs extends StatelessComponent {
     // Add the current page as the final breadcrumb.
     breadcrumbs.add(
       _BreadcrumbItem(
-        title: displayTitle,
+        title: pageBreadcrumb,
         url: pageUrl,
       ),
     );
 
     return breadcrumbs;
+  }
+}
+
+extension on Page {
+  String? get breadcrumb {
+    final pageData = data.page;
+
+    final breadcrumbString =
+        pageData['breadcrumb'] ?? pageData['shortTitle'] ?? pageData['title'];
+    if (breadcrumbString is! String || breadcrumbString.isEmpty) {
+      return null;
+    }
+    return breadcrumbString;
   }
 }
 

--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -1,6 +1,6 @@
 ---
 title: Community and support
-short-title: Community
+shortTitle: Community
 description: Communities, mailing lists, and bug databases for the Dart project.
 group: https://groups.google.com/a/dartlang.org
 ---

--- a/src/content/get-dart/archive/index.md
+++ b/src/content/get-dart/archive/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dart SDK archive
-short-title: Archive
+shortTitle: Archive
 description: >-
   Download specific stable, beta, dev, and main channel versions of
   the Dart SDK and the Dart API documentation.

--- a/src/content/get-dart/index.md
+++ b/src/content/get-dart/index.md
@@ -1,6 +1,6 @@
 ---
 title: Get the Dart SDK
-short-title: Get Dart
+shortTitle: Get Dart
 description: >-
   Get the libraries and command-line tools that you need to develop
   Dart web, command-line, and server apps.

--- a/src/content/get-started/add-commands.md
+++ b/src/content/get-started/add-commands.md
@@ -1,6 +1,6 @@
 ---
 title: Make your CLI program interactive
-short-title: Add commands
+shortTitle: Add commands
 description: >-
   Add simple commands to your cli application. Learn the fundamentals of Dart
   syntax including control flow, collections, variables, functions, and more.

--- a/src/content/get-started/advanced-oop.md
+++ b/src/content/get-started/advanced-oop.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced OOP-adjacent features
-short-title: Advanced OOP Features
+shortTitle: Advanced OOP Features
 description: >-
   Enhance your Dart skills by exploring advanced features like enhanced enums
   and extensions. Improve your application's output formatting and color,

--- a/src/content/get-started/async.md
+++ b/src/content/get-started/async.md
@@ -1,6 +1,6 @@
 ---
 title: Intro to async and HTTP
-short-title: Async and HTTP
+shortTitle: Async and HTTP
 description: >-
   Learn about asynchronous programming in Dart and how to make HTTP requests.
 sitemap: false

--- a/src/content/get-started/command-runner-polish.md
+++ b/src/content/get-started/command-runner-polish.md
@@ -1,6 +1,6 @@
 ---
 title: Command_runner polish
-short-title: Command_runner polish
+shortTitle: Command_runner polish
 description: >-
   Improve the HelpCommand to provide more detailed information and add an
   onOutput argument for flexible output handling.

--- a/src/content/get-started/error-handling.md
+++ b/src/content/get-started/error-handling.md
@@ -1,6 +1,6 @@
 ---
 title: Error handling
-short-title: Error handling
+shortTitle: Error handling
 description: >-
   Improve app robustness by handling errors. Learn about exceptions, errors,
   `try/catch`, `throw`, and `rethrow`.

--- a/src/content/get-started/hello-world.md
+++ b/src/content/get-started/hello-world.md
@@ -1,6 +1,6 @@
 ---
 title: Your first Dart program
-short-title: Your first app
+shortTitle: Your first app
 description: >-
   Create, run, and make your first change to a Dart command-line program.
 sitemap: false

--- a/src/content/get-started/http.md
+++ b/src/content/get-started/http.md
@@ -1,6 +1,6 @@
 ---
 title: Http
-short-title: Http
+shortTitle: Http
 description: >-
   Implement Wikipedia API calls to complete the core functionality of the
   Wikipedia CLI.

--- a/src/content/get-started/index.md
+++ b/src/content/get-started/index.md
@@ -1,6 +1,6 @@
 ---
 title: Learn Dart
-short-title: Learn
+shortTitle: Learn
 breadcrumb: Tutorial
 description: >-
   Begin your Dart learning journey by building an interactive CLI app.

--- a/src/content/get-started/object-oriented.md
+++ b/src/content/get-started/object-oriented.md
@@ -1,6 +1,6 @@
 ---
 title: Object-oriented Dart programming
-short-title: Object oriented Dart
+shortTitle: Object oriented Dart
 description: >-
   Learn about object-oriented programming in Dart, including
   abstract classes, inheritance, overrides, and enums.

--- a/src/content/get-started/packages-libs.md
+++ b/src/content/get-started/packages-libs.md
@@ -1,6 +1,6 @@
 ---
 title: Organizing Dart code with packages and libraries
-short-title: Packages and libraries
+shortTitle: Packages and libraries
 description: >-
   Learn how to organize your Dart code into reusable libraries and packages.
 sitemap: false

--- a/src/content/get-started/testing.md
+++ b/src/content/get-started/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-short-title: Testing
+shortTitle: Testing
 description: >-
   Learn how to write tests for your Dart code using the `package:test` library.
 sitemap: false

--- a/src/content/interop/c-interop.md
+++ b/src/content/interop/c-interop.md
@@ -1,6 +1,6 @@
 ---
 title: "C interop using dart:ffi"
-short-title: C interop
+shortTitle: C interop
 description: >-
   To use C code in your Dart program, use the dart:ffi library.
 ---

--- a/src/content/interop/index.md
+++ b/src/content/interop/index.md
@@ -1,6 +1,6 @@
 ---
 title: Native interop with Dart
-short-title: Interop
+shortTitle: Interop
 description: >-
   Learn to interact with native code and other programming languages from Dart.
 toc: false

--- a/src/content/interop/java-interop.md
+++ b/src/content/interop/java-interop.md
@@ -1,6 +1,6 @@
 ---
 title: 'Java interop using package:jnigen'
-short-title: Java interop
+shortTitle: Java interop
 breadcrumb: Java
 description: >-
   To use Java in your Dart program, use package:jnigen.

--- a/src/content/interop/js-interop/index.md
+++ b/src/content/interop/js-interop/index.md
@@ -1,6 +1,6 @@
 ---
 title: JavaScript interoperability
-short-title: JS interop
+shortTitle: JS interop
 description: Integrate JavaScript code into your Dart web app.
 nextpage:
   url: /interop/js-interop/usage

--- a/src/content/interop/js-interop/mock.md
+++ b/src/content/interop/js-interop/mock.md
@@ -1,6 +1,6 @@
 ---
 title: How to mock JavaScript interop objects
-short-title: Mock JS interop objects
+shortTitle: Mock JS interop objects
 description: Learn how to mock JS interop objects in Dart for testing.
 ---
 

--- a/src/content/interop/objective-c-interop.md
+++ b/src/content/interop/objective-c-interop.md
@@ -1,6 +1,6 @@
 ---
 title: "Objective-C and Swift interop using package:ffigen"
-short-title: Objective-C & Swift interop
+shortTitle: Objective-C & Swift interop
 breadcrumb: Objective-C & Swift
 description: >-
   To use Objective-C and Swift code in your Dart program, use package:ffigen.

--- a/src/content/language/async.md
+++ b/src/content/language/async.md
@@ -1,7 +1,7 @@
 ---
 title: Asynchronous programming
 description: Information on writing asynchronous code in Dart.
-short-title: Async programming
+shortTitle: Async programming
 prevpage:
   url: /language/concurrency
   title: Concurrency

--- a/src/content/language/concurrency.md
+++ b/src/content/language/concurrency.md
@@ -2,7 +2,7 @@
 title: Concurrency in Dart
 description: >-
   Use isolates to enable parallel code execution on multiple processor cores.
-short-title: Concurrency
+shortTitle: Concurrency
 lastVerified: 2023-12-14
 prevpage:
   url: /language/modifier-reference

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -1,7 +1,7 @@
 ---
 title: Enumerated types
 description: Learn about the enum type in Dart.
-short-title: Enums
+shortTitle: Enums
 prevpage:
   url: /language/mixins
   title: Mixins

--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Dart
-short-title: Dart basics
+shortTitle: Dart basics
 breadcrumb: Language
 description: A brief introduction to Dart programs and important concepts.
 nextpage:

--- a/src/content/language/isolates.md
+++ b/src/content/language/isolates.md
@@ -1,7 +1,7 @@
 ---
 title: Isolates
 description: Information on writing isolates in Dart.
-short-title: Isolates
+shortTitle: Isolates
 lastVerified: 2024-01-04
 prevpage:
   url: /language/async

--- a/src/content/language/libraries.md
+++ b/src/content/language/libraries.md
@@ -1,6 +1,6 @@
 ---
 title: Libraries & imports
-short-title: Libraries
+shortTitle: Libraries
 description: Guidance on importing and implementing libraries.
 prevpage:
   url: /language/metadata

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -1,6 +1,6 @@
 ---
 title: The Dart type system
-short-title: Type system
+shortTitle: Type system
 description: Why and how to write sound Dart code.
 prevpage:
   url: /language/typedefs

--- a/src/content/libraries/async/async-await.md
+++ b/src/content/libraries/async/async-await.md
@@ -1,6 +1,6 @@
 ---
 title: "Asynchronous programming: futures, async, await"
-short-title: Futures, async, and await
+shortTitle: Futures, async, and await
 description: Learn about and practice writing asynchronous code in DartPad!
 js: [{url: '/assets/js/inject_dartpad.js', defer: true}]
 ---

--- a/src/content/libraries/async/creating-streams.md
+++ b/src/content/libraries/async/creating-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Creating streams in Dart
-short-title: Creating streams
+shortTitle: Creating streams
 description: A stream is a sequence of results; learn how to create your own.
 original-date: 2013-04-08
 date: 2021-05-16

--- a/src/content/libraries/async/index.md
+++ b/src/content/libraries/async/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dart's support for asynchronous programming
-short-title: Asynchronous programming
+shortTitle: Asynchronous programming
 breadcrumb: Async
 description: >-
   Learn about Dart's library support for asynchronous programming.

--- a/src/content/libraries/index.md
+++ b/src/content/libraries/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dart's core libraries
-short-title: Core libraries
+shortTitle: Core libraries
 description: Learn about Dart's core libraries and APIs.
 nextpage:
   url: /libraries/dart-core

--- a/src/content/null-safety/faq.md
+++ b/src/content/null-safety/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Null safety: Frequently asked questions"
 description: FAQs to help you migrate your Dart code to null safety
-short-title: FAQ (null safety)
+shortTitle: FAQ (null safety)
 ---
 
 This page collects some common questions we've heard about [null safety](/null-safety)

--- a/src/content/resources/books.md
+++ b/src/content/resources/books.md
@@ -1,6 +1,6 @@
 ---
 title: Books about Dart
-short-title: Books
+shortTitle: Books
 description: Read all about it! Here's a collection of books about Dart.
 showToc: false
 ---

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Dart FAQ
-short-title: FAQ
+shortTitle: FAQ
 description: You have questions about Dart, we have answers.
 ---
 

--- a/src/content/resources/google-apis.md
+++ b/src/content/resources/google-apis.md
@@ -1,6 +1,6 @@
 ---
 title: Using Google APIs
-short-title: Google APIs
+shortTitle: Google APIs
 description: Your Dart apps can use Firebase and Google client APIs.
 lastVerified: 2021-05-13
 ---

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -1,6 +1,6 @@
 ---
 title: Dart language evolution
-short-title: Language evolution
+shortTitle: Language evolution
 breadcrumb: Evolution
 description: Notable changes and additions to the Dart programming language.
 lastVerified: 2024-08-04

--- a/src/content/resources/language/spec/index.md
+++ b/src/content/resources/language/spec/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dart language specification
-short-title: Language specification
+shortTitle: Language specification
 breadcrumb: Specification
 description: The formal specification for the Dart language.
 ---

--- a/src/content/resources/useful-packages.md
+++ b/src/content/resources/useful-packages.md
@@ -1,6 +1,6 @@
 ---
 title: Commonly used packages
-short-title: Common packages
+shortTitle: Common packages
 description: >-
   Some of the most useful and popular packages, and where you can learn more.
 ---

--- a/src/content/resources/videos.md
+++ b/src/content/resources/videos.md
@@ -1,6 +1,6 @@
 ---
 title: Dart videos
-short-title: Videos
+shortTitle: Videos
 description: Learn by watching! Here's a collection of videos about Dart.
 ---
 

--- a/src/content/search.html
+++ b/src/content/search.html
@@ -1,6 +1,6 @@
 ---
 title: Search dart.dev
-short-title: Search
+shortTitle: Search
 description: Search for documentation on dart.dev.
 showToc: false
 showBreadcrumbs: false

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Using Google Cloud
-short-title: Google Cloud
+shortTitle: Google Cloud
 description: >-
   Your Dart app can use many Google Cloud services:
   Firebase, Google Cloud Platform, and more.

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -1,6 +1,6 @@
 ---
 title: Command-line and server apps
-short-title: CLI & server apps
+shortTitle: CLI & server apps
 description: All things relating to command-line and server apps.
 showToc: false
 ---

--- a/src/content/server/libraries.md
+++ b/src/content/server/libraries.md
@@ -1,6 +1,6 @@
 ---
 title: Command-line and server libraries and packages
-short-title: CLI & server libraries
+shortTitle: CLI & server libraries
 description: >-
   Libraries and packages that can help you
   write Dart command-line & server apps.

--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -1,6 +1,6 @@
 ---
 title: Customizing static analysis
-short-title: Static analysis
+shortTitle: Static analysis
 description: >-
   Use an analysis options file and code comments to customize static analysis.
 bodyClass: highlight-diagnostics

--- a/src/content/tools/dart-devtools.md
+++ b/src/content/tools/dart-devtools.md
@@ -1,6 +1,6 @@
 ---
 title: Dart DevTools
-short-title: DevTools
+shortTitle: DevTools
 description: A suite of debugging and performance tools.
 ---
 

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -1,6 +1,6 @@
 ---
 title: "dart: The Dart command-line tool"
-short-title: Dart CLI
+shortTitle: Dart CLI
 description: "The reference page for using 'dart' in a terminal window."
 showToc: false
 ---

--- a/src/content/tools/dart2js.md
+++ b/src/content/tools/dart2js.md
@@ -1,6 +1,6 @@
 ---
 title: "dart2js: Dart-to-JavaScript compiler"
-short-title: dart2js
+shortTitle: dart2js
 description: The dart2js compiler compiles Dart code to deployable JavaScript.
 ---
 

--- a/src/content/tools/dartdevc.md
+++ b/src/content/tools/dartdevc.md
@@ -1,6 +1,6 @@
 ---
 title: "dartdevc: The Dart development compiler"
-short-title: dartdevc
+shortTitle: dartdevc
 description: A development compiler for fast, modular compilation of Dart code to JavaScript.
 ---
 

--- a/src/content/tools/diagnostics/index.md
+++ b/src/content/tools/diagnostics/index.md
@@ -1,6 +1,6 @@
 ---
 title: Diagnostic messages
-short-title: Diagnostics
+shortTitle: Diagnostics
 description: >-
   An index of the diagnostics produced by the Dart analyzer.
 skipFreshness: true

--- a/src/content/tools/doc-comments/references.md
+++ b/src/content/tools/doc-comments/references.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation comment references
-short-title: Comment references
+shortTitle: Comment references
 description: Learn about doc comment references and their syntax.
 ---
 

--- a/src/content/tools/mcp-server.md
+++ b/src/content/tools/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: Dart and Flutter MCP server
-short-title: MCP server
+shortTitle: MCP server
 description: >-
   Learn about the Dart and Flutter MCP server tool that
   exposes Dart and Flutter tools to compatible

--- a/src/content/tools/pub/automated-publishing.md
+++ b/src/content/tools/pub/automated-publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Automated publishing of packages to pub.dev
-short-title: Automated publishing
+shortTitle: Automated publishing
 description: Publish Dart packages to pub.dev directly from GitHub Actions.
 ---
 

--- a/src/content/tools/pub/environment-variables.md
+++ b/src/content/tools/pub/environment-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring pub environment variables
-short-title: Pub environment variables
+shortTitle: Pub environment variables
 description: >-
   How to configure your environment for Dart's package management tool, pub.
 showToc: false

--- a/src/content/tools/pub/index.md
+++ b/src/content/tools/pub/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dart package support and tools
-short-title: Dart packages
+shortTitle: Dart packages
 breadcrumb: Packages
 description: >-
   Learn about package support in Dart and supporting tooling.

--- a/src/content/tools/pub/packages.md
+++ b/src/content/tools/pub/packages.md
@@ -1,6 +1,6 @@
 ---
 title: How to use packages
-short-title: Packages
+shortTitle: Packages
 breadcrumb: Overview
 description: Learn more about pub, Dart's tool for managing packages.
 ---

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -1,6 +1,6 @@
 ---
 title: The pubspec file
-short-title: Pubspec file
+shortTitle: Pubspec file
 description: Reference guide for the fields in pubspec.yaml.
 ---
 

--- a/src/content/tools/pub/workspaces.md
+++ b/src/content/tools/pub/workspaces.md
@@ -1,6 +1,6 @@
 ---
 title: Pub workspaces (monorepo support)
-short-title: Workspaces
+shortTitle: Workspaces
 description: Learn more about pub workspaces, a way to manage package monorepos.
 ---
 

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Dart SDK overview
-short-title: SDK overview
+shortTitle: SDK overview
 breadcrumb: SDK
 description: Dart libraries and command-line tools.
 ---

--- a/src/content/tools/testing.md
+++ b/src/content/tools/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Dart testing
-short-title: Testing
+shortTitle: Testing
 description: How to test Flutter, web, and VM applications.
 ---
 

--- a/src/content/tutorials/server/index.md
+++ b/src/content/tutorials/server/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorials: Command-line apps and servers"
-short-title: Command-line apps
+shortTitle: Command-line apps
 description: Tutorials for writing command-line apps and servers.
 showToc: false
 ---

--- a/src/content/web/debugging.md
+++ b/src/content/web/debugging.md
@@ -1,6 +1,6 @@
 ---
 title: Debugging Dart web apps
-short-title: Debugging web apps
+shortTitle: Debugging web apps
 breadcrumb: Debugging
 description: Learn how to debug your Dart web app.
 ---

--- a/src/content/web/index.md
+++ b/src/content/web/index.md
@@ -1,6 +1,6 @@
 ---
 title: Web platform
-short-title: Web
+shortTitle: Web
 description: Resources for developing Dart web apps.
 showToc: false
 ---

--- a/src/content/web/libraries.md
+++ b/src/content/web/libraries.md
@@ -1,6 +1,6 @@
 ---
 title: Web libraries and packages
-short-title: Web libraries
+shortTitle: Web libraries
 description: Libraries and packages that can help you write Dart web apps.
 ---
 


### PR DESCRIPTION
This updates the Dart docs site to align with the naming on the Flutter docs site.