### PR TITLE
Fix Dartpedia Chapter 8 Task 2 code

### DIFF
--- a/src/content/learn/tutorial/cli-polish.md
+++ b/src/content/learn/tutorial/cli-polish.md
@@ -174,7 +174,7 @@ allow for flexible output handling.
             }
           }
         } on Exception catch (exception) {
-          if(onError != null) {
+          if (onError != null) {
             onError!(exception);
           } else {
             rethrow;


### PR DESCRIPTION
In the Dartpedia CLI app tutorial in Chapter 8 Task 2 the code that is given to be replaced is in the `run` method in `command_runner/lib/src/command_runner_base.dart` is not entirely correct. It is given:

```dart
  Future<void> run(List<String> input) async {
    try {
      final ArgResults results = parse(input);
      if (results.command != null) {
        Object? output = await results.command!.run(results);
        if (onOutput != null) {
          await onOutput!(output.toString());
        } else {
          print(output.toString());
        }
      }
    } on Exception catch (e) {
      print(e);
    }
  }
```

but in a chapter 6 was implemented custom error handling so the catch until this point was:

```dart
    } on Exception catch (exception) {
      if (onError != null) {
        onError!(exception);
      } else {
        rethrow;
      }
    }
```

This PR suggests a change in the .md of this chapter to include both the old code that uses `onError` and the new code which adds `onOutput`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
