### PR TITLE
Mark MaterialIcon as hidden if it has no label

### DIFF
--- a/site/lib/src/components/material_icon.dart
+++ b/site/lib/src/components/material_icon.dart
@@ -26,7 +26,10 @@ class MaterialIcon extends StatelessComponent {
       classes: ['material-symbols', ...classes].toClasses,
       attributes: {
         'title': ?title,
-        'aria-label': ?(label ?? title),
+        if (label ?? title case final labelToUse?)
+          'aria-label': labelToUse
+        else
+          'aria-hidden': 'true',
         'translate': 'no',
       },
       [text(id)],


### PR DESCRIPTION
This prevents the icon's ID being treated as text in some scenarios.