### PR TITLE
Add transition from Dart FWE -> Flutter FWE

### DIFF
--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -625,6 +625,7 @@ items:
 Congratulations! You've now completed all the
 core chapters of the Dart Getting Started tutorial.
 Want to continue learning?
-Check out the next step in the [Dart and Flutter learning pathway] on the Flutter site.
+Check out the next step in the
+[Dart and Flutter learning pathway][] on the Flutter site.
 
 [Dart and Flutter learning pathway]: {{site.flutter-docs}}/learn/pathway


### PR DESCRIPTION
This replaces the final paragraph of Dart Getting Started to point to Flutter Getting STarted, rather than an aspirational 2nd tutorial that we didn't get around to :)

Fixes #7115

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
