### PR TITLE
Fix analyzer Google Group link on community page

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -87,7 +87,7 @@ Get answers and connect with Dart developers.
   <Card title="General discussions" link="{{page.group}}/d/forum/misc">
     Discuss miscellaneous Dart topics.
   </Card>
-  <Card title="Dart analyzer" link="{{page.group}}/d/forum/analyzer-discuss>">
+  <Card title="Dart analyzer" link="{{page.group}}/d/forum/analyzer-discuss">
     Get help understanding the Dart analyzer.
   </Card>
 </div>


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/7287

**Staged:** https://dart-dev--pr7288-fix-7287-yohuk8vz.web.app/community#google-groups
