### PR TITLE
doc(install): add brew trust step for Homebrew on macOS

### DIFF
--- a/src/_includes/install/macos.md
+++ b/src/_includes/install/macos.md
@@ -5,10 +5,11 @@ To install the Dart SDK, use [Homebrew][].
 
 1. Install Homebrew if needed.
 
-1. Add the [official tap][tap].
+1. Add and trust the [official tap][tap].
 
    ```console
    $ brew tap dart-lang/dart
+   $ brew trust dart-lang/dart
    ```
 
 1. Install the Dart SDK.


### PR DESCRIPTION
Update Homebrew instructions for macOS to include `brew trust dart-lang/dart` following `brew tap`, required since Homebrew v6.

Fixes https://github.com/dart-lang/site-www/issues/7380
Fixes https://github.com/dart-lang/homebrew-dart/issues/242