### PR TITLE
docs: remove unnecessary Set conversion in Map keys example

### DIFF
--- a/examples/misc/test/library_tour/core_test.dart
+++ b/examples/misc/test/library_tour/core_test.dart
@@ -375,7 +375,7 @@ void main() {
       var keys = hawaiianBeaches.keys;
 
       assert(keys.length == 3);
-      assert(Set.from(keys).contains('Oahu'));
+      assert(keys.contains('Oahu'));
 
       // Get all the values as an unordered collection
       // (an Iterable of Lists).

--- a/src/content/libraries/dart-core.md
+++ b/src/content/libraries/dart-core.md
@@ -525,7 +525,7 @@ var hawaiianBeaches = {
 var keys = hawaiianBeaches.keys;
 
 assert(keys.length == 3);
-assert(Set.from(keys).contains('Oahu'));
+assert(keys.contains('Oahu'));
 
 // Get all the values as an unordered collection
 // (an Iterable of Lists).


### PR DESCRIPTION
## Description

Removes an unnecessary `Set.from()` conversion in the Map keys example on the `dart:core` page.

The example already returns an `Iterable` from `Map.keys`, and `Iterable.contains()` can be used directly. This simplifies the code while preserving the intended behavior.

## Issues fixed

Fixes #7317

## PR dependencies

None.
