### PR TITLE
Remove developed by Jetbrains on Intellij page

### DIFF
--- a/src/content/tools/jetbrains-plugin.md
+++ b/src/content/tools/jetbrains-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: IntelliJ & Android Studio
-description: Use the Dart plugin with a variety of  IntelliJ Platform-based IDEs.
+description: Use the Dart plugin with a variety of IntelliJ Platform-based IDEs.
 ---
 
 The [Dart plugin][] adds Dart support


### PR DESCRIPTION
Remove developed by Jetbrains on [Intellij page](https://dart.dev/tools/jetbrains-plugin). 

First of many edits for this page. Removed 'developed by Jetbrains' asap since the Dart Developer Experience team just announced that they have taken ownership of the Dart Plugin.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
