### PR TITLE
fix(site): prevent docs page title overflow on small screens

### DIFF
--- a/site/lib/_sass/components/_content.scss
+++ b/site/lib/_sass/components/_content.scss
@@ -68,7 +68,7 @@ article {
       min-width: 0;
       max-width: 100%;
       word-break: normal;
-      overflow-wrap: normal;
+      overflow-wrap: break-word;
 
       @media (max-width: 390px) {
         font-size: 2.375rem;

--- a/site/lib/_sass/components/_content.scss
+++ b/site/lib/_sass/components/_content.scss
@@ -55,14 +55,27 @@ article {
       display: flex;
       flex-direction: column;
       gap: 0.35rem;
+      min-width: 0;
 
       background-color: var(--site-raised-bgColor);
       padding: 1rem;
+      padding-inline-end: 2.75rem;
       border-radius: var(--site-radius);
     }
 
     h1 {
       text-wrap: pretty;
+      min-width: 0;
+      max-width: 100%;
+      word-break: normal;
+      overflow-wrap: normal;
+
+      @media (max-width: 390px) {
+        font-size: 2.375rem;
+      }
+      @media (max-width: 350px) {
+        font-size: 2rem;
+      }
     }
 
     .page-description {

--- a/site/lib/_sass/components/_content.scss
+++ b/site/lib/_sass/components/_content.scss
@@ -56,10 +56,8 @@ article {
       flex-direction: column;
       gap: 0.35rem;
       min-width: 0;
-
       background-color: var(--site-raised-bgColor);
       padding: 1rem;
-      padding-inline-end: 2.75rem;
       border-radius: var(--site-radius);
     }
 


### PR DESCRIPTION
### Summary

Fixes the docs **page header card** layout on very narrow viewports so the title stays inside the card, wraps at word boundaries, and leaves room for the **page options (⋮)** control.

### Problem

- On small screens, the raised header (`#site-content-title.wrap`) could **overflow horizontally**.
- Long titles could break in the **middle of a word** (e.g. “documentation” split oddly).
- The **⋮** button in the top-right could **overlap** the title without enough inline padding.

### Changes

**`site/lib/_sass/components/_content.scss`**

- `min-width: 0` on the wrapped header and `h1` so flex items can shrink instead of overflowing.
- Extra `padding-inline-end` on the card so the title clears the options control.
- `word-break: normal`, `overflow-wrap: normal`, and `text-wrap: pretty` so line breaks prefer **spaces between words**.
- **≤360px width:** page title `h1` uses **`2.375rem`**; wider viewports keep the default **`2.75rem`** from `_base.scss`.

### Screenshots

<img width="993" height="478" alt="Screenshot 2026-05-03 at 1 15 29 AM" src="https://github.com/user-attachments/assets/c24d48df-9b28-44b8-b314-959378c78870" />
<img width="989" height="489" alt="Screenshot 2026-05-03 at 1 15 16 AM" src="https://github.com/user-attachments/assets/58496ff6-3c26-4254-9418-b3b2cb684a17" />

### Testing

- Resize to a narrow width (e.g. ~360px) on a docs page with the card header (e.g. `/docs`) and confirm no horizontal overflow and sensible title wrapping.