### PR TITLE
Standardize and consolidate font setup

### DIFF
--- a/site/lib/_sass/base/_base.scss
+++ b/site/lib/_sass/base/_base.scss
@@ -3,8 +3,9 @@
 body {
   font-family: var(--site-body-fontFamily);
   font-size: 1rem;
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
   line-height: 1.5;
+  font-optical-sizing: auto;
   background-color: var(--site-base-bgColor);
   color: var(--site-base-fgColor);
 
@@ -23,7 +24,7 @@ section {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--site-ui-fontFamily);
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
   line-height: 1.2;
   color: var(--site-base-fgColor);
 }

--- a/site/lib/_sass/base/_root.scss
+++ b/site/lib/_sass/base/_root.scss
@@ -5,11 +5,14 @@ $base_primary_color: #1967d2;
 // Root variables shared by both light and dark mode.
 body {
   // Site typography.
-  --site-ui-fontFamily: 'Google Sans', 'Roboto', ui-sans, sans-serif;
-  --site-body-fontFamily: 'Google Sans Text', 'Roboto', ui-sans, sans-serif;
-  --site-code-fontFamily: 'Google Sans Mono', 'Roboto Mono', ui-monospace, monospace;
+  --site-ui-fontFamily: 'Google Sans Flex', 'Roboto', ui-sans, sans-serif;
+  --site-body-fontFamily: 'Google Sans Flex', 'Roboto', ui-sans, sans-serif;
+  --site-code-fontFamily: 'Google Sans Code', 'Roboto Mono', ui-monospace, monospace;
+  --site-blog-fontFamily: 'Roboto Serif', 'Noto Serif', var(--site-body-fontFamily);
   --site-icon-fontFamily: 'Material Symbols Outlined', 'Material Symbols', 'Material Icons';
-  --site-blog-fontFamily: 'Noto Serif', serif;
+  --site-fontWeight-normal: 400;
+  --site-fontWeight-bold: 600;
+  --site-fontWeight-bolder: 700;
 
   // Site layout sizes.
   --site-header-height: 3.25rem;

--- a/site/lib/_sass/components/_banner.scss
+++ b/site/lib/_sass/components/_banner.scss
@@ -24,7 +24,7 @@
   }
 
   a, button {
-    font-weight: 700;
+    font-weight: var(--site-fontWeight-bold);
     white-space: nowrap;
     color: var(--site-onPrimary-color);
     font-family: var(--site-ui-fontFamily);

--- a/site/lib/_sass/components/_blog.scss
+++ b/site/lib/_sass/components/_blog.scss
@@ -313,7 +313,7 @@
 
   .author,
   .author-link {
-    font-weight: 600;
+    font-weight: var(--site-fontWeight-bold);
     color: var(--site-base-fgColor);
     text-decoration: none;
   }
@@ -371,14 +371,14 @@
   .post-info-name {
     margin: 0;
     font-size: 1rem;
-    font-weight: 700;
+    font-weight: var(--site-fontWeight-bold);
     line-height: 1.2;
   }
 
   .post-info-meta {
     font-size: 0.95rem;
     color: var(--site-base-fgColor-alt);
-    font-weight: 400;
+    font-weight: var(--site-fontWeight-normal);
     white-space: nowrap;
 
     &::before {
@@ -451,7 +451,7 @@
   color: var(--site-base-fgColor-alt);
   margin-top: 0;
   margin-bottom: 2rem;
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
 }
 
 .post-content {
@@ -466,7 +466,7 @@
   h5,
   h6 {
     font-family: var(--site-ui-fontFamily);
-    font-weight: 700;
+    font-weight: var(--site-fontWeight-bold);
   }
 
   .postbreak span {

--- a/site/lib/_sass/components/_buttons.scss
+++ b/site/lib/_sass/components/_buttons.scss
@@ -6,7 +6,7 @@ a, button {
   cursor: pointer;
   background: none;
   border: none;
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
 
   &.filled-button, &.icon-button, &.text-button, &.outlined-button, &.outlined-button-cta {
     // Reset style of buttons.

--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -13,7 +13,7 @@
 pre {
   margin: 0 0 1rem;
   font-size: 0.9375rem;
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
   padding: 1.25rem;
 
   code {

--- a/site/lib/_sass/components/_content.scss
+++ b/site/lib/_sass/components/_content.scss
@@ -178,7 +178,7 @@ article {
         left: -25px;
         top: -3px;
         font-size: 20px;
-        font-weight: bold;
+        font-weight: var(--site-fontWeight-bold);
         padding: 3px 8px;
       }
     }

--- a/site/lib/_sass/components/_footer.scss
+++ b/site/lib/_sass/components/_footer.scss
@@ -4,7 +4,7 @@
   padding: 2rem;
 
   color: var(--site-chrome-fgColor);
-  font-weight: 400;
+  font-weight: var(--site-fontWeight-normal);
   font-family: var(--site-ui-fontFamily);
   font-size: 0.875rem;
 

--- a/site/lib/_sass/components/_github-embed.scss
+++ b/site/lib/_sass/components/_github-embed.scss
@@ -1,70 +1,70 @@
 .github-embed {
-    display: block;
-    border: 1px solid var(--site-outline);
-    border-radius: 2px;
-    margin: 2rem 0;
-    text-decoration: none !important;
-    color: inherit !important;
+  display: block;
+  border: 1px solid var(--site-outline);
+  border-radius: 2px;
+  margin: 2rem 0;
+  text-decoration: none !important;
+  color: inherit !important;
+  overflow: hidden;
+  transition: background-color 0.2s ease;
+  background-color: var(--site-bg-color);
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.02);
+  }
+
+  .github-embed-content {
+    display: flex;
+    flex-direction: row;
+    min-height: 160px;
+  }
+
+  .github-embed-text {
+    flex: 1;
+    padding: 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+
+  .github-embed-title {
+    font-size: 1.125rem;
+    font-weight: var(--site-fontWeight-bold);
+    color: var(--site-base-fgColor);
+    margin-bottom: 0.25rem;
+  }
+
+  .github-embed-description {
+    font-size: 1rem;
+    color: var(--site-base-fgColor-alt);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    transition: background-color 0.2s ease;
-    background-color: var(--site-bg-color);
+  }
 
-    &:hover {
-        background-color: rgba(0, 0, 0, 0.02);
+  .github-embed-footer {
+    font-size: 0.875rem;
+    color: var(--site-base-fgColor-alt);
+    margin-top: 0.75rem;
+  }
+
+  .github-embed-image {
+    width: 200px;
+    flex-shrink: 0;
+    background-color: #f0f0f0;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
 
-    .github-embed-content {
-        display: flex;
-        flex-direction: row;
-        min-height: 160px;
+    @media (max-width: 600px) {
+      display: none;
     }
-
-    .github-embed-text {
-        flex: 1;
-        padding: 1.5rem 2rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        gap: 0.25rem;
-    }
-
-    .github-embed-title {
-        font-size: 1.125rem;
-        font-weight: 700;
-        color: var(--site-base-fgColor);
-        margin-bottom: 0.25rem;
-    }
-
-    .github-embed-description {
-        font-size: 1rem;
-        color: var(--site-base-fgColor-alt);
-        line-height: 1.3;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-    }
-
-    .github-embed-footer {
-        font-size: 0.875rem;
-        color: var(--site-base-fgColor-alt);
-        margin-top: 0.75rem;
-    }
-
-    .github-embed-image {
-        width: 200px;
-        flex-shrink: 0;
-        background-color: #f0f0f0;
-
-        img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
-
-        @media (max-width: 600px) {
-            display: none;
-        }
-    }
+  }
 }

--- a/site/lib/_sass/components/_quiz.scss
+++ b/site/lib/_sass/components/_quiz.scss
@@ -84,7 +84,7 @@
           p.correct,
           p.incorrect {
             padding-top: 0.5rem;
-            font-weight: 600;
+            font-weight: var(--site-fontWeight-bold);
             margin-bottom: 0.5rem;
 
             &::before {

--- a/site/lib/_sass/components/_sidenav.scss
+++ b/site/lib/_sass/components/_sidenav.scss
@@ -50,7 +50,7 @@ $sidenav-wide-layout: 1024px;
   }
 
   .nav-header {
-    font-weight: bolder;
+    font-weight: var(--site-fontWeight-bold);
     padding: 0.25rem 0.4rem 0;
     color: var(--site-base-fgColor-lighter);
   }

--- a/site/lib/_sass/components/_site-switcher.scss
+++ b/site/lib/_sass/components/_site-switcher.scss
@@ -30,7 +30,7 @@
   font-variant-ligatures: none;
   font-size: 1.75rem;
   line-height: 1.25em;
-  font-family: 'Google Sans', sans-serif;
+  font-family: var(--site-ui-fontFamily);
   user-select: none;
 
   color: var(--site-wordmark-fgColor);

--- a/site/lib/_sass/components/_summary-card.scss
+++ b/site/lib/_sass/components/_summary-card.scss
@@ -17,7 +17,7 @@
     h3 {
       margin: 0;
       font-size: 1.25rem;
-      font-weight: 600;
+      font-weight: var(--site-fontWeight-bold);
       color: var(--site-base-fgColor);
     }
 

--- a/site/lib/_sass/pages/_changelog-index.scss
+++ b/site/lib/_sass/pages/_changelog-index.scss
@@ -211,7 +211,7 @@ body.dark-mode {
     color: var(--site-base-fgColor-alt);
     background-color: var(--site-raised-bgColor);
     font-family: var(--site-ui-fontFamily);
-    font-weight: 700;
+    font-weight: var(--site-fontWeight-bold);
     font-size: 1rem;
     padding: .75rem;
     border-bottom: 1px solid var(--site-inset-borderColor);
@@ -224,7 +224,7 @@ body.dark-mode {
       margin-top: 1rem;
       margin-bottom: 0.5rem;
       font-size: 1rem;
-      font-weight: 600;
+      font-weight: var(--site-fontWeight-bold);
     }
 
     .version-group {
@@ -233,7 +233,7 @@ body.dark-mode {
 
       summary {
         font-family: var(--site-ui-fontFamily);
-        font-weight: 400;
+        font-weight: var(--site-fontWeight-normal);
         font-size: 0.9rem;
         cursor: pointer;
         color: var(--site-base-fgColor);
@@ -309,7 +309,7 @@ body.dark-mode {
 
   h4 {
     font-size: 1.125rem;
-    font-weight: 400;
+    font-weight: var(--site-fontWeight-normal);
     margin: 1rem 0 .5rem;
     padding: 0;
   }
@@ -487,7 +487,7 @@ body.dark-mode {
         color: var(--site-onPrimary-color);
         padding: 0.25rem 0.5rem;
         border-radius: 4px;
-        font-weight: bold;
+        font-weight: var(--site-fontWeight-bold);
         font-size: 0.9rem;
       }
 
@@ -497,12 +497,12 @@ body.dark-mode {
         color: var(--site-onPrimary-color);
         padding: 0.25rem 0.5rem;
         border-radius: 4px;
-        font-weight: bold;
+        font-weight: var(--site-fontWeight-bolder);
         font-size: 0.9rem;
       }
 
       .entry-title {
-        font-weight: 600;
+        font-weight: var(--site-fontWeight-bold);
         font-size: 1rem;
         color: var(--site-base-fgColor);
       }
@@ -639,7 +639,7 @@ body.dark-mode {
       }
 
       dt {
-        font-weight: bold;
+        font-weight: var(--site-fontWeight-bold);
         grid-column: 1;
       }
 

--- a/site/lib/src/layouts/dash_layout.dart
+++ b/site/lib/src/layouts/dash_layout.dart
@@ -128,37 +128,39 @@ abstract class DashLayout extends PageLayoutBase {
         },
       ),
 
+      // Preload font and other script sources.
       const link(rel: 'preconnect', href: 'https://fonts.googleapis.com'),
       const link(
         rel: 'preconnect',
         href: 'https://fonts.gstatic.com',
         attributes: {'crossorigin': ''},
       ),
+
+      // Set up site fonts and icons.
       const link(
         rel: 'stylesheet',
         href:
-            'https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap',
+            'https://fonts.googleapis.com/css2?'
+            'family=Google+Sans+Flex:opsz,wght@6..72,400..700'
+            '&family=Google+Sans+Code:ital,wght@0,400..700;1,400..700'
+            '&display=swap',
       ),
       const link(
         rel: 'stylesheet',
         href:
-            'https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;500;700&display=swap',
+            'https://fonts.googleapis.com/css2?'
+            'family=Roboto+Serif:ital,opsz,wght@'
+            '0,8..72,400..700;1,8..72,400..700'
+            '&display=swap',
       ),
       const link(
         rel: 'stylesheet',
         href:
-            'https://fonts.googleapis.com/css2?family=Google+Sans+Text:wght@400;500;700&display=swap',
+            'https://fonts.googleapis.com/css2?'
+            'family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@'
+            '24,400,0..1,0',
       ),
-      const link(
-        rel: 'stylesheet',
-        href:
-            'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0..1,0',
-      ),
-      const link(
-        rel: 'stylesheet',
-        href:
-            'https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap',
-      ),
+
       link(
         rel: 'stylesheet',
         href:


### PR DESCRIPTION
Corresponds to https://github.com/flutter/website/pull/13518, updating the Dart site to use newer fonts, consistent with the Flutter docs site. These Google Sans Flex and Code fonts are publicly available and support variable axes. This increases consistency across the sites and enables compliant use of the same fonts on forked/translated sites.

- Replaces many manual font-weights to use one of the updated CSS properties.
- Converts uses of Google Sans and Google Sans Text to Google Sans Flex.
- Converts uses of Google Sans Mono to Google Sans Code.
- Combines some of the requests for slightly faster font loading.
- Switches the blog from Noto Serif to Roboto Serif to be more consistent with the nearby sans serif fonts.