### PR TITLE
Update Objective-C example code

### DIFF
--- a/src/content/interop/objective-c-interop.md
+++ b/src/content/interop/objective-c-interop.md
@@ -295,10 +295,7 @@ To initialize the `AVAudioPlayer`,
 use the [`initWithContentsOfURL:error:`][] method:
 
 ```dart
-final player = AVAudioPlayer.alloc().initWithContentsOfURL(
-  fileUrl,
-  error: nullptr,
-);
+final player = AVAudioPlayer.alloc().initWithContentsOfURL(fileUrl);
 ```
 
 This Dart `AVAudioPlayer` object is a wrapper around an underlying


### PR DESCRIPTION
Update Objective-C example code for consistency with this pr: https://github.com/dart-lang/native/pull/2746

FFIgen has a heuristic to detect errors returned as out-params, and convert them to thrown errors. But this heuristic wasn't working correctly for the example. Now that it's fixed, this part of the example is a bit cleaner, and actually handles the error instead of ignoring it.