### PR TITLE
Add blog link to top-nav

### DIFF
--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -66,6 +66,16 @@ class DashHeader extends StatelessComponent {
           ]),
           li([
             a(
+              href: 'https://blog.dart.dev',
+              classes: [
+                'nav-link',
+                if (activeEntry == _ActiveNavEntry.blog) 'active',
+              ].join(' '),
+              [text('Blog')],
+            ),
+          ]),
+          li([
+            a(
               href: '/community',
               classes: [
                 'nav-link',
@@ -329,6 +339,7 @@ _ActiveNavEntry? _activeNavEntry(String pageUrlPath) {
 
   return switch (firstFragment) {
     'overview' => _ActiveNavEntry.overview,
+    'blog' => _ActiveNavEntry.blog,
     'community' => _ActiveNavEntry.community,
     'get-started' => _ActiveNavEntry.learn,
     'get-dart' => _ActiveNavEntry.getDart,
@@ -352,6 +363,7 @@ _ActiveNavEntry? _activeNavEntry(String pageUrlPath) {
 
 enum _ActiveNavEntry {
   overview,
+  blog,
   community,
   getDart,
   docs,


### PR DESCRIPTION
Adds the blog to the top-nav, similar to flutter.dev

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
