### PR TITLE
[hooks] Document user-defines in pubspec

### DIFF
--- a/src/content/tools/hooks.md
+++ b/src/content/tools/hooks.md
@@ -187,13 +187,13 @@ native assets (such as C or Rust libraries), which are then
 made available to be called from the Dart code of a package,
 create a `build.dart` script similar to the following:
 
-1.  In your Dart project, create or open `hooks/build.dart`. 
+1.  In your Dart project, create or open `hook/build.dart`. 
 
 1.  In the `main` method, call the `build` function from
     `package:hooks/hooks.dart` and use the appropriate
     toolchain to compile the native library. For example:
 
-    ```dart title="hooks/build.dart" highlightLines=6
+    ```dart title="hook/build.dart" highlightLines=6
     import 'package:hooks/hooks.dart';
     import 'package:logging/logging.dart';
     import 'package:native_toolchain_c/native_toolchain_c.dart';
@@ -332,16 +332,17 @@ Configure custom parameters inside the root package `pubspec.yaml` file,
 or in the workspace `pubspec.yaml` file if you use a workspace.
 Only end-users—the authors of the root app or package consuming
 the dependencies—can configure user-defines.
-Dependencies cannot supply their own default user-defines.
+Dependencies can't supply their own default user-defines.
 
 The configured values under `user_defines` can be any JSON-compatible type,
 such as booleans, strings, numbers, nested maps, or lists.
 User-defines are filtered per package.
 A hook inside `my_package` can only access keys configured under
 `hooks.user_defines.my_package`.
-It cannot access the user-defines of other packages.
+It can't access the user-defines of other packages.
 
-Here is an example of configuring user-defines:
+The following is an example of passing two user-defines
+to the hooks of the `my_package` package:
 
 ```yaml title="pubspec.yaml"
 hooks:
@@ -353,7 +354,8 @@ hooks:
 
 ### Access user-defines in a hook {: #access-user-defines }
 
-To access configured user-defines in your `build.dart` or `link.dart` hook script,
+To access configured user-defines in your
+`build.dart` or `link.dart` hook script,
 use the `input.userDefines` object:
 
 1. Read raw values using the bracket operator, such as `input.userDefines['key']`.
@@ -369,9 +371,10 @@ register it as a dependency using
 This ensures that the build system invalidates the cache and
 re-runs the hook when the file changes.
 
-Here is an example hook script using user-defines:
+The following is an example hook script that accesses the
+`enable_experimental` and `custom_lib` user-defines:
 
-```dart title="hooks/build.dart"
+```dart title="hook/build.dart"
 import 'dart:io';
 import 'package:hooks/hooks.dart';
 
@@ -385,7 +388,7 @@ void main(List<String> args) async {
       );
     }
 
-    if (experimental == true) {
+    if (experimental ?? false) {
       print('Experimental features enabled.');
     }
 

--- a/src/content/tools/hooks.md
+++ b/src/content/tools/hooks.md
@@ -319,6 +319,84 @@ void main() {
 }
 ```
 
+## Hook configuration {: #hook-configuration }
+
+You can pass custom parameters or local file paths to build and link hooks
+from your project's build environment.
+Configure these parameters under the `hooks` key in your `pubspec.yaml` file.
+Currently, this block supports only the `user_defines` option.
+
+### Configure user-defines {: #configure-user-defines }
+
+Configure custom parameters inside the root package `pubspec.yaml` file,
+or in the workspace `pubspec.yaml` file if you use a workspace.
+Only end-users—the authors of the root app or package consuming
+the dependencies—can configure user-defines.
+Dependencies cannot supply their own default user-defines.
+
+The configured values under `pubspec.yaml` can be any JSON-compatible type,
+such as booleans, strings, numbers, nested maps, or lists.
+User-defines are filtered per package.
+A hook inside `my_package` can only access keys configured under
+`hooks.user_defines.my_package`.
+It cannot access defines of other packages.
+
+Here is an example of configuring user-defines:
+
+```yaml title="pubspec.yaml"
+hooks:
+  user_defines:
+    my_package:
+      enable_experimental: true
+      custom_lib: assets/libnative.so
+```
+
+### Access user-defines in a hook {: #access-user-defines }
+
+To access configured user-defines in your `build.dart` or `link.dart` hook script,
+use the `input.userDefines` object:
+
+1. Read raw values using the bracket operator, such as `input.userDefines['key']`.
+1. Resolve relative paths using the `path()` method, such as `input.userDefines.path('key')`.
+   This resolves the relative path against the directory of the `pubspec.yaml`
+   where the user-define is declared.
+
+If the hook reads a resolved file or directory,
+register it as a dependency in `HookOutputBuilder` using
+`output.dependencies.add()`.
+This ensures that the build system invalidates the cache and
+re-runs the hook when the file changes.
+
+Here is an example hook script using user-defines:
+
+```dart title="hooks/build.dart"
+import 'dart:io';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await build(args, (input, output) async {
+    final experimental = input.userDefines['enable_experimental'];
+    if (experimental is! bool?) {
+      throw const FormatException(
+        'hooks.user_defines.my_package.enable_experimental must be a '
+        'boolean (or omitted)',
+      );
+    }
+
+    if (experimental == true) {
+      print('Experimental features enabled.');
+    }
+
+    final customLibUri = input.userDefines.path('custom_lib');
+    if (customLibUri != null) {
+      final file = File.fromUri(customLibUri);
+      output.dependencies.add(file.uri);
+      // Use the file...
+    }
+  });
+}
+```
+
 ## Example projects
 
 There are several example projects to help you get started

--- a/src/content/tools/hooks.md
+++ b/src/content/tools/hooks.md
@@ -321,7 +321,7 @@ void main() {
 
 ## Hook configuration {: #hook-configuration }
 
-You can pass custom parameters or local file paths to build and link hooks
+Pass custom parameters or local file paths to build and link hooks
 from your project's build environment.
 Configure these parameters under the `hooks` key in your `pubspec.yaml` file.
 Currently, this block supports only the `user_defines` option.
@@ -339,7 +339,7 @@ such as booleans, strings, numbers, nested maps, or lists.
 User-defines are filtered per package.
 A hook inside `my_package` can only access keys configured under
 `hooks.user_defines.my_package`.
-It cannot access defines of other packages.
+It cannot access the user-defines of other packages.
 
 Here is an example of configuring user-defines:
 
@@ -361,7 +361,7 @@ use the `input.userDefines` object:
    using the `path()` method,
    such as `input.userDefines.path('key')`.
    This resolves the relative path against the directory of the `pubspec.yaml`
-   where the user-define is declared.
+   where the user-defines are declared.
 
 If the hook reads a resolved file or directory,
 register it as a dependency using

--- a/src/content/tools/hooks.md
+++ b/src/content/tools/hooks.md
@@ -334,7 +334,7 @@ Only end-users—the authors of the root app or package consuming
 the dependencies—can configure user-defines.
 Dependencies cannot supply their own default user-defines.
 
-The configured values under `pubspec.yaml` can be any JSON-compatible type,
+The configured values under `user_defines` can be any JSON-compatible type,
 such as booleans, strings, numbers, nested maps, or lists.
 User-defines are filtered per package.
 A hook inside `my_package` can only access keys configured under
@@ -357,12 +357,14 @@ To access configured user-defines in your `build.dart` or `link.dart` hook scrip
 use the `input.userDefines` object:
 
 1. Read raw values using the bracket operator, such as `input.userDefines['key']`.
-1. Resolve relative paths using the `path()` method, such as `input.userDefines.path('key')`.
+1. Resolve relative paths to a `Uri`
+   using the `path()` method,
+   such as `input.userDefines.path('key')`.
    This resolves the relative path against the directory of the `pubspec.yaml`
    where the user-define is declared.
 
 If the hook reads a resolved file or directory,
-register it as a dependency in `HookOutputBuilder` using
+register it as a dependency using
 `output.dependencies.add()`.
 This ensures that the build system invalidates the cache and
 re-runs the hook when the file changes.

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -506,7 +506,10 @@ hooks:
       enable_experimental: true
 ```
 
-For more information, check out the [Hooks](/tools/hooks) page.
+To learn more about configuring hooks,
+check out [Hook configuration][].
+
+[Hook configuration]: /tools/hooks#hook-configuration
 
 ### SDK constraints
 

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -495,7 +495,7 @@ For more information, check out
 To configure package-specific hooks, such as native build or link hooks,
 use the `hooks` field.
 Under the `hooks` field,
-you can configure parameters that customize how hooks run.
+configure parameters that customize how hooks run.
 
 For example:
 

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -99,6 +99,10 @@ A pubspec can have the following fields:
 : Optional. List of ignored security advisories.
   [_Learn more._](#ignored_advisories)
 
+`hooks`
+: Optional. Configure package-specific hooks, such as native build or link hooks.
+  [_Learn more._](#hooks)
+
 Pub ignores all other fields.
 
 :::flutter-note
@@ -485,6 +489,24 @@ ignored_advisories:
 
 For more information, check out
 [Security advisories](/tools/pub/security-advisories).
+
+### Hooks
+
+To configure package-specific hooks, such as native build or link hooks,
+use the `hooks` field.
+Under the `hooks` field,
+you can configure parameters that customize how hooks run.
+
+For example:
+
+```yaml
+hooks:
+  user_defines:
+    my_package:
+      enable_experimental: true
+```
+
+For more information, check out the [Hooks](/tools/hooks) page.
 
 ### SDK constraints
 


### PR DESCRIPTION
Document the pubspec yaml section for hooks.

And then also document it in detail on the hooks page.

Corresponding PR for Dartdoc on the API:

* https://github.com/dart-lang/native/pull/3407