### PR TITLE
Fix typo in Effective Dart

### DIFF
--- a/src/content/effective-dart/design.md
+++ b/src/content/effective-dart/design.md
@@ -660,7 +660,7 @@ intend, and they may break your code without realizing it.
 ### DO use class modifiers to control if your class can be an interface
 
 When designing a library, use class modifiers like `final`, `base`, or `sealed` to enforce intended
-usage. For example, use `final class C {}` or `base class D{}` to prevent
+usage. For example, use `final class C {}` or `base class D {}` to prevent
 implementation outside the current library.
 While it's ideal for all libraries to use these modifiers to enforce design intent,
 developers may still encounter cases where they aren't applied. In such cases, be mindful of


### PR DESCRIPTION

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
