### PR TITLE
Fix contrast of highlighted spans in code blocks

### DIFF
--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -19,6 +19,8 @@ pre {
   code {
     white-space: pre;
     font-family: var(--site-code-fontFamily);
+    color: var(--site-base-fgColor);
+    --opal-dark-color: var(--site-base-fgColor);
   }
 
   a {


### PR DESCRIPTION
Sets the default text color for code blocks so that code that's not syntax highlighted, but has a highlighted background, has sufficient contrast.

**Before:**
<img width="240" alt="Screenshot of before contrast issue" src="https://github.com/user-attachments/assets/2b08734b-ed68-48d6-8457-9a03f6d74666" />

**After:**
<img width="240" alt="Screenshot with improved contrast" src="https://github.com/user-attachments/assets/beb69854-94ba-4fde-96e3-7e5d91c56876" />

