### PR TITLE
Reduce duplicated class and icon logic

### DIFF
--- a/site/lib/src/components/breadcrumbs.dart
+++ b/site/lib/src/components/breadcrumbs.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
+import '../util.dart';
 import 'material_icon.dart';
 
 /// Breadcrumbs navigation component that
@@ -149,7 +150,7 @@ final class _BreadcrumbItemComponent extends StatelessComponent {
     classes: [
       'breadcrumb-item',
       if (isLast) 'active',
-    ].join(' '),
+    ].toClasses,
     attributes: {
       'property': 'itemListElement',
       'typeof': 'ListItem',

--- a/site/lib/src/components/button.dart
+++ b/site/lib/src/components/button.dart
@@ -4,6 +4,7 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import '../util.dart';
 import 'material_icon.dart';
 
 /// A generic button component with different style variants.
@@ -48,7 +49,7 @@ class Button extends StatelessComponent {
       style.cssClass,
       if (icon != null && content == null) 'icon-button',
       ...?classes,
-    ].join(' ');
+    ].toClasses;
 
     final children = [
       if (icon case final iconId?) MaterialIcon(iconId),

--- a/site/lib/src/components/card.dart
+++ b/site/lib/src/components/card.dart
@@ -4,6 +4,8 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import '../util.dart';
+
 class Card extends StatelessComponent {
   /// Creates a card that can have a [header], [content], and [actions].
   ///
@@ -62,7 +64,7 @@ class Card extends StatelessComponent {
       if (filled) 'filled-card',
       if (expandable) 'expandable-card',
       if (additionalClasses != null) additionalClasses!,
-    ].join(' ');
+    ].toClasses;
 
     final children = [
       if (header.isNotEmpty) div(classes: 'card-header', header),
@@ -73,7 +75,7 @@ class Card extends StatelessComponent {
         classes: [
           'card-content',
           if (expandable) 'expandable-content',
-        ].join(' '),
+        ].toClasses,
         content,
       ),
       ?actions,

--- a/site/lib/src/components/chip.dart
+++ b/site/lib/src/components/chip.dart
@@ -4,6 +4,9 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import '../util.dart';
+import 'material_icon.dart';
+
 /// A set of Material Design-like chips for configuration.
 class ChipSet extends StatelessComponent {
   const ChipSet(this.chips, {this.resettable = false});
@@ -50,19 +53,12 @@ class InfoChip extends StatelessComponent {
     final chipClasses = ['chip', 'info-chip', ...?classes];
 
     return div(
-      classes: chipClasses.join(' '),
+      classes: chipClasses.toClasses,
       attributes: attributes,
       [
-        if (icon != null)
-          span(
-            classes: 'material-symbols chip-icon',
-            attributes: {
-              'aria-hidden': 'true',
-              if (title != null) 'title': title!,
-            },
-            [text(icon!)],
-          )
-        else if (iconPath != null)
+        if (icon case final icon?)
+          MaterialIcon(icon, title: title, classes: ['chip-icon'])
+        else if (iconPath case final iconPath?)
           svg(
             classes: 'chip-icon',
             width: iconSize.px,
@@ -70,12 +66,12 @@ class InfoChip extends StatelessComponent {
             viewBox: iconViewBox,
             attributes: {
               'aria-hidden': 'true',
-              if (title != null) 'title': title!,
+              'title': ?title,
             },
             [
               Component.element(
                 tag: 'path',
-                attributes: {'d': iconPath!},
+                attributes: {'d': iconPath},
               ),
             ],
           ),
@@ -117,7 +113,7 @@ class FilterChip extends StatelessComponent {
         'data-filter': dataFilter,
         'role': 'checkbox',
         'aria-checked': 'false',
-        if (ariaLabel != null) 'aria-label': ariaLabel!,
+        'aria-label': ?ariaLabel,
       },
       [
         if (showCheckIcon)
@@ -139,13 +135,9 @@ class FilterChip extends StatelessComponent {
               ),
             ],
           )
-        else if (icon != null)
-          span(
-            classes: 'material-symbols chip-icon leading-icon',
-            attributes: {'aria-hidden': 'true'},
-            [text(icon!)],
-          )
-        else if (iconPath != null)
+        else if (icon case final icon?)
+          MaterialIcon(icon, classes: ['chip-icon', 'leading-icon'])
+        else if (iconPath case final iconPath?)
           svg(
             classes: 'chip-icon leading-icon',
             width: iconSize.px,
@@ -155,7 +147,7 @@ class FilterChip extends StatelessComponent {
             [
               Component.element(
                 tag: 'path',
-                attributes: {'d': iconPath!},
+                attributes: {'d': iconPath},
               ),
             ],
           ),
@@ -190,7 +182,7 @@ class SelectChip extends StatelessComponent {
         classes: 'chip select-chip',
         attributes: {
           'data-menu': menuId,
-          if (dataTitle != null) 'data-title': dataTitle!,
+          'data-title': ?dataTitle,
           'aria-controls': menuId,
           'aria-expanded': 'false',
         },
@@ -261,13 +253,9 @@ class SelectMenuItem extends StatelessComponent {
           'aria-selected': isSelected.toString(),
         },
         [
-          if (icon != null)
-            span(
-              classes: 'material-symbols',
-              attributes: {'aria-hidden': 'true'},
-              [text(icon!)],
-            )
-          else if (iconPath != null)
+          if (icon case final icon?)
+            MaterialIcon(icon)
+          else if (iconPath case final iconPath?)
             svg(
               classes: 'menu-icon',
               width: iconSize.px,
@@ -277,7 +265,7 @@ class SelectMenuItem extends StatelessComponent {
               [
                 Component.element(
                   tag: 'path',
-                  attributes: {'d': iconPath!},
+                  attributes: {'d': iconPath},
                 ),
               ],
             ),

--- a/site/lib/src/components/cookie_notice.dart
+++ b/site/lib/src/components/cookie_notice.dart
@@ -5,6 +5,7 @@
 import 'package:jaspr/jaspr.dart';
 import 'package:universal_web/web.dart' as web;
 
+import '../util.dart';
 import 'button.dart';
 
 /// The cookie banner to show on a user's first time visiting the site.
@@ -48,7 +49,7 @@ final class _CookieNoticeState extends State<CookieNotice> {
   Component build(BuildContext context) {
     return section(
       id: 'cookie-notice',
-      classes: [if (showNotice) 'show'].join(' '),
+      classes: [if (showNotice) 'show'].toClasses,
       attributes: {'data-nosnippet': 'true'},
       [
         div(classes: 'container', [

--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
+import '../util.dart';
 import 'material_icon.dart';
 
 /// The site-wide top navigation bar.
@@ -48,7 +49,7 @@ class DashHeader extends StatelessComponent {
               classes: [
                 'nav-link',
                 if (activeEntry == _ActiveNavEntry.overview) 'active',
-              ].join(' '),
+              ].toClasses,
               [text('Overview')],
             ),
           ]),
@@ -58,7 +59,7 @@ class DashHeader extends StatelessComponent {
               classes: [
                 'nav-link',
                 if (activeEntry == _ActiveNavEntry.docs) 'active',
-              ].join(' '),
+              ].toClasses,
               [
                 span([text('Docs')]),
               ],
@@ -70,7 +71,7 @@ class DashHeader extends StatelessComponent {
               classes: [
                 'nav-link',
                 if (activeEntry == _ActiveNavEntry.blog) 'active',
-              ].join(' '),
+              ].toClasses,
               [text('Blog')],
             ),
           ]),
@@ -80,7 +81,7 @@ class DashHeader extends StatelessComponent {
               classes: [
                 'nav-link',
                 if (activeEntry == _ActiveNavEntry.community) 'active',
-              ].join(' '),
+              ].toClasses,
               [text('Community')],
             ),
           ]),
@@ -100,7 +101,7 @@ class DashHeader extends StatelessComponent {
               classes: [
                 'nav-link',
                 if (activeEntry == _ActiveNavEntry.getDart) 'active',
-              ].join(' '),
+              ].toClasses,
               [text('Get Dart')],
             ),
           ]),
@@ -297,7 +298,7 @@ class _SiteWordMarkListEntry extends StatelessComponent {
       [
         a(
           href: href,
-          classes: ['site-wordmark', if (current) 'current-site'].join(' '),
+          classes: ['site-wordmark', if (current) 'current-site'].toClasses,
           attributes: {
             'role': 'menuitem',
             'title': 'Navigate to the $_combinedName website.',

--- a/site/lib/src/components/material_icon.dart
+++ b/site/lib/src/components/material_icon.dart
@@ -4,6 +4,8 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import '../util.dart';
+
 /// A Material Symbols icon rendered as a span element.
 class MaterialIcon extends StatelessComponent {
   const MaterialIcon(
@@ -21,7 +23,7 @@ class MaterialIcon extends StatelessComponent {
   @override
   Component build(BuildContext _) {
     return span(
-      classes: ['material-symbols', ...classes].join(' '),
+      classes: ['material-symbols', ...classes].toClasses,
       attributes: {
         'title': ?title,
         'aria-label': ?(label ?? title),

--- a/site/lib/src/components/prev_next.dart
+++ b/site/lib/src/components/prev_next.dart
@@ -4,6 +4,8 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import 'material_icon.dart';
+
 /// Previous and next page buttons to display at the end of a page
 /// in a connected series of pages, such as the language docs.
 class PrevNext extends StatelessComponent {
@@ -38,15 +40,9 @@ class _PrevNextCard extends StatelessComponent {
     final classes = isPrevious ? 'prev' : 'next';
     final subtitle = isPrevious ? 'Previous' : 'Next';
     final ariaLabel = isPrevious ? 'Previous page: ' : 'Next page: ';
-    final iconName = isPrevious ? 'chevron_left' : 'chevron_right';
 
     return a(classes: classes, href: page.url, [
-      if (isPrevious)
-        span(
-          classes: 'material-symbols',
-          attributes: {'aria-hidden': 'true'},
-          [text(iconName)],
-        ),
+      if (isPrevious) const MaterialIcon('chevron_left'),
       div([
         span(
           classes: 'prev-next-subtitle',
@@ -55,12 +51,7 @@ class _PrevNextCard extends StatelessComponent {
         ),
         span(classes: 'prev-next-title', [text(page.title)]),
       ]),
-      if (!isPrevious)
-        span(
-          classes: 'material-symbols',
-          attributes: {'aria-hidden': 'true'},
-          [text(iconName)],
-        ),
+      if (!isPrevious) const MaterialIcon('chevron_right'),
     ]);
   }
 }

--- a/site/lib/src/components/tabs.dart
+++ b/site/lib/src/components/tabs.dart
@@ -66,7 +66,7 @@ class _DashTabsWrapper extends StatelessComponent {
   Component build(BuildContext context) {
     return div(
       id: id,
-      classes: ['tabs-wrapper', if (wrapped) 'wrapped'].join(' '),
+      classes: ['tabs-wrapper', if (wrapped) 'wrapped'].toClasses,
       attributes: {
         'data-tab-save-key': ?saveKey,
       },
@@ -85,7 +85,7 @@ class _DashTabsWrapper extends StatelessComponent {
                   classes: [
                     'nav-link',
                     if (tab.isActive) 'active',
-                  ].join(' '),
+                  ].toClasses,
                   attributes: {
                     'tabindex': '0',
                     'data-tab-save-id': tab.saveId,

--- a/site/lib/src/components/wrapped_code_block.dart
+++ b/site/lib/src/components/wrapped_code_block.dart
@@ -4,6 +4,7 @@
 
 import 'package:jaspr/jaspr.dart';
 
+import '../util.dart';
 import 'copy_button.dart';
 
 /// A rendered code block with support for syntax highlighting,
@@ -50,7 +51,7 @@ final class WrappedCodeBlock extends StatelessComponent {
           classes: [
             'code-block-body',
             if (tag case final codeTag?) ...['has-tag', codeTag.parentClass],
-          ].join(' '),
+          ].toClasses,
           [
             if (tag case final codeTag?)
               span(
@@ -67,7 +68,7 @@ final class WrappedCodeBlock extends StatelessComponent {
               classes: [
                 if (showLineNumbers) 'show-line-numbers',
                 'opal',
-              ].join(' '),
+              ].toClasses,
               attributes: {'tabindex': '0'},
               [
                 code(
@@ -82,7 +83,7 @@ final class WrappedCodeBlock extends StatelessComponent {
                           'line',
                           if (highlightLines.contains(lineIndex + 1))
                             'highlighted-line',
-                        ].join(' '),
+                        ].toClasses,
                         attributes: {
                           if (showLineNumbers)
                             'data-line': '${initialLineNumber + lineIndex}',


### PR DESCRIPTION
This PR cleans up the Jaspr site implementation a bit and has no functional changes.

- Use the `.toClasses` extension to convert a list of strings into a single class string.
- Migrate remaining manual material symbol creation to use shared `MaterialIcon` component.
- Some other nearby cleanup to avoid the not-null assertion operator.
