### PR TITLE
Remove changelog read more bottom margin

### DIFF
--- a/site/lib/_sass/pages/_changelog-index.scss
+++ b/site/lib/_sass/pages/_changelog-index.scss
@@ -538,7 +538,6 @@ body.dark-mode {
       }
 
       .read-more {
-        margin-bottom: 0.8rem;
         text-align: right;
 
         a {


### PR DESCRIPTION
<img width="1348" height="837" alt="image" src="https://github.com/user-attachments/assets/5957db73-b013-4d2f-9258-ef7c723fd603" />

I believe that `margin-bottom` was a mistake because changelog cards get visually unbalanced (much more to the bottom than other sides). Maybe as part of a redesign no one saw it. If you need an issue I can open it, but it is that simple, that small, that basic.