### PR TITLE
Add learn to mobile version of sidenav to match top nav

### DIFF
--- a/site/lib/src/components/layout/sidenav.dart
+++ b/site/lib/src/components/layout/sidenav.dart
@@ -72,10 +72,11 @@ final class DashSideNav extends StatelessComponent {
           iconId: 'public',
           active: activeEntry == ActiveNavEntry.community,
         ),
-        const _TopNavItem(
-          href: 'https://dart.dev',
-          label: 'Try Dart',
-          iconId: 'code_blocks',
+        _TopNavItem(
+          href: '/learn',
+          label: 'Learn Dart',
+          iconId: 'play_lesson',
+          active: activeEntry == ActiveNavEntry.learn,
         ),
         _TopNavItem(
           href: '/get-dart',


### PR DESCRIPTION
Ensures the `/learn` content is discoverable on mobile and narrow browser windows as well.

**Staged:** https://dart-dev--pr7197-fix-add-learn-to-narrow-sidenav-39etuw8x.web.app/learn