### PR TITLE
Updated deprecated code in web getting started

### DIFF
--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -103,7 +103,7 @@ Let's customize the app you just created.
    Iterable<String> thingsTodo() sync* {
      const actions = ['Walk', 'Wash', 'Feed'];
      const pets = ['cats', 'dogs'];
-   
+
      for (final action in actions) {
        for (final pet in pets) {
          if (pet != 'cats' || action == 'Feed') {
@@ -117,29 +117,31 @@ Let's customize the app you just created.
 2. Add the `newLI()` function (as shown below).
    It creates a new `LIElement` containing the specified `String`.
 
-   ```dart
+   ```dart highlightLines=3-5
    Iterable<String> thingsTodo() sync* { /* ... */ }
 
-   [!web.HTMLLIElement newLI(String itemText) =>!]
-     [!(web.document.createElement('li') as web.HTMLLIElement)..textContent = itemText;!]
-    
+   web.HTMLLIElement newLI(String itemText) =>
+       (web.document.createElement('li') as web.HTMLLIElement)
+         ..textContent = itemText;
+
    void main() { /* ... */ }
    ```
 
 3. In the `main()` function, append content to the `output` element
    using `appendChild` and the values from `thingsTodo()`:
 
-   ```dart
+   ```dart highlightLines=9-11
    Iterable<String> thingsTodo() sync* { /* ... */ }
 
    web.HTMLLIElement newLI(String itemText) =>
-     (web.document.createElement('li') as web.HTMLLIElement)..textContent = itemText;
+       (web.document.createElement('li') as web.HTMLLIElement)
+         ..textContent = itemText;
 
    void main() {
-    final output = web.document.querySelector('#output');
-    [!for (final item in thingsTodo()) {!]
-      [!output?.appendChild(newLI(item));!]
-    [!}!]
+     final output = web.document.querySelector('#output');
+     for (final item in thingsTodo()) {
+       output?.appendChild(newLI(item));
+     }
    }
    ```
 
@@ -154,10 +156,10 @@ Let's customize the app you just created.
 6. Optionally, improve the formatting by editing `web/styles.css`,
    then reload the app to check your changes.
 
-   ```css
+   ```css highlightLines=3
    #output {
      padding: 20px;
-     [!text-align: left;!]
+     text-align: left;
    }
    ```
 

--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -120,8 +120,8 @@ Let's customize the app you just created.
    ```dart
    Iterable<String> thingsTodo() sync* { /* ... */ }
 
-   [!HTMLLIElement newLI(String itemText) =>!]
-     [!(document.createElement('li') as HTMLLIElement)..text = itemText;!]
+   [!web.HTMLLIElement newLI(String itemText) =>!]
+     [!(web.document.createElement('li') as web.HTMLLIElement)..textContent = itemText;!]
     
    void main() { /* ... */ }
    ```
@@ -132,11 +132,11 @@ Let's customize the app you just created.
    ```dart
    Iterable<String> thingsTodo() sync* { /* ... */ }
 
-   HTMLLIElement newLI(String itemText) =>
-     (document.createElement('li') as HTMLLIElement)..text = itemText;
+   web.HTMLLIElement newLI(String itemText) =>
+     (web.document.createElement('li') as web.HTMLLIElement)..textContent = itemText;
 
    void main() {
-    final output = querySelector('#output');
+    final output = web.document.querySelector('#output');
     [!for (final item in thingsTodo()) {!]
       [!output?.appendChild(newLI(item));!]
     [!}!]

--- a/src/content/web/get-started.md
+++ b/src/content/web/get-started.md
@@ -96,11 +96,11 @@ Once your app has compiled, the browser should display
 
 Let's customize the app you just created.
 
-1. Copy the `thingsTodo()` function from the following snippet
+1. Copy the `thingsToDo()` function from the following snippet
    to the `web/main.dart` file:
 
    ```dart
-   Iterable<String> thingsTodo() sync* {
+   Iterable<String> thingsToDo() sync* {
      const actions = ['Walk', 'Wash', 'Feed'];
      const pets = ['cats', 'dogs'];
 
@@ -118,7 +118,7 @@ Let's customize the app you just created.
    It creates a new `LIElement` containing the specified `String`.
 
    ```dart highlightLines=3-5
-   Iterable<String> thingsTodo() sync* { /* ... */ }
+   Iterable<String> thingsToDo() sync* { /* ... */ }
 
    web.HTMLLIElement newLI(String itemText) =>
        (web.document.createElement('li') as web.HTMLLIElement)
@@ -128,10 +128,10 @@ Let's customize the app you just created.
    ```
 
 3. In the `main()` function, append content to the `output` element
-   using `appendChild` and the values from `thingsTodo()`:
+   using `appendChild` and the values from `thingsToDo()`:
 
    ```dart highlightLines=9-11
-   Iterable<String> thingsTodo() sync* { /* ... */ }
+   Iterable<String> thingsToDo() sync* { /* ... */ }
 
    web.HTMLLIElement newLI(String itemText) =>
        (web.document.createElement('li') as web.HTMLLIElement)
@@ -139,7 +139,7 @@ Let's customize the app you just created.
 
    void main() {
      final output = web.document.querySelector('#output');
-     for (final item in thingsTodo()) {
+     for (final item in thingsToDo()) {
        output?.appendChild(newLI(item));
      }
    }


### PR DESCRIPTION
Updated the sample code to align with the current `package:web` API usage.

* Added the `web.` prefix to `querySelector` and `HTMLLIElement` references when using `import 'package:web/web.dart as web;`.
* Replaced deprecated usage of `HTMLLIElement.text` with the recommended alternative supported by the current API `HTMLLIElement.textContent`.

These changes allow the sample code to compile and run correctly when using a namespaced `web` import and remove warnings caused by deprecated API usage.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
