### PR TITLE
Fix: Strip the terminal prefixes while copying commands/codecblock

### DIFF
--- a/site/lib/src/extensions/code_block_processor.dart
+++ b/site/lib/src/extensions/code_block_processor.dart
@@ -394,7 +394,7 @@ final class _CodeLine {
 
 extension on List<_CodeLine> {
   static final RegExp _terminalReplacementPattern = RegExp(
-    r'^(\s*\$\s*)|(C:\\(.*)>\s*)',
+    r'^(\s*\$\s*)|(PS\s+)?(C:\\(.*)>\s*)',
     multiLine: true,
   );
   static final RegExp _zeroWidthSpaceReplacementPattern = RegExp(r'\u200B');


### PR DESCRIPTION
Issue:

When I copy the code blocks, it also copies the terminal prefixes (i.e. $, PS, C:// etc) too. I see there is already a function stripping them, but it had a minor issue which is fixed in this PR.

**Steps to reproduce**
- Go to https://dart.dev/get-dart#install
- Click on copy button on the right hand side of the command
- Paste it anywhere

**Issue**
It copies the terminal prefixes too. Which one has to manually remove.
<img width="524" height="36" alt="Screenshot From 2025-10-17 22-16-22" src="https://github.com/user-attachments/assets/a488f652-87dc-4041-a61c-3873ac1872cb" />

**Expected**
Only copy the command part.
<img width="524" height="36" alt="Screenshot From 2025-10-17 22-16-38" src="https://github.com/user-attachments/assets/fe77dd71-49df-42f3-ac4a-1908a544f606" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
