### PR TITLE
Remove historical references to older compile tools

### DIFF
--- a/src/content/tools/dart-compile.md
+++ b/src/content/tools/dart-compile.md
@@ -50,9 +50,6 @@ run `dart compile [<subcommand>] --help`:
 $ dart compile exe --help
 ```
 
-The `dart compile` command replaces the
-`dart2native`, `dart2aot`, and `dart2js` commands.
-
 :::note
 You don't need to compile Dart programs before running them.
 Instead, you can use the [`dart run` command][dart-run],

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -41,7 +41,7 @@ you might use the [`flutter` tool][] instead.
 | Command   | Example of use                                         | More information                                                                                                   |
 |-----------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | `analyze` | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                                 |
-| `compile` | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (e.g. executable, JavaScript or WebAssembly).<br>[Learn more.][compile]               | 
+| `compile` | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (executable, JavaScript or WebAssembly).<br>[Learn more.][compile]               | 
 | `create`  | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                                    | 
 | `doc`     | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>Replaces [`dartdoc`][].<br>[Learn more.][doc]                            |
 | `fix`     | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                                 | 

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -41,7 +41,7 @@ you might use the [`flutter` tool][] instead.
 | Command   | Example of use                                         | More information                                                                                                   |
 |-----------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | `analyze` | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                                 |
-| `compile` | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats.<br>Replaces `dart2js` and `dart2native`.<br>[Learn more.][compile]               | 
+| `compile` | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (e.g. executable, JavaScript or WebAssembly).<br>[Learn more.][compile]               | 
 | `create`  | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                                    | 
 | `doc`     | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>Replaces [`dartdoc`][].<br>[Learn more.][doc]                            |
 | `fix`     | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                                 | 


### PR DESCRIPTION
Remove mentioning of `dart2native`

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
