### PR TITLE
Fix rendering of conditional expression structure examples

### DIFF
--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -367,11 +367,11 @@ requires a [language version][] of at least 2.14.
 Dart has two operators that let you concisely evaluate expressions
 that might otherwise require [if-else][] statements:
 
-*`condition `* `? ` *`expr1 `* `: ` *`expr2`*
+_`condition`_ `?` _`expr1`_ `:` _`expr2`_
 : If _condition_ is true, evaluates _expr1_ (and returns its value);
   otherwise, evaluates and returns the value of _expr2_.
 
- *`expr1 `* `?? ` *`expr2`*
+_`expr1`_ `??` _`expr2`_
 : If _expr1_ is non-null, returns its value;
   otherwise, evaluates and returns the value of _expr2_.
 


### PR DESCRIPTION
Before:

<img width="420" alt="Showcase of incorrect rendering" src="https://github.com/user-attachments/assets/bed2a9a1-0df2-466d-a204-3f7cdc8e4091" />

After:

<img width="420" alt="Showcase of fixed rendering" src="https://github.com/user-attachments/assets/85e7cda3-103e-43e2-b5c4-7c2852ba8cb7" />




**Staged:** https://dart-dev--pr6938-fix-conditional-expressions-rendering-4ordzkkp.web.app/language/operators#conditional-expressions