### PR TITLE
Remove redundant "if you allow null safety"

### DIFF
--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -523,8 +523,7 @@ keep these facts and concepts in mind:
     because Dart can infer types. In `var number = 101`, `number`
     is inferred to be of type `int`.
 
--   If you enable [null safety][ns],
-    variables can't contain `null` unless you say they can.
+-   Variables can't contain `null` unless you say they can.
     You can make a variable nullable by
     putting a question mark (`?`) at the end of its type.
     For example, a variable of type `int?` might be an integer,


### PR DESCRIPTION
since it's now required

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
