### PR TITLE
doc(js-interop): explain Wasm type checks and add Zone binding example

### DIFF
--- a/examples/misc/lib/interop/zones_example.dart
+++ b/examples/misc/lib/interop/zones_example.dart
@@ -14,7 +14,7 @@ void main() {
   element.addEventListener(
     'click',
     (web.Event event) {
-      // ... relies on zone variables
+      // ... relies on zone-local values
     }.toJS,
   );
   // #enddocregion before
@@ -24,7 +24,7 @@ void main() {
   element.addEventListener(
     'click',
     Zone.current.bindUnaryCallback((web.Event event) {
-      // ... zone variables are preserved
+      // ... zone-local values are preserved
     }).toJS,
   );
   // #enddocregion after

--- a/examples/misc/lib/interop/zones_example.dart
+++ b/examples/misc/lib/interop/zones_example.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'package:web/web.dart' as web;
+
+void main() {
+  final element = web.document.querySelector('#my-element')!;
+
+  // #docregion before
+  // Before: Callback lost zone context
+  element.addEventListener(
+    'click',
+    (web.Event event) {
+      // ... relies on zone variables
+    }.toJS,
+  );
+  // #enddocregion before
+
+  // After: Manually bind to the current zone
+  // #docregion after
+  element.addEventListener(
+    'click',
+    Zone.current.bindUnaryCallback((web.Event event) {
+      // ... zone variables are preserved
+    }).toJS,
+  );
+  // #enddocregion after
+}

--- a/src/content/interop/js-interop/js-types.md
+++ b/src/content/interop/js-interop/js-types.md
@@ -164,7 +164,7 @@ The runtime type of JS types might differ based on the compiler. This affects
 runtime type-checking and casts. Therefore, almost always avoid `is` checks
 where the value is an interop type or where the target type is an interop type:
 
-On WebAssembly, all JS interop types (such as `JSString`, `JSArray`, and user-defined extension types) share a single underlying runtime representation (typically `externref`). Because Dart's extension types are erased at compile time, a runtime check like `value is JSString` cannot distinguish a string from any other JS object, and will evaluate to `true` for almost any JS object, leading to silent bugs.
+On WebAssembly, all JS interop types (such as `JSString`, `JSArray`, and user-defined extension types) share a single underlying runtime representation (typically `externref`). Because Dart's extension types are erased at compile time, a runtime check like `value is JSString` cannot distinguish a string from any other JS value, and will evaluate to `true` for almost any JS value, leading to silent bugs.
 
 ```dart tag=bad
 void f(JSAny a) {

--- a/src/content/interop/js-interop/js-types.md
+++ b/src/content/interop/js-interop/js-types.md
@@ -164,7 +164,14 @@ The runtime type of JS types might differ based on the compiler. This affects
 runtime type-checking and casts. Therefore, almost always avoid `is` checks
 where the value is an interop type or where the target type is an interop type:
 
-On WebAssembly, all JS interop types (such as `JSString`, `JSArray`, and user-defined extension types) share a single underlying runtime representation (typically `externref`). Because Dart's extension types are erased at compile time, a runtime check like `value is JSString` cannot distinguish a string from any other JS value, and will evaluate to `true` for almost any JS value, leading to silent bugs.
+On WebAssembly, all JS interop types
+(such as `JSString`, `JSArray`, and user-defined extension types)
+share a single underlying runtime representation (typically `externref`).
+Because Dart's extension types are erased at compile time,
+a runtime check like `value is JSString` cannot distinguish
+a string from any other JS value,
+and will evaluate to `true` for almost any JS value,
+leading to silent bugs.
 
 ```dart tag=bad
 void f(JSAny a) {

--- a/src/content/interop/js-interop/js-types.md
+++ b/src/content/interop/js-interop/js-types.md
@@ -164,6 +164,8 @@ The runtime type of JS types might differ based on the compiler. This affects
 runtime type-checking and casts. Therefore, almost always avoid `is` checks
 where the value is an interop type or where the target type is an interop type:
 
+On WebAssembly, all JS interop types (such as `JSString`, `JSArray`, and user-defined extension types) share a single underlying runtime representation (typically `externref`). Because Dart's extension types are erased at compile time, a runtime check like `value is JSString` cannot distinguish a string from any other JS object, and will evaluate to `true` for almost any JS object, leading to silent bugs.
+
 ```dart tag=bad
 void f(JSAny a) {
   if (a is String) { … }
@@ -210,10 +212,7 @@ void f(JSAny a) {
 Depending on the type parameter, it'll transform the call into the appropriate
 type-check for that type.
 
-{% comment %}
-TODO: Add a link to and an example using `isA` once it's in a dev release. Users
-should prefer that method if it's available.
-{% endcomment %}
+
 
 To avoid invalid type checks with JS interop types,
 enable the [`invalid_runtime_check_with_js_interop_types`][] lint rule.

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -344,7 +344,7 @@ For example, when passing a callback to a DOM event listener, manually bind it t
 element.addEventListener(
   'click',
   (web.Event event) {
-    // ... relies on zone variables
+    // ... relies on zone-local values
   }.toJS,
 );
 ```
@@ -354,7 +354,7 @@ element.addEventListener(
 element.addEventListener(
   'click',
   Zone.current.bindUnaryCallback((web.Event event) {
-    // ... zone variables are preserved
+    // ... zone-local values are preserved
   }).toJS,
 );
 ```

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -336,7 +336,8 @@ If this matters for your application, you can still use zones, but you will have
 to [write them yourself][zones] by binding the callback. See [#54507] for more
 details.
 
-For example, when passing a callback to a DOM event listener, manually bind it to the current zone before converting it with `.toJS`:
+For example, when passing a callback to a DOM event listener,
+manually bind it to the current zone before converting it with `.toJS`:
 
 <?code-excerpt "misc/lib/interop/zones_example.dart (before)"?>
 ```dart

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -335,6 +335,30 @@ callbacks in the current zone.
 If this matters for your application, you can still use zones, but you will have
 to [write them yourself][zones] by binding the callback. See [#54507] for more
 details.
+
+For example, when passing a callback to a DOM event listener, manually bind it to the current zone before converting it with `.toJS`:
+
+<?code-excerpt "misc/lib/interop/zones_example.dart (before)"?>
+```dart
+// Before: Callback lost zone context
+element.addEventListener(
+  'click',
+  (web.Event event) {
+    // ... relies on zone variables
+  }.toJS,
+);
+```
+
+<?code-excerpt "misc/lib/interop/zones_example.dart (after)"?>
+```dart
+element.addEventListener(
+  'click',
+  Zone.current.bindUnaryCallback((web.Event event) {
+    // ... zone variables are preserved
+  }).toJS,
+);
+```
+
 There is no conversion API or [helper](#helpers) available yet to
 automatically do this.
 


### PR DESCRIPTION
- Remove stale TODO comment about isA in js-types.md.
- Add technical explanation of why runtime type checks fail on Wasm.
- Add concrete code example of Zone-binding callbacks in package-web.md.
