### PR TITLE
Use deferred loading for the wasm built app.

### DIFF
--- a/site/build.yaml
+++ b/site/build.yaml
@@ -24,7 +24,7 @@ targets:
             dart2wasm:
               # Use -O2 to catch more potential runtime issues, it is not much
               # slower than -O4: https://github.com/dart-lang/site-www/pull/6953#discussion_r2453318668
-              args: [-O2, -Djaspr.flags.release=true]
+              args: [-O2, -Djaspr.flags.release=true, --enable-deferred-loading]
       dart_dev_site:stylesHashBuilder:
         dev_options:
           fixed_hash: true

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
       path: packages/analysis_defaults
       ref: 6d50799f4dc347398863b83f5dc46d1da8f6c5cd
   build_runner: ^2.13.1
-  build_web_compilers: ^4.4.17
+  build_web_compilers: ^4.4.19
   jaspr_builder: ^0.23.0
   jaspr_test: ^0.23.0
   lints: ^6.0.0


### PR DESCRIPTION
- Update the pubspec to use `build_web_compilers 4.4.19` which now supports wasm deferred loading.
- Pass the necessary flag to use deferred loading for the dart2wasm builder.