### PR TITLE
Add override of requiresArgument to SearchCommand

### DIFF
--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -265,6 +265,9 @@ add the necessary code, including the logging and error handling.
       String get description => 'Search for Wikipedia articles.';
 
       @override
+      bool get requiresArgument => true;
+
+      @override
       String get name => 'search';
 
       @override
@@ -302,6 +305,9 @@ add the necessary code, including the logging and error handling.
 
       @override
       String get description => 'Search for Wikipedia articles.';
+
+      @override
+      bool get requiresArgument => true;
 
       @override
       String get name => 'search';
@@ -357,6 +363,9 @@ add the necessary code, including the logging and error handling.
 
       @override
       String get description => 'Search for Wikipedia articles.';
+
+      @override
+      bool get requiresArgument => true;
 
       @override
       String get name => 'search';
@@ -425,6 +434,9 @@ add the necessary code, including the logging and error handling.
 
       @override
       String get description => 'Search for Wikipedia articles.';
+
+      @override
+      bool get requiresArgument => true;
 
       @override
       String get name => 'search';


### PR DESCRIPTION
Add override of `requiresArgument` to `SearchCommand` examples.

There is only a `.md` file change. I searched through the repository for a `search.dart` file, but could not find the actual `/examples` file corresponding to this tutorial file. There is nothing under `/examples/cli` that correspond to this.

Fixes https://github.com/dart-lang/site-www/issues/7201

---

- [Y] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [Y] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [Y] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [Y] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
