### PR TITLE
docs: mention Dart 3.12 support for private named parameters

### DIFF
--- a/src/data/diagnostics.json
+++ b/src/data/diagnostics.json
@@ -7522,7 +7522,7 @@
   {
     "id": "private_optional_parameter",
     "description": "_Named parameters can't start with an underscore._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the name of a named parameter\nstarts with an underscore.\n\n## Example\n\nThe following code produces this diagnostic because the named parameter\n`_x` starts with an underscore:\n\n```dart\n// @dart=3.11\nclass C {\n  void m({int [!_x!] = 0}) {}\n}\n```\n\n## Common fixes\n\nRename the parameter so that it doesn't start with an underscore:\n\n```dart\nclass C {\n  void m({int x = 0}) {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the name of a named parameter\nstarts with an underscore.\n\nAs of Dart 3.12, private names are allowed for named parameters that are\ninitializing formals or primary constructor parameters. In those cases,\nthis diagnostic isn't reported.\n\n## Example\n\nThe following code produces this diagnostic because the named parameter\n`_x` starts with an underscore:\n\n```dart\n// @dart=3.11\nclass C {\n  void m({int [!_x!] = 0}) {}\n}\n```\n\nPrivate named parameters are allowed when used as initializing formals:\n\n```dart\nclass C {\n  final int _x;\n\n  C({required this._x});\n}\n```\n\n## Common fixes\n\nRename the parameter so that it doesn't start with an underscore:\n\n```dart\nclass C {\n  void m({int x = 0}) {}\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []


### PR DESCRIPTION
Fixes #7337

## Changes

- Added documentation noting that private named parameters are allowed
  starting in Dart 3.12 when used as initializing formals or primary
  constructor parameters.
- Added an example demonstrating a valid private named parameter.
- Clarified when the `private_optional_parameter` diagnostic is not
  reported.