### PR TITLE
docs:added information about trailing_commas and all its possibles v…

### DIFF
--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -658,7 +658,10 @@ For more information, read [Configuring formatter page width][].
 
 #### `trailing_commas`
 
-You can configure how the formatter handles trailing commas in argument and parameter lists using the `trailing_commas` option. It accepts one of two values:
+You can configure how the formatter handles trailing commas
+in argument and parameter lists
+using the `trailing_commas` option.
+It accepts one of two values:
 
 `automate` (default)
 : The formatter adds and removes trailing commas based on


### PR DESCRIPTION
fixes #6642 

Added trailing_commas subsection with:
Description of both available values (automate and preserve)
Detailed explanation of each value's behavior (matching the text from the GitHub PR mentioned in the issue)
Example YAML configuration showing both options together.

This addresses the Issue #6642 by documenting the trailing_commas option and its possible values, making it clear to users how to configure this formatter behavior.

@parlough @conooi @antfitch  please review