### PR TITLE
tutorial/testing: use intended function Article.listFromJson

### DIFF
--- a/src/content/learn/tutorial/testing.md
+++ b/src/content/learn/tutorial/testing.md
@@ -297,7 +297,7 @@ You'll use the `group`, `test`, and `expect` functions from the `test` package.
     -   Reads the contents of the `cat_extract.json` file.
     -   Decodes the JSON string into a `Map<String, Object?>`.
     -   Creates the `List<Article>` object from the map using
-        the `Article.listFromJson` constructor.
+        the `Article.listFromJson` static method.
     -   Uses the `expect` function to assert that
         the `title` property of the first article is equal to `'cat'`.
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/7184, use intended function in the test example code.

I don't think there is a corresponded code file related to this change, so only the markdown file is changed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

