### PR TITLE
Add support for highlighting additional languages

### DIFF
--- a/site/lib/src/components/footer.dart
+++ b/site/lib/src/components/footer.dart
@@ -148,8 +148,8 @@ final class DashFooter extends StatelessComponent {
                       'Jaspr web framework for Dart.',
                 },
                 [
-                  span([JasprBadge.light()]),
-                  span([JasprBadge.lightTwoTone()]),
+                  span([const JasprBadge.light()]),
+                  span([const JasprBadge.lightTwoTone()]),
                 ],
               ),
             ]),

--- a/site/lib/src/extensions/code_block_processor.dart
+++ b/site/lib/src/extensions/code_block_processor.dart
@@ -18,20 +18,7 @@ import '../highlight/token_renderer.dart' as highlighter;
 
 final class CodeBlockProcessor implements PageExtension {
   static final opal.LanguageRegistry _languageRegistry =
-      opal.LanguageRegistry.of(
-        [
-          opal.BuiltInLanguages.dart,
-          opal.BuiltInLanguages.xml,
-          opal.BuiltInLanguages.html,
-          opal.BuiltInLanguages.kotlin,
-          opal.BuiltInLanguages.markdown,
-          opal.BuiltInLanguages.java,
-          opal.BuiltInLanguages.js,
-          opal.BuiltInLanguages.yaml,
-          opal.BuiltInLanguages.json,
-        ],
-        fallbackLanguageNames: {'md': 'markdown', 'yml': 'yaml'},
-      );
+      opal.LanguageRegistry.withDefaults();
 
   const CodeBlockProcessor();
 

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   markdown_description_list: ^0.1.1
   meta: ^1.17.0
   # Used for syntax highlighting.
-  opal: ^0.0.1
+  opal: ^0.1.0
   path: ^1.9.1
   # Used in the SDK archive.
   pub_semver: ^2.2.0


### PR DESCRIPTION
Updates `package:opal` to version 0.1.0 which adds support for syntax highlighting Swift, Kotlin, and Obj-C. It also significantly improves syntax highlighting for YAML.