### PR TITLE
Fixes to Objective-C interop docs

### DIFF
--- a/src/content/interop/objective-c-interop.md
+++ b/src/content/interop/objective-c-interop.md
@@ -145,11 +145,7 @@ If FFIgen produces this file, you must compile it into your package,
 otherwise you might get runtime exceptions relating to missing symbols.
 For this example, FFIgen doesn't generate a `.m` file.
 
-Use the `output.preamble` option to insert text at the top of the Dart output,
-such as license headers or lint directives.
-In this case, disable several lints:
-
-```dart highlightLines=11-16
+```dart highlightLines=11-13
 import 'package:ffigen/ffigen.dart';
 
 final config = FfiGenerator(
@@ -162,9 +158,6 @@ final config = FfiGenerator(
   ),
   output: Output(
     dartFile: Uri.file('avf_audio_bindings.dart'),
-    preamble: '''
-// ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field, void_checks, annotate_overrides, no_leading_underscores_for_local_identifiers, library_private_types_in_public_api
-'''
   ),
 );
 
@@ -197,9 +190,6 @@ final config = FfiGenerator(
   ),
   output: Output(
     dartFile: Uri.file('lib/avf_audio_bindings.dart'),
-    preamble: '''
-// ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field, void_checks, annotate_overrides, no_leading_underscores_for_local_identifiers, library_private_types_in_public_api
-'''
   ),
 );
 
@@ -566,8 +556,6 @@ ffigen:
   headers:
     entry-points:
       - 'swift_api.h'
-  preamble: |
-    // ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field, return_of_invalid_type, void_checks, annotate_overrides, no_leading_underscores_for_local_identifiers, library_private_types_in_public_api
 ```
 
 As before, set the language to `objc`,


### PR DESCRIPTION
I tried out the revamped Objective-C interop instructions from https://github.com/dart-lang/site-www/pull/6942 (thank you for updating them 🙏 ) and noticed a handful of minor issues that this PR addresses:

* Instruct people to add dependencies to the helpers `package:objective_c` and `package:ffi`.
* Add a missing import to `package:objective_c` to the sample code to resolve `NSString`.
* Adjusted some file paths to align with best practices (e.g. generate the bindings into the `lib` directory).
* Fixed a nullability issue by checking `player == null` and bailing early.
* ~Fixed an issue with the enumeration in the multithreading section.~ Already fixed in https://github.com/dart-lang/site-www/pull/6995.
* Removed the `ignore_for_file` preamble configuration since FFIgen auto-generates `// ignore_for_file: type=lint`.

I also changed the second half to use highlights in the sample code just like it is done in the first half. I find that easier for following along. Plus, in the end you get to see the complete code.

I've also incorporated https://github.com/dart-lang/site-www/pull/6990 into this PR.