### PR TITLE
Migrate theme handling to Dart and Jaspr

### DIFF
--- a/site/lib/_sass/components/_theming.scss
+++ b/site/lib/_sass/components/_theming.scss
@@ -9,21 +9,7 @@
     }
   }
 
-  @at-root body:not(.dark-mode):not(.auto-mode) & {
-    button[data-theme="light"] {
-      background-color: var(--site-primary-color-highlight);
-    }
-  }
-
-  @at-root body.dark-mode:not(.auto-mode) & {
-    button[data-theme="dark"] {
-      background-color: var(--site-primary-color-highlight);
-    }
-  }
-
-  @at-root body.auto-mode & {
-    button[data-theme="auto"] {
-      background-color: var(--site-primary-color-highlight);
-    }
+  button[aria-selected="true"] {
+    background-color: var(--site-primary-color-highlight);
   }
 }

--- a/site/lib/src/components/header/theme_switcher.dart
+++ b/site/lib/src/components/header/theme_switcher.dart
@@ -22,11 +22,11 @@ enum _Theme {
   dark('Dark', 'Switch to the dark theme.', 'dark_mode'),
   auto('Automatic', 'Match theme to device theme.', 'night_sight_auto');
 
-  final String name;
+  final String label;
   final String description;
   final String iconId;
 
-  const _Theme(this.name, this.description, this.iconId);
+  const _Theme(this.label, this.description, this.iconId);
 
   String get id => '$name-mode';
 }
@@ -132,7 +132,7 @@ final class _ThemeButtonEntry extends StatelessComponent {
       },
       [
         MaterialIcon(mode.iconId),
-        span([text(mode.name)]),
+        span([text(mode.label)]),
       ],
     ),
   ]);

--- a/site/lib/src/components/header/theme_switcher.dart
+++ b/site/lib/src/components/header/theme_switcher.dart
@@ -3,14 +3,81 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:jaspr/jaspr.dart';
+import 'package:universal_web/web.dart' as web;
 
 import '../button.dart';
 import '../dropdown.dart';
 import '../material_icon.dart';
 
 @client
-final class ThemeSwitcher extends StatelessComponent {
+final class ThemeSwitcher extends StatefulComponent {
   const ThemeSwitcher();
+
+  @override
+  State<StatefulComponent> createState() => _ThemeSwitcherState();
+}
+
+enum _Theme {
+  light('Light', 'Switch to the light theme.', 'light_mode'),
+  dark('Dark', 'Switch to the dark theme.', 'dark_mode'),
+  auto('Automatic', 'Match theme to device theme.', 'night_sight_auto');
+
+  final String name;
+  final String description;
+  final String iconId;
+
+  const _Theme(this.name, this.description, this.iconId);
+
+  String get id => '$name-mode';
+}
+
+final class _ThemeSwitcherState extends State<ThemeSwitcher> {
+  _Theme _currentTheme = _Theme.light;
+
+  @override
+  void initState() {
+    if (kIsWeb) {
+      final classList = web.document.body!.classList;
+      // If them theme is auto, it and the result will be added as classes.
+      // So it should be checked for first.
+      if (classList.contains(_Theme.auto.id)) {
+        _currentTheme = _Theme.auto;
+      } else if (classList.contains(_Theme.dark.id)) {
+        _currentTheme = _Theme.dark;
+      } else if (classList.contains(_Theme.light.id)) {
+        _currentTheme = _Theme.light;
+      } else {
+        // Default to light mode if no theme is set yet.
+        _currentTheme = _Theme.light;
+        classList.add(_Theme.light.id);
+      }
+    }
+
+    super.initState();
+  }
+
+  void _setTheme(_Theme newTheme) {
+    if (newTheme == _currentTheme) return;
+
+    final classList = web.document.body!.classList;
+    for (final mode in _Theme.values) {
+      classList.remove(mode.id);
+    }
+    classList.add(newTheme.id);
+    if (newTheme == _Theme.auto) {
+      classList.add(
+        web.window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? _Theme.dark.id
+            : _Theme.light.id,
+      );
+    }
+
+    web.window.localStorage.setItem('theme', newTheme.id);
+
+    setState(() {
+      _currentTheme = newTheme;
+    });
+  }
 
   @override
   Component build(BuildContext _) => Dropdown(
@@ -23,25 +90,13 @@ final class ThemeSwitcher extends StatelessComponent {
           [
             ul(
               attributes: {'role': 'listbox'},
-              const [
-                _ThemeButtonEntry(
-                  themeId: 'light',
-                  themeName: 'Light',
-                  title: 'Switch to light mode.',
-                  iconId: 'light_mode',
-                ),
-                _ThemeButtonEntry(
-                  themeId: 'dark',
-                  themeName: 'Dark',
-                  title: 'Switch to dark mode.',
-                  iconId: 'dark_mode',
-                ),
-                _ThemeButtonEntry(
-                  themeId: 'auto',
-                  themeName: 'Automatic',
-                  title: 'Match theme to device theme.',
-                  iconId: 'night_sight_auto',
-                ),
+              [
+                for (final mode in _Theme.values)
+                  _ThemeButtonEntry(
+                    mode: mode,
+                    selected: _currentTheme == mode,
+                    setMode: _setTheme,
+                  ),
               ],
             ),
           ],
@@ -53,29 +108,31 @@ final class ThemeSwitcher extends StatelessComponent {
 
 final class _ThemeButtonEntry extends StatelessComponent {
   const _ThemeButtonEntry({
-    required this.themeId,
-    required this.themeName,
-    required this.title,
-    required this.iconId,
+    required this.mode,
+    required this.selected,
+    required this.setMode,
   });
 
-  final String themeId;
-  final String themeName;
-  final String title;
-  final String iconId;
+  final _Theme mode;
+  final bool selected;
+  final void Function(_Theme) setMode;
 
   @override
   Component build(BuildContext _) => li([
     button(
+      events: {
+        'click': (_) {
+          setMode(mode);
+        },
+      },
       attributes: {
-        'data-theme': themeId,
-        'title': title,
-        'aria-label': title,
-        'aria-selected': 'false',
+        'title': mode.description,
+        'aria-label': mode.description,
+        'aria-selected': selected.toString(),
       },
       [
-        MaterialIcon(iconId),
-        span([text(themeName)]),
+        MaterialIcon(mode.iconId),
+        span([text(mode.name)]),
       ],
     ),
   ]);

--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -113,7 +113,7 @@ abstract class DashLayout extends PageLayoutBase {
       ),
       link(rel: 'stylesheet', href: '/assets/css/main.css?v=3'),
 
-      script(src: '/assets/js/main.js?v=2'),
+      script(src: '/assets/js/main.js?v=4'),
       if (pageData['js'] case final List<Object?> jsList)
         for (final js in jsList)
           if (js case {'url': final String jsUrl, 'defer': final Object? defer})
@@ -206,6 +206,23 @@ ga('send', 'pageview');
           ]),
           const DashFooter(),
         ]),
+        // The theme setting logic should remain before other scripts to
+        // avoid a flash of the initial theme on load.
+        raw('''
+<script>
+const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
+const storedTheme = window.localStorage.getItem('theme') ?? 'light-mode';
+if (storedTheme === 'auto-mode') {
+  document.body.classList.add(
+      'auto-mode',
+      prefersDarkMode.matches ? 'dark-mode' : 'light-mode',
+  );
+} else {
+  document.body.classList.add(storedTheme);
+}
+</script>
+      '''),
         GlobalScripts(),
       ],
     );

--- a/site/web/assets/js/main.js
+++ b/site/web/assets/js/main.js
@@ -1,62 +1,3 @@
-const _prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
-
-function setupTheme() {
-  const storedTheme = window.localStorage.getItem('theme') ?? 'light-mode';
-  if (storedTheme === 'auto-mode') {
-    document.body.classList.add(
-        'auto-mode',
-        _prefersDarkMode.matches ? 'dark-mode' : 'light-mode',
-    );
-  } else {
-    document.body.classList.add(storedTheme);
-  }
-
-  const themeMenu = document.getElementById('theme-switcher-content');
-  if (themeMenu) {
-    const themeButtons = themeMenu.querySelectorAll('button');
-
-    function updateButtonSelectedState() {
-      const theme =
-          document.body.classList.contains('auto-mode') ? 'auto' :
-              document.body.classList.contains('dark-mode') ? 'dark' : 'light';
-
-      themeButtons.forEach((button) => {
-        button.ariaSelected = button.dataset.theme === theme ? 'true' : 'false';
-      });
-    }
-
-    themeButtons.forEach((button) => {
-      button.addEventListener('click', (_) => {
-        const newMode = `${button.dataset.theme}-mode`;
-
-        document.body.classList.remove('auto-mode', 'dark-mode', 'light-mode');
-        document.body.classList.add(newMode);
-
-        window.localStorage.setItem('theme', newMode);
-        _switchToPreferenceIfAuto();
-
-        updateButtonSelectedState();
-      });
-    });
-
-    updateButtonSelectedState();
-  }
-
-  _prefersDarkMode.addEventListener('change', _switchToPreferenceIfAuto);
-}
-
-function _switchToPreferenceIfAuto() {
-  if (document.body.classList.contains('auto-mode')) {
-    if (_prefersDarkMode.matches) {
-      document.body.classList.remove('light-mode');
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-      document.body.classList.add('light-mode');
-    }
-  }
-}
-
 function handleSearchShortcut(event) {
   const activeElement = document.activeElement;
   if (activeElement instanceof HTMLInputElement ||
@@ -282,7 +223,6 @@ function setupExpandableCards() {
 }
 
 function _setupSite() {
-  setupTheme();
   setupSidenav();
 
   // Set up collapse and expand for sidenav buttons.


### PR DESCRIPTION
Migrates the theme button handling to Dart and Jaspr without changing the behavior.

Checking the developer's previous settings is done in and inline script to avoid theme flashing on load.

Contributes to https://github.com/dart-lang/site-www/issues/6853