### PR TITLE
Add a .json version of the tool/linter-rules/all page

### DIFF
--- a/site/lib/main.dart
+++ b/site/lib/main.dart
@@ -52,7 +52,7 @@ Component get _dartDevSite => ContentApp.custom(
       DashMarkdownParser(),
       HtmlParser(),
     ],
-    rawOutputPattern: RegExp(r'.*\.txt$'),
+    rawOutputPattern: RegExp(r'.*\.(txt|json)$'),
     extensions: allNodeProcessingExtensions,
     components: _embeddableComponents,
     layouts: const [DocLayout(), HomepageLayout()],


### PR DESCRIPTION
Adds a JSON version of the list available on https://dart.dev/tools/linter-rules/all as requested by some teams that want to use the list for some automation.

**Staged:** https://dart-dev--pr6920-feat-6899-h0npk13j.web.app/tools/linter-rules/all.json

Resolves https://github.com/dart-lang/site-www/issues/6899