### PR TITLE
Update language version links to new standalone page

### DIFF
--- a/src/content/blog/announcing-dart-2-13/index.md
+++ b/src/content/blog/announcing-dart-2-13/index.md
@@ -138,7 +138,7 @@ environment:
 ```
 
 
-This feature is backward compatible, thanks to [language versioning](https://dart.dev/guides/language/evolution#language-versioning). Packages with lower SDK constraints under 2.13 can safely refer to type aliases defined in 2.13 packages, even though pre-2.13 packages can’t define their own type aliases.
+This feature is backward compatible, thanks to [language versioning](https://dart.dev/language/versioning). Packages with lower SDK constraints under 2.13 can safely refer to type aliases defined in 2.13 packages, even though pre-2.13 packages can’t define their own type aliases.
 
 ## Dart 2.13 FFI changes
 

--- a/src/content/blog/announcing-dart-3-2/index.md
+++ b/src/content/blog/announcing-dart-3-2/index.md
@@ -49,7 +49,7 @@ class Container {
 
 This limitation was due to several complex cases where flow analysis could not safely determine when or how a field might change. In the case of field promotion on a class, for example, it could be an issue if a subclass overrides a field with a getter, which sometimes returns null.
 
-In Dart 3.2, we’ve improved our flow analysis engine and are now able to type promote **private final fields**. Now, the code snippet above passes without errors. This leverages the understanding that for a private & final field, the value never changes after the initial assignment, so checking it just once is considered safe. Private final field promotion is available starting with Dart 3.2, and will be applied to projects that have a Dart SDK [lower bound](https://dart.dev/guides/language/evolution#language-versioning) of 3.2 or higher.
+In Dart 3.2, we’ve improved our flow analysis engine and are now able to type promote **private final fields**. Now, the code snippet above passes without errors. This leverages the understanding that for a private & final field, the value never changes after the initial assignment, so checking it just once is considered safe. Private final field promotion is available starting with Dart 3.2, and will be applied to projects that have a Dart SDK [lower bound](https://dart.dev/language/versioning) of 3.2 or higher.
 
 ## New code analysis options in package:lints 3.0
 

--- a/src/content/blog/announcing-dart-3-7/index.md
+++ b/src/content/blog/announcing-dart-3-7/index.md
@@ -99,7 +99,7 @@ void writeArgumentList(
 ```
 
 
-This is a large change both to the tool, the output it produces, and how it behaves. To make the transition as smooth as possible, the formatting style you get depends on the [language version](https://dart.dev/guides/language/evolution) of the code you’re formatting. If the language version is 3.6 or earlier, the code is formatted with the old style. If it’s 3.7 or later, it gets the new style.
+This is a large change both to the tool, the output it produces, and how it behaves. To make the transition as smooth as possible, the formatting style you get depends on the [language version](https://dart.dev/language/versioning) of the code you’re formatting. If the language version is 3.6 or earlier, the code is formatted with the old style. If it’s 3.7 or later, it gets the new style.
 
 When you upgrade your package to use Dart 3.7 by bumping the SDK constraint in your package’s pubspec (and running `dart pub get`!), you are opting in to the new formatting style.
 

--- a/src/content/blog/announcing-dart-3-8/index.md
+++ b/src/content/blog/announcing-dart-3-8/index.md
@@ -18,7 +18,7 @@ This release brings formatter updates, null-aware elements for collections, new 
 
 In the previous release, Dart included a largely rewritten formatter that supported a new [“tall” style](https://github.com/dart-lang/dart_style/issues/1253). The Dart 3.8 release incorporates additional feedback, fixes bug reports, and adds other improvements.
 
-Note that if you upgrade to the Dart 3.8 SDK, your formatting won’t change until you change your package’s pubspec to opt in to the latest language version.
+Note that if you upgrade to the Dart 3.8 SDK, your formatting won’t change until you change your package’s pubspec to opt in to the latest [language version](https://dart.dev/language/versioning).
 
 ### **Trailing commas and taller code**
 

--- a/src/content/blog/announcing-dart-3-9/index.md
+++ b/src/content/blog/announcing-dart-3-9/index.md
@@ -86,7 +86,7 @@ dependencies:
 ```
 
 
-Starting from language version 3.9, the `flutter` constraint upper bound is now respected in your root package (the `dart` constraint was already respected). Setting a narrow dart or flutter constraint can be useful to ensure a team of developers all use the same SDK version when jointly developing an app (see [issue #95472](https://github.com/flutter/flutter/issues/95472) for details).
+Starting from [language version](https://dart.dev/language/versioning) 3.9, the `flutter` constraint upper bound is now respected in your root package (the `dart` constraint was already respected). Setting a narrow dart or flutter constraint can be useful to ensure a team of developers all use the same SDK version when jointly developing an app (see [issue #95472](https://github.com/flutter/flutter/issues/95472) for details).
 
 For example, in a root pubspec like this `pub get` will fail if invoked with a version of the Flutter SDK that is not 3.33.0:
 

--- a/src/content/blog/dart-2-18-objective-c-swift-interop/index.md
+++ b/src/content/blog/dart-2-18-objective-c-swift-interop/index.md
@@ -250,7 +250,7 @@ The following graph shows the unsound vs. sound null safety executions of `flutt
 
 Supporting both unsound and sound null safety adds overhead and complexity.
 
-First, Dart developers need to learn and understand both modes. Whenever reading a piece of Dart code, check the [language version](https://dart.dev/guides/language/evolution#language-versioning) to see if types are non-null by default (Dart 2.12 and later) or nullable by default (Dart 2.11 and earlier).
+First, Dart developers need to learn and understand both modes. Whenever reading a piece of Dart code, check the [language version](https://dart.dev/language/versioning) to see if types are non-null by default (Dart 2.12 and later) or nullable by default (Dart 2.11 and earlier).
 
 Second, supporting both modes in our compilers and runtimes slows down evolving the Dart SDK to support new features.
 

--- a/src/content/blog/the-road-to-dart-3-a-fully-sound-null-safe-language/index.md
+++ b/src/content/blog/the-road-to-dart-3-a-fully-sound-null-safe-language/index.md
@@ -28,7 +28,7 @@ For Dart, we chose the path of sound null safety. This involved a tradeoff. In a
 
 It’s been three years since we introduced null safety to the Dart language in [Dart 2.12](https://dart.dev/guides/language/evolution#dart-212). As mentioned in the previous section, we recognize the impact needed to migrate existing Dart packages and apps. To help migration, Dart has supported running your app code in three ways. It can run without null safety, in a mixed mode with partial null safety, or with full sound null safety. Full sound null safety occurs when 100% of the code, including all dependencies, has been migrated. This gave Dart developers time to migrate existing code one step at a time. However, having support for several modes added overhead and complexity.
 
-First, Dart developers need to be aware of all three modes. Whenever you read a piece of Dart code, you must check the language version to see if types are non-null by default, nullable by default, or some combination thereof.
+First, Dart developers need to be aware of all three modes. Whenever you read a piece of Dart code, you must check the [language version](https://dart.dev/language/versioning) to see if types are non-null by default, nullable by default, or some combination thereof.
 
 Second, supporting all three modes in our compilers and runtimes slows down evolving the Dart SDK. This support increases the cost and complexity of adding new features.
 

--- a/src/content/changelog.md
+++ b/src/content/changelog.md
@@ -6,6 +6,8 @@ showBreadcrumbs: false
 ---
 
 This page lists the full history of changes to the Dart SDK and Dart language, organized by release. We use tags to classify changes, such as `New` for features, `Fixed` for bugs, and `Breaking` for incompatible changes.
-Some changes are `Language versioned`, meaning they only take effect when you upgrade your code's language version.
+Some changes are `Language versioned`,
+meaning they only take effect when you
+upgrade your code's [language version](/language/versioning).
 
 <ChangelogIndex />

--- a/src/content/effective-dart/design.md
+++ b/src/content/effective-dart/design.md
@@ -673,7 +673,8 @@ unintended implementation issues.
 
 {% render 'linter-rule-mention.md', rules:'prefer_mixin' %}
 
-Dart previously (language version [2.12](/resources/language/evolution#dart-2-12)
+Dart previously (in [language versions](/language/versioning)
+[2.12](/resources/language/evolution#dart-2-12)
 to [2.19](/resources/language/evolution#dart-2-19)) allowed any class that
 met certain restrictions (no non-default constructor, no superclass, etc.)
 to be mixed into other classes.

--- a/src/content/effective-dart/style.md
+++ b/src/content/effective-dart/style.md
@@ -327,7 +327,7 @@ enable the [`unnecessary_underscores`][] lint.
 :::
 
 [wildcards]: /language/variables#wildcard-variables
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [`no_wildcard_variable_uses`]: /tools/linter-rules/no_wildcard_variable_uses
 [`unnecessary_underscores`]: /tools/linter-rules/unnecessary_underscores
 

--- a/src/content/language/branches.md
+++ b/src/content/language/branches.md
@@ -292,7 +292,7 @@ When the guard clause evaluates to false,
 execution proceeds to the next case rather
 than exiting the entire switch.
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [loops]: /language/loops
 [exceptions]: /language/error-handling
 [conditional expressions]: /language/operators#conditional-expressions

--- a/src/content/language/built-in-types.md
+++ b/src/content/language/built-in-types.md
@@ -440,4 +440,4 @@ Symbol literals are compile-time constants.
 [characters API]: {{site.pub-api}}/characters
 [characters example]: {{site.pub-pkg}}/characters/example
 [`Symbol`]: {{site.dart-api}}/dart-core/Symbol-class.html
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning

--- a/src/content/language/class-modifiers-for-apis.md
+++ b/src/content/language/class-modifiers-for-apis.md
@@ -34,7 +34,7 @@ and how they affect users of your libraries.
 ## The `mixin` modifier on classes
 
 The most important modifier to be aware of is `mixin`.
-Language versions prior to Dart 3.0 allow any class to be used as a mixin
+[Language versions][] prior to Dart 3.0 allow any class to be used as a mixin
 in another class's `with` clause, _UNLESS_ the class:
 
 *   Declares any non-factory constructors.
@@ -58,6 +58,8 @@ If you update your package to Dart 3.0 and don't change any of your code,
 you may not see any errors.
 But you may inadvertently break users of your package
 if they were using your classes as mixins.
+
+[Language versions]: /language/versioning
 
 ### Migrating classes as mixins
 

--- a/src/content/language/class-modifiers.md
+++ b/src/content/language/class-modifiers.md
@@ -346,7 +346,7 @@ check out the [Class modifiers reference][].
 [Class modifiers reference]: /language/modifier-reference
 
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [class, mixin, or mixin class]: /language/mixins#class-mixin-or-mixin-class
 [mixin]: /language/mixins
 [fragile base class problem]: https://en.wikipedia.org/wiki/Fragile_base_class

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -407,7 +407,7 @@ var itemsE = {absentKey: absentValue}; // {null: null}
 var itemsF = {?absentKey: ?absentValue}; // {}
 ```
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 
 ### Spread elements {: #spread-element }
 

--- a/src/content/language/constructors.md
+++ b/src/content/language/constructors.md
@@ -422,7 +422,7 @@ class PointD {
 
 :::version-note
 Using private named parameters as initializing formals
-requires a language version of at least 3.12.
+requires a [language version][] of at least 3.12.
 :::
 
 In Dart, fields starting with an underscore are private to their library.
@@ -744,7 +744,7 @@ class Vector3d extends Vector2d {
 }
 ```
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [using constructors]: /language/classes#using-constructors
 [late-final-ivar]: /effective-dart/design#avoid-public-late-final-fields-without-initializers
 [static method]: /language/classes#static-methods

--- a/src/content/language/dot-shorthands.md
+++ b/src/content/language/dot-shorthands.md
@@ -15,7 +15,7 @@ nextpage:
 Dot shorthands require a [language version][] of at least 3.10.
 :::
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 
 ## Overview
 

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -175,6 +175,6 @@ print(Vehicle.car.carbonFootprint);
 [mixins]: /language/mixins
 [generative constructors]: /language/constructors#constant-constructors
 [Factory constructors]: /language/constructors#factory-constructors
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [static variable]: /language/classes#class-variables-and-methods
 [switch statements]: /language/branches#switch

--- a/src/content/language/index.md
+++ b/src/content/language/index.md
@@ -591,7 +591,7 @@ This site's code follows the conventions in the
 [The main() function]: /language/functions#the-main-function
 [ns]: /null-safety
 [`Object`]: {{site.dart-api}}/dart-core/Object-class.html
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [ObjectVsDynamic]: /effective-dart/design#avoid-using-dynamic-unless-you-want-to-disable-static-checking
 [Libraries and imports]: /language/libraries
 [conditional expression]: /language/operators#conditional-expressions

--- a/src/content/language/mixins.md
+++ b/src/content/language/mixins.md
@@ -212,6 +212,6 @@ Any restrictions that apply to classes or mixins also apply to mixin classes:
 - Mixins can't have `extends` or `with` clauses, so neither can a `mixin class`.
 - Classes can't have an `on` clause, so neither can a `mixin class`.
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [class]: /language/classes
 [class modifiers]: /language/class-modifiers

--- a/src/content/language/operators.md
+++ b/src/content/language/operators.md
@@ -549,5 +549,5 @@ For more information about the `.`, `?.`, and `..` operators, see
 [Operators]: /language/methods#operators
 [library prefixes]: /language/libraries#specifying-a-library-prefix
 [if-else]: /language/branches#if
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [Classes]: /language/classes

--- a/src/content/language/patterns.md
+++ b/src/content/language/patterns.md
@@ -417,7 +417,7 @@ This case pattern simultaneously validates that:
 - The new local variables to hold the values are `name` and `age`. 
 
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [types]: /language/pattern-types
 [collection-type]: /language/collections
 [wildcard pattern]: /language/pattern-types#wildcard

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -10,8 +10,10 @@ nextpage:
 ---
 
 :::version-note
-Primary constructors require a language version of at least 3.13.
+Primary constructors require a [language version][] of at least 3.13.
 :::
+
+[language version]: /language/versioning
 
 ## Overview
 

--- a/src/content/language/records.md
+++ b/src/content/language/records.md
@@ -343,7 +343,7 @@ for the code using it as a reference, that the value being aliased is a record.
 Extension types, also, offer little protection.
 Only a class can provide full abstraction and encapsulation.
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [collection types]: /language/collections
 [pattern]: /language/patterns#destructuring-multiple-returns
 [`dart:async` documentation]: /libraries/dart-async#handling-errors-for-multiple-futures

--- a/src/content/language/type-system.md
+++ b/src/content/language/type-system.md
@@ -669,5 +669,5 @@ The following resources have further information on sound Dart:
 
 
 [analysis]: /tools/analysis
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [null safety]: /null-safety

--- a/src/content/language/typedefs.md
+++ b/src/content/language/typedefs.md
@@ -52,5 +52,5 @@ void main() {
 }
 ```
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [inline function types]: /effective-dart/design#prefer-inline-function-types-over-typedefs

--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -363,5 +363,5 @@ multiple binding underscores (`__`,`___`, etc.) to avoid name collisions.
 [Lists]: /language/collections#lists
 [Maps]: /language/collections#maps
 [Classes]: /language/classes
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [`unnecessary_underscores`]: /tools/linter-rules/unnecessary_underscores

--- a/src/content/resources/breaking-changes.md
+++ b/src/content/resources/breaking-changes.md
@@ -64,7 +64,7 @@ To be notified about future breaking changes, join the [Dart announce][] group.
 [breaking change policy]: {{site.repo.dart.sdk}}/blob/main/docs/process/breaking-changes.md
 [changelog]: {{site.repo.dart.sdk}}/blob/main/CHANGELOG.md
 [sdk]: /get-dart
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [Dart announce]: {{site.announce}}
 
 {% comment %}
@@ -287,7 +287,7 @@ don't include the section header.
   The formatter made changes and fixes that result in new output when
   formatting code with a [language version][] of 3.8 or greater.
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 
 ## 3.7.0
 
@@ -347,7 +347,7 @@ don't include the section header.
   All usages should be migrated to the new `--page-width` option.
 
 [new style]: {{site.repo.dart.org}}/dart_style/issues/1253
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [configure your analysis options]: /tools/analysis
 [`dart fix`]: /tools/dart-fix
 

--- a/src/content/resources/dart-3-migration.md
+++ b/src/content/resources/dart-3-migration.md
@@ -24,7 +24,7 @@ The potentially breaking changes listed below fall into one of two categories:
 
 * **Versioned changes**: These changes only apply when the package or app's
   language version is set to >= Dart 3.0. 
-  The [language version](/resources/language/evolution#language-version-numbers)
+  The [language version](/language/versioning#language-version-numbers)
   is derived from the `sdk` lower-constraint in the
   [`pubspec.yaml` file](/tools/pub/packages#creating-a-pubspec). 
   An SDK constraint like this does *not* apply the Dart 3 versioned changes:
@@ -144,7 +144,7 @@ $ dart run bin/my_app.dart
 ^^^^^^^^^^^^
 ```
 
-[language version comments]: /resources/language/evolution#per-library-language-version-selection
+[language version comments]: /language/versioning#library-override
 
 #### Migration
 

--- a/src/content/resources/language/evolution.md
+++ b/src/content/resources/language/evolution.md
@@ -37,7 +37,7 @@ environment:
 
 [2.12]: #dart-2-12
 [SDK constraint]: /tools/pub/pubspec#sdk-constraints
-[language versioned]: #language-versioning
+[language versioned]: /language/versioning
 [Breaking changes]: /resources/breaking-changes
 
 :::tip
@@ -351,7 +351,7 @@ The 3.0 release of the Dart SDK dropped support for
 [Switch expressions]: /language/branches#switch-expressions
 [If-case clauses]: /language/branches#if-case
 [`mixin`]: /language/mixins#class-mixin-or-mixin-class
-[language versions]: #language-versioning
+[language versions]: /language/versioning
 
 ### Dart 2.19
 _Released 25 January 2023_

--- a/src/content/resources/whats-new.md
+++ b/src/content/resources/whats-new.md
@@ -752,7 +752,7 @@ we made the following changes:
 [sound null safety]: /null-safety
 [Dart 3 migration guide]: /resources/dart-3-migration
 [language evolution]: /resources/language/evolution
-[language versioning]: /resources/language/evolution#language-versioning
+[language versioning]: /language/versioning
 [compilation environment declarations]: /libraries/core/environment-declarations
 [Java interop]: /interop/java-interop
 [unnamed extensions]: /language/extension-methods#unnamed-extensions

--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -691,7 +691,7 @@ Use the following resources to learn more about static analysis in Dart:
 [change the severity of rules]: #changing-the-severity-of-rules
 [diagnostics]: /tools/diagnostic-messages
 [invalid_assignment]: /tools/diagnostic-messages#invalid_assignment
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [linter rules]: /tools/linter-rules
 [type-system]: /language/type-system
 [dead_code]: /tools/diagnostic-messages#dead_code

--- a/src/content/tools/dart-fix.md
+++ b/src/content/tools/dart-fix.md
@@ -115,7 +115,7 @@ To learn more about customizing analysis results and behavior,
 see [Customizing static analysis](/tools/analysis).
 
 [`dart analyze`]: /tools/dart-analyze
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 
 ## VS Code support
 

--- a/src/content/tools/dart-format.md
+++ b/src/content/tools/dart-format.md
@@ -173,5 +173,5 @@ Check out the [formatter FAQ][] for more context behind formatting decisions.
 [dart_style]: {{site.pub-pkg}}/dart_style
 [dart-guidelines]: /effective-dart/style#formatting
 [`analysis_options.yaml`]: /tools/analysis
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning
 [formatter FAQ]: {{site.repo.dart.org}}/dart_style/wiki/FAQ

--- a/src/content/tools/non-promotion-reasons.md
+++ b/src/content/tools/non-promotion-reasons.md
@@ -1211,4 +1211,4 @@ void f(int? i, int? j) {
 }
 ```
 
-[language version]: /resources/language/evolution#language-versioning
+[language version]: /language/versioning

--- a/src/content/tools/pub/dependencies.md
+++ b/src/content/tools/pub/dependencies.md
@@ -128,7 +128,7 @@ dependencies:
 ```
 :::
 
-[SDK version]: /resources/language/evolution#language-versioning
+[SDK version]: /language/versioning
 
 ### Git packages
 

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -506,7 +506,7 @@ the version when the feature was introduced.
 For details, check out [Language versioning][].
 :::
 
-[Language versioning]: /resources/language/evolution#language-versioning
+[Language versioning]: /language/versioning
 
 For example, the following constraint says that this package
 works with any Dart SDK that's version 3.0.0 or higher:

--- a/src/data/changelog.yml
+++ b/src/data/changelog.yml
@@ -2525,8 +2525,8 @@
   area: Language
   subArea: Language versioning
   description: |
-    The 3.0 release of the Dart SDK dropped support for [language
-    versions](/resources/language/evolution#language-versioning) before 2.12.
+    The 3.0 release of the Dart SDK dropped support for
+    [language versions](/language/versioning) before 2.12.
   tags:
     - removed
     - breaking

--- a/src/data/glossary.yml
+++ b/src/data/glossary.yml
@@ -487,7 +487,7 @@
       link: "/tools/pub/pubspec#sdk-constraints"
       type: "doc"
     - text: "Language versions"
-      link: "/resources/language/evolution#language-versioning"
+      link: "/language/versioning"
       type: "doc"
   labels:
     - "pub"


### PR DESCRIPTION
Follow-up to the consolidation of the content to the new page in https://github.com/dart-lang/site-www/pull/7173