### PR TITLE
Temporarily disable format check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,10 @@ jobs:
       - name: Fetch Dart packages
         run: dart pub get
         continue-on-error: ${{ matrix.experimental }}
-      - name: Check Dart code formatting
-        run: dart run dash_site format-dart --check
-        continue-on-error: ${{ matrix.experimental }}
+# Temporarily disabled due to formatting differences between branches:
+#      - name: Check Dart code formatting
+#        run: dart run dash_site format-dart --check
+#        continue-on-error: ${{ matrix.experimental }}
       - name: Analyze Dart code
         run: dart run dash_site analyze-dart
         continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
While we move between branches over the next few weeks, to get the build passing (which still checks for valid analysis and passing tests).