### PR TITLE
Update `analysis_defaults` and `excerpter` dependencies to new location

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,5 @@ Fixes <Replace with issue link>
   - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
   - Larger or significant changes should be discussed in an issue before creating a PR.
   - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
-  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
+  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
 </details>

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ run `dart run dash_site refresh-excerpts`.
 To learn more about creating, editing, and using code excerpts,
 check out the [excerpt updater package documentation][].
 
-[excerpt updater package documentation]: https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter#readme
+[excerpt updater package documentation]: https://github.com/flutter/website/tree/main/packages/excerpter#readme
 
 
 [Build Status SVG]: https://github.com/dart-lang/site-www/workflows/build/badge.svg

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -35,9 +35,9 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     git:
-      url: https://github.com/dart-lang/site-shared
-      path: pkgs/analysis_defaults
-      ref: e2534e272132813a1cdcf6ea71a6fd9c904a69fb
+      url: https://github.com/flutter/website
+      path: packages/analysis_defaults
+      ref: 6d50799f4dc347398863b83f5dc46d1da8f6c5cd
   build_runner: ^2.13.1
   build_web_compilers: ^4.4.17
   jaspr_builder: ^0.23.0

--- a/src/data/site.yaml
+++ b/src/data/site.yaml
@@ -9,7 +9,6 @@ redirect:
   go: https://dart.dev/go
 repo:
   this: https://github.com/dart-lang/site-www
-  shared: https://github.com/dart-lang/site-shared
   dart:
     org: https://github.com/dart-lang
     sdk: https://github.com/dart-lang/sdk

--- a/tool/dash_site/pubspec.yaml
+++ b/tool/dash_site/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   collection: ^1.19.1
   excerpter:
     git:
-      url: https://github.com/dart-lang/site-shared
-      path: pkgs/excerpter
-      ref: e2534e272132813a1cdcf6ea71a6fd9c904a69fb
+      url: https://github.com/flutter/website
+      path: packages/excerpter
+      ref: 6d50799f4dc347398863b83f5dc46d1da8f6c5cd
   fbh_front_matter: ^0.0.1
   html_unescape: ^2.0.0
   http: ^1.6.0
@@ -29,6 +29,6 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     git:
-      url: https://github.com/dart-lang/site-shared
-      path: pkgs/analysis_defaults
-      ref: e2534e272132813a1cdcf6ea71a6fd9c904a69fb
+      url: https://github.com/flutter/website
+      path: packages/analysis_defaults
+      ref: 6d50799f4dc347398863b83f5dc46d1da8f6c5cd


### PR DESCRIPTION
These packages are now hosted in the `flutter/website` GitHub repository rather than `dart-lang/site-shared`: https://github.com/flutter/website/tree/main/packages