### PR TITLE
Add "Tree shaking" entry to glossary

### DIFF
--- a/src/data/glossary.yml
+++ b/src/data/glossary.yml
@@ -1424,15 +1424,15 @@
   short_description: |-
     A compiler optimization that removes unused code.
   long_description: |-
-    **Tree shaking** is a compiler optimization that analyzes which parts of
-    the code are actually used by an application and removes everything else
-    from the final output.
+    **Tree shaking** is a compiler optimization that
+    analyzes which parts of the code are actually used by an application and
+    removes everything else from the final output.
 
     This makes the compiled program smaller and faster to load, since dead code
     that is never referenced doesn't end up in the binary or bundle.
 
-    Tree shaking is especially important for web and mobile apps, where code size
-    directly impacts download time and runtime performance.
+    Tree shaking is especially important for web and mobile apps, where
+    code size directly impacts download time and runtime performance.
 
     For example, if you import a library that defines ten top-level functions,
     but your app only calls two, tree shaking ensures


### PR DESCRIPTION
Adds "tree shaking" term to the site-wide glossary that can be referenced when explaining the behavior of Dart's various compilers.

Contributes to https://github.com/dart-lang/site-www/issues/6461 