### PR TITLE
Update variable name to the name in the example

### DIFF
--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -369,8 +369,8 @@ map entry element:
 ```
 
 In the following example, the result for the
-null-aware element `?a` is not added to a list called
-`items` because `a` is `null`:
+null-aware element `?absentValue` is not added to a list called
+`items` because `absentValue` is `null`:
 
 <?code-excerpt "misc/test/language_tour/collections/null_aware_element_a.dart (code-sample)"?>
 ```dart


### PR DESCRIPTION
Clarified explanation about null-aware elements in collections.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.