### PR TITLE
Migrate more global script logic to Dart

### DIFF
--- a/site/lib/src/client/global_scripts.dart
+++ b/site/lib/src/client/global_scripts.dart
@@ -38,13 +38,74 @@ final class _GlobalScriptsState extends State<GlobalScripts> {
 }
 
 void _setupSite() {
-  _setupTabs();
+  _setUpSidenav();
+  _setUpSearchKeybindings();
+  _setUpTabs();
 }
 
+void _setUpSidenav() {
+  final sidenav = web.document.getElementById('sidenav');
+  if (sidenav == null) return;
+  final activeEntries = sidenav.querySelectorAll('a.nav-link.active');
+
+  if (activeEntries.length > 0) {
+    // Scroll the last active entry into view.
+    // This is usually the most specific active entry.
+    final lastActiveEntry = activeEntries.item(activeEntries.length - 1);
+    if (lastActiveEntry case final web.HTMLElement lastActiveEntry) {
+      sidenav.scrollTo(
+        web.ScrollToOptions(
+          top: lastActiveEntry.offsetTop - (web.window.innerHeight / 3),
+        ),
+      );
+    }
+  }
+}
+
+void _setUpSearchKeybindings() {
+  web.document.addEventListener('keydown', _handleSearchShortcut.toJS);
+}
+
+void _handleSearchShortcut(web.Event event) {
+  final keyboardEvent = event as web.KeyboardEvent;
+  final activeElement = web.document.activeElement;
+
+  // Don't intercept if typing in an input field or not pressing slash key.
+  if (activeElement.isA<web.HTMLInputElement>() ||
+      activeElement.isA<web.HTMLTextAreaElement>() ||
+      keyboardEvent.code != 'Slash') {
+    return;
+  }
+
+  final web.Element? parentElement;
+  // If the sidebar is open, focus its search field.
+  if (web.document.body!.classList.contains('open_menu')) {
+    parentElement = web.document.getElementById('sidenav');
+  } else {
+    // If the page has a search field in the body, focus that.
+    if (web.document.getElementById('in-content-search')
+        case final bodySearch?) {
+      parentElement = bodySearch;
+    } else {
+      // Otherwise, fallback to the top navbar search field.
+      parentElement = web.document.getElementById('header-search');
+    }
+  }
+
+  // If we found any search field, focus it.
+  if (parentElement?.querySelector('.search-field')
+      case final web.HTMLElement searchField) {
+    searchField.focus();
+    // Prevent the initial slash from showing up in the search field.
+    event.preventDefault();
+  }
+}
+
+// TODO(parlough): Migrate interactivity of tabs to the Jaspr components.
 /// Set up interactivity of tabs created with
 /// the `<Tabs>` and `<Tab>` custom components.
-void _setupTabs() {
-  _applyFromQueryParameters();
+void _setUpTabs() {
+  _updateTabsFromQueryParameters();
 
   final tabsWrappers = web.document.querySelectorAll('.tabs-wrapper');
 
@@ -106,7 +167,7 @@ void _setupTabs() {
 }
 
 /// Apply force overrides from query parameters to saved tabs.
-void _applyFromQueryParameters() {
+void _updateTabsFromQueryParameters() {
   final currentUrl = Uri.parse(web.window.location.href);
   final originalQueryParameters = currentUrl.queryParameters;
   final updatedQueryParameters = {...originalQueryParameters};

--- a/site/lib/src/client/global_scripts.dart
+++ b/site/lib/src/client/global_scripts.dart
@@ -22,9 +22,9 @@ final class _GlobalScriptsState extends State<GlobalScripts> {
     if (kIsWeb) {
       // Run setup if DOM is loaded, otherwise do it after it has loaded.
       if (web.document.readyState == 'loading') {
-        web.document.addEventListener('DOMContentLoaded', _setupSite.toJS);
+        web.document.addEventListener('DOMContentLoaded', _setUpSite.toJS);
       } else {
-        _setupSite();
+        _setUpSite();
       }
     }
 
@@ -32,12 +32,10 @@ final class _GlobalScriptsState extends State<GlobalScripts> {
   }
 
   @override
-  Component build(BuildContext context) {
-    return const Component.empty();
-  }
+  Component build(BuildContext context) => const Component.empty();
 }
 
-void _setupSite() {
+void _setUpSite() {
   _setUpSidenav();
   _setUpSearchKeybindings();
   _setUpTabs();

--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -113,7 +113,7 @@ abstract class DashLayout extends PageLayoutBase {
       ),
       link(rel: 'stylesheet', href: '/assets/css/main.css?v=3'),
 
-      script(src: '/assets/js/main.js?v=2'),
+      script(src: '/assets/js/main.js?v=3'),
       if (pageData['js'] case final List<Object?> jsList)
         for (final js in jsList)
           if (js case {'url': final String jsUrl, 'defer': final Object? defer})

--- a/site/web/assets/js/main.js
+++ b/site/web/assets/js/main.js
@@ -57,56 +57,6 @@ function _switchToPreferenceIfAuto() {
   }
 }
 
-function handleSearchShortcut(event) {
-  const activeElement = document.activeElement;
-  if (activeElement instanceof HTMLInputElement ||
-      activeElement instanceof HTMLTextAreaElement ||
-      event.code !== 'Slash'
-  ) {
-    return;
-  }
-
-  let parentElement;
-  // If the sidebar is open, focus its search field.
-  if (document.body.classList.contains('open_menu')) {
-    parentElement = document.getElementById('sidenav');
-  } else {
-    const bodySearch = document.getElementById('in-content-search');
-    // If the page has a search field in the body, focus that.
-    if (bodySearch !== null) {
-      parentElement = bodySearch;
-    } else {
-      // Otherwise, fallback to the top navbar search field.
-      parentElement = document.getElementById('header-search');
-    }
-  }
-
-  // If we found any search field, focus it.
-  if (parentElement !== null) {
-    parentElement
-        .querySelector('.search-field')
-        .focus();
-    // Prevent the initial slash from showing up in the search field.
-    event.preventDefault();
-  }
-}
-
-function setupSidenav() {
-  const sidenav = document.getElementById('sidenav');
-  if (!sidenav) {
-    return;
-  }
-
-  const activeEntries = sidenav.querySelectorAll('a.nav-link.active');
-  if (activeEntries.length > 0) {
-    const activeEntry = activeEntries[activeEntries.length - 1];
-
-    sidenav.scrollTo({
-      top: activeEntry.offsetTop - window.innerHeight / 3,
-    });
-  }
-}
-
 function setupTableOfContents() {
   const tocHeader = document.querySelector('#toc-side header');
 
@@ -283,7 +233,6 @@ function setupExpandableCards() {
 
 function _setupSite() {
   setupTheme();
-  setupSidenav();
 
   // Set up collapse and expand for sidenav buttons.
   const toggles = document.querySelectorAll('.nav-link.collapsible');

--- a/site/web/assets/js/main.js
+++ b/site/web/assets/js/main.js
@@ -266,8 +266,6 @@ function _setupSite() {
     });
   });
 
-  document.addEventListener('keydown', handleSearchShortcut);
-
   createGallery(
     'galleryOne',
     'galleryTwo',


### PR DESCRIPTION
Migrates more logic from `main.js` to Dart code. No behavior changes, simply migrating the logic.

Contributes to https://github.com/dart-lang/site-www/issues/6853
