### PR TITLE
Remove no longer used portions of `install.js`

### DIFF
--- a/site/web/assets/js/get-dart/install.js
+++ b/site/web/assets/js/get-dart/install.js
@@ -1,22 +1,11 @@
-function displayVersion() {
-  fetchVersion('stable');
-  fetchVersion('beta');
-  fetchVersion('dev');
-}
-
 function updatePlaceholders(channel, version) {
   for (const revisionElement of document.querySelectorAll('.build-rev-' + channel)) {
     revisionElement.textContent = version;
   }
 
-  const download = 'https://storage.googleapis.com/dart-archive/channels/' + channel + '/release/latest/linux_packages/dart_' + version + '-1_amd64.deb';
   if (channel === 'stable') {
+    const download = 'https://storage.googleapis.com/dart-archive/channels/' + channel + '/release/latest/linux_packages/dart_' + version + '-1_amd64.deb';
     const targets = document.querySelectorAll('.debian-link-stable');
-    for (const target of targets) {
-      target.setAttribute('href', download);
-    }
-  } else {
-    const targets = document.querySelectorAll('.debian-link-dev');
     for (const target of targets) {
       target.setAttribute('href', download);
     }
@@ -29,77 +18,10 @@ function fetchVersion(channel) {
       .then((data) => updatePlaceholders(channel, data['version']));
 }
 
-// OS SWITCHER
-const osList = ['macos', 'windows', 'linux'];
-
-function detectPlatform() {
-  const platform = navigator.platform;
-  // default to 'linux', since linux strings are unpredictable.
-  if (platform.includes('Win')) {
-    return 'windows';
-  } else if (platform.includes('Mac')) {
-    return 'macos';
-  } else {
-    return 'linux';
-  }
-}
-
-function filterPlatformText(showId) {
-  for (const os of osList) {
-    const shouldShow = os === showId;
-    for (const osElement of document.querySelectorAll('.' + os)) {
-      if (shouldShow) {
-        osElement.style.display = 'block';
-      } else {
-        osElement.style.display = 'none';
-      }
-    }
-  }
-}
-
-function resetButtons(el) {
-  if (el.tagName === "BUTTON") {
-    const buttons = document.querySelectorAll('.btn-group.os-choices button');
-    for (const button of buttons) {
-      button.classList.remove('active');
-      button.classList.add('inactive');
-    }
-  }
-  el.classList.remove('inactive');
-  el.classList.add('active');
-}
-
-function registerHandlers() {
-  for (const os of osList) {
-    let osElement = document.getElementById(os);
-    if (osElement) {
-      osElement.addEventListener('click', function(e) {
-        filterPlatformText(e.target.id);
-        resetButtons(e.target);
-      });
-    }
-  }
-}
-
 function setup() {
-  displayVersion();
-
-  const defaultOs = detectPlatform();
-
-  for (const option of document.querySelectorAll('.' + defaultOs + '-option')) {
-    option.selected = true;
-  }
-
-  for (const defaultOsInput of document.querySelectorAll('input#' + defaultOs)) {
-    defaultOsInput.setAttribute('checked', 'checked');
-  }
-
-  for (const defaultOsButton of document.querySelectorAll('button#' + defaultOs)) {
-    resetButtons(defaultOsButton);
-  }
-
-  filterPlatformText(defaultOs);
-  registerHandlers();
+  fetchVersion('stable');
+  fetchVersion('beta');
+  fetchVersion('dev');
 }
 
 if (document.readyState !== "loading") {

--- a/src/content/get-dart/archive/index.md
+++ b/src/content/get-dart/archive/index.md
@@ -4,9 +4,6 @@ shortTitle: Archive
 description: >-
   Download specific stable, beta, dev, and main channel versions of
   the Dart SDK and the Dart API documentation.
-js:
-- url: /assets/js/get-dart/install.js
-  defer: true
 ---
 
 Use this archive to download


### PR DESCRIPTION
- Removes portions of `install.js` that haven't had any affect for a long time due to changes to the Get Dart page.
- No longer includes `install.js` on the archive page where it has no effect.

These changes result in no functional difference, but can slightly reduce the loading time of these pages.