### PR TITLE
Migrate header dropdown menus to Jaspr

### DIFF
--- a/site/lib/_sass/components/_dropdown.scss
+++ b/site/lib/_sass/components/_dropdown.scss
@@ -1,5 +1,11 @@
 @use '../base/mixins';
 
+.dropdown[data-expanded="true"] {
+  .dropdown-content {
+    display: block;
+  }
+}
+
 .dropdown-content {
   display: none;
   position: absolute;
@@ -10,10 +16,6 @@
   width: max-content;
   border: var(--site-chrome-borderColor) 1px solid;
   z-index: var(--site-z-dropdown);
-
-  &.show {
-    display: block;
-  }
 
   .dropdown-divider {
     background-color: var(--site-outline-variant);

--- a/site/lib/_sass/components/_dropdown.scss
+++ b/site/lib/_sass/components/_dropdown.scss
@@ -1,63 +1,65 @@
 @use '../base/mixins';
 
-.dropdown[data-expanded="true"] {
+.dropdown {
   .dropdown-content {
-    display: block;
-  }
-}
+    display: none;
+    position: absolute;
+    background-color: var(--site-chrome-bgColor);
+    color: var(--site-chrome-fgColor);
+    box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.2);
+    border-radius: calc(var(--site-radius) * 1.25);
+    width: max-content;
+    border: var(--site-chrome-borderColor) 1px solid;
+    z-index: var(--site-z-dropdown);
 
-.dropdown-content {
-  display: none;
-  position: absolute;
-  background-color: var(--site-chrome-bgColor);
-  color: var(--site-chrome-fgColor);
-  box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.2);
-  border-radius: calc(var(--site-radius) * 1.25);
-  width: max-content;
-  border: var(--site-chrome-borderColor) 1px solid;
-  z-index: var(--site-z-dropdown);
+    .dropdown-divider {
+      background-color: var(--site-outline-variant);
+      border-radius: 0.5rem;
+      height: 0.125rem;
+      margin: 0.25rem;
+      padding: 0 !important;
+    }
 
-  .dropdown-divider {
-    background-color: var(--site-outline-variant);
-    border-radius: 0.5rem;
-    height: 0.125rem;
-    margin: 0.25rem;
-    padding: 0 !important;
-  }
+    .dropdown-menu {
+      padding: 0.2rem;
 
-  .dropdown-menu {
-    padding: 0.2rem;
+      ul {
+        display: flex;
+        flex-direction: column;
+        list-style: none;
+        padding: 0;
+        margin: 0;
 
-    ul {
-      display: flex;
-      flex-direction: column;
-      list-style: none;
-      padding: 0;
-      margin: 0;
+        li {
+          padding: 0.25rem;
 
-      li {
-        padding: 0.25rem;
+          a, button {
+            display: flex;
+            align-items: center;
+            flex-direction: row;
+            width: 100%;
+            gap: 0.4rem;
+            padding: 0.2rem 0.4rem;
+            border-radius: var(--site-radius);
 
-        a, button {
-          display: flex;
-          align-items: center;
-          flex-direction: row;
-          width: 100%;
-          gap: 0.4rem;
-          padding: 0.2rem 0.4rem;
-          border-radius: var(--site-radius);
+            text-decoration: none;
 
-          text-decoration: none;
+            &:hover {
+              @include mixins.interaction-style(4%);
+            }
 
-          &:hover {
-            @include mixins.interaction-style(4%);
-          }
-
-          &:active {
-            @include mixins.interaction-style(6%);
+            &:active {
+              @include mixins.interaction-style(6%);
+            }
           }
         }
       }
+    }
+  }
+
+  &[data-expanded="true"] {
+    .dropdown-content {
+      display: block;
     }
   }
 }

--- a/site/lib/jaspr_options.dart
+++ b/site/lib/jaspr_options.dart
@@ -7,9 +7,13 @@
 import 'package:jaspr/jaspr.dart';
 import 'package:dart_dev_site/src/archive/archive_table.dart' as prefix0;
 import 'package:dart_dev_site/src/client/global_scripts.dart' as prefix1;
-import 'package:dart_dev_site/src/components/cookie_notice.dart' as prefix2;
-import 'package:dart_dev_site/src/components/copy_button.dart' as prefix3;
-import 'package:dart_dev_site/src/components/feedback.dart' as prefix4;
+import 'package:dart_dev_site/src/components/header/site_switcher.dart'
+    as prefix2;
+import 'package:dart_dev_site/src/components/header/theme_switcher.dart'
+    as prefix3;
+import 'package:dart_dev_site/src/components/cookie_notice.dart' as prefix4;
+import 'package:dart_dev_site/src/components/copy_button.dart' as prefix5;
+import 'package:dart_dev_site/src/components/feedback.dart' as prefix6;
 
 /// Default [JasprOptions] for use with your jaspr project.
 ///
@@ -38,18 +42,26 @@ JasprOptions get defaultJasprOptions => JasprOptions(
       'src/client/global_scripts',
     ),
 
-    prefix2.CookieNotice: ClientTarget<prefix2.CookieNotice>(
+    prefix4.CookieNotice: ClientTarget<prefix4.CookieNotice>(
       'src/components/cookie_notice',
     ),
 
-    prefix3.CopyButton: ClientTarget<prefix3.CopyButton>(
+    prefix5.CopyButton: ClientTarget<prefix5.CopyButton>(
       'src/components/copy_button',
-      params: _prefix3CopyButton,
+      params: _prefix5CopyButton,
     ),
 
-    prefix4.FeedbackComponent: ClientTarget<prefix4.FeedbackComponent>(
+    prefix6.FeedbackComponent: ClientTarget<prefix6.FeedbackComponent>(
       'src/components/feedback',
-      params: _prefix4FeedbackComponent,
+      params: _prefix6FeedbackComponent,
+    ),
+
+    prefix2.SiteSwitcher: ClientTarget<prefix2.SiteSwitcher>(
+      'src/components/header/site_switcher',
+    ),
+
+    prefix3.ThemeSwitcher: ClientTarget<prefix3.ThemeSwitcher>(
+      'src/components/header/theme_switcher',
     ),
   },
   styles: () => [],
@@ -58,12 +70,12 @@ JasprOptions get defaultJasprOptions => JasprOptions(
 Map<String, dynamic> _prefix0ArchiveTable(prefix0.ArchiveTable c) => {
   'channel': c.channel,
 };
-Map<String, dynamic> _prefix3CopyButton(prefix3.CopyButton c) => {
+Map<String, dynamic> _prefix5CopyButton(prefix5.CopyButton c) => {
   'toCopy': c.toCopy,
   'buttonText': c.buttonText,
   'classes': c.classes,
   'title': c.title,
 };
-Map<String, dynamic> _prefix4FeedbackComponent(prefix4.FeedbackComponent c) => {
+Map<String, dynamic> _prefix6FeedbackComponent(prefix6.FeedbackComponent c) => {
   'issueUrl': c.issueUrl,
 };

--- a/site/lib/src/components/dropdown.dart
+++ b/site/lib/src/components/dropdown.dart
@@ -56,6 +56,14 @@ final class _DropdownState extends State<Dropdown> {
                 toggle(to: false);
               }
             },
+            'focusout': (e) {
+              final relatedTarget =
+                  (e as web.FocusEvent).relatedTarget as web.HTMLElement?;
+              if (relatedTarget != null &&
+                  relatedTarget.closest('#${component.id}') == null) {
+                toggle(to: false);
+              }
+            },
           },
           component.children,
         ),

--- a/site/lib/src/components/dropdown.dart
+++ b/site/lib/src/components/dropdown.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+
+import 'package:universal_web/web.dart' as web;
+
+import 'util/global_click.dart';
+
+/// The root component of a dropdown in a client component.
+///
+/// Should include a [DropdownToggle] and [DropdownContent]
+/// as children.
+final class Dropdown extends StatefulComponent {
+  const Dropdown({required this.id, required this.children});
+
+  final String id;
+  final List<Component> children;
+
+  @override
+  State<Dropdown> createState() => _DropdownState();
+}
+
+final class _DropdownState extends State<Dropdown> {
+  bool _expanded = false;
+
+  void toggle({bool? to}) {
+    setState(() {
+      _expanded = to ?? !_expanded;
+    });
+  }
+
+  @override
+  Component build(BuildContext _) {
+    return GlobalClickListener(
+      onClick: (event) {
+        if (!_expanded) return;
+        final target = event.target as web.HTMLElement?;
+        if (target == null || target.closest('#${component.id}') == null) {
+          toggle(to: false);
+        }
+      },
+      _DropdownRoot(
+        id: component.id,
+        expanded: _expanded,
+        toggle: toggle,
+        child: div(
+          id: component.id,
+          classes: 'dropdown',
+          attributes: {'data-expanded': _expanded.toString()},
+          events: {
+            'keydown': (e) {
+              final keydownEvent = e as web.KeyboardEvent;
+              if (_expanded && keydownEvent.key == 'Escape') {
+                toggle(to: false);
+              }
+            },
+          },
+          component.children,
+        ),
+      ),
+    );
+  }
+}
+
+final class DropdownToggle extends StatelessComponent {
+  const DropdownToggle(this.child);
+
+  final Component child;
+
+  @override
+  Component build(BuildContext context) {
+    final root = _DropdownRoot.of(context);
+
+    return Component.wrapElement(
+      child: child,
+      classes: 'dropdown-button',
+      events: {
+        'click': (e) {
+          root.toggle();
+        },
+      },
+      attributes: {
+        'aria-controls': root.contentId,
+        'aria-expanded': root.expanded.toString(),
+      },
+    );
+  }
+}
+
+final class DropdownContent extends StatelessComponent {
+  const DropdownContent(this.child);
+
+  final Component child;
+
+  @override
+  Component build(BuildContext context) => div(
+    id: _DropdownRoot.of(context).contentId,
+    classes: 'dropdown-content',
+    [child],
+  );
+}
+
+final class _DropdownRoot extends InheritedComponent {
+  const _DropdownRoot({
+    required this.id,
+    required this.toggle,
+    this.expanded = false,
+    required super.child,
+  });
+
+  final String id;
+  final bool expanded;
+  final void Function({bool? to}) toggle;
+
+  String get contentId => '$id-content';
+
+  @override
+  bool updateShouldNotify(_DropdownRoot oldRoot) =>
+      expanded != oldRoot.expanded;
+
+  static _DropdownRoot of(BuildContext context) =>
+      context.dependOnInheritedComponentOfExactType<_DropdownRoot>()!;
+}

--- a/site/lib/src/components/header.dart
+++ b/site/lib/src/components/header.dart
@@ -7,6 +7,8 @@ import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
 import '../util.dart';
+import 'header/site_switcher.dart';
+import 'header/theme_switcher.dart';
 import 'material_icon.dart';
 
 /// The site-wide top navigation bar.
@@ -140,123 +142,8 @@ class DashHeader extends StatelessComponent {
                 MaterialIcon('search'),
               ],
             ),
-            if (layout != 'homepage')
-              div(id: 'theme-switcher', classes: 'dropdown', [
-                button(
-                  classes: 'dropdown-button icon-button',
-                  attributes: {
-                    'title': 'Select a theme',
-                    'aria-label': 'Select a theme',
-                    'aria-expanded': 'false',
-                    'aria-controls': 'theme-menu',
-                  },
-                  const [MaterialIcon('routine')],
-                ),
-                div(classes: 'dropdown-content', id: 'theme-menu', [
-                  div(classes: 'dropdown-menu', [
-                    ul(
-                      attributes: {'role': 'listbox'},
-                      [
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'light',
-                              'title': 'Switch to light mode',
-                              'aria-label': 'Switch to light mode',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              const MaterialIcon('light_mode'),
-                              span([text('Light')]),
-                            ],
-                          ),
-                        ]),
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'dark',
-                              'title': 'Switch to dark mode',
-                              'aria-label': 'Switch to dark mode',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              const MaterialIcon('dark_mode'),
-                              span([text('Dark')]),
-                            ],
-                          ),
-                        ]),
-                        li([
-                          button(
-                            attributes: {
-                              'data-theme': 'auto',
-                              'title': 'Follow the device theme',
-                              'aria-label': 'Follow the device theme',
-                              'aria-selected': 'false',
-                            },
-                            [
-                              const MaterialIcon('night_sight_auto'),
-                              span([text('Automatic')]),
-                            ],
-                          ),
-                        ]),
-                      ],
-                    ),
-                  ]),
-                ]),
-              ]),
-            div(
-              id: 'site-switcher',
-              classes: 'dropdown',
-              [
-                button(
-                  classes: 'dropdown-button icon-button',
-                  attributes: {
-                    'title': 'Select a theme',
-                    'aria-label': 'Select a theme',
-                    'aria-expanded': 'false',
-                    'aria-controls': 'site-switcher-menu',
-                  },
-                  const [MaterialIcon('apps')],
-                ),
-
-                div(
-                  id: 'site-switcher-menu',
-                  classes: 'dropdown-content',
-                  [
-                    nav(
-                      classes: 'dropdown-menu',
-                      attributes: {
-                        'role': 'menu',
-                      },
-                      [
-                        ul(
-                          const [
-                            _SiteWordMarkListEntry(
-                              name: 'Dart',
-                              href: '/',
-                              current: true,
-                            ),
-                            _SiteWordMarkListEntry(
-                              name: 'Dart',
-                              subtype: 'API',
-                              href: 'https://api.dart.dev',
-                            ),
-                            _SiteWordMarkListEntry(
-                              name: 'DartPad',
-                              href: 'https://dartpad.dev',
-                            ),
-                            _SiteWordMarkListEntry(
-                              name: 'pub.dev',
-                              href: 'https://pub.dev',
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ],
-            ),
+            if (layout != 'homepage') const ThemeSwitcher(),
+            const SiteSwitcher(),
             button(
               id: 'menu-toggle',
               classes: 'icon-button',
@@ -275,60 +162,6 @@ class DashHeader extends StatelessComponent {
         ),
       ]),
     ]);
-  }
-}
-
-class _SiteWordMarkListEntry extends StatelessComponent {
-  const _SiteWordMarkListEntry({
-    required this.href,
-    required this.name,
-    this.subtype,
-    this.current = false,
-  });
-
-  final String href;
-  final String name;
-  final String? subtype;
-  final bool current;
-
-  String get _combinedName => '$name${subtype != null ? ' $subtype' : ''}';
-
-  @override
-  Component build(BuildContext context) {
-    return li(
-      attributes: {'role': 'presentation'},
-      [
-        a(
-          href: href,
-          classes: ['site-wordmark', if (current) 'current-site'].toClasses,
-          attributes: {
-            'role': 'menuitem',
-            'title': 'Navigate to the $_combinedName website.',
-            'aria-label': 'Navigate to the $_combinedName website.',
-          },
-          [
-            img(
-              src: '/assets/img/logo/dart-192.svg',
-              alt: 'Dart logo',
-              width: 28,
-              height: 28,
-            ),
-            span(
-              classes: 'name',
-              attributes: {
-                'translate': 'no',
-              },
-              [text(name)],
-            ),
-            if (subtype case final subtype?)
-              span(
-                classes: 'subtype',
-                [text(subtype)],
-              ),
-          ],
-        ),
-      ],
-    );
   }
 }
 

--- a/site/lib/src/components/header/site_switcher.dart
+++ b/site/lib/src/components/header/site_switcher.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+
+import '../../util.dart';
+import '../button.dart';
+import '../dropdown.dart';
+
+@client
+final class SiteSwitcher extends StatelessComponent {
+  const SiteSwitcher();
+
+  @override
+  Component build(BuildContext _) => Dropdown(
+    id: 'site-switcher',
+    children: [
+      const DropdownToggle(Button(icon: 'apps', title: 'Visit related sites.')),
+      DropdownContent(
+        nav(
+          classes: 'dropdown-menu',
+          attributes: {
+            'role': 'menu',
+          },
+          [
+            ul(
+              const [
+                _SiteWordMarkListEntry(
+                  name: 'Dart',
+                  href: '/',
+                  current: true,
+                ),
+                _SiteWordMarkListEntry(
+                  name: 'Dart',
+                  subtype: 'API',
+                  href: 'https://api.dart.dev',
+                ),
+                _SiteWordMarkListEntry(
+                  name: 'DartPad',
+                  href: 'https://dartpad.dev',
+                ),
+                _SiteWordMarkListEntry(
+                  name: 'pub.dev',
+                  href: 'https://pub.dev',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}
+
+class _SiteWordMarkListEntry extends StatelessComponent {
+  const _SiteWordMarkListEntry({
+    required this.href,
+    required this.name,
+    this.subtype,
+    this.current = false,
+  });
+
+  final String href;
+  final String name;
+  final String? subtype;
+  final bool current;
+
+  String get _combinedName => '$name${subtype != null ? ' $subtype' : ''}';
+
+  @override
+  Component build(BuildContext _) {
+    return li(
+      attributes: {'role': 'presentation'},
+      [
+        a(
+          href: href,
+          classes: ['site-wordmark', if (current) 'current-site'].toClasses,
+          attributes: {
+            'role': 'menuitem',
+            'title': 'Navigate to the $_combinedName website.',
+            'aria-label': 'Navigate to the $_combinedName website.',
+          },
+          [
+            img(
+              src: '/assets/img/logo/dart-192.svg',
+              alt: 'Dart logo',
+              width: 28,
+              height: 28,
+            ),
+            span(
+              classes: 'name',
+              attributes: {
+                'translate': 'no',
+              },
+              [text(name)],
+            ),
+            if (subtype case final subtype?)
+              span(
+                classes: 'subtype',
+                [text(subtype)],
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/site/lib/src/components/header/theme_switcher.dart
+++ b/site/lib/src/components/header/theme_switcher.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+
+import '../button.dart';
+import '../dropdown.dart';
+import '../material_icon.dart';
+
+@client
+final class ThemeSwitcher extends StatelessComponent {
+  const ThemeSwitcher();
+
+  @override
+  Component build(BuildContext _) => Dropdown(
+    id: 'theme-switcher',
+    children: [
+      const DropdownToggle(Button(icon: 'routine', title: 'Select a theme.')),
+      DropdownContent(
+        div(
+          classes: 'dropdown-menu',
+          [
+            ul(
+              attributes: {'role': 'listbox'},
+              const [
+                _ThemeButtonEntry(
+                  themeId: 'light',
+                  themeName: 'Light',
+                  title: 'Switch to light mode.',
+                  iconId: 'light_mode',
+                ),
+                _ThemeButtonEntry(
+                  themeId: 'dark',
+                  themeName: 'Dark',
+                  title: 'Switch to dark mode.',
+                  iconId: 'dark_mode',
+                ),
+                _ThemeButtonEntry(
+                  themeId: 'auto',
+                  themeName: 'Automatic',
+                  title: 'Match theme to device theme.',
+                  iconId: 'night_sight_auto',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}
+
+final class _ThemeButtonEntry extends StatelessComponent {
+  const _ThemeButtonEntry({
+    required this.themeId,
+    required this.themeName,
+    required this.title,
+    required this.iconId,
+  });
+
+  final String themeId;
+  final String themeName;
+  final String title;
+  final String iconId;
+
+  @override
+  Component build(BuildContext _) => li([
+    button(
+      attributes: {
+        'data-theme': themeId,
+        'title': title,
+        'aria-label': title,
+        'aria-selected': 'false',
+      },
+      [
+        MaterialIcon(iconId),
+        span([text(themeName)]),
+      ],
+    ),
+  ]);
+}

--- a/site/lib/src/components/util/global_click.dart
+++ b/site/lib/src/components/util/global_click.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+import 'package:universal_web/js_interop.dart';
+import 'package:universal_web/web.dart' as web;
+
+final class GlobalClickListener extends StatefulComponent {
+  const GlobalClickListener(this.child, {required this.onClick});
+
+  final Component child;
+  final void Function(web.MouseEvent) onClick;
+
+  @override
+  State<GlobalClickListener> createState() => _GlobalClickListenerState();
+}
+
+class _GlobalClickListenerState extends State<GlobalClickListener> {
+  @override
+  void initState() {
+    if (kIsWeb) {
+      web.document.addEventListener('click', component.onClick.toJS);
+    }
+
+    super.initState();
+  }
+
+  @override
+  Component build(BuildContext _) => component.child;
+}

--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -111,9 +111,9 @@ abstract class DashLayout extends PageLayoutBase {
         href:
             'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0..1,0',
       ),
-      link(rel: 'stylesheet', href: '/assets/css/main.css?v=2'),
+      link(rel: 'stylesheet', href: '/assets/css/main.css?v=3'),
 
-      script(src: '/assets/js/main.js'),
+      script(src: '/assets/js/main.js?v=2'),
       if (pageData['js'] case final List<Object?> jsList)
         for (final js in jsList)
           if (js case {'url': final String jsUrl, 'defer': final Object? defer})

--- a/site/web/assets/js/main.js
+++ b/site/web/assets/js/main.js
@@ -11,7 +11,7 @@ function setupTheme() {
     document.body.classList.add(storedTheme);
   }
 
-  const themeMenu = document.getElementById('theme-menu');
+  const themeMenu = document.getElementById('theme-switcher-content');
   if (themeMenu) {
     const themeButtons = themeMenu.querySelectorAll('button');
 
@@ -55,103 +55,6 @@ function _switchToPreferenceIfAuto() {
       document.body.classList.add('light-mode');
     }
   }
-}
-
-function setupThemeSwitcher() {
-  const themeSwitcher = document.getElementById('theme-switcher');
-  if (!themeSwitcher) {
-    return;
-  }
-
-  const themeSwitcherButton = themeSwitcher.querySelector('.dropdown-button');
-  const themeSwitcherMenu = themeSwitcher.querySelector('#theme-menu');
-  if (!themeSwitcherButton || !themeSwitcherMenu) {
-    return;
-  }
-
-  function _closeMenusAndToggle() {
-    themeSwitcherMenu.classList.remove('show');
-    themeSwitcherButton.ariaExpanded = 'false';
-  }
-
-  themeSwitcherButton.addEventListener('click', (_) => {
-    if (themeSwitcherMenu.classList.contains('show')) {
-      _closeMenusAndToggle();
-    } else {
-      themeSwitcherMenu.classList.add('show');
-      themeSwitcherButton.ariaExpanded = 'true';
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    // If pressing the `esc` key in the menu area, close the menu.
-    if (event.key === 'Escape' && event.target.closest('#theme-switcher')) {
-      _closeMenusAndToggle();
-    }
-  });
-
-  themeSwitcher.addEventListener('focusout', (e) => {
-    // If focus leaves the theme-switcher, hide the menu.
-    if (e.relatedTarget && !e.relatedTarget.closest('#theme-switcher')) {
-      _closeMenusAndToggle();
-    }
-  });
-
-  document.addEventListener('click', (event) => {
-    // If not clicking inside the theme switcher, close the menu.
-    if (!event.target.closest('#theme-switcher')) {
-      _closeMenusAndToggle();
-    }
-  })
-}
-
-function setupSiteSwitcher() {
-  const siteSwitcher = document.getElementById('site-switcher');
-
-  if (!siteSwitcher) {
-    return;
-  }
-
-  const siteSwitcherButton = siteSwitcher.querySelector('.dropdown-button');
-  const siteSwitcherMenu = siteSwitcher.querySelector('#site-switcher-menu');
-  if (!siteSwitcherButton || !siteSwitcherMenu) {
-    return;
-  }
-
-  function _closeMenusAndToggle() {
-    siteSwitcherMenu.classList.remove('show');
-    siteSwitcherButton.ariaExpanded = 'false';
-  }
-
-  siteSwitcherButton.addEventListener('click', (_) => {
-    if (siteSwitcherMenu.classList.contains('show')) {
-      _closeMenusAndToggle();
-    } else {
-      siteSwitcherMenu.classList.add('show');
-      siteSwitcherButton.ariaExpanded = 'true';
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    // If pressing the `esc` key in the menu area, close the menu.
-    if (event.key === 'Escape' && event.target.closest('#site-switcher')) {
-      _closeMenusAndToggle();
-    }
-  });
-
-  siteSwitcher.addEventListener('focusout', (e) => {
-    // If focus leaves the site-switcher, hide the menu.
-    if (e.relatedTarget && !e.relatedTarget.closest('#site-switcher')) {
-      _closeMenusAndToggle();
-    }
-  });
-
-  document.addEventListener('click', (event) => {
-    // If not clicking inside the site switcher, close the menu.
-    if (!event.target.closest('#site-switcher')) {
-      _closeMenusAndToggle();
-    }
-  });
 }
 
 function handleSearchShortcut(event) {
@@ -233,15 +136,15 @@ function _setupInlineTocDropdown() {
   if (!dropdownButton || !dropdownMenu) return;
 
   function _closeMenu() {
-    dropdownMenu.classList.remove('show');
+    inlineToc.dataset.expanded = 'false';
     dropdownButton.ariaExpanded = 'false';
   }
 
   dropdownButton.addEventListener('click', (_) => {
-    if (dropdownMenu.classList.contains('show')) {
+    if (inlineToc.dataset.expanded === 'true') {
       _closeMenu();
     } else {
-      dropdownMenu.classList.add('show');
+      inlineToc.dataset.expanded = 'true';
       dropdownButton.ariaExpanded = 'true';
     }
   });
@@ -381,8 +284,6 @@ function setupExpandableCards() {
 function _setupSite() {
   setupTheme();
   setupSidenav();
-  setupThemeSwitcher();
-  setupSiteSwitcher();
 
   // Set up collapse and expand for sidenav buttons.
   const toggles = document.querySelectorAll('.nav-link.collapsible');


### PR DESCRIPTION
Creates a reusable `Dropdown` client component that the theme switcher and site switcher migrate to use.

Contributes to https://github.com/dart-lang/site-www/issues/6853

**Staged:** https://dart-dev--pr6909-feat-dropdown-menus-km2fhsxe.web.app/docs