### PR TITLE
Add welcome note to blog index

### DIFF
--- a/src/content/blog/index.md
+++ b/src/content/blog/index.md
@@ -5,4 +5,10 @@ layout: blog
 showBreadcrumbs: false
 ---
 
+:::tip 🎉 Welcome to our new home!
+We've moved the Dart Blog from Medium to our own site to bring you a better,
+more integrated reading experience. Bookmark this page to stay up-to-date with
+everything Dart!
+:::
+
 <BlogIndex />

--- a/src/content/blog/index.md
+++ b/src/content/blog/index.md
@@ -5,7 +5,7 @@ layout: blog
 showBreadcrumbs: false
 ---
 
-:::tip 🎉 Welcome to our new home!
+:::note 🎉 Welcome to our new home!
 We've moved the Dart Blog from Medium to our own site to bring you a better,
 more integrated reading experience. Bookmark this page to stay up-to-date with
 everything Dart!


### PR DESCRIPTION
This PR adds a cheerful welcome note to the blog index page, informing users that the blog has moved from Medium to our own domain.