### PR TITLE
docs: fix incorrect output in collections example

### DIFF
--- a/examples/misc/test/language_tour/collections/if_case_operator_in_collection_a.dart
+++ b/examples/misc/test/language_tour/collections/if_case_operator_in_collection_a.dart
@@ -8,12 +8,9 @@ void main() {
     if (data case String s) 'Data is a string: $s',
     if (data case bool b) 'Data is a boolean: $b',
     if (data case double d) 'Data is a double: $d',
-  ]; // [Data is an integer: 123, Data is a double: 123]
+  ]; // [Data is an integer: 123]
   // #enddocregion code_sample
 
   print(typeInfo);
-  expect(
-    typeInfo,
-    equals(['Data is an integer: 123', 'Data is a double: 123']),
-  );
+  expect(typeInfo, equals(['Data is an integer: 123']));
 }

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -597,7 +597,7 @@ var typeInfo = [
   if (data case String s) 'Data is a string: $s',
   if (data case bool b) 'Data is a boolean: $b',
   if (data case double d) 'Data is a double: $d',
-]; // [Data is an integer: 123, Data is a double: 123]
+]; // [Data is an integer: 123]
 ```
 
 <?code-excerpt "misc/test/language_tour/collections/if_case_operator_in_collection_d.dart (code_sample)"?>


### PR DESCRIPTION
Fixes incorrect output shown in the collections documentation example.

The example currently includes a double match in the resulting list,
but for the given input (`Object data = 123`), only the integer case
matches. The updated comment reflects the actual output.

Fixes https://github.com/dart-lang/site-www/issues/7255

---

* [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
* [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
* [x] This PR follows the Google Developer Documentation Style Guidelines — for example, it doesn't use *i.e.* or *e.g.*, and it avoids *I* and *we* (first person).
* [x] This PR uses semantic line breaks of 80 characters or fewer.
