### PR TITLE
Added missing trailing comma to the trailing comma example

### DIFF
--- a/examples/misc/lib/language_tour/built_in_types.dart
+++ b/examples/misc/lib/language_tour/built_in_types.dart
@@ -106,7 +106,7 @@ void miscDeclAnalyzedButNotTested() {
 
   {
     // #docregion trailing-commas
-    var list = ['Car', 'Boat', 'Plane'];
+    var list = ['Car', 'Boat', 'Plane',];
     // #enddocregion trailing-commas
   }
 

--- a/src/content/language/collections.md
+++ b/src/content/language/collections.md
@@ -44,7 +44,7 @@ but it can help prevent copy-paste errors.
 
 <?code-excerpt "misc/lib/language_tour/built_in_types.dart (trailing-commas)"?>
 ```dart
-var list = ['Car', 'Boat', 'Plane'];
+var list = ['Car', 'Boat', 'Plane',];
 ```
 
 Lists use zero-based indexing, where 0 is the index of the first element


### PR DESCRIPTION
The trailing comma example in the [Collections](https://dart.dev/language/collections) language docs did not have a trailing comma. The trailing comma was added.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
