### PR TITLE
docs: add beginner tutorial links to overview page

### DIFF
--- a/src/content/overview.md
+++ b/src/content/overview.md
@@ -34,6 +34,11 @@ Dart provides the language and runtimes that power Flutter apps,
 but Dart also supports many core developer tasks like
 formatting, analyzing, and testing code.
 
+:::tip New to programming?
+If you are completely new to coding and development, some of the concepts on this page might feel a bit advanced. We recommend starting with a foundational introduction:
+* Check out the [Codelabs Dart tutorials](https://codelabs.developers.google.com/?cat=Dart) for step-by-step guided basics.
+* Take a look at the introductory [Language Tour](/language) to learn fundamental syntax at your own pace.
+:::
 
 ## Dart: The language {:#language}
 

--- a/src/content/overview.md
+++ b/src/content/overview.md
@@ -35,9 +35,9 @@ but Dart also supports many core developer tasks like
 formatting, analyzing, and testing code.
 
 :::tip New to programming?
-If you are completely new to coding and development, some of the concepts on
-this page might feel a bit advanced. Consider starting with a foundational
-introduction:
+If you are new to programming,
++some concepts on this page can be advanced.
++Consider starting with a foundational introduction:
 * Check out the
   [Codelabs Dart tutorials](https://codelabs.developers.google.com/?cat=Dart)
   for step-by-step guided basics.

--- a/src/content/overview.md
+++ b/src/content/overview.md
@@ -35,9 +35,14 @@ but Dart also supports many core developer tasks like
 formatting, analyzing, and testing code.
 
 :::tip New to programming?
-If you are completely new to coding and development, some of the concepts on this page might feel a bit advanced. We recommend starting with a foundational introduction:
-* Check out the [Codelabs Dart tutorials](https://codelabs.developers.google.com/?cat=Dart) for step-by-step guided basics.
-* Take a look at the introductory [Language Tour](/language) to learn fundamental syntax at your own pace.
+If you are completely new to coding and development, some of the concepts on
+this page might feel a bit advanced. Consider starting with a foundational
+introduction:
+* Check out the
+  [Codelabs Dart tutorials](https://codelabs.developers.google.com/?cat=Dart)
+  for step-by-step guided basics.
+* Take a look at the introductory [Language Tour](/language)
+  to learn fundamental syntax at your own pace.
 :::
 
 ## Dart: The language {:#language}


### PR DESCRIPTION
Resolves #7216 by adding a beginner-friendly tip block pointing newcomers to foundational tutorials.

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Fixes <Replace with issue link>

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
