### PR TITLE
Update articleTitle to be non-nullable

### DIFF
--- a/src/content/learn/tutorial/async.md
+++ b/src/content/learn/tutorial/async.md
@@ -188,7 +188,7 @@ This function will house the core logic for handling the `wikipedia` command.
     // ... (your existing main function)
 
     void searchWikipedia(List<String>? arguments) async { // Added 'async'
-      final String? articleTitle;
+      final String articleTitle;
 
       // If the user didn't pass in arguments, request an article title.
       if (arguments == null || arguments.isEmpty) {


### PR DESCRIPTION
Changed articleTitle from nullable to non-nullable.

The code snippet from the tutorial suddendly declares `articleTitle` as nullable when it should be non-nullable. Other code snippets that have the same code declare it as non-nullable.

[Fixes](https://github.com/dart-lang/site-www/issues/7339)

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.