### PR TITLE
Fix formatting of lint rule descriptions in index

### DIFF
--- a/site/lib/src/pages/lint_index.dart
+++ b/site/lib/src/pages/lint_index.dart
@@ -79,7 +79,7 @@ class _LintRuleCard extends StatelessComponent {
       ],
       content: [
         if (lint.description.isNotEmpty)
-          DashMarkdown(content: lint.description, inline: true),
+          DashMarkdown(content: lint.description),
       ],
       actions: CardActions(
         leading: _statusIcons,


### PR DESCRIPTION
These descriptions are expected to be wrapped in a `<p>` and can actually contain separated paragraphs occasionally, so they shouldn't be parsed as inline markdown.

Fixes https://github.com/dart-lang/site-www/issues/7138