### PR TITLE
Hide theme switcher on homepage layout pages

### DIFF
--- a/site/lib/_sass/components/_theming.scss
+++ b/site/lib/_sass/components/_theming.scss
@@ -1,10 +1,6 @@
 #theme-switcher {
   position: relative;
 
-  //.icon-button span {
-  //  font-size: 1.5rem;
-  //}
-
   > .dropdown-content {
     right: -0.5rem;
 

--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -16,6 +16,7 @@ class DashHeader extends StatelessComponent {
   @override
   Component build(BuildContext context) {
     final pageUrlPath = context.page.url;
+    final layout = context.page.data.page['layout'];
     final activeEntry = _activeNavEntry(pageUrlPath);
 
     return header(id: 'site-header', classes: 'always-dark-mode', [
@@ -139,69 +140,70 @@ class DashHeader extends StatelessComponent {
                 MaterialIcon('search'),
               ],
             ),
-            div(id: 'theme-switcher', classes: 'dropdown', [
-              button(
-                classes: 'dropdown-button icon-button',
-                attributes: {
-                  'title': 'Select a theme',
-                  'aria-label': 'Select a theme',
-                  'aria-expanded': 'false',
-                  'aria-controls': 'theme-menu',
-                },
-                const [MaterialIcon('routine')],
-              ),
-              div(classes: 'dropdown-content', id: 'theme-menu', [
-                div(classes: 'dropdown-menu', [
-                  ul(
-                    attributes: {'role': 'listbox'},
-                    [
-                      li([
-                        button(
-                          attributes: {
-                            'data-theme': 'light',
-                            'title': 'Switch to light mode',
-                            'aria-label': 'Switch to light mode',
-                            'aria-selected': 'false',
-                          },
-                          [
-                            const MaterialIcon('light_mode'),
-                            span([text('Light')]),
-                          ],
-                        ),
-                      ]),
-                      li([
-                        button(
-                          attributes: {
-                            'data-theme': 'dark',
-                            'title': 'Switch to dark mode',
-                            'aria-label': 'Switch to dark mode',
-                            'aria-selected': 'false',
-                          },
-                          [
-                            const MaterialIcon('dark_mode'),
-                            span([text('Dark')]),
-                          ],
-                        ),
-                      ]),
-                      li([
-                        button(
-                          attributes: {
-                            'data-theme': 'auto',
-                            'title': 'Follow the device theme',
-                            'aria-label': 'Follow the device theme',
-                            'aria-selected': 'false',
-                          },
-                          [
-                            const MaterialIcon('night_sight_auto'),
-                            span([text('Automatic')]),
-                          ],
-                        ),
-                      ]),
-                    ],
-                  ),
+            if (layout != 'homepage')
+              div(id: 'theme-switcher', classes: 'dropdown', [
+                button(
+                  classes: 'dropdown-button icon-button',
+                  attributes: {
+                    'title': 'Select a theme',
+                    'aria-label': 'Select a theme',
+                    'aria-expanded': 'false',
+                    'aria-controls': 'theme-menu',
+                  },
+                  const [MaterialIcon('routine')],
+                ),
+                div(classes: 'dropdown-content', id: 'theme-menu', [
+                  div(classes: 'dropdown-menu', [
+                    ul(
+                      attributes: {'role': 'listbox'},
+                      [
+                        li([
+                          button(
+                            attributes: {
+                              'data-theme': 'light',
+                              'title': 'Switch to light mode',
+                              'aria-label': 'Switch to light mode',
+                              'aria-selected': 'false',
+                            },
+                            [
+                              const MaterialIcon('light_mode'),
+                              span([text('Light')]),
+                            ],
+                          ),
+                        ]),
+                        li([
+                          button(
+                            attributes: {
+                              'data-theme': 'dark',
+                              'title': 'Switch to dark mode',
+                              'aria-label': 'Switch to dark mode',
+                              'aria-selected': 'false',
+                            },
+                            [
+                              const MaterialIcon('dark_mode'),
+                              span([text('Dark')]),
+                            ],
+                          ),
+                        ]),
+                        li([
+                          button(
+                            attributes: {
+                              'data-theme': 'auto',
+                              'title': 'Follow the device theme',
+                              'aria-label': 'Follow the device theme',
+                              'aria-selected': 'false',
+                            },
+                            [
+                              const MaterialIcon('night_sight_auto'),
+                              span([text('Automatic')]),
+                            ],
+                          ),
+                        ]),
+                      ],
+                    ),
+                  ]),
                 ]),
               ]),
-            ]),
             div(
               id: 'site-switcher',
               classes: 'dropdown',


### PR DESCRIPTION
The code looks like a larger change due to whitespace differences, but it just doesn't render the theme switcher on pages with the 'homepage' layout. Which is currently the home page and the 404 page.

@mit-mit Suggested this to avoid confusion on the page which (for now) only has a dark mode version.

**Staged:**

- Landing page: https://dart-dev--pr6905-misc-hide-theme-switcher-u5rlnhl2.web.app/
- 404 page: https://dart-dev--pr6905-misc-hide-theme-switcher-u5rlnhl2.web.app/404
- Another page where it still renders: https://dart-dev--pr6905-misc-hide-theme-switcher-u5rlnhl2.web.app/docs
