### PR TITLE
Fix adding no-toc class overriding other body classes

### DIFF
--- a/site/lib/_sass/base/_layout.scss
+++ b/site/lib/_sass/base/_layout.scss
@@ -60,8 +60,9 @@ body {
     --site-subheader-height: 0rem;
   }
 
-  // If the TOC is not shown,
-  &.no-toc {
+  // If the TOC is disabled, reduce the subheader height to
+  // ensure offset calculations are still correct.
+  &[data-toc="false"] {
     --site-subheader-height: 0rem;
   }
 }

--- a/site/lib/src/layouts/doc_layout.dart
+++ b/site/lib/src/layouts/doc_layout.dart
@@ -33,18 +33,20 @@ class DocLayout extends DashLayout {
       page,
       Component.fragment(
         [
-          if (noToc) const Document.body(attributes: {'data-toc': 'false'}),
-          if (tocData case final TableOfContents toc)
+          if (noToc)
+            const Document.body(attributes: {'data-toc': 'false'})
+          else if (tocData case final TableOfContents toc)
             TopTableOfContents(
               toc,
               currentTitle: pageTitle,
               maxDepth: maxTocDepth,
             ),
           div(classes: 'after-leading-content', [
-            if (tocData case final TableOfContents toc)
-              aside(id: 'side-menu', [
-                SideTableOfContents(toc, maxDepth: maxTocDepth),
-              ]),
+            if (!noToc)
+              if (tocData case final TableOfContents toc)
+                aside(id: 'side-menu', [
+                  SideTableOfContents(toc, maxDepth: maxTocDepth),
+                ]),
             article([
               div(classes: 'content', [
                 div(id: 'site-content-title', [

--- a/site/lib/src/layouts/doc_layout.dart
+++ b/site/lib/src/layouts/doc_layout.dart
@@ -33,7 +33,7 @@ class DocLayout extends DashLayout {
       page,
       Component.fragment(
         [
-          if (noToc) const Document.body(attributes: {'class': 'no-toc'}),
+          if (noToc) const Document.body(attributes: {'data-toc': 'false'}),
           if (tocData case final TableOfContents toc)
             TopTableOfContents(
               toc,


### PR DESCRIPTION
Caused by https://github.com/dart-lang/site-www/commit/08de1f133ea56844721cf66d2b767329560bc2cf as `Document.body` overrides previously defined body classes, which we rely on for various pages, such as the glossary.

To avoid the classes being overridden, use a data attribute for the style selector instead of a class.