### PR TITLE
Remove type argument from class Command and update path parsing logic

### DIFF
--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -101,8 +101,8 @@ creating a new file for the logger and setting up the necessary imports.
       final now = DateTime.now();
 
       // Get the path to the project directory from the current script.
-      final segments = Platform.script.path.split('/');
-      final projectDir = segments.sublist(0, segments.length - 2).join('/');
+      final scriptFile = File(Platform.script.toFilePath());
+      final projectDir = scriptFile.parent.parent.path;
 
       // Create a 'logs' directory if it doesn't exist.
       final dir = Directory('$projectDir/logs');
@@ -130,8 +130,8 @@ creating a new file for the logger and setting up the necessary imports.
       final logger = Logger(name);
       final now = DateTime.now();
 
-      final segments = Platform.script.path.split('/');
-      final projectDir = segments.sublist(0, segments.length - 2).join('/');
+      final scriptFile = File(Platform.script.toFilePath());
+      final projectDir = scriptFile.parent.parent.path;
       final dir = Directory('$projectDir/logs');
       if (!dir.existsSync()) dir.createSync();
       final logFile = File(


### PR DESCRIPTION
*Note: This is my very first pull request, so I apologize in advance for any mistakes*

When following the tutorial chapter "logging", I ran into several issues with the provided code on the page:
1. `Command<String>` should be `Command`: VS Code reports `The type 'Command' is declared with 0 type parameters, but 1 type arguments were given.`
2. The logic for finding the `projectDir` throws an exception when executed, which might be related to the fact that the custom-edited path starts with a `/`, even on Windows


Fixes https://github.com/dart-lang/site-www/issues/7134

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
