### PR TITLE
Add enums, const, and more sections to primary constructor docs

### DIFF
--- a/examples/language/lib/primary_constructors/enum.dart
+++ b/examples/language/lib/primary_constructors/enum.dart
@@ -1,0 +1,18 @@
+// #docregion enhanced-primary
+enum Vehicle(
+  final int tires,
+  final int passengers,
+  final int carbonPerKilometer,
+) implements Comparable<Vehicle> {
+  car(4, 5, 400),
+  bus(6, 50, 800),
+  bicycle(2, 1, 0);
+
+  int get carbonFootprint => (carbonPerKilometer / passengers).round();
+
+  bool get isTwoWheeled => this == Vehicle.bicycle;
+
+  @override
+  int compareTo(Vehicle other) => carbonFootprint - other.carbonFootprint;
+}
+// #enddocregion enhanced-primary

--- a/examples/language/lib/primary_constructors/point.dart
+++ b/examples/language/lib/primary_constructors/point.dart
@@ -22,4 +22,3 @@ class PointNamed.custom(var int x, var int y);
 // A private named primary constructor.
 class PointPrivate._(var int x, var int y);
 // #enddocregion point-private
-

--- a/examples/language/lib/primary_constructors/point.dart
+++ b/examples/language/lib/primary_constructors/point.dart
@@ -12,3 +12,14 @@ class Point {
 // Using a primary constructor.
 class PointPrimary(var int x, var int y);
 // #enddocregion point-primary
+
+// #docregion point-named
+// A named primary constructor.
+class PointNamed.custom(var int x, var int y);
+// #enddocregion point-named
+
+// #docregion point-private
+// A private named primary constructor.
+class PointPrivate._(var int x, var int y);
+// #enddocregion point-private
+

--- a/examples/language/lib/primary_constructors/point.dart
+++ b/examples/language/lib/primary_constructors/point.dart
@@ -6,6 +6,7 @@ class Point {
 
   Point(this.x, this.y);
 }
+
 // #enddocregion point
 
 // #docregion point-primary

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -62,6 +62,4 @@ enum Color(final String hex) {
   green('#00FF00'),
   blue('#0000FF');
 }
-
 // #enddocregion enums
-

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -6,6 +6,7 @@ class Point(var int x, var int y);
 
 // Doesn't declare a field.
 class User(String name);
+
 // #enddocregion declaring-parameters
 
 // #docregion initializer-scope
@@ -13,6 +14,7 @@ class DeltaPoint(final int x, int delta) {
   // Accesses 'x' and 'delta' parameters directly!
   final int y = x + delta;
 }
+
 // #enddocregion initializer-scope
 
 // #docregion constructor-bodies
@@ -21,6 +23,7 @@ class PointWithBody(var int x, var int y) {
     print('Point initialized at ($x, $y)');
   }
 }
+
 // #enddocregion constructor-bodies
 
 // #docregion private-fields
@@ -28,24 +31,27 @@ class PointWithBody(var int x, var int y) {
 class UserWithPrivateField(String name) {
   final String _name = name; // '_name' is private.
 }
+
 // #enddocregion private-fields
 
 // #docregion empty-bodies
 class EmptyBodyPoint(var int x, var int y);
+
 // #enddocregion empty-bodies
 
 // #docregion scoping-shadowing
 class ScopingDemo(var String x) {
-  // In a field initializer, 'x' refers to the parameter 'x'.
-  late final String captureAtDeclaration = x;
-  late final String captureInInitializer;
+  // In a non-late field initializer, 'x' refers to the parameter 'x'.
+  final String fieldAtDeclaration = x;
+  final String fieldInInitializer;
 
   // In the initializer list, 'x' refers to the parameter 'x'.
-  this : captureInInitializer = x {
+  this : fieldInInitializer = x {
     // Inside the body, 'x' refers to the instance variable!
-    print(x); 
+    print(x);
   }
 }
+
 // #enddocregion scoping-shadowing
 
 // #docregion const-constructor
@@ -54,6 +60,7 @@ class const ConstPoint(final int x, final int y) {
   // A constant primary constructor can have an initializer list, but no body block.
   this : z = x + y;
 }
+
 // #enddocregion const-constructor
 
 // #docregion enums

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -40,15 +40,18 @@ class EmptyBodyPoint(var int x, var int y);
 // #enddocregion empty-bodies
 
 // #docregion scoping-shadowing
-class ScopingDemo(var String x) {
+class ScopingDemo(var String x, String suffix) {
   // In a non-late field initializer, 'x' refers to the parameter 'x'.
   final String fieldAtDeclaration = x;
   final String fieldInInitializer;
 
   // In the initializer list, 'x' refers to the parameter 'x'.
   this : fieldInInitializer = x {
-    // Inside the body, 'x' refers to the instance variable!
-    print(x);
+    // Inside the body, 'x' refers to the induced instance variable,
+    // so assigning to it updates the field.
+    x = x.toUpperCase();
+    // 'suffix' induces no field, so it still refers to the parameter.
+    print('$x$suffix');
   }
 }
 

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -57,7 +57,8 @@ class ScopingDemo(var String x) {
 // #docregion const-constructor
 class const ConstPoint(final int x, final int y) {
   final int z;
-  // A constant primary constructor can have an initializer list, but no body block.
+  // A constant primary constructor can have an initializer list,
+  // but can't have a body block.
   this : z = x + y;
 }
 

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -34,6 +34,28 @@ class UserWithPrivateField(String name) {
 class EmptyBodyPoint(var int x, var int y);
 // #enddocregion empty-bodies
 
+// #docregion scoping-shadowing
+class ScopingDemo(var String x) {
+  // In a field initializer, 'x' refers to the parameter 'x'.
+  late final String captureAtDeclaration = x;
+  late final String captureInInitializer;
+
+  // In the initializer list, 'x' refers to the parameter 'x'.
+  this : captureInInitializer = x {
+    // Inside the body, 'x' refers to the instance variable!
+    print(x); 
+  }
+}
+// #enddocregion scoping-shadowing
+
+// #docregion const-constructor
+class const ConstPoint(final int x, final int y) {
+  final int z;
+  // A constant primary constructor can have an initializer list, but no body block.
+  this : z = x + y;
+}
+// #enddocregion const-constructor
+
 // #docregion enums
 enum Color(final String hex) {
   red('#FF0000'),
@@ -42,3 +64,4 @@ enum Color(final String hex) {
 }
 
 // #enddocregion enums
+

--- a/examples/language/lib/primary_constructors/private_named_parameters.dart
+++ b/examples/language/lib/primary_constructors/private_named_parameters.dart
@@ -5,6 +5,7 @@
 class UserOld({required String name}) {
   String _name = name;
 }
+
 // #enddocregion private-named-old
 
 // #docregion private-named-new

--- a/examples/language/lib/primary_constructors/super_parameters.dart
+++ b/examples/language/lib/primary_constructors/super_parameters.dart
@@ -1,5 +1,24 @@
+abstract class Widget {
+  final Key? key;
+  const Widget({this.key});
+}
+
+abstract class Key {
+  const Key();
+}
+
+abstract class StatelessWidget extends Widget {
+  const StatelessWidget({super.key});
+}
+
 // #docregion super-parameters
 class A(final int a);
 
 class B(super.a) extends A;
 // #enddocregion super-parameters
+
+// #docregion widget-example
+class MyWidget({super.key, required final String title})
+    extends StatelessWidget;
+// #enddocregion widget-example
+

--- a/examples/language/lib/primary_constructors/super_parameters.dart
+++ b/examples/language/lib/primary_constructors/super_parameters.dart
@@ -21,4 +21,3 @@ class B(super.a) extends A;
 class MyWidget({super.key, required final String title})
     extends StatelessWidget;
 // #enddocregion widget-example
-

--- a/examples/language/lib/primary_constructors/super_parameters.dart
+++ b/examples/language/lib/primary_constructors/super_parameters.dart
@@ -1,23 +1,5 @@
-abstract class Widget {
-  final Key? key;
-  const Widget({this.key});
-}
-
-abstract class Key {
-  const Key();
-}
-
-abstract class StatelessWidget extends Widget {
-  const StatelessWidget({super.key});
-}
-
 // #docregion super-parameters
-class A(final int a);
+class Person(final String name, final int age);
 
-class B(super.a) extends A;
+class Employee(super.name, super.age, final String role) extends Person;
 // #enddocregion super-parameters
-
-// #docregion widget-example
-class MyWidget({super.key, required final String title})
-    extends StatelessWidget;
-// #enddocregion widget-example

--- a/examples/misc/lib/language_tour/classes/enum.dart
+++ b/examples/misc/lib/language_tour/classes/enum.dart
@@ -69,3 +69,24 @@ enum Vehicle implements Comparable<Vehicle> {
 }
 
 // #enddocregion enhanced
+
+// #docregion enhanced-primary
+enum VehiclePrimary(
+  final int tires,
+  final int passengers,
+  final int carbonPerKilometer,
+) implements Comparable<VehiclePrimary> {
+  car(4, 5, 400),
+  bus(6, 50, 800),
+  bicycle(2, 1, 0);
+
+  int get carbonFootprint => (carbonPerKilometer / passengers).round();
+
+  bool get isTwoWheeled => this == VehiclePrimary.bicycle;
+
+  @override
+  int compareTo(VehiclePrimary other) =>
+      carbonFootprint - other.carbonFootprint;
+}
+// #enddocregion enhanced-primary
+

--- a/examples/misc/lib/language_tour/classes/enum.dart
+++ b/examples/misc/lib/language_tour/classes/enum.dart
@@ -1,5 +1,6 @@
 // #docregion enum
 enum Color { red, green, blue }
+
 // #enddocregion enum
 
 void main() {
@@ -69,23 +70,3 @@ enum Vehicle implements Comparable<Vehicle> {
 }
 
 // #enddocregion enhanced
-
-// #docregion enhanced-primary
-enum VehiclePrimary(
-  final int tires,
-  final int passengers,
-  final int carbonPerKilometer,
-) implements Comparable<VehiclePrimary> {
-  car(4, 5, 400),
-  bus(6, 50, 800),
-  bicycle(2, 1, 0);
-
-  int get carbonFootprint => (carbonPerKilometer / passengers).round();
-
-  bool get isTwoWheeled => this == VehiclePrimary.bicycle;
-
-  @override
-  int compareTo(VehiclePrimary other) =>
-      carbonFootprint - other.carbonFootprint;
-}
-// #enddocregion enhanced-primary

--- a/examples/misc/lib/language_tour/classes/enum.dart
+++ b/examples/misc/lib/language_tour/classes/enum.dart
@@ -89,4 +89,3 @@ enum VehiclePrimary(
       carbonFootprint - other.carbonFootprint;
 }
 // #enddocregion enhanced-primary
-

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -43,6 +43,10 @@ to help prevent copy-paste errors.
 
 ## Declaring enhanced enums
 
+:::version-note
+Enhanced enums require a [language version][] of at least 2.17.
+:::
+
 Dart also allows enum declarations to declare classes
 with fields, methods, and const constructors
 which are limited to a fixed number of known constant instances.
@@ -97,8 +101,30 @@ enum Vehicle implements Comparable<Vehicle> {
 }
 ```
 
-:::version-note
-Enhanced enums require a [language version][] of at least 2.17.
+:::tip
+In Dart 3.13 and later, you can declare enhanced enums even more concisely
+using [primary constructors](/language/primary-constructors):
+
+<?code-excerpt "misc/lib/language_tour/classes/enum.dart (enhanced-primary)" replace="/VehiclePrimary/Vehicle/g"?>
+```dart
+enum Vehicle(
+  final int tires,
+  final int passengers,
+  final int carbonPerKilometer,
+) implements Comparable<Vehicle> {
+  car(4, 5, 400),
+  bus(6, 50, 800),
+  bicycle(2, 1, 0);
+
+  int get carbonFootprint => (carbonPerKilometer / passengers).round();
+
+  bool get isTwoWheeled => this == Vehicle.bicycle;
+
+  @override
+  int compareTo(Vehicle other) =>
+      carbonFootprint - other.carbonFootprint;
+}
+```
 :::
 
 ## Using enums

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -102,8 +102,9 @@ enum Vehicle implements Comparable<Vehicle> {
 ```
 
 :::tip
-In Dart 3.13 and later, you can declare enhanced enums even more concisely
-using [primary constructors](/language/primary-constructors):
+In Dart 3.13 and later,
+you can declare enhanced enums even more concisely
+using [primary constructors][]:
 
 <?code-excerpt "language/lib/primary_constructors/enum.dart (enhanced-primary)"?>
 ```dart
@@ -125,6 +126,9 @@ enum Vehicle(
 }
 ```
 :::
+
+[language version]: /language/versioning
+[primary constructors]: /language/primary-constructors
 
 ## Using enums
 
@@ -200,6 +204,5 @@ print(Vehicle.car.carbonFootprint);
 [mixins]: /language/mixins
 [generative constructors]: /language/constructors#constant-constructors
 [Factory constructors]: /language/constructors#factory-constructors
-[language version]: /language/versioning
 [static variable]: /language/classes#class-variables-and-methods
 [switch statements]: /language/branches#switch

--- a/src/content/language/enums.md
+++ b/src/content/language/enums.md
@@ -105,7 +105,7 @@ enum Vehicle implements Comparable<Vehicle> {
 In Dart 3.13 and later, you can declare enhanced enums even more concisely
 using [primary constructors](/language/primary-constructors):
 
-<?code-excerpt "misc/lib/language_tour/classes/enum.dart (enhanced-primary)" replace="/VehiclePrimary/Vehicle/g"?>
+<?code-excerpt "language/lib/primary_constructors/enum.dart (enhanced-primary)"?>
 ```dart
 enum Vehicle(
   final int tires,
@@ -121,8 +121,7 @@ enum Vehicle(
   bool get isTwoWheeled => this == Vehicle.bicycle;
 
   @override
-  int compareTo(Vehicle other) =>
-      carbonFootprint - other.carbonFootprint;
+  int compareTo(Vehicle other) => carbonFootprint - other.carbonFootprint;
 }
 ```
 :::

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -240,15 +240,18 @@ class const ConstPoint(final int x, final int y) {
 
 Constant primary constructors have these important constraints:
 
-*   They **can't have a body block**.
-    That is, `{ ... }` is a compile-time error, even if it is empty.
-    They can only use an initializer list followed by a semicolon.
-*   Like any class with a generative const constructor,
+*   **No body block**:
+    Having a `{ ... }` body is a compile-time error, even if it is empty.
+    A constant primary constructor can only use
+    an initializer list followed by a semicolon.
+*   **Definitely initialized final fields**:
+    Like any class with a generative const constructor,
     every instance variable must be `final`, can't be `late`,
     and must be definitely initialized by a declaring parameter,
     field initializer, or the primary constructor's initializer list.
-*   The initializer expressions for each
-    instance variable must be **potentially constant**.
+*   **Potentially constant initializers**:
+    The initializing expressions for each instance variable
+    must be able to be evaluated at compile time.
     This includes field initializers and
     expressions in the primary constructor's initializer list.
 
@@ -264,10 +267,10 @@ a name after the class name in the class header:
 class Point.custom(var int x, var int y);
 ```
 
-This is particularly useful when you want to
-define a private primary constructor (such as `Point._`) to
-restrict direct instantiation and force callers to
-use factory methods or other constructors:
+A common pattern is to
+define a private primary constructor (such as `Point._`) that
+restricts direct instantiation and
+forces callers to use factory methods or other constructors:
 
 <?code-excerpt "language/lib/primary_constructors/point.dart (point-private)" replace="/PointPrivate/Point/g"?>
 ```dart
@@ -287,12 +290,11 @@ class Person(final String name, final int age);
 class Employee(super.name, super.age, final String role) extends Person;
 ```
 
-This is particularly useful for reducing boilerplate
-in hierarchical class structures,
-as it eliminates the need to manually write initializer lists
+This reduces boilerplate in hierarchical class structures,
+eliminating the need to manually write initializer lists
 or duplicate parameter declarations.
 
-## Enums
+## Enum primary constructors
 
 You can use primary constructors to declare
 [enhanced enums][] much more concisely.
@@ -333,7 +335,7 @@ when using primary constructors:
 *   **No assignments to primary constructor parameters**:
     Primary constructor parameters are read-only
     within the primary initializer scope.
-    Assigning to them (for example, `x = 5` or `x++`) in a field initializer or
+    Assigning to them (such as with `x = 5` or `x++`) in a field initializer or
     the primary constructor's initializer list is a compile-time error.
 *   **Double initialization**:
     You can't initialize an instance variable both in

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -138,12 +138,12 @@ to the original parameters.
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (scoping-shadowing)"?>
 ```dart
 class ScopingDemo(var String x) {
-  // In a field initializer, 'x' refers to the parameter 'x'.
-  late final String captureAtDeclaration = x;
-  late final String captureInInitializer;
+  // In a non-late field initializer, 'x' refers to the parameter 'x'.
+  final String fieldAtDeclaration = x;
+  final String fieldInInitializer;
 
   // In the initializer list, 'x' refers to the parameter 'x'.
-  this : captureInInitializer = x {
+  this : fieldInInitializer = x {
     // Inside the body, 'x' refers to the instance variable!
     print(x);
   }
@@ -258,23 +258,20 @@ class Point._(var int x, var int y);
 
 ## Super parameters
 
-Super parameters work just like they do in traditional constructors:
+Super parameters work just like they do in traditional constructors,
+allowing you to forward parameters to the superclass constructor:
 
 <?code-excerpt "language/lib/primary_constructors/super_parameters.dart (super-parameters)"?>
 ```dart
-class A(final int a);
+class Person(final String name, final int age);
 
-class B(super.a) extends A;
+class Employee(super.name, super.age, final String role) extends Person;
 ```
 
-This is particularly useful for reducing boilerplate in Flutter widgets
-and other hierarchical class structures:
-
-<?code-excerpt "language/lib/primary_constructors/super_parameters.dart (widget-example)"?>
-```dart
-class MyWidget({super.key, required final String title})
-    extends StatelessWidget;
-```
+This is particularly useful for reducing boilerplate
+in hierarchical class structures,
+as it eliminates the need to manually write initializer lists
+or duplicate parameter declarations.
 
 ## Enums
 
@@ -310,7 +307,7 @@ when using primary constructors:
 *   **Name collisions**: Declaring a parameter in the primary constructor
     with the same name as a method or another field in the class body
     results in a compile-time error.
-*   **No assignments to primary parameters**:
+*   **No assignments to primary constructor parameters**:
     Primary constructor parameters are read-only within the primary initializer
     scope. Assigning to them (for example, `x = 5` or `x++`) in a field
     initializer or the primary constructor's initializer list is a

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -50,9 +50,18 @@ class Point(var int x, var int y);
 Declaring a parameter in the primary constructor with `var` or `final`
 implicitly induces an instance variable for that parameter.
 
-To ensure this constructor executes on every new instance,
+Any other constructors declared inside the class body are referred to as
+**in-body constructors**.
+
+To ensure the primary constructor executes on every new instance,
 a class, mixin class, or enum with a primary constructor
-cannot have any other non-redirecting generative constructors.
+cannot have any other non-redirecting generative in-body constructors.
+
+:::note
+If you want to declare traditional constructors in the class body more concisely
+without repeating the class name, see
+[Concise constructor syntax](/language/constructors#concise-constructor-syntax).
+:::
 
 ## Field declarations in parameters
 
@@ -104,6 +113,40 @@ class DeltaPoint(final int x, int delta) {
 
 This makes refactoring between traditional and primary constructors
 simpler and safer.
+
+### Primary constructor scopes
+
+Because primary constructor parameters are available in different parts
+of the class declaration, Dart manages their visibility using two distinct
+scopes:
+
+*   **Primary initializer scope**: Applies to non-late field initializers
+    in the class body and the primary constructor's initializer list (after
+    `this :`). In this scope, referencing a parameter name (like `x`) refers
+    directly to the constructor parameter.
+*   **Primary parameter scope**: Applies to the body block of the primary
+    constructor (inside `{ ... }`). In this scope, referencing a parameter
+    name refers to the *induced instance variable* (field) rather than the
+    parameter itself.
+
+This distinction ensures that any updates to instance variables are correctly
+reflected in the constructor body, while initializers still have access
+to the original parameters.
+
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (scoping-shadowing)"?>
+```dart
+class ScopingDemo(var String x) {
+  // In a field initializer, 'x' refers to the parameter 'x'.
+  late final String captureAtDeclaration = x;
+  late final String captureInInitializer;
+
+  // In the initializer list, 'x' refers to the parameter 'x'.
+  this : captureInInitializer = x {
+    // Inside the body, 'x' refers to the instance variable!
+    print(x);
+  }
+}
+```
 
 ## Add constructor bodies
 
@@ -159,23 +202,99 @@ at the call site: `User(name: 'John Doe')`.
 An empty body of a class, mixin class, extension, or extension type (`{}`)
 can be replaced by a semicolon (`;`).
 While this is true in general for these declarations, it is particularly
-useful when using a primary constructor to keep the entire declaration on a single line.
+useful when using a primary constructor to keep the entire declaration
+on a single line.
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (empty-bodies)" replace="/EmptyBodyPoint/Point/g"?>
 ```dart
 class Point(var int x, var int y);
 ```
 
+## Constant primary constructors
+
+Just like traditional constructors, a primary constructor can be constant
+if the class and its fields allow it. To declare a constant primary constructor,
+place the `const` modifier before the class name in the class header:
+
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (const-constructor)"?>
+```dart
+class const ConstPoint(final int x, final int y) {
+  final int z;
+  // A constant primary constructor can have an initializer list, but no body block.
+  this : z = x + y;
+}
+```
+
+Constant primary constructors have two important constraints:
+
+*   They **cannot have a body block** (that is, `{ ... }` is a compile-time
+    error, even if it is empty). They can only use an initializer list
+    followed by a semicolon.
+*   Any non-late instance variables in the class body must have initializing
+    expressions that are **potentially constant**.
+
+## Named primary constructors
+
+You can also declare a primary constructor as a **named constructor** by
+appending a dot (`.`) and a name after the class name in the class header:
+
+<?code-excerpt "language/lib/primary_constructors/point.dart (point-named)" replace="/PointNamed/Point/g"?>
+```dart
+// A named primary constructor.
+class Point.custom(var int x, var int y);
+```
+
+This is particularly useful when you want to define a private primary
+constructor (such as `Point._`) to restrict direct instantiation and force
+callers to use factory methods or other constructors:
+
+<?code-excerpt "language/lib/primary_constructors/point.dart (point-private)" replace="/PointPrivate/Point/g"?>
+```dart
+// A private named primary constructor.
+class Point._(var int x, var int y);
+```
+
 ## Super parameters
 
 Super parameters work just like they do in traditional constructors:
 
-<?code-excerpt "language/lib/primary_constructors/super_parameters.dart"?>
+<?code-excerpt "language/lib/primary_constructors/super_parameters.dart (super-parameters)"?>
 ```dart
 class A(final int a);
 
 class B(super.a) extends A;
 ```
+
+This is particularly useful for reducing boilerplate in Flutter widgets
+and other hierarchical class structures:
+
+<?code-excerpt "language/lib/primary_constructors/super_parameters.dart (widget-example)"?>
+```dart
+class MyWidget({super.key, required final String title})
+    extends StatelessWidget;
+```
+
+## Enums
+
+You can use primary constructors to declare
+[enhanced enums](/language/enums#declaring-enhanced-enums) much more concisely.
+
+By using a primary constructor, you can define the enum's fields and its
+constructor in a single line, eliminating the usual boilerplate of declaring
+fields, parameters, and initializing them:
+
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (enums)"?>
+```dart
+enum Color(final String hex) {
+  red('#FF0000'),
+  green('#00FF00'),
+  blue('#0000FF');
+}
+```
+
+Primary constructors in enums are **implicitly constant**. While you can
+optionally write the `const` modifier before the enum name or the primary
+constructor name, it is redundant and can be omitted.
 
 ## Constraints and breaking changes
 
@@ -189,6 +308,31 @@ when using primary constructors:
 *   **Name collisions**: Declaring a parameter in the primary constructor
     with the same name as a method or another field in the class body
     results in a compile-time error.
+*   **No assignments to primary parameters**:
+    Primary constructor parameters are read-only within the primary initializer
+    scope. Assigning to them (for example, `x = 5` or `x++`) in a field
+    initializer or the primary constructor's initializer list is a
+    compile-time error.
+*   **Double initialization**:
+    You cannot initialize an instance variable both in its declaration
+    and in the primary constructor's initializer list (or as an initializing
+    formal parameter), even if the field is mutable. Doing so results
+    in a compile-time error.
+*   **Body part constraints**:
+    *   A primary constructor body part (the `this` block) cannot use the
+        `async`, `async*`, or `sync*` modifiers, and it cannot use the
+        expression body arrow (`=>`) syntax.
+    *   You cannot write a `this` block if the class header does not declare
+        a primary constructor.
+    *   A class can have at most one primary constructor body part.
+*   **Mixin class primary constructors must be trivial**:
+    A mixin class can only declare a primary constructor if it has
+    no parameters, no initializer list, and no body.
+*   **Covariant parameters**:
+    You can only use the `covariant` modifier on a primary constructor
+    parameter if it is a declaring parameter (uses the `var` modifier).
+    Using `covariant` on `final` or non-declaring parameters is a
+    compile-time error because they do not induce a setter.
 
 :::warning
 **Important breaking changes and edge cases:**
@@ -199,8 +343,8 @@ when using primary constructors:
     becomes a compile-time error.
     They are reserved exclusively for declaring parameters
     in primary constructors.
-    Note that the lints `avoid_final_parameters` and `var_with_no_type_annotation`
-    only work in Dart 3.12 and below.
+    Note that the lints `avoid_final_parameters` and
+    `var_with_no_type_annotation` only work in Dart 3.12 and below.
     To enforce immutable parameters as a style choice in Dart 3.13 and later,
     use the
     [parameter_assignments](https://dart.dev/tools/linter-rules/parameter_assignments)
@@ -213,4 +357,5 @@ when using primary constructors:
     Make sure such methods have explicit return types
     to avoid this conflict.
 :::
+
 

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -369,7 +369,8 @@ when using primary constructors:
     They are reserved exclusively for
     declaring parameters in primary constructors.
     Note that the lints `avoid_final_parameters` and
-    `var_with_no_type_annotation` only work in Dart 3.12 and below.
+    `var_with_no_type_annotation` only work with
+    a [language version][] of 3.12 or lower.
     To enforce immutable parameters as a style choice in Dart 3.13 and later,
     use the [`parameter_assignments`][] linter rule.
 *   **The `factory` method edge case**:
@@ -382,3 +383,4 @@ when using primary constructors:
 :::
 
 [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
+[language version]: /language/versioning

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -72,7 +72,7 @@ check out [Concise constructor syntax][].
 Parameters in primary constructors with the `var` or `final` modifier,
 called **declaring parameters**, implicitly induce a field.
 
-If you omit the modifier, the parameter does not create a field.
+If you omit the modifier, the parameter doesn't create a field.
 It behaves just like a parameter in a traditional constructor.
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters)"?>
@@ -86,7 +86,7 @@ class User(String name);
 
 Because `final` and `var` modifiers on parameters are reserved exclusively
 for declaring parameters in primary constructors,
-you cannot use them on parameters in other kinds of functions.
+you can't use them on parameters in other kinds of functions.
 
 For extension types, the primary constructor must have exactly one parameter.
 This parameter is always a declaring parameter, even if you omit the modifier.
@@ -322,8 +322,8 @@ While you can optionally write the `const` modifier before the enum name
 Keep these constraints and potential errors in mind
 when using primary constructors:
 
-*   **Declaring parameters cannot be `late` or `external`**:
-    The `late` and `external` modifiers are not allowed
+*   **Declaring parameters can't be `late` or `external`**:
+    The `late` and `external` modifiers aren't allowed
     on parameters in the primary constructor header.
     To use these modifiers, declare the fields in the class body as usual.
 *   **Name collisions**:
@@ -336,16 +336,16 @@ when using primary constructors:
     Assigning to them (for example, `x = 5` or `x++`) in a field initializer or
     the primary constructor's initializer list is a compile-time error.
 *   **Double initialization**:
-    You cannot initialize an instance variable both in
+    You can't initialize an instance variable both in
     its declaration and in the primary constructor's initializer list
     (or as an initializing formal parameter), even if the field is mutable.
     Doing so results in a compile-time error.
 *   **Body part constraints**:
-    *   A primary constructor body part (the `this` block) cannot
+    *   A primary constructor body part (the `this` block) can't
         use the `async`, `async*`, or `sync*` modifiers, and it
-        cannot use the expression body arrow (`=>`) syntax.
-    *   You cannot write a `this` block if the class header
-        does not declare a primary constructor.
+        can't use the expression body arrow (`=>`) syntax.
+    *   You can't write a `this` block if the class header
+        doesn't declare a primary constructor.
     *   A class can have at most one primary constructor body part.
 *   **Mixin class primary constructors must be trivial**:
     A mixin class can only declare a primary constructor if it has
@@ -354,7 +354,7 @@ when using primary constructors:
     You can only use the `covariant` modifier on a primary constructor
     parameter if it is a mutable declaring parameter (uses the `var` modifier).
     Using `covariant` on `final` or non-declaring parameters is a
-    compile-time error because they do not induce a setter.
+    compile-time error because they don't induce a setter.
 
 :::warning
 **Important breaking changes and edge cases:**

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -90,7 +90,7 @@ you can't use them on parameters in other kinds of functions.
 
 For extension types, the primary constructor must have exactly one parameter.
 This parameter is always a declaring parameter, even if you omit the modifier.
-You can use the `final` modifier, but it is an error to use `var`.
+You can use the `final` modifier, but it's an error to use `var`.
 
 Mixin classes can only have a primary constructor
 with no parameters, body, or initializer list.
@@ -212,7 +212,7 @@ at the call site: `User(name: 'John Doe')`.
 An empty body of a class, mixin class, extension, or extension type (`{}`)
 can be replaced by a semicolon (`;`).
 While this is true in general for these declarations,
-it is particularly useful when using a primary constructor to
+it's particularly useful when using a primary constructor to
 keep the entire declaration on a single line.
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (empty-bodies)" replace="/EmptyBodyPoint/Point/g"?>
@@ -241,7 +241,7 @@ class const ConstPoint(final int x, final int y) {
 Constant primary constructors have these important constraints:
 
 *   **No body block**:
-    Having a `{ ... }` body is a compile-time error, even if it is empty.
+    Having a `{ ... }` body is a compile-time error, even if it's empty.
     A constant primary constructor can only use
     an initializer list followed by a semicolon.
 *   **Definitely initialized final fields**:
@@ -267,8 +267,8 @@ a name after the class name in the class header:
 class Point.custom(var int x, var int y);
 ```
 
-A common pattern is to
-define a private primary constructor (such as `Point._`) that
+A common pattern is to define a
+private primary constructor (such as `Point._`) that
 restricts direct instantiation and
 forces callers to use factory methods or other constructors:
 
@@ -315,7 +315,7 @@ enum Color(final String hex) {
 
 Primary constructors in enums are **implicitly constant**.
 While you can optionally write the `const` modifier before the enum name
-(such as in `enum const Color`), it is redundant and can be omitted.
+(such as in `enum const Color`), it's redundant and can be omitted.
 
 [enhanced enums]: /language/enums#declaring-enhanced-enums
 
@@ -353,8 +353,9 @@ when using primary constructors:
     A mixin class can only declare a primary constructor if it has
     no parameters, no initializer list, and no body.
 *   **Covariant parameters**:
-    You can only use the `covariant` modifier on a primary constructor
-    parameter if it is a mutable declaring parameter (uses the `var` modifier).
+    You can only use the `covariant` modifier on a
+    primary constructor parameter if it's a
+    mutable declaring parameter (uses the `var` modifier).
     Using `covariant` on `final` or non-declaring parameters is a
     compile-time error because they don't induce a setter.
 

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -222,18 +222,25 @@ place the `const` modifier before the class name in the class header:
 ```dart
 class const ConstPoint(final int x, final int y) {
   final int z;
-  // A constant primary constructor can have an initializer list, but no body block.
+  // A constant primary constructor can have an initializer list,
+  // but can't have a body block.
   this : z = x + y;
 }
 ```
 
-Constant primary constructors have two important constraints:
+Constant primary constructors have these important constraints:
 
-*   They **cannot have a body block** (that is, `{ ... }` is a compile-time
-    error, even if it is empty). They can only use an initializer list
-    followed by a semicolon.
-*   Any non-late instance variables in the class body must have initializing
-    expressions that are **potentially constant**.
+*   They **can't have a body block**.
+    That is, `{ ... }` is a compile-time error, even if it is empty.
+    They can only use an initializer list followed by a semicolon.
+*   Like any class with a generative const constructor,
+    every instance variable must be `final`, can't be `late`,
+    and must be definitely initialized by a declaring parameter,
+    field initializer, or the primary constructor's initializer list.
+*   The initializer expressions for each
+    instance variable must be **potentially constant**.
+    This includes field initializers and
+    expressions in the primary constructor's initializer list.
 
 ## Named primary constructors
 

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -52,18 +52,20 @@ class Point(var int x, var int y);
 Declaring a parameter in the primary constructor with `var` or `final`
 implicitly induces an instance variable for that parameter.
 
-Any other constructors declared inside the class body are referred to as
-**in-body constructors**.
+Any other constructors declared inside the class body are
+referred to as **in-body constructors**.
 
 To ensure the primary constructor executes on every new instance,
 a class, mixin class, or enum with a primary constructor
-cannot have any other non-redirecting generative in-body constructors.
+can't have any other non-redirecting generative in-body constructors.
 
 :::note
-If you want to declare traditional constructors in the class body more concisely
-without repeating the class name, see
-[Concise constructor syntax](/language/constructors#concise-constructor-syntax).
+If you want to declare traditional constructors in
+the class body more concisely without repeating the class name,
+check out [Concise constructor syntax][].
 :::
+
+[Concise constructor syntax]: /language/constructors#concise-constructor-syntax
 
 ## Field declarations in parameters
 
@@ -220,8 +222,10 @@ class Point(var int x, var int y);
 
 ## Constant primary constructors
 
-Just like traditional constructors, a primary constructor can be constant
-if the class and its fields allow it. To declare a constant primary constructor,
+Just like traditional constructors,
+a primary constructor can be constant
+if the class and its fields allow it.
+To declare a constant primary constructor,
 place the `const` modifier before the class name in the class header:
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (const-constructor)"?>
@@ -250,8 +254,9 @@ Constant primary constructors have these important constraints:
 
 ## Named primary constructors
 
-You can also declare a primary constructor as a **named constructor** by
-appending a dot (`.`) and a name after the class name in the class header:
+You can also declare a primary constructor as
+a **named constructor** by appending a dot (`.`) and
+a name after the class name in the class header:
 
 <?code-excerpt "language/lib/primary_constructors/point.dart (point-named)" replace="/PointNamed/Point/g"?>
 ```dart
@@ -259,9 +264,10 @@ appending a dot (`.`) and a name after the class name in the class header:
 class Point.custom(var int x, var int y);
 ```
 
-This is particularly useful when you want to define a private primary
-constructor (such as `Point._`) to restrict direct instantiation and force
-callers to use factory methods or other constructors:
+This is particularly useful when you want to
+define a private primary constructor (such as `Point._`) to
+restrict direct instantiation and force callers to
+use factory methods or other constructors:
 
 <?code-excerpt "language/lib/primary_constructors/point.dart (point-private)" replace="/PointPrivate/Point/g"?>
 ```dart
@@ -289,11 +295,12 @@ or duplicate parameter declarations.
 ## Enums
 
 You can use primary constructors to declare
-[enhanced enums](/language/enums#declaring-enhanced-enums) much more concisely.
+[enhanced enums][] much more concisely.
 
-By using a primary constructor, you can define the enum's fields and its
-constructor in a single line, eliminating the usual boilerplate of declaring
-fields, parameters, and initializing them:
+By using a primary constructor,
+you can define the enum's fields and its constructor in a single line,
+eliminating the usual boilerplate of
+declaring fields, parameters, and initializing them:
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (enums)"?>
 ```dart
@@ -308,6 +315,8 @@ Primary constructors in enums are **implicitly constant**.
 While you can optionally write the `const` modifier before the enum name
 (such as in `enum const Color`), it is redundant and can be omitted.
 
+[enhanced enums]: /language/enums#declaring-enhanced-enums
+
 ## Constraints and breaking changes
 
 Keep these constraints and potential errors in mind
@@ -317,25 +326,26 @@ when using primary constructors:
     The `late` and `external` modifiers are not allowed
     on parameters in the primary constructor header.
     To use these modifiers, declare the fields in the class body as usual.
-*   **Name collisions**: Declaring a parameter in the primary constructor
+*   **Name collisions**:
+    Declaring a parameter in the primary constructor
     with the same name as a method or another field in the class body
     results in a compile-time error.
 *   **No assignments to primary constructor parameters**:
-    Primary constructor parameters are read-only within the primary initializer
-    scope. Assigning to them (for example, `x = 5` or `x++`) in a field
-    initializer or the primary constructor's initializer list is a
-    compile-time error.
+    Primary constructor parameters are read-only
+    within the primary initializer scope.
+    Assigning to them (for example, `x = 5` or `x++`) in a field initializer or
+    the primary constructor's initializer list is a compile-time error.
 *   **Double initialization**:
-    You cannot initialize an instance variable both in its declaration
-    and in the primary constructor's initializer list (or as an initializing
-    formal parameter), even if the field is mutable. Doing so results
-    in a compile-time error.
+    You cannot initialize an instance variable both in
+    its declaration and in the primary constructor's initializer list
+    (or as an initializing formal parameter), even if the field is mutable.
+    Doing so results in a compile-time error.
 *   **Body part constraints**:
-    *   A primary constructor body part (the `this` block) cannot use the
-        `async`, `async*`, or `sync*` modifiers, and it cannot use the
-        expression body arrow (`=>`) syntax.
-    *   You cannot write a `this` block if the class header does not declare
-        a primary constructor.
+    *   A primary constructor body part (the `this` block) cannot
+        use the `async`, `async*`, or `sync*` modifiers, and it
+        cannot use the expression body arrow (`=>`) syntax.
+    *   You cannot write a `this` block if the class header
+        does not declare a primary constructor.
     *   A class can have at most one primary constructor body part.
 *   **Mixin class primary constructors must be trivial**:
     A mixin class can only declare a primary constructor if it has
@@ -353,8 +363,8 @@ when using primary constructors:
     With primary constructors,
     using `final` or `var` on formal parameters in normal functions
     becomes a compile-time error.
-    They are reserved exclusively for declaring parameters
-    in primary constructors.
+    They are reserved exclusively for
+    declaring parameters in primary constructors.
     Note that the lints `avoid_final_parameters` and
     `var_with_no_type_annotation` only work in Dart 3.12 and below.
     To enforce immutable parameters as a style choice in Dart 3.13 and later,

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -15,8 +15,6 @@ nextpage:
 Primary constructors require a [language version][] of at least 3.13.
 :::
 
-[language version]: /language/versioning
-
 ## Overview
 
 Primary constructors provide a concise way to declare a class's fields
@@ -382,5 +380,5 @@ when using primary constructors:
     to avoid this conflict.
 :::
 
-[`parameter_assignments`]: /tools/linter-rules/parameter_assignments
 [language version]: /language/versioning
+[`parameter_assignments`]: /tools/linter-rules/parameter_assignments

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -93,17 +93,32 @@ You can use the `final` modifier, but it is an error to use `var`.
 Mixin classes can only have a primary constructor
 with no parameters, body, or initializer list.
 
+<a id="primary-initializer-scope" aria-hidden="true"></a>
 
-## Primary initializer scope
+## Primary constructor scopes
 
-When you use a primary constructor, the parameters you declare
-in the class header become directly available
-for initializing non-late fields in the class body.
+When you use a primary constructor,
+the parameters you declare in the class header are
+available in different parts of the class declaration.
+Dart manages their visibility using two distinct scopes:
 
-This eliminates the need for a separate initializer list
-when calculating values for other fields.
-It works just as if you were initializing variables
-in a traditional constructor's initializer list.
+*   **Primary initializer scope**:
+    Applies to non-late field initializers in the class body and
+    to the primary constructor's initializer list (after `this :`).
+    In this scope, a parameter name like `x` refers
+    directly to the constructor parameter.
+*   **Primary parameter scope**:
+    Applies to the body block of the primary constructor (inside `{ ... }`).
+    In this scope, a declaring parameter's name
+    refers to the _induced instance variable_ (field),
+    while a non-declaring parameter's name still
+    refers to the constructor parameter.
+
+The primary initializer scope makes the header parameters directly
+available for initializing non-late fields,
+which removes the need for a separate initializer list.
+It works just as if you were initializing
+variables in a traditional constructor's initializer list:
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (initializer-scope)"?>
 ```dart
@@ -113,42 +128,33 @@ class DeltaPoint(final int x, int delta) {
 }
 ```
 
-This makes refactoring between traditional and primary constructors
-simpler and safer.
-
-### Primary constructor scopes
-
-Because primary constructor parameters are available in different parts
-of the class declaration, Dart manages their visibility using two distinct
-scopes:
-
-*   **Primary initializer scope**: Applies to non-late field initializers
-    in the class body and the primary constructor's initializer list (after
-    `this :`). In this scope, referencing a parameter name (like `x`) refers
-    directly to the constructor parameter.
-*   **Primary parameter scope**: Applies to the body block of the primary
-    constructor (inside `{ ... }`). In this scope, referencing a parameter
-    name refers to the *induced instance variable* (field) rather than the
-    parameter itself.
-
-This distinction ensures that any updates to instance variables are correctly
-reflected in the constructor body, while initializers still have access
-to the original parameters.
+The primary parameter scope ensures that
+any updates to instance variables are
+correctly reflected in the constructor body,
+while initializers still have access to the original parameters.
+The following example shows how the
+same name `x` resolves differently in each scope:
 
 <?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (scoping-shadowing)"?>
 ```dart
-class ScopingDemo(var String x) {
+class ScopingDemo(var String x, String suffix) {
   // In a non-late field initializer, 'x' refers to the parameter 'x'.
   final String fieldAtDeclaration = x;
   final String fieldInInitializer;
 
   // In the initializer list, 'x' refers to the parameter 'x'.
   this : fieldInInitializer = x {
-    // Inside the body, 'x' refers to the instance variable!
-    print(x);
+    // Inside the body, 'x' refers to the induced instance variable,
+    // so assigning to it updates the field.
+    x = x.toUpperCase();
+    // 'suffix' induces no field, so it still refers to the parameter.
+    print('$x$suffix');
   }
 }
 ```
+
+This consistent behavior makes refactoring between
+traditional and primary constructors simpler and safer.
 
 ## Add constructor bodies
 

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -298,9 +298,9 @@ enum Color(final String hex) {
 }
 ```
 
-Primary constructors in enums are **implicitly constant**. While you can
-optionally write the `const` modifier before the enum name or the primary
-constructor name, it is redundant and can be omitted.
+Primary constructors in enums are **implicitly constant**.
+While you can optionally write the `const` modifier before the enum name
+(such as in `enum const Color`), it is redundant and can be omitted.
 
 ## Constraints and breaking changes
 
@@ -336,7 +336,7 @@ when using primary constructors:
     no parameters, no initializer list, and no body.
 *   **Covariant parameters**:
     You can only use the `covariant` modifier on a primary constructor
-    parameter if it is a declaring parameter (uses the `var` modifier).
+    parameter if it is a mutable declaring parameter (uses the `var` modifier).
     Using `covariant` on `final` or non-declaring parameters is a
     compile-time error because they do not induce a setter.
 


### PR DESCRIPTION
Added deep-dive sections and compiling code examples for constructor scopes, constant/named constructors, enhanced enums, and super parameters. Also documented all spec-defined compile-time constraints and established the correct ["in-body constructor" terminology](https://github.com/dart-lang/sdk/issues/63564#issuecomment-4664006209).

Fixes https://github.com/dart-lang/site-www/issues/7331
