### PR TITLE
Add keyboard input styles and usage

### DIFF
--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -10,6 +10,24 @@
   white-space: nowrap;
 }
 
+main kbd {
+  font-family: var(--site-code-fontFamily);
+  font-size: 0.875em;
+  font-weight: 500;
+  line-height: 1.25em;
+  padding: 0 0.25rem;
+  background-color: var(--site-inset-bgColor-translucent);
+  border: 1.5px solid var(--site-inset-borderColor);
+  border-bottom-width: 2.5px;
+  border-radius: 0.35rem;
+  box-shadow: inset 0 1px 1px rgb(var(--site-interaction-base-values) / 5%);
+
+  white-space: normal;
+  word-wrap: break-word;
+  word-break: normal;
+  word-spacing: -0.25em;
+}
+
 pre {
   margin: 0 0 1rem;
   font-size: 0.9375rem;

--- a/site/lib/src/client/global_scripts.dart
+++ b/site/lib/src/client/global_scripts.dart
@@ -20,6 +20,7 @@ void setUpSite() {
   _setUpTabs();
   _setUpGallery();
   _setUpExpandableCards();
+  _setUpPlatformKeys();
   _setUpTableOfContents();
   _setUpReleaseTags();
   _setUpTooltips();
@@ -313,6 +314,18 @@ enum _ClientOperatingSystem {
     }
 
     return fallback;
+  }
+}
+
+void _setUpPlatformKeys() {
+  final specialKey = switch (_ClientOperatingSystem.fromUserAgent()) {
+    .macos => 'Command',
+    _ => 'Control',
+  };
+  final keys = web.document.querySelectorAll('kbd.special-key');
+  for (var i = 0; i < keys.length; i += 1) {
+    final element = keys.item(i) as web.Element;
+    element.textContent = specialKey;
   }
 }
 

--- a/src/_includes/tools/debug-prod-js-code.md
+++ b/src/_includes/tools/debug-prod-js-code.md
@@ -36,11 +36,14 @@ To debug in Chrome:
 
 To debug in Edge:
 
-1. Update to the latest version of Edge. 
-2. Load **Developer Tools** (**[F12](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/landing/)**).
+1. Update to the latest version of Edge.
+2. Load [**Developer Tools**][edge-devtools] (<kbd>F12</kbd>).
 3. Reload the app. The **debugger** tab shows source-mapped files.
-4. Exception behavior can be controlled through **Ctrl+Shift+E**;
+4. Exception behavior can be controlled through
+   <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd>;
    the default is **Break on unhandled exceptions**.
+
+[edge-devtools]: https://learn.microsoft.com/en-us/microsoft-edge/devtools/landing/
 
 ### Firefox {:#dart2js-debugging-firefox}
 

--- a/src/content/tools/jetbrains-plugin.md
+++ b/src/content/tools/jetbrains-plugin.md
@@ -91,7 +91,9 @@ To work on an existing Dart application, open the project in the IDE and enable 
 
 #### Enable Dart support
 
-1. Open **Settings** (`Cmd` + `,`) and choose **Dart** under **Languages and Frameworks**. This will open the Dart page.
+1. Open **Settings** (<kbd>Cmd</kbd> + <kbd>,</kbd>) and
+   choose **Dart** under **Languages and Frameworks**.
+   This will open the Dart page.
 2. Check **Enable Dart support for the project &lt;project name&gt;**.
 3. Verify the **Dart SDK Path**.
    The IDE usually detects this automatically.
@@ -116,7 +118,8 @@ add the additional project's root folder as a content root or as a new module.
 
 You can customize Dart syntax highlighting to match your preferences.
 
-1. Open **Settings** (`Cmd` + `,`) and go to **Editor | Color Scheme | Dart**.
+1. Open **Settings** (<kbd>Cmd</kbd> + <kbd>,</kbd>) and
+   go to **Editor | Color Scheme | Dart**.
 2. Select a color scheme, or customize the default settings as described in
    [Colors and fonts](https://www.jetbrains.com/help/idea/configuring-colors-and-fonts.html).
 

--- a/src/content/tools/pub/writing-package-pages.md
+++ b/src/content/tools/pub/writing-package-pages.md
@@ -320,7 +320,7 @@ final like = 'this';
 
 A recent UX study found that
 many users use the within-page search feature
-(`Control+F` or `Command+F`)
+(<kbd class="special-key">Cmd/Ctrl</kbd>+<kbd>F</kbd>)
 to search for the feature they are looking for.
 Thus, be sure to mention important terms in the README,
 so that users can find them. 

--- a/src/content/tools/vs-code.md
+++ b/src/content/tools/vs-code.md
@@ -29,9 +29,9 @@ These include syntax highlighting, package resolution, hot reload, and others.
 
 1. Launch **VS Code**.
 
-1. Click **Extensions** in the **Activity Bar**.  
+1. Click **Extensions** in the **Activity Bar**.
    You can also press
-   <kbd>Control</kbd> / <kbd>Command</kbd> +
+   <kbd class="special-key">Cmd/Ctrl</kbd> +
    <kbd>Shift</kbd> + <kbd>X</kbd>.
 
 1. In the Search box, type `Dart`.


### PR DESCRIPTION
Adds custom styles for `<kbd>` (migrated from `flutter/website`) and use it in more locations for better semantics and styling of keybindings. Also add support for a `special-key` class that replaces `Cmd/Ctrl` with the OS-appropriate key on load.

Some example usages: https://dart-dev--pr7349-feat-kbd-styles-8lpgp5fe.web.app/web/debugging#overview