### PR TITLE
Slightly increase the tutorial's code snippets consistency

### DIFF
--- a/src/content/learn/tutorial/cli-polish.md
+++ b/src/content/learn/tutorial/cli-polish.md
@@ -89,8 +89,8 @@ understand how to use your CLI application.
           (command) => command.name == input,
           orElse: () {
             throw ArgumentException(
-              'Input ${input} is not a known command.',
-              name
+              'Input $input is not a known command.',
+              name,
             );
           },
         );

--- a/src/content/learn/tutorial/cli-polish.md
+++ b/src/content/learn/tutorial/cli-polish.md
@@ -89,7 +89,8 @@ understand how to use your CLI application.
           (command) => command.name == input,
           orElse: () {
             throw ArgumentException(
-              'Input ${args.commandArg} is not a known command.',
+              'Input ${input} is not a known command.',
+              name
             );
           },
         );

--- a/src/content/learn/tutorial/fetch-data.md
+++ b/src/content/learn/tutorial/fetch-data.md
@@ -102,7 +102,7 @@ You'll create three files:
           return Summary.fromJson(jsonData);
         } else {
           throw HttpException(
-            '[WikipediaDart.getRandomArticle] '
+            '[WikipediaApiClient.getRandomArticleSummary] '
             'statusCode=${response.statusCode}, body=${response.body}',
           );
         }
@@ -128,7 +128,7 @@ You'll create three files:
           return Summary.fromJson(jsonData);
         } else {
           throw HttpException(
-            '[WikipediaDart.getArticleSummary] '
+            '[WikipediaApiClient.getArticleSummaryByTitle] '
             'statusCode=${response.statusCode}, body=${response.body}',
           );
         }
@@ -179,7 +179,7 @@ You'll create three files:
           return SearchResults.fromJson(jsonData);
         } else {
           throw HttpException(
-            '[WikimediaApiClient.getArticleByTitle] '
+            '[WikipediaApiClient.search] '
             'statusCode=${response.statusCode}, '
             'body=${response.body}',
           );
@@ -232,7 +232,7 @@ You'll create three files:
           return Article.listFromJson(jsonData);
         } else {
           throw HttpException(
-            '[ApiClient.getArticleByTitle] '
+            '[WikipediaApiClient.getArticleByTitle] '
             'statusCode=${response.statusCode}, '
             'body=${response.body}',
           );

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -215,6 +215,7 @@ create a logger instance and log messages to a file.
                 }
                 if (error is Exception) {
                   errorLogger.warning(error);
+                  print(error);
                 }
               },
             )
@@ -323,10 +324,10 @@ add the necessary code, including the logging and error handling.
       FutureOr<String> run(ArgResults args) async {
         if (requiresArgument &&
             (args.commandArg == null || args.commandArg!.isEmpty)) {
-          return 'Please include a search term';
+          throw ArgumentException('Please include a search term', name);
         }
 
-        final buffer = StringBuffer('Search results:');
+        final buffer = StringBuffer('Search results:\n');
         final SearchResults results = await search(args.commandArg!);
 
         for (var result in results.results) {
@@ -381,10 +382,10 @@ add the necessary code, including the logging and error handling.
       FutureOr<String> run(ArgResults args) async {
         if (requiresArgument &&
             (args.commandArg == null || args.commandArg!.isEmpty)) {
-          return 'Please include a search term';
+          throw ArgumentException('Please include a search term', name);
         }
 
-        final buffer = StringBuffer('Search results:');
+        final buffer = StringBuffer('Search results:\n');
         final SearchResults results = await search(args.commandArg!);
 
         if (args.flag('im-feeling-lucky')) {
@@ -452,10 +453,10 @@ add the necessary code, including the logging and error handling.
       FutureOr<String> run(ArgResults args) async {
         if (requiresArgument &&
             (args.commandArg == null || args.commandArg!.isEmpty)) {
-          return 'Please include a search term';
+          throw ArgumentException('Please include a search term', name);
         }
 
-        final buffer = StringBuffer('Search results:');
+        final buffer = StringBuffer('Search results:\n');
         try {
           final SearchResults results = await search(args.commandArg!);
 


### PR DESCRIPTION
# Tutorial code snippets a little more consistent

The changes in the commit slightly increase the consistency of the code snippets in the tutorial.


## Polish your CLI app

When running `cli.dart help --command <input>` an exception is thrown if `<input>` is not a valid command as shown in the following piece of code where `<input>` is contained in the variable named `input`:
```dart
var cmd = runner.commands.firstWhere(
    (command) => command.name == input,
    orElse: () {
        throw ArgumentException(
            'Input ${args.commandArg} is not a known command.',
        );
    },
);
```
Here, `args.commandArg` is the positional argument's value for the `help` command, but the user wants to view the details of the command specified as value to the option `--command`. So, shouldn't the `input` variable be used instead of `args.commandArg` when creating the exception message?
Furthermore, the name of the running command is also passed to the constructor of the `ArgumentException` class.


## Fetch data from the internet

In this chapter are defined the functions `getRandomArticleSummary()`, `getArticleSummaryByTitle()`, `search()` and `getArticleByTitle()`. Each function makes the proper API request and then throws an `HttpException` if the response's status code is not 200. This commit uniforms the exception message by using the same message prefix for all functions and by specifying the exact name of the function that is throwing the exception.


## Add logging for debugging and monitoring

The first change for this chapter is within the `main()` function in which the `onError` callback is passed to the `CommandRunner` constructor. If the error received by this callback is an `Exception` instance, then it is not printed to the console anymore, it's instead just logged. This causes an `ArgumentException` error to not be shown as console output and the user must look into the log file. With this commit, the exception is printed again after being logged.

The second change is made in the `run()` method of the `SearchCommand` class. Now, the arguments validation will throw an `ArgumentException` instead of just returning a string. This behavior is consistent with that of the `HelpCommand` class.

The last change is also in the `run()` method of `SearchCommand` class and it adds a new line character between the string `'Search results:'` and the first result element.