### PR TITLE
Fix: Flicker on page load

### DIFF
--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -190,6 +190,23 @@ ga('send', 'pageview');
             'class': [?bodyClass, ...defaultBodyClasses].toClasses,
           },
         ),
+        // The theme setting logic should remain before other scripts to
+        // avoid a flash of the initial theme on load.
+        raw('''
+<script>
+const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
+const storedTheme = window.localStorage.getItem('theme') ?? 'light-mode';
+if (storedTheme === 'auto-mode') {
+  document.body.classList.add(
+      'auto-mode',
+      prefersDarkMode.matches ? 'dark-mode' : 'light-mode',
+  );
+} else {
+  document.body.classList.add(storedTheme);
+}
+</script>
+      '''),
         raw('''
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VSZM5J" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 '''),
@@ -225,23 +242,6 @@ ga('send', 'pageview');
           ]),
           const DashFooter(),
         ]),
-        // The theme setting logic should remain before other scripts to
-        // avoid a flash of the initial theme on load.
-        raw('''
-<script>
-const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
-
-const storedTheme = window.localStorage.getItem('theme') ?? 'light-mode';
-if (storedTheme === 'auto-mode') {
-  document.body.classList.add(
-      'auto-mode',
-      prefersDarkMode.matches ? 'dark-mode' : 'light-mode',
-  );
-} else {
-  document.body.classList.add(storedTheme);
-}
-</script>
-      '''),
         GlobalScripts(),
       ],
     );


### PR DESCRIPTION
In some chromium based browsers, and mobile browsers, the theme flicker happens if the device theme is set to dark and landing on the website has 'automatic' theme setting.

**Before**
The flickering starts after 7s in the video.
https://github.com/user-attachments/assets/b2e1a2ec-e610-42de-9ab2-6f3c0a2123a4

**About the Changes:**
Moved the script that already handles the flash case before the main page contents is loaded.

**After**
https://github.com/user-attachments/assets/484ed6d1-5822-4fc8-ad2d-4beb3dd45ce8

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
