### PR TITLE
Remove problematic width styling on homepage

### DIFF
--- a/site/lib/_sass/pages/_dash.scss
+++ b/site/lib/_sass/pages/_dash.scss
@@ -319,7 +319,6 @@ body.homepage {
     flex-direction: column;
     align-items: center;
 
-    width: 100vw;
     height: 102vh;
     padding: 3rem 2rem;
 


### PR DESCRIPTION
This width specification didn't do anything besides adding an unnecessary horizontal scrollbar on some platform/browser combinations.

Fixes https://github.com/dart-lang/site-www/issues/7067
