### PR TITLE
Update Jaspr to 0.23 as well as related dependencies

### DIFF
--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -7,17 +7,17 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  build: ^4.0.3
+  build: ^4.0.5
   collection: ^1.19.1
   crypto: ^3.0.7
   # Used for accessing the SDK archive storage buckets.
-  googleapis: ^15.0.0
+  googleapis: ^16.0.0
   html: ^0.15.6
   http: ^1.6.0
   # Used for formatting dates in the SDK archive.
   intl: ^0.20.2
-  jaspr: ^0.22.4
-  jaspr_content: ^0.5.1
+  jaspr: ^0.23.0
+  jaspr_content: ^0.5.2
   # Used as our template engine.
   liquify: 1.3.1
   markdown: ^7.3.0
@@ -38,10 +38,10 @@ dev_dependencies:
       url: https://github.com/dart-lang/site-shared
       path: pkgs/analysis_defaults
       ref: e2534e272132813a1cdcf6ea71a6fd9c904a69fb
-  build_runner: ^2.10.4
-  build_web_compilers: ^4.4.6
-  jaspr_builder: ^0.22.4
-  jaspr_test: ^0.22.4
+  build_runner: ^2.13.1
+  build_web_compilers: ^4.4.17
+  jaspr_builder: ^0.23.0
+  jaspr_test: ^0.23.0
   lints: ^6.0.0
   sass: ^1.94.2
   sass_builder: ^2.4.0

--- a/tool/dash_site/lib/src/utils.dart
+++ b/tool/dash_site/lib/src/utils.dart
@@ -47,7 +47,7 @@ int installJasprCliIfNecessary() {
     'global',
     'activate',
     'jaspr_cli',
-    '^0.22.4',
+    '^0.23.0',
   ]);
 
   if (activateOutput.exitCode != 0) {


### PR DESCRIPTION
These updates come with fixes to some issues we've been hitting, including double template rendering and running out of file descriptors.