### PR TITLE
Add shortlink to dot shorthands docs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -389,6 +389,7 @@
 
       { "source": "/to/cross-compilation", "destination": "/tools/dart-compile#cross-compilation", "type": 301 },
       { "source": "/to/doc-comment-references", "destination": "/tools/doc-comments/references", "type": 301 },
+      { "source": "/to/dot-shorthands", "destination": "/language/dot-shorthands", "type": 301 },
       { "source": "/to/downgrade-testing", "destination": "/tools/pub/dependencies#test-with-downgraded-dependencies", "type": 301 },
       { "source": "/to/enforce-lockfile", "destination": "/tools/pub/packages#get-dependencies-for-production", "type": 301 },
       { "source": "/to/language-version", "destination": "/resources/language/evolution#language-versioning", "type": 301 },


### PR DESCRIPTION
I plan to link to this shortlink from some external docs and announcements.

**Staged:** https://dart-dev--pr7000-feat-dot-shorthands-shortlink-vmnea22t.web.app/to/dot-shorthands