### PR TITLE
Add "Asynchronous" term to glossary

### DIFF
--- a/site/lib/src/style_hash.dart
+++ b/site/lib/src/style_hash.dart
@@ -2,4 +2,4 @@
 // dart format off
 
 /// The generated hash of the `main.css` file.
-const generatedStylesHash = 'RHmO6DK8CuPj';
+const generatedStylesHash = '';

--- a/src/data/glossary.yml
+++ b/src/data/glossary.yml
@@ -52,21 +52,26 @@
 
 - term: "Asynchronous"
   short_description: |-
-    Programming paradigm in Dart where operations like I/O or network calls 
-    complete later without blocking the event loop, using Futures, Streams, 
-    async/await, and isolates.
+    Programming paradigm in Dart where operations like
+    I/O or network calls complete later without blocking the event loop.
   long_description: |-
     Dart uses a single-threaded event loop model for asynchronous programming, 
-    allowing non-blocking execution of time-consuming tasks such as file I/O, 
-    HTTP requests, or timers. Unlike synchronous code that blocks until completion, 
-    async operations queue via microtasks/events, keeping UIs responsive.
+    allowing non-blocking execution of time-consuming tasks such as
+    file I/O, HTTP requests, and timers.
+    Unlike synchronous code that blocks until completion, 
+    async operations queue through microtasks/events, keeping UIs responsive.
 
     Key components include:
 
-    - "**Futures**": Represent a value available later, created by APIs like `http.get()`.
-    - "**async/await**": Syntactic sugar for readable async code (`Future<String> getData() async { return await http.get(url); }`).
-    - "**Streams**": Handle sequences of async events like WebSocket data.
-    - "**Isolates**": Enable true parallelism via independent execution contexts with message passing.
+    - **Futures**:
+      Represent a value available later, created by APIs like `http.get()`.
+    - **async/await**:
+      Dart keywords for writing maintainable and readable asynchronous code.
+    - **Streams**:
+      Handle sequences of async events like data from web sockets.
+    - **Isolates**:
+      Enable true parallelism through
+      independent execution contexts with message passing.
   related_links:
     - text: "Asynchronous programming: futures, async, await"
       link: "/libraries/async/async-await"


### PR DESCRIPTION
feat(glossary): Add "Asynchronous" entry with Dart-specific context

- Added comprehensive entry explaining Dart's event loop model, Futures, 
  async/await, Streams, and isolates
- Short description optimized for site-wide hover tooltips
- Related links to official Dart async programming docs
- Labels for filtering: async, futures, event-loop, concurrency

Enables better developer onboarding by defining core Dart concurrency 
concepts in the shared glossary system.

Contributes to #6461