### PR TITLE
Adjust footer with initial Jaspr callout

### DIFF
--- a/site/lib/_sass/components/_footer.scss
+++ b/site/lib/_sass/components/_footer.scss
@@ -76,25 +76,31 @@
     }
   }
 
-  ul {
-    list-style-type: none;
-    margin: 12px 0 0;
-    padding: 0;
-
-    li {
-      display: inline;
-      margin-left: 16px;
-
-      &:first-child {
-        margin-left: 0;
-      }
+  .footer-utility-links {
+    @media (min-width: 768px) {
+      text-align: right;
     }
 
-    @media (min-width: 768px) {
-      margin-top: 0;
+    ul {
+      list-style-type: none;
+      margin: 12px 0 0;
+      padding: 0;
 
-      li:first-child {
+      li {
+        display: inline;
         margin-left: 16px;
+
+        &:first-child {
+          margin-left: 0;
+        }
+      }
+
+      @media (min-width: 768px) {
+        margin-top: 0;
+
+        li:first-child {
+          margin-left: 16px;
+        }
       }
     }
   }

--- a/site/lib/src/components/footer.dart
+++ b/site/lib/src/components/footer.dart
@@ -104,13 +104,12 @@ final class DashFooter extends StatelessComponent {
           div(classes: 'footer-licenses', [
             text('Except as otherwise noted, this site is licensed under a '),
             a(href: 'https://creativecommons.org/licenses/by/4.0/', [
-              text('Creative Commons Attribution 4.0 International License'),
+              text('Creative Commons Attribution 4.0 International License,'),
             ]),
-            text(', and code samples are licensed under the '),
+            text(' and code samples are licensed under the '),
             a(href: 'https://opensource.org/licenses/BSD-3-Clause', [
-              text('3-Clause BSD License'),
+              text('3-Clause BSD License.'),
             ]),
-            text('.'),
           ]),
           div(classes: 'footer-utility-links', [
             ul([
@@ -136,6 +135,19 @@ final class DashFooter extends StatelessComponent {
                   [text('Security')],
                 ),
               ]),
+            ]),
+            div(classes: 'footer-technology', [
+              a(
+                href: 'https://jaspr.site',
+                target: Target.blank,
+                attributes: {
+                  'rel': 'noopener',
+                  'title':
+                      'This site is built with the '
+                      'Jaspr web framework for Dart.',
+                },
+                [text('Built with Jaspr')],
+              ),
             ]),
           ]),
         ]),


### PR DESCRIPTION
Adds a "Built with Jaspr" text and link to the footer. This is temporary until there's an agreed upon, provided badge for inclusion on sites using Jaspr.

**Preview:**

<img width="256" alt="Screenshot of hovering over the Built with Jaspr mention" src="https://github.com/user-attachments/assets/42c8723d-5104-4785-b4c3-cdb7b611ca80" />

Contributes to https://github.com/dart-lang/site-www/issues/6853