### PR TITLE
publish-blog skill for Dart iX

### DIFF
--- a/.agents/skills/publish-blog/SKILL.md
+++ b/.agents/skills/publish-blog/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: publish_blog
+description: Publish a new article to the Dart blog from a Google Doc.
+---
+
+# Publish Blog Article
+
+## Overview
+
+Use this skill to add a new article to the Dart blog by extracting content from
+a Google Doc, formatting it, and placing it in the correct directory.
+
+## Workflow
+
+### 1. Get content and images from Google Doc
+
+- [ ] Ask the user to provide a link to the Google Doc.
+- [ ] In your browser, open the Google Doc.
+- [ ] Download the document as a Web Page (.html, zipped) via
+      **File > Download > Web Page** (or ask the user to provide the zip if
+      download fails).
+- [ ] Extract the text content from the downloaded HTML file and convert it to
+      Markdown.
+- [ ] Extract the images from the `images/` folder in the zip file.
+- [ ] Create a new folder for the blog post in `src/content/blog/` using a
+      concise title.
+- [ ] Save the markdown content to `index.md` and move the images to the
+      `images/` directory in that folder.
+- [ ] Reference the images in the markdown file using `<DashImage>` or
+      standard markdown image tags as appropriate.
+
+### 2. Format the markdown
+
+- [ ] Apply semantic line breaks to any lines over 80 characters, following the
+      guidelines in [semantic_breaks.md](../proofread-markdown/references/semantic_breaks.md).
+- [ ] Ensure there is a blank line after each heading.
+
+### 3. Review
+
+- [ ] Don't create a PR until the user has looked over the article.

--- a/.agents/skills/publish-blog/SKILL.md
+++ b/.agents/skills/publish-blog/SKILL.md
@@ -35,6 +35,14 @@ a Google Doc, formatting it, and placing it in the correct directory.
       guidelines in [semantic_breaks.md](../proofread-markdown/references/semantic_breaks.md).
 - [ ] Ensure there is a blank line after each heading.
 
-### 3. Review
+### 3. Add the author
+
+- [ ] Ask the user to provide the author's github handle. Search in
+      `src/data/authors/` for the handle. If the author is not found, create a
+      new author YAML file. Add the image and any other metadata you can find
+      from the user's github profile.
+- [ ] Update the frontmatter for the blog post with the author's handle.
+
+### 4. Review
 
 - [ ] Don't create a PR until the user has looked over the article.


### PR DESCRIPTION
This skill converts a Dart blog draft in a Google Doc to to an actual blog post on the Dart site. It will move your text, your images, and set up your links and formatting. We can refine this skill as time goes on.

Steps to use this skill:

1. Create your blog post in Google Docs
2. Open a branch for `github.com/dart-lang/site-www` in Antigravity.
3. Ask Antigravity to use the `publish-blog` skill.
4. When asked, provide a link to your Google Doc to Antigravity.
5. Antigravity will create a blog entry for you in src/content/blog.
6. Use the `stage-site-locally` skill to preview the blog post on your local machine.
7. Check links to make sure everything works.
8. Create when you're ready for a review + launch!