### PR TITLE
Clarify Dart Pub package size limits

### DIFF
--- a/src/content/tools/pub/publishing.md
+++ b/src/content/tools/pub/publishing.md
@@ -52,8 +52,8 @@ Beyond these conventions, you must follow these requirements:
 * Verify that you have the legal right to redistribute anything that
   you upload as part of your package.
 
-* Keep package size within limits: less than **100 MB after gzip compression**
-  and less than **256 MB uncompressed**.
+* Keep package size within limits. We recommend less than
+  100 MB after gzip compression and less than 256 MB uncompressed.
 
   If your package is too large, consider splitting it into multiple packages,
   using a `.pubignore` file to remove unnecessary content, or reducing the


### PR DESCRIPTION
Updates the Dart pub documentation to clarify package size limits.

Fixes https://github.com/dart-lang/site-www/issues/7035 