### PR TITLE
Update index table of dart CLI tools

### DIFF
--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -1,15 +1,19 @@
 ---
 title: "dart: The Dart command-line tool"
 shortTitle: Dart CLI
-description: "The reference page for using 'dart' in a terminal window."
-showToc: false
+description: >-
+  Learn about the 'dart' CLI and its available subcommands.
 ---
 
-The `dart` tool (`bin/dart`)
-is a command-line interface to the [Dart SDK](/tools/sdk).
-The tool is available no matter how you get the Dart SDK—whether 
-you download the Dart SDK explicitly 
-or download only the [Flutter SDK.]({{site.flutter}})
+The `dart` tool is the command-line interface to the [Dart SDK][].
+The tool is available no matter how you get the Dart SDK—whether
+you download the Dart SDK explicitly
+or download only the [Flutter SDK][].
+
+[Dart SDK]: /tools/sdk
+[Flutter SDK]: {{site.flutter}}
+
+## Usage example
 
 Here's how you might use the `dart` tool
 to create, analyze, test, and run an app:
@@ -29,6 +33,8 @@ $ dart pub get
 $ dart pub outdated
 $ dart pub upgrade
 ```
+
+## Available commands
 
 The following table shows which commands you can use with the `dart` tool.
 
@@ -65,7 +71,9 @@ The following table shows which commands you can use with the `dart` tool.
 [run]: /tools/dart-run
 [test]: /tools/dart-test
 
-To get help with any of the commands, enter `dart help <command>`.
+## Learn more
+
+To get help with any of the commands, run `dart help <command>`.
 You can also get details on `pub` commands.
 
 ```console

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -38,7 +38,7 @@ The following table shows which commands you can use with the `dart` tool.
 | `build`    | `dart build <APP_TYPE>`                                | **Experimental**<br>Builds a Dart app including [native assets][].<br>[Learn more.][build]                  |
 | `compile`  | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (native executable, JavaScript, or WebAssembly).<br>[Learn more.][compile] |
 | `create`   | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                             |
-| `devtools` | `dart devtools`                                        | Opens Dart DevTools.<br>[Learn more.][devtools]                                                             |
+| `devtools` | `dart devtools`                                        | Opens Dart DevTools, a suite of debugging and performance tools for Dart.<br>[Learn more.][devtools]        |
 | `doc`      | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>[Learn more.][doc]                                                |
 | `fix`      | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                          |
 | `format`   | <code>dart format <DIRECTORY&#124;DART_FILE></code>    | Formats Dart source code.<br>[Learn more.][format]                                                          |

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -31,32 +31,32 @@ $ dart pub upgrade
 ```
 
 The following table shows which commands you can use with the `dart` tool.
-If you're developing for Flutter,
-you might use the [`flutter` tool][] instead.
 
-[`flutter` tool]: {{site.flutter-docs}}/reference/flutter-cli
-
-<code>&#124;</code>
-
-| Command   | Example of use                                         | More information                                                                                                   |
-|-----------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| `analyze` | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                                 |
-| `compile` | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (executable, JavaScript or WebAssembly).<br>[Learn more.][compile]               | 
-| `create`  | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                                    | 
-| `doc`     | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>Replaces [`dartdoc`][].<br>[Learn more.][doc]                            |
-| `fix`     | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                                 | 
-| `format`  | <code>dart format <DIRECTORY&#124;DART_FILE></code>    | Formats Dart source code.<br>[Learn more.][format]                                                                 |
-| `info`    | `dart info`                                            | Outputs Dart tooling diagnostic information.<br>[Learn more.][info]                                                |
-| `pub`     | `dart pub <PUB_COMMAND>`                               | Works with packages.<br>Replaces `pub`.<br>[Learn more.][pub]                                                      | 
-| `run`     | `dart run <DART_FILE>`                                 | Runs a Dart program. <br>Replaces the pre-existing Dart VM command (`dart` with no command).<br>[Learn more.][run] | 
-| `test`    | <code>dart test <DIRECTORY&#124;DART_FILE></code>      | Runs tests in this package.<br>Replaces `pub run test`.<br>[Learn more.][test]                                     |
-| _(none)_  | `dart <DART_FILE>`                                     | Runs a Dart program; identical to the pre-existing Dart VM command.<br>Prefer [`dart run`][run].                   |
+| Command    | Example of use                                         | More information                                                                                            |
+|------------|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `analyze`  | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                          |
+| `build`    | `dart build <APP_TYPE>`                                | **Experimental**<br>Builds a Dart app including [native assets][].<br>[Learn more.][build]                  |
+| `compile`  | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (native executable, JavaScript, or WebAssembly).<br>[Learn more.][compile] |
+| `create`   | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                             |
+| `devtools` | `dart devtools`                                        | Opens Dart DevTools.<br>[Learn more.][devtools]                                                             |
+| `doc`      | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>[Learn more.][doc]                                                |
+| `fix`      | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                          |
+| `format`   | <code>dart format <DIRECTORY&#124;DART_FILE></code>    | Formats Dart source code.<br>[Learn more.][format]                                                          |
+| `info`     | `dart info`                                            | Outputs Dart tooling diagnostic information.<br>[Learn more.][info]                                         |
+| `pub`      | `dart pub <PUB_COMMAND>`                               | Works with packages.<br>Replaces `pub`.<br>[Learn more.][pub]                                               |
+| `run`      | `dart run <DART_FILE>`                                 | Runs a Dart program.<br>[Learn more.][run]                                                                  |
+| `test`     | <code>dart test <DIRECTORY&#124;DART_FILE></code>      | Runs tests in this package.<br>[Learn more.][test]                                                          |
+| _(none)_   | `dart <DART_FILE>`                                     | Runs a Dart program.<br>Prefer [`dart run`][run].                                                           |
 
 {:.table .table-striped .nowrap}
 
+[native assets]: /tools/hooks#assets
+
 [analyze]: /tools/dart-analyze
+[build]: /tools/hooks
 [compile]: /tools/dart-compile
 [create]: /tools/dart-create
+[devtools]: /tools/dart-devtools
 [doc]: /tools/dart-doc
 [fix]: /tools/dart-fix
 [format]: /tools/dart-format
@@ -71,5 +71,3 @@ You can also get details on `pub` commands.
 ```console
 $ dart help pub outdated
 ```
-
-[`dartdoc`]: {{site.pub-pkg}}/dartdoc

--- a/src/content/tools/dart-tool.md
+++ b/src/content/tools/dart-tool.md
@@ -32,21 +32,21 @@ $ dart pub upgrade
 
 The following table shows which commands you can use with the `dart` tool.
 
-| Command    | Example of use                                         | More information                                                                                            |
-|------------|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `analyze`  | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                          |
-| `build`    | `dart build <APP_TYPE>`                                | **Experimental**<br>Builds a Dart app including [native assets][].<br>[Learn more.][build]                  |
-| `compile`  | `dart compile exe <DART_FILE>`                         | Compiles Dart to various formats (native executable, JavaScript, or WebAssembly).<br>[Learn more.][compile] |
-| `create`   | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                             |
-| `devtools` | `dart devtools`                                        | Opens Dart DevTools, a suite of debugging and performance tools for Dart.<br>[Learn more.][devtools]        |
-| `doc`      | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>[Learn more.][doc]                                                |
-| `fix`      | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                          |
-| `format`   | <code>dart format <DIRECTORY&#124;DART_FILE></code>    | Formats Dart source code.<br>[Learn more.][format]                                                          |
-| `info`     | `dart info`                                            | Outputs Dart tooling diagnostic information.<br>[Learn more.][info]                                         |
-| `pub`      | `dart pub <PUB_COMMAND>`                               | Works with packages.<br>Replaces `pub`.<br>[Learn more.][pub]                                               |
-| `run`      | `dart run <DART_FILE>`                                 | Runs a Dart program.<br>[Learn more.][run]                                                                  |
-| `test`     | <code>dart test <DIRECTORY&#124;DART_FILE></code>      | Runs tests in this package.<br>[Learn more.][test]                                                          |
-| _(none)_   | `dart <DART_FILE>`                                     | Runs a Dart program.<br>Prefer [`dart run`][run].                                                           |
+| Command    | Format of command                                      | More information                                                                                         |
+|------------|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `analyze`  | <code>dart analyze [<DIRECTORY&#124;DART_FILE>]</code> | Analyzes the project's Dart source code.<br>[Learn more.][analyze]                                       |
+| `build`    | `dart build <APP_TYPE>`                                | **Experimental**<br>Builds a Dart app including [native assets][].<br>[Learn more.][build]               |
+| `compile`  | `dart compile <FORMAT>`                                | Compiles Dart to various formats (native executable, JavaScript, WebAssembly).<br>[Learn more.][compile] |
+| `create`   | `dart create <DIRECTORY>`                              | Creates a new project.<br>[Learn more.][create]                                                          |
+| `devtools` | `dart devtools`                                        | Opens Dart DevTools, a suite of debugging and performance tools for Dart.<br>[Learn more.][devtools]     |
+| `doc`      | `dart doc <DIRECTORY>`                                 | Generates API reference documentation.<br>[Learn more.][doc]                                             |
+| `fix`      | <code>dart fix <DIRECTORY&#124;DART_FILE></code>       | Applies automated fixes to Dart source code.<br>[Learn more.][fix]                                       |
+| `format`   | <code>dart format <DIRECTORY&#124;DART_FILE></code>    | Formats Dart source code.<br>[Learn more.][format]                                                       |
+| `info`     | `dart info`                                            | Outputs Dart tooling diagnostic information.<br>[Learn more.][info]                                      |
+| `pub`      | `dart pub <PUB_COMMAND>`                               | Works with packages.<br>Replaces `pub`.<br>[Learn more.][pub]                                            |
+| `run`      | `dart run <DART_FILE>`                                 | Runs a Dart program.<br>[Learn more.][run]                                                               |
+| `test`     | <code>dart test <DIRECTORY&#124;DART_FILE></code>      | Runs tests in this package.<br>[Learn more.][test]                                                       |
+| _(none)_   | `dart <DART_FILE>`                                     | Runs a Dart program.<br>Prefer [`dart run`][run].                                                        |
 
 {:.table .table-striped .nowrap}
 


### PR DESCRIPTION
- Add headings and enable the TOC
- Remove mention of `flutter` CLI as Flutter uses can and should still use `dart` for the commands that are shared.
- Remove stray `|` before the table
- Remove mention of old tools now that it has been quite a while since they were superseded (`dartdoc`, just `pub`, `pub run test`)
- Change "Example of use" column name to "Format of command" since they were not full examples, but rather basic formats and mention of the primary expected arguments.
- Adds the `dart devtools` command and links to the [Dart DevTools page](https://dart.dev/tools/dart-devtools)
- Adds the `dart build` command and links to the [hooks page](https://dart.dev/tools/hooks) until we have a dedicated `dart build` reference page.
  - I created https://github.com/dart-lang/site-www/issues/6881 to track creating the new page.
  
**Staged:** https://dart-dev--pr6882-misc-update-dart-tool-index-eed9k2yf.web.app/tools/dart-tool