### PR TITLE
Work around aspect-ratio issue on older WebKit versions

### DIFF
--- a/site/lib/_sass/components/_blog.scss
+++ b/site/lib/_sass/components/_blog.scss
@@ -214,10 +214,6 @@
       .blog-card-image {
         flex: 1.5;
         border-radius: 4px;
-
-        img {
-          border-radius: 4px;
-        }
       }
 
       .blog-card-content {

--- a/site/lib/_sass/components/_blog.scss
+++ b/site/lib/_sass/components/_blog.scss
@@ -148,12 +148,18 @@
     color: inherit;
   }
 
-  .blog-card-image img {
+  .blog-card-image {
     width: 100%;
-    height: auto;
     aspect-ratio: 16/9;
-    object-fit: cover;
+    overflow: hidden;
     border-radius: 8px;
+
+    img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 
   .blog-card-title {
@@ -207,9 +213,9 @@
 
       .blog-card-image {
         flex: 1.5;
+        border-radius: 4px;
 
         img {
-          aspect-ratio: 16/9;
           border-radius: 4px;
         }
       }
@@ -253,10 +259,7 @@
 
       .blog-card-image {
         margin-bottom: 1rem;
-
-        img {
-          aspect-ratio: 16/10;
-        }
+        aspect-ratio: 16/10;
       }
 
       .blog-card-title {


### PR DESCRIPTION
Work around an issue with `aspect-ratio` on older WebKit versions by moving the relevant styles to the image's parent element.

Fixes https://github.com/dart-lang/site-www/issues/7289


I verified the issue existed on an iPad Pro 10.5 inch simulator that had iOS 17.5 installed and validated this fix on the simulator as well:

<img width="260" alt="Screenshot of blog index page with simulator in portrait mode" src="https://github.com/user-attachments/assets/54af64f0-3dd1-4530-b088-6ed38f48dac2" />
<img width="320" alt="Screenshot of blog index page with simulator in landscape mode " src="https://github.com/user-attachments/assets/c457cb9c-611d-43d4-bc5a-5517b886c29b" />

Before:

<img width="260" alt="Screenshot of blog index page with simulator in portrait mode before the fix" src="https://github.com/user-attachments/assets/36a5d35b-28ca-42ed-ac8f-93452d37b859" />