### PR TITLE
Change help property from nullable to non-nullable

### DIFF
--- a/src/content/learn/tutorial/object-oriented.md
+++ b/src/content/learn/tutorial/object-oriented.md
@@ -594,7 +594,7 @@ prints usage information.
       String get description => 'Prints usage information to the command line.';
 
       @override
-      String? get help => 'Prints this usage information';
+      String get help => 'Prints this usage information';
 
       @override
       FutureOr<Object?> run(ArgResults args) async {


### PR DESCRIPTION
The compiler complains about nullable property: `'HelpCommand.help' ('String? Function()') isn't a valid override of 'Command.help' ('String Function()')`

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
