### PR TITLE
[fwe] Fix `getWikipediaArticle` not closing the http client

### DIFF
--- a/src/content/learn/tutorial/async.md
+++ b/src/content/learn/tutorial/async.md
@@ -413,7 +413,7 @@ items:
     icon: cloud_download
     details: >-
       You built `getWikipediaArticle()` to
-      make HTTP GET requests using `package:http`, constructed URIs,
+      make HTTP GET requests using the `get` function from `package:http`, constructed URIs,
       checked status codes, and returned the response body.
       Your CLI now fetches real data from the web!
 </SummaryCard>


### PR DESCRIPTION
The client wasn't closed, so instead of manually creating a client (and closing it), use the top level `get` function that handles it for them.

Fixes https://github.com/dart-lang/site-www/issues/7127
Closes https://github.com/dart-lang/site-www/issues/7149 by avoiding the mistake of using `HttpClient` from `dart:io`