### PR TITLE
Update dart_skills_lint dependency to 3d375fe

### DIFF
--- a/site/dart_skills_lint.yaml
+++ b/site/dart_skills_lint.yaml
@@ -1,0 +1,7 @@
+dart_skills_lint:
+  rules:
+    check-relative-paths: error
+    check-absolute-paths: error
+    check-trailing-whitespace: error
+  directories:
+    - path: "../.agents/skills"

--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -46,7 +46,7 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills
       path: tool/dart_skills_lint
-      ref: 66db75d9f221741c33c70d3e641bdfe7bbcfe2f0
+      ref: 3d375fed1b5f6bfe2881a601a4b6d91588594ff6
   jaspr_builder: ^0.23.1
   jaspr_test: ^0.23.1
   lints: ^6.1.0

--- a/site/test/lint_skills_test.dart
+++ b/site/test/lint_skills_test.dart
@@ -1,9 +1,15 @@
 @TestOn('vm')
 library;
 
+import 'dart:io';
+
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
+
+final String _configFilePath = Directory.current.path.endsWith('site')
+    ? 'dart_skills_lint.yaml'
+    : 'site/dart_skills_lint.yaml';
 
 void main() {
   test('Run skills linter', () async {
@@ -15,14 +21,10 @@ void main() {
     );
 
     try {
-      final isValid = await validateSkills(
-        skillDirPaths: ['../.agents/skills'],
-        resolvedRules: {
-          'check-relative-paths': AnalysisSeverity.error,
-          'check-absolute-paths': AnalysisSeverity.error,
-          'check-trailing-whitespace': AnalysisSeverity.error,
-        },
+      final config = await ConfigParser.loadConfig(
+        path: _configFilePath,
       );
+      final isValid = await validateSkills(config: config);
       expect(
         isValid,
         isTrue,


### PR DESCRIPTION
This updates the a version of dart_skills_lint that allows parameters in the rules and uses a config so that the cli invocations and the dart test use the same configuration. 
It also contains breaking changes that will have deprecated methods removed in the next version. -@reidbaker 

Agent authored description below
---
Bumps the pinned `dart_skills_lint` dependency ref in `site/pubspec.yaml` to the latest main commit (`3d375fed1b5f6bfe2881a601a4b6d91588594ff6`).

- **Dependency Update**: Pinned `dart_skills_lint` to `3d375fed1b5f6bfe2881a601a4b6d91588594ff6`.
- **Verification**: `dart analyze` and `dart test` passed cleanly.