### PR TITLE
Add skills linting as part of the test suite

### DIFF
--- a/.agents/skills/publish-blog/SKILL.md
+++ b/.agents/skills/publish-blog/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: publish_blog
+name: publish-blog
 description: Publish a new article to the Dart blog from a Google Doc.
 ---
 

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -40,11 +40,18 @@ dev_dependencies:
       ref: e2534e272132813a1cdcf6ea71a6fd9c904a69fb
   build_runner: ^2.13.1
   build_web_compilers: ^4.4.17
+  dart_skills_lint:
+    git:
+      url: https://github.com/flutter/skills
+      path: tool/dart_skills_lint
+      ref: 66db75d9f221741c33c70d3e641bdfe7bbcfe2f0
   jaspr_builder: ^0.23.0
   jaspr_test: ^0.23.0
   lints: ^6.0.0
+  logging: ^1.2.0
   sass: ^1.94.2
   sass_builder: ^2.4.0
+  test: ^1.24.0
 
 jaspr:
   mode: static

--- a/site/test/lint_skills_test.dart
+++ b/site/test/lint_skills_test.dart
@@ -1,0 +1,36 @@
+@TestOn('vm')
+library;
+
+import 'package:dart_skills_lint/dart_skills_lint.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Run skills linter', () async {
+    // Enable logging to see detailed validation errors in test output.
+    final oldLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    final subscription = Logger.root.onRecord.listen(
+      (record) => print(record.message),
+    );
+
+    try {
+      final isValid = await validateSkills(
+        skillDirPaths: ['../.agents/skills'],
+        resolvedRules: {
+          'check-relative-paths': AnalysisSeverity.error,
+          'check-absolute-paths': AnalysisSeverity.error,
+          'check-trailing-whitespace': AnalysisSeverity.error,
+        },
+      );
+      expect(
+        isValid,
+        isTrue,
+        reason: 'Skills validation failed. See above for details.',
+      );
+    } finally {
+      Logger.root.level = oldLevel;
+      await subscription.cancel();
+    }
+  });
+}


### PR DESCRIPTION
Add linting to skills repo and fix one skill that used _ instead of kebab case as is defined in the spec https://agentskills.io/specification#name-field. 

This is similar to the prs to add linting to flutter skills in https://github.com/flutter/flutter/pull/185033 and dev/tool https://github.com/flutter/devtools/pull/9770

AI Assisted pr: antigravity, dragonally
Prompt: 
"""
use the skill in /Users/reidbaker/Documents/flutter-skills/tool/dart_skills_lint/skills/dart-skills-lint-validation/SKILL.md to add a test to [dash_site](directory;file:///Users/reidbaker/Documents/dart-lang-site-www/tool/dash_site)/test that validates the skills in @directory:agents/skills
"""

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/dart-lang/site-shared/blob/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
