### PR TITLE
Use analyzer not CFE codes for diagnostic pages

### DIFF
--- a/src/data/diagnostics.json
+++ b/src/data/diagnostics.json
@@ -99,7 +99,7 @@
   {
     "id": "abstract_super_member_reference",
     "description": "_The {0} '{1}' is always abstract in the supertype._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an inherited member is\nreferenced using `super`, but there is no concrete implementation of the\nmember in the superclass chain. Abstract members can't be invoked.\n\n## Example\n\nThe following code produces this diagnostic because `B` doesn't inherit a\nconcrete implementation of `a`:\n\n```dart\nabstract class A {\n  int get a;\n}\n\nclass B extends A {\n  int get a => super.[!a!];\n}\n```\n\n## Common fixes\n\nRemove the invocation of the abstract member, possibly replacing it with an\ninvocation of a concrete member.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an inherited member is\nreferenced using `super`, but there is no concrete implementation of the\nmember in the superclass chain. Abstract members can't be invoked.\n\n## Example\n\nThe following code produces this diagnostic because `B` doesn't inherit a\nconcrete implementation of `a`:\n\n```dart\nabstract class A {\n  int get a;\n}\n\nclass B extends A {\n  @override\n  int get a => super.[!a!];\n}\n```\n\n## Common fixes\n\nRemove the invocation of the abstract member, possibly replacing it with an\ninvocation of a concrete member.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -131,7 +131,7 @@
   {
     "id": "always_put_control_body_on_new_line",
     "description": "_Statement should be on a separate line._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the code being controlled by a\ncontrol flow statement (`if`, `for`, `while`, or `do`) is on the same line\nas the control flow statement.\n\n## Example\n\nThe following code produces this diagnostic because the `return` statement\nis on the same line as the `if` that controls whether the `return` will be\nexecuted:\n\n```dart\nvoid f(bool b) {\n  if (b) [!return!];\n}\n```\n\n## Common fixes\n\nPut the controlled statement onto a separate, indented, line:\n\n```dart\nvoid f(bool b) {\n  if (b)\n    return;\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the code being controlled by a\ncontrol flow statement (`if`, `for`, `while`, or `do`) is on the same line\nas the control flow statement.\n\n## Example\n\nThe following code produces this diagnostic because the `return` statement\nis on the same line as the `if` that controls whether the `return` will be\nexecuted:\n\n```dart\nvoid f(bool b) {\n  if (b) [!return!];\n}\n```\n\n## Common fixes\n\nPut the controlled statement onto a separate, indented, line:\n\n```dart\nvoid f(bool b) {\n  if (b) {\n    return;\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -216,6 +216,13 @@
     "previousNames": []
   },
   {
+    "id": "analysis_options_deprecated_plugins",
+    "description": "_Support for legacy plugins is deprecated, and will be removed in an upcoming version of Dart._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "analyzer_element_model_tracking_bad",
     "description": "_Bad tracking annotation for this member._",
     "hasDocumentation": false,
@@ -282,7 +289,7 @@
   {
     "id": "annotate_redeclares",
     "description": "_The member '{0}' is redeclaring but isn't annotated with '@redeclare'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an extension type member redeclares\na member from an implemented interface without the `@redeclare` annotation.\n\n## Example\n\nThe following code produces this diagnostic because the `f` method in the\nextension type E redeclares the `f` method from `C` without the `@redeclare` annotation:\n\n```dart\nclass C {\n  void f() { }\n}\n\nextension type E(C c) implements C {\n  void [!f!]() { }\n}\n```\n\n## Common fixes\n\nAdd the `@redeclare` annotation to make the redeclaration explicit:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  void f() { }\n}\n\nextension type E(C c) implements C {\n  @redeclare\n  void f() { }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an extension type member redeclares\na member from an implemented interface without the `@redeclare` annotation.\n\n## Example\n\nThe following code produces this diagnostic because the `f` method in the\nextension type E redeclares the `f` method from `C` without the `@redeclare` annotation:\n\n```dart\nclass C {\n  void f() {}\n}\n\nextension type E(C c) implements C {\n  void [!f!]() {}\n}\n```\n\n## Common fixes\n\nAdd the `@redeclare` annotation to make the redeclaration explicit:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  void f() {}\n}\n\nextension type E(C c) implements C {\n  @redeclare\n  void f() {}\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -298,6 +305,27 @@
   {
     "id": "annotation_on_type_argument",
     "description": "_Type arguments can't have annotations because they aren't declarations._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "annotation_space_before_parenthesis",
+    "description": "_Annotations can't have spaces or comments before the parenthesis._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "annotation_with_type_arguments",
+    "description": "_An annotation can't use type arguments._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "annotation_with_type_arguments_uninstantiated",
+    "description": "_An annotation with type arguments must be followed by an argument list._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -351,7 +379,7 @@
   {
     "id": "assert_in_redirecting_constructor",
     "description": "_A redirecting constructor can't have an 'assert' initializer._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a redirecting constructor (a\nconstructor that redirects to another constructor in the same class) has an\nassert in the initializer list.\n\n## Example\n\nThe following code produces this diagnostic because the unnamed constructor\nis a redirecting constructor and also has an assert in the initializer\nlist:\n\n```dart\nclass C {\n  C(int x) : [!assert(x > 0)!], this.name();\n  C.name() {}\n}\n```\n\n## Common fixes\n\nIf the assert isn't needed, then remove it:\n\n```dart\nclass C {\n  C(int x) : this.name();\n  C.name() {}\n}\n```\n\nIf the assert is needed, then convert the constructor into a factory\nconstructor:\n\n```dart\nclass C {\n  factory C(int x) {\n    assert(x > 0);\n    return C.name();\n  }\n  C.name() {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a redirecting constructor (a\nconstructor that redirects to another constructor in the same class) has an\nassert in the initializer list.\n\n## Example\n\nThe following code produces this diagnostic because the unnamed constructor\nis a redirecting constructor and also has an assert in the initializer\nlist:\n\n```dart\nclass C {\n  C(int x) : [!assert(x > 0)!], this.name();\n  C.name();\n}\n```\n\n## Common fixes\n\nIf the assert isn't needed, then remove it:\n\n```dart\nclass C {\n  C(int x) : this.name();\n  C.name();\n}\n```\n\nIf the assert is needed, then convert the constructor into a factory\nconstructor:\n\n```dart\nclass C {\n  factory C(int x) {\n    assert(x > 0);\n    return C.name();\n  }\n  C.name();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -478,7 +506,7 @@
   {
     "id": "assignment_to_type",
     "description": "_Types can't be assigned a value._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the name of a type name appears\non the left-hand side of an assignment expression.\n\n## Example\n\nThe following code produces this diagnostic because the assignment to the\nclass `C` is invalid:\n\n```dart\nclass C {}\n\nvoid f() {\n  [!C!] = null;\n}\n```\n\n## Common fixes\n\nIf the right-hand side should be assigned to something else, such as a\nlocal variable, then change the left-hand side:\n\n```dart\nvoid f() {}\n\nvoid g() {\n  var c = null;\n  print(c);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the name of a type name appears\non the left-hand side of an assignment expression.\n\n## Example\n\nThe following code produces this diagnostic because the assignment to the\nclass `C` is invalid:\n\n```dart\nclass C {}\n\nvoid f() {\n  [!C!] = 0;\n}\n```\n\n## Common fixes\n\nIf the right-hand side should be assigned to something else, such as a\nlocal variable, then change the left-hand side:\n\n```dart\nvoid f() {}\n\nvoid g() {\n  var c = 0;\n  print(c);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -678,7 +706,7 @@
   {
     "id": "avoid_bool_literals_in_conditional_expressions",
     "description": "_Conditional expressions with a 'bool' literal can be simplified._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a conditional expression uses a\nboolean literal, and both branches are booleans. You can simplify these\nexpressions using `&&` or `||`.\n\n## Examples\n\nThe following code produces this diagnostic because the then expression\nis the `bool` literal `true`:\n\n```dart\nbool f(bool a, bool b) => [!a ? true : b!];\n```\n\nThe following code produces this diagnostic because the else expression\nis the `bool` literal `false`:\n\n```dart\nbool f(bool a, bool b) => [!a ? b : false!];\n```\n\n## Common fixes\n\nReplace the conditional expression with the equivalent logical expression.\nIf the then expression is a boolean literal, replace it with one of the following:\n\n```dart\nbool f(bool a, bool b) => a || b;  // replaces: a ? true : b\nbool g(bool a, bool b) => !a && b; // replaces: a ? false : b\n```\n\nIf the else expression is a boolean literal, replace it with one of the following:\n\n```dart\nbool f(bool a, bool b) => !a || b; // replaces: a ? b : true\nbool g(bool a, bool b) => a && b;  // replaces: a ? b : false\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a conditional expression uses a\nboolean literal, and both branches are booleans. You can simplify these\nexpressions using `&&` or `||`.\n\n## Examples\n\nThe following code produces this diagnostic because the then expression\nis the `bool` literal `true`:\n\n```dart\nbool f(bool a, bool b) => [!a ? true : b!];\n```\n\nThe following code produces this diagnostic because the else expression\nis the `bool` literal `false`:\n\n```dart\nbool f(bool a, bool b) => [!a ? b : false!];\n```\n\n## Common fixes\n\nReplace the conditional expression with the equivalent logical expression.\nIf the then expression is a boolean literal, replace it with one of the following:\n\n```dart\nbool f(bool a, bool b) => a || b; // replaces: a ? true : b\nbool g(bool a, bool b) => !a && b; // replaces: a ? false : b\n```\n\nIf the else expression is a boolean literal, replace it with one of the following:\n\n```dart\nbool f(bool a, bool b) => !a || b; // replaces: a ? b : true\nbool g(bool a, bool b) => a && b; // replaces: a ? b : false\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -724,7 +752,7 @@
   {
     "id": "avoid_empty_else",
     "description": "_Empty statements are not allowed in an 'else' clause._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the statement after an `else`\nis an empty statement (a semicolon).\n\nFor more information, see the documentation for\n[`avoid_empty_else`](https://dart.dev/diagnostics/avoid_empty_else).\n\n## Example\n\nThe following code produces this diagnostic because the statement\nfollowing the `else` is an empty statement:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y)\n    print(\"1\");\n  else [!;!]\n    print(\"2\");\n}\n```\n\n## Common fixes\n\nIf the statement after the empty statement is intended to be executed only\nwhen the condition is `false`, then remove the empty statement:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y)\n    print(\"1\");\n  else\n    print(\"2\");\n}\n```\n\nIf there is no code that is intended to be executed only when the\ncondition is `false`, then remove the whole `else` clause:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y)\n    print(\"1\");\n  print(\"2\");\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the statement after an `else`\nis an empty statement (a semicolon).\n\nFor more information, see the documentation for\n[`avoid_empty_else`](https://dart.dev/diagnostics/avoid_empty_else).\n\n## Example\n\nThe following code produces this diagnostic because the statement\nfollowing the `else` is an empty statement:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y) {\n    print('1');\n  } else\n    [!;!]\n  print('2');\n}\n```\n\n## Common fixes\n\nIf the statement after the empty statement is intended to be executed only\nwhen the condition is `false`, then remove the empty statement:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y) {\n    print('1');\n  } else {\n    print('2');\n  }\n}\n```\n\nIf there is no code that is intended to be executed only when the\ncondition is `false`, then remove the whole `else` clause:\n\n```dart\nvoid f(int x, int y) {\n  if (x > y) print('1');\n  print('2');\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -814,7 +842,7 @@
   {
     "id": "avoid_positional_boolean_parameters",
     "description": "_'bool' parameters should be named parameters._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-overriding, public\nfunction has a positional parameter of type `bool`.\n\nPositional boolean parameters can cause ambiguity when\nthe function is invoked because the function of the\nspecified boolean value might not be clear from the value alone.\nNamed parameters make their intent explicit.\n\n## Example\n\nThe following code produces this diagnostic because\nthe function `f` has a positional parameter with a type of `bool`:\n\n```dart\nvoid f([!bool b!]) {}\n```\n\n## Common fixes\n\nConvert the positional parameter to a named parameter:\n\n```dart\nvoid f({bool b = false}) {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-overriding, public\nfunction has two or more positional parameters of type `bool`.\n\nA function with multiple positional Boolean parameters can be a source of\nambiguity at call sites because the purpose of the specified\nBoolean values might not be clear from the values alone.\nNamed parameters make their intent explicit.\n\n## Example\n\nThe following code produces this diagnostic because\nthe function `f` has two positional parameters with a type of `bool`:\n\n```dart\nvoid f(bool a, [!bool b!]) {}\n```\n\n## Common fixes\n\nConvert all of the positional parameters to be named parameters (possibly\nexcepting one):\n\n```dart\nvoid f(bool a, {bool b = false}) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -953,7 +981,7 @@
   {
     "id": "avoid_unnecessary_containers",
     "description": "_Unnecessary instance of 'Container'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a widget tree contains an\ninstance of `Container` and the only argument to the constructor is\n`child:`.\n\n## Example\n\nThe following code produces this diagnostic because the invocation of the\n`Container` constructor only has a `child:` argument:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return [!Container!](\n    child: Row(\n      children: [\n        Text('a'),\n        Text('b'),\n      ],\n    )\n  );\n}\n```\n\n## Common fixes\n\nIf you intended to provide other arguments to the constructor, then add\nthem:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Container(\n    color: Colors.red.shade100,\n    child: Row(\n      children: [\n        Text('a'),\n        Text('b'),\n      ],\n    )\n  );\n}\n```\n\nIf no other arguments are needed, then unwrap the child widget:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(\n    children: [\n      Text('a'),\n      Text('b'),\n    ],\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a widget tree contains an\ninstance of `Container` and the only argument to the constructor is\n`child:`.\n\n## Example\n\nThe following code produces this diagnostic because the invocation of the\n`Container` constructor only has a `child:` argument:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return [!Container!](child: Row(children: [Text('a'), Text('b')]));\n}\n```\n\n## Common fixes\n\nIf you intended to provide other arguments to the constructor, then add\nthem:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Container(\n    color: Colors.red.shade100,\n    child: Row(children: [Text('a'), Text('b')]),\n  );\n}\n```\n\nIf no other arguments are needed, then unwrap the child widget:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(children: [Text('a'), Text('b')]);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -968,7 +996,7 @@
   {
     "id": "avoid_unused_constructor_parameters",
     "description": "_The parameter '{0}' is not used in the constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor parameter\nisn't used in the constructor body or initializer list, and isn't an\ninitializing formal parameter (`this.x`), a super parameter (`super.x`),\nor a declaring parameter.\n\nParameters that are only declared but never referenced are\nlikely unintentional and add unnecessary complexity to the constructor.\n\n## Examples\n\nThe following code produces this diagnostic because\nthe parameter `x` isn't used in the constructor:\n\n```dart\nclass C {\n  C([!int x!]);\n}\n```\n\nThe following code produces this diagnostic because\nthe parameter `c` isn't used in the constructor initializer list:\n\n```dart\nclass C {\n  int x;\n\n  C(int a, int b, [!int c!]): x = a + b {\n    print(x);\n  }\n}\n```\n\n## Common fixes\n\nIf the parameter is meant to initialize a field,\nthen use an initializing formal parameter:\n\n```dart\nclass C {\n  int x;\n\n  C(this.x);\n}\n```\n\nIf the parameter isn't needed, then remove it:\n\n```dart\nclass C {\n  int x;\n\n  C(int a, int b): x = a + b {\n    print(x);\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor parameter\nisn't used in the constructor body or initializer list, and isn't an\ninitializing formal parameter (`this.x`), a super parameter (`super.x`),\nor a declaring parameter.\n\nParameters that are only declared but never referenced are\nlikely unintentional and add unnecessary complexity to the constructor.\n\n## Examples\n\nThe following code produces this diagnostic because\nthe parameter `x` isn't used in the constructor:\n\n```dart\nclass C {\n  C([!int x!]);\n}\n```\n\nThe following code produces this diagnostic because\nthe parameter `c` isn't used in the constructor initializer list:\n\n```dart\nclass C {\n  int x;\n\n  C(int a, int b, [!int c!]) : x = a + b {\n    print(x);\n  }\n}\n```\n\n## Common fixes\n\nIf the parameter is meant to initialize a field,\nthen use an initializing formal parameter:\n\n```dart\nclass C {\n  int x;\n\n  C(this.x);\n}\n```\n\nIf the parameter isn't needed, then remove it:\n\n```dart\nclass C {\n  int x;\n\n  C(int a, int b) : x = a + b {\n    print(x);\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -991,7 +1019,7 @@
   {
     "id": "await_in_late_local_variable_initializer",
     "description": "_The 'await' expression can't be used in a 'late' local variable's initializer._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a local variable that has the\n`late` modifier uses an `await` expression in the initializer.\n\n## Example\n\nThe following code produces this diagnostic because an `await` expression\nis used in the initializer for `v`, a local variable that is marked `late`:\n\n```dart\nFuture<int> f() async {\n  late var v = [!await!] 42;\n  return v;\n}\n```\n\n## Common fixes\n\nIf the initializer can be rewritten to not use `await`, then rewrite it:\n\n```dart\nFuture<int> f() async {\n  late var v = 42;\n  return v;\n}\n```\n\nIf the initializer can't be rewritten, then remove the `late` modifier:\n\n```dart\nFuture<int> f() async {\n  var v = await 42;\n  return v;\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a local variable that has the\n`late` modifier uses an `await` expression in the initializer.\n\n## Example\n\nThe following code produces this diagnostic because an `await` expression\nis used in the initializer for `v`, a local variable that is marked `late`:\n\n```dart\nFuture<int> f(Future<int> future) async {\n  late var v = [!await!] future;\n  return v;\n}\n```\n\n## Common fixes\n\nIf the initializer can be rewritten to not use `await`, then rewrite it:\n\n```dart\nFuture<int> f(Future<int> future) async {\n  late var v = future;\n  return v;\n}\n```\n\nIf the initializer can't be rewritten, then remove the `late` modifier:\n\n```dart\nFuture<int> f(Future<int> future) async {\n  var v = await future;\n  return v;\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1137,7 +1165,7 @@
   {
     "id": "case_expression_type_implements_equals",
     "description": "_The switch case expression type '{0}' can't override the '==' operator._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the type of the expression\nfollowing the keyword `case` has an implementation of the `==` operator\nother than the one in `Object`.\n\n## Example\n\nThe following code produces this diagnostic because the expression\nfollowing the keyword `case` (`C(0)`) has the type `C`, and the class `C`\noverrides the `==` operator:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  switch (c) {\n    case [!C(0)!]:\n      break;\n  }\n}\n```\n\n## Common fixes\n\nIf there isn't a strong reason not to do so, then rewrite the code to use\nan if-else structure:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  if (c == C(0)) {\n    // ...\n  }\n}\n```\n\nIf you can't rewrite the switch statement and the implementation of `==`\nisn't necessary, then remove it:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case C(0):\n      break;\n  }\n}\n```\n\nIf you can't rewrite the switch statement and you can't remove the\ndefinition of `==`, then find some other value that can be used to control\nthe switch:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  switch (c.value) {\n    case 0:\n      break;\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the type of the expression\nfollowing the keyword `case` has an implementation of the `==` operator\nother than the one in `Object`.\n\n## Example\n\nThe following code produces this diagnostic because the expression\nfollowing the keyword `case` (`C(0)`) has the type `C`, and the class `C`\noverrides the `==` operator:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  @override\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  switch (c) {\n    case [!C(0)!]:\n      break;\n  }\n}\n```\n\n## Common fixes\n\nIf there isn't a strong reason not to do so, then rewrite the code to use\nan if-else structure:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  @override\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  if (c == C(0)) {\n    // ...\n  }\n}\n```\n\nIf you can't rewrite the switch statement and the implementation of `==`\nisn't necessary, then remove it:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case C(0):\n      break;\n  }\n}\n```\n\nIf you can't rewrite the switch statement and you can't remove the\ndefinition of `==`, then find some other value that can be used to control\nthe switch:\n\n```dart\nclass C {\n  final int value;\n\n  const C(this.value);\n\n  @override\n  bool operator ==(Object other) {\n    return false;\n  }\n}\n\nvoid f(C c) {\n  switch (c.value) {\n    case 0:\n      break;\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1244,7 +1272,7 @@
   {
     "id": "collection_methods_unrelated_type",
     "description": "_The argument type '{0}' isn't related to '{1}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when any one of several methods in\nthe core libraries are invoked with arguments of an inappropriate type.\nThese methods are ones that don't provide a specific enough type for the\nparameter to allow the normal type checking to catch the error.\n\nThe arguments that are checked are:\n- an argument to `Iterable<E>.contains` should be related to `E`\n- an argument to `List<E>.remove` should be related to `E`\n- an argument to `Map<K, V>.containsKey` should be related to `K`\n- an argument to `Map<K, V>.containsValue` should be related to `V`\n- an argument to `Map<K, V>.remove` should be related to `K`\n- an argument to `Map<K, V>.[]` should be related to `K`\n- an argument to `Queue<E>.remove` should be related to `E`\n- an argument to `Set<E>.lookup` should be related to `E`\n- an argument to `Set<E>.remove` should be related to `E`\n\n## Example\n\nThe following code produces this diagnostic because the argument to\n`contains` is a `String`, which isn't assignable to `int`, the element\ntype of the list `l`:\n\n```dart\nbool f(List<int> l)  => l.contains([!'1'!]);\n```\n\n## Common fixes\n\nIf the element type is correct, then change the argument to have the same\ntype:\n\n```dart\nbool f(List<int> l)  => l.contains(1);\n```\n\nIf the argument type is correct, then change the element type:\n\n```dart\nbool f(List<String> l)  => l.contains('1');\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when any one of several methods in\nthe core libraries are invoked with arguments of an inappropriate type.\nThese methods are ones that don't provide a specific enough type for the\nparameter to allow the normal type checking to catch the error.\n\nThe arguments that are checked are:\n- an argument to `Iterable<E>.contains` should be related to `E`\n- an argument to `List<E>.remove` should be related to `E`\n- an argument to `Map<K, V>.containsKey` should be related to `K`\n- an argument to `Map<K, V>.containsValue` should be related to `V`\n- an argument to `Map<K, V>.remove` should be related to `K`\n- an argument to `Map<K, V>.[]` should be related to `K`\n- an argument to `Queue<E>.remove` should be related to `E`\n- an argument to `Set<E>.lookup` should be related to `E`\n- an argument to `Set<E>.remove` should be related to `E`\n\n## Example\n\nThe following code produces this diagnostic because the argument to\n`contains` is a `String`, which isn't assignable to `int`, the element\ntype of the list `l`:\n\n```dart\nbool f(List<int> l) => l.contains([!'1'!]);\n```\n\n## Common fixes\n\nIf the element type is correct, then change the argument to have the same\ntype:\n\n```dart\nbool f(List<int> l) => l.contains(1);\n```\n\nIf the argument type is correct, then change the element type:\n\n```dart\nbool f(List<String> l) => l.contains('1');\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -1319,7 +1347,7 @@
   {
     "id": "conflicting_generic_interfaces",
     "description": "_The {0} '{1}' can't implement both '{2}' and '{3}' because the type arguments are different._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class attempts to implement a\ngeneric interface multiple times, and the values of the type arguments\naren't the same.\n\n## Example\n\nThe following code produces this diagnostic because `C` is defined to\nimplement both `I<int>` (because it extends `A`) and `I<String>` (because\nit implements`B`), but `int` and `String` aren't the same type:\n\n```dart\nclass I<T> {}\n\nclass A implements I<int> {}\n\nclass B implements I<String> {}\n\nclass [!C!] extends A implements B {}\n```\n\n## Common fixes\n\nRework the type hierarchy to avoid this situation. For example, you might\nmake one or both of the inherited types generic so that `C` can specify the\nsame type for both type arguments:\n\n```dart\nclass I<T> {}\n\nclass A<S> implements I<S> {}\n\nclass B implements I<String> {}\n\nclass C extends A<String> implements B {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class attempts to implement a\ngeneric interface multiple times, and the values of the type arguments\naren't the same.\n\n## Example\n\nThe following code produces this diagnostic because `C` is defined to\nimplement both `I<int>` (because it extends `A`) and `I<String>` (because\nit implements `B`), but `int` and `String` aren't the same type:\n\n```dart\nclass I<T> {}\n\nclass A implements I<int> {}\n\nclass B implements I<String> {}\n\nclass [!C!] extends A implements B {}\n```\n\n## Common fixes\n\nRework the type hierarchy to avoid this situation. For example, you might\nmake one or both of the inherited types generic so that `C` can specify the\nsame type for both type arguments:\n\n```dart\nclass I<T> {}\n\nclass A<S> implements I<S> {}\n\nclass B implements I<String> {}\n\nclass C extends A<String> implements B {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1617,7 +1645,7 @@
   {
     "id": "const_map_key_not_primitive_equality",
     "description": "_The type of a key in a constant map can't override the '==' operator, or 'hashCode', but the class '{0}' does._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the class of object used as a\nkey in a constant map literal implements either the `==` operator, the\ngetter `hashCode`, or both. The implementation of constant maps uses both\nthe `==` operator and the `hashCode` getter, so any implementation other\nthan the ones inherited from `Object` requires executing arbitrary code at\ncompile time, which isn't supported.\n\n## Examples\n\nThe following code produces this diagnostic because the constant map\ncontains a key whose type is `C`, and the class `C` overrides the\nimplementation of `==`:\n\n```dart\nclass C {\n  const C();\n\n  bool operator ==(Object other) => true;\n}\n\nconst map = {[!C()!]: 0};\n```\n\nThe following code produces this diagnostic because the constant map\ncontains a key whose type is `C`, and the class `C` overrides the\nimplementation of `hashCode`:\n\n```dart\nclass C {\n  const C();\n\n  int get hashCode => 3;\n}\n\nconst map = {[!C()!]: 0};\n```\n\n## Common fixes\n\nIf you can remove the implementation of `==` and `hashCode` from the\nclass, then do so:\n\n```dart\nclass C {\n  const C();\n}\n\nconst map = {C(): 0};\n```\n\nIf you can't remove the implementation of `==` and `hashCode` from the\nclass, then make the map non-constant:\n\n```dart\nclass C {\n  const C();\n\n  bool operator ==(Object other) => true;\n}\n\nfinal map = {C(): 0};\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the class of object used as a\nkey in a constant map literal implements either the `==` operator, the\ngetter `hashCode`, or both. The implementation of constant maps uses both\nthe `==` operator and the `hashCode` getter, so any implementation other\nthan the ones inherited from `Object` requires executing arbitrary code at\ncompile time, which isn't supported.\n\n## Examples\n\nThe following code produces this diagnostic because the constant map\ncontains a key whose type is `C`, and the class `C` overrides the\nimplementation of `==`:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  bool operator ==(Object other) => true;\n}\n\nconst map = {[!C()!]: 0};\n```\n\nThe following code produces this diagnostic because the constant map\ncontains a key whose type is `C`, and the class `C` overrides the\nimplementation of `hashCode`:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  int get hashCode => 3;\n}\n\nconst map = {[!C()!]: 0};\n```\n\n## Common fixes\n\nIf you can remove the implementation of `==` and `hashCode` from the\nclass, then do so:\n\n```dart\nclass C {\n  const C();\n}\n\nconst map = {C(): 0};\n```\n\nIf you can't remove the implementation of `==` and `hashCode` from the\nclass, then make the map non-constant:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  bool operator ==(Object other) => true;\n}\n\nfinal map = {C(): 0};\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1632,7 +1660,7 @@
   {
     "id": "const_not_initialized",
     "description": "_The constant '{0}' must be initialized._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a variable that is declared to\nbe a constant doesn't have an initializer.\n\n## Example\n\nThe following code produces this diagnostic because `c` isn't initialized:\n\n```dart\nconst [!c!];\n```\n\n## Common fixes\n\nAdd an initializer:\n\n```dart\nconst c = 'c';\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a variable that is declared to\nbe a constant doesn't have an initializer.\n\n## Example\n\nThe following code produces this diagnostic because `c` isn't initialized:\n\n```dart\nconst String [!c!];\n```\n\n## Common fixes\n\nAdd an initializer:\n\n```dart\nconst String c = 'c';\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1647,7 +1675,7 @@
   {
     "id": "const_set_element_not_primitive_equality",
     "description": "_An element in a constant set can't override the '==' operator, or 'hashCode', but the type '{0}' does._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the class of object used as an\nelement in a constant set literal implements either the `==` operator, the\ngetter `hashCode`, or both. The implementation of constant sets uses both\nthe `==` operator and the `hashCode` getter, so any implementation other\nthan the ones inherited from `Object` requires executing arbitrary code at\ncompile time, which isn't supported.\n\n## Example\n\nThe following code produces this diagnostic because the constant set\ncontains an element whose type is `C`, and the class `C` overrides the\nimplementation of `==`:\n\n```dart\nclass C {\n  const C();\n\n  bool operator ==(Object other) => true;\n}\n\nconst set = {[!C()!]};\n```\n\nThe following code produces this diagnostic because the constant set\ncontains an element whose type is `C`, and the class `C` overrides the\nimplementation of `hashCode`:\n\n```dart\nclass C {\n  const C();\n\n  int get hashCode => 3;\n}\n\nconst map = {[!C()!]};\n```\n\n## Common fixes\n\nIf you can remove the implementation of `==` and `hashCode` from the\nclass, then do so:\n\n```dart\nclass C {\n  const C();\n}\n\nconst set = {C()};\n```\n\nIf you can't remove the implementation of `==` and `hashCode` from the\nclass, then make the set non-constant:\n\n```dart\nclass C {\n  const C();\n\n  bool operator ==(Object other) => true;\n}\n\nfinal set = {C()};\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the class of object used as an\nelement in a constant set literal implements either the `==` operator, the\ngetter `hashCode`, or both. The implementation of constant sets uses both\nthe `==` operator and the `hashCode` getter, so any implementation other\nthan the ones inherited from `Object` requires executing arbitrary code at\ncompile time, which isn't supported.\n\n## Example\n\nThe following code produces this diagnostic because the constant set\ncontains an element whose type is `C`, and the class `C` overrides the\nimplementation of `==`:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  bool operator ==(Object other) => true;\n}\n\nconst set = {[!C()!]};\n```\n\nThe following code produces this diagnostic because the constant set\ncontains an element whose type is `C`, and the class `C` overrides the\nimplementation of `hashCode`:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  int get hashCode => 3;\n}\n\nconst map = {[!C()!]};\n```\n\n## Common fixes\n\nIf you can remove the implementation of `==` and `hashCode` from the\nclass, then do so:\n\n```dart\nclass C {\n  const C();\n}\n\nconst set = {C()};\n```\n\nIf you can't remove the implementation of `==` and `hashCode` from the\nclass, then make the set non-constant:\n\n```dart\nclass C {\n  const C();\n\n  @override\n  bool operator ==(Object other) => true;\n}\n\nfinal set = {C()};\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": [
@@ -1768,20 +1796,6 @@
     "previousNames": []
   },
   {
-    "id": "constructor_with_type_parameters",
-    "description": "_Constructors can't have type parameters._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "constructor_with_wrong_name",
-    "description": "_The name of a constructor must match the name of the enclosing class._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "continue_label_invalid",
     "description": "_The label used in a 'continue' statement must be defined on either a loop or a switch member._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when the label in a `continue`\nstatement resolves to a label on a `switch` statement.\n\n## Example\n\nThe following code produces this diagnostic because the label `l`, used to\nlabel a `switch` statement, is used in the `continue` statement:\n\n```dart\nvoid f(int i) {\n  l:\n  switch (i) {\n    case 0:\n      [!continue l;!]\n  }\n}\n```\n\n## Common fixes\n\nFind a different way to achieve the control flow you need; for example, by\nintroducing a loop that re-executes the `switch` statement.\n",
@@ -1844,7 +1858,7 @@
   {
     "id": "creation_of_struct_or_union",
     "description": "_Subclasses of 'Struct' and 'Union' are backed by native memory, and can't be instantiated by a generative constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a subclass of either `Struct`\nor `Union` is instantiated using a generative constructor.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the class `C` is being\ninstantiated using a generative constructor:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  @Int32()\n  external int a;\n}\n\nvoid f() {\n  [!C!]();\n}\n```\n\n## Common fixes\n\nIf you need to allocate the structure described by the class, then use the\n`ffi` package to do so:\n\n```dart\nimport 'dart:ffi';\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  @Int32()\n  external int a;\n}\n\nvoid f() {\n  final pointer = calloc.allocate<C>(4);\n  final c = pointer.ref;\n  print(c);\n  calloc.free(pointer);\n}\n```\n\n[ffi]: /interop/c-interop\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a subclass of either `Struct`\nor `Union` is instantiated using a generative constructor.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the class `C` is being\ninstantiated using a generative constructor:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  @Int32()\n  external int a;\n}\n\nvoid f() {\n  [!C!]();\n}\n```\n\n## Common fixes\n\nIf you need to allocate the structure described by the class, then use the\n`ffi` package to do so:\n\n```dart\nimport 'dart:ffi';\n\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  @Int32()\n  external int a;\n}\n\nvoid f() {\n  final pointer = calloc.allocate<C>(4);\n  final c = pointer.ref;\n  print(c);\n  calloc.free(pointer);\n}\n```\n\n[ffi]: /interop/c-interop\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1884,7 +1898,7 @@
   {
     "id": "dead_code_catch_following_catch",
     "description": "_Dead code: Catch clauses after a 'catch (e)' or an 'on Object catch (e)' are never reached._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `catch` clause is found that\ncan't be executed because it's after a `catch` clause of the form\n`catch (e)` or `on Object catch (e)`. The first `catch` clause that matches\nthe thrown object is selected, and both of those forms will match any\nobject, so no `catch` clauses that follow them will be selected.\n\n## Example\n\nThe following code produces this diagnostic:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (e) {\n  } [!on String {!]\n    [!// ...!]\n  [!}!]\n}\n```\n\n## Common fixes\n\nIf the clause should be selectable, then move the clause before the general\nclause:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } on String {\n    // ...\n  } catch (e) {\n    // ...\n  }\n}\n```\n\nIf the clause doesn't need to be selectable, then remove it:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (e) {\n    // ...\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `catch` clause is found that\ncan't be executed because it's after a `catch` clause of the form\n`catch (e)` or `on Object catch (e)`. The first `catch` clause that matches\nthe thrown object is selected, and both of those forms will match any\nobject, so no `catch` clauses that follow them will be selected.\n\n## Example\n\nThe following code produces this diagnostic:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (e) {\n    // Not reached.\n  } [!on String {!]\n    [!// ...!]\n  [!}!]\n}\n```\n\n## Common fixes\n\nIf the clause should be selectable, then move the clause before the general\nclause:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } on String {\n    // ...\n  } catch (e) {\n    // ...\n  }\n}\n```\n\nIf the clause doesn't need to be selectable, then remove it:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (e) {\n    // ...\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -1945,7 +1959,7 @@
   {
     "id": "default_value_in_redirecting_factory_constructor",
     "description": "_Default values aren't allowed in factory constructors that redirect to another constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a factory constructor that\nredirects to another constructor specifies a default value for an optional\nparameter.\n\n## Example\n\nThe following code produces this diagnostic because the factory constructor\nin `A` has a default value for the optional parameter `x`:\n\n```dart\nclass A {\n  factory A([int [!x!] = 0]) = B;\n}\n\nclass B implements A {\n  B([int x = 1]) {}\n}\n```\n\n## Common fixes\n\nRemove the default value from the factory constructor:\n\n```dart\nclass A {\n  factory A([int x]) = B;\n}\n\nclass B implements A {\n  B([int x = 1]) {}\n}\n```\n\nNote that this fix might change the value used when the optional parameter\nis omitted. If that happens, and if that change is a problem, then consider\nmaking the optional parameter a required parameter in the factory method:\n\n```dart\nclass A {\n  factory A(int x) = B;\n}\n\nclass B implements A {\n  B([int x = 1]) {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a factory constructor that\nredirects to another constructor specifies a default value for an optional\nparameter.\n\n## Example\n\nThe following code produces this diagnostic because the factory constructor\nin `A` has a default value for the optional parameter `x`:\n\n```dart\nclass A {\n  factory A([int x [!=!] 0]) = B;\n}\n\nclass B implements A {\n  B([int x = 1]);\n}\n```\n\n## Common fixes\n\nRemove the default value from the factory constructor:\n\n```dart\nclass A {\n  factory A([int x]) = B;\n}\n\nclass B implements A {\n  B([int x = 1]);\n}\n```\n\nNote that this fix might change the value used when the optional parameter\nis omitted. If that happens, and if that change is a problem, then consider\nmaking the optional parameter a required parameter in the factory method:\n\n```dart\nclass A {\n  factory A(int x) = B;\n}\n\nclass B implements A {\n  B([int x = 1]);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -2000,7 +2014,7 @@
   {
     "id": "deprecated_colon_for_default_value",
     "description": "_Using a colon as the separator before a default value is deprecated and will not be supported in language version 3.0 and later._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a colon (`:`) is used as the\nseparator before the default value of an optional named parameter.\nWhile this syntax is allowed, it is deprecated in favor of\nusing an equal sign (`=`).\n\n## Example\n\nThe following code produces this diagnostic because a colon is being used\nbefore the default value of the optional parameter `i`:\n\n```dart\nvoid f({int i [!:!] 0}) {}\n```\n\n## Common fixes\n\nReplace the colon with an equal sign.\n\n```dart\nvoid f({int i = 0}) {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a colon (`:`) is used as the\nseparator before the default value of an optional named parameter.\nWhile this syntax is allowed, it is deprecated in favor of\nusing an equal sign (`=`).\n\n## Example\n\nThe following code produces this diagnostic because a colon is being used\nbefore the default value of the optional parameter `i`:\n\n```dart\nvoid f({int i[!:!] 0}) {}\n```\n\n## Common fixes\n\nReplace the colon with an equal sign.\n\n```dart\nvoid f({int i = 0}) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -2133,7 +2147,7 @@
   {
     "id": "diagnostic_describe_all_properties",
     "description": "_The public property isn't described by either 'debugFillProperties' or 'debugDescribeChildren'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class that implements\n`Diagnosticable` has a public property that isn't added as a property in\neither a `debugFillProperties` or `debugDescribeChildren` method.\n\n## Example\n\nThe following code produces this diagnostic because the property `p2`\nisn't added in the `debugFillProperties` method:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass C extends Widget {\n  bool get p1 => true;\n\n  bool get [!p2!] => false;\n\n  @override\n  void debugFillProperties(DiagnosticPropertiesBuilder properties) {\n    super.debugFillProperties(properties);\n    properties.add(DiagnosticsProperty<bool>('p1', p1));\n  }\n}\n```\n\n## Common fixes\n\nIf there isn't on override of either the `debugFillProperties` or\n`debugDescribeChildren` method, then add one.\n\nAdd a description of the property in the `debugFillProperties` or\n`debugDescribeChildren` method:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass C extends Widget {\n  bool get p1 => true;\n\n  bool get p2 => false;\n\n  @override\n  void debugFillProperties(DiagnosticPropertiesBuilder properties) {\n    super.debugFillProperties(properties);\n    properties.add(DiagnosticsProperty<bool>('p1', p1));\n    properties.add(DiagnosticsProperty<bool>('p2', p2));\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class that implements\n`Diagnosticable` has a public property that isn't added as a property in\neither a `debugFillProperties` or `debugDescribeChildren` method.\n\n## Example\n\nThe following code produces this diagnostic because the property `p2`\nisn't added in the `debugFillProperties` method:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const C({super.key}) extends Widget {\n  bool get p1 => true;\n\n  bool get [!p2!] => false;\n\n  @override\n  void debugFillProperties(DiagnosticPropertiesBuilder properties) {\n    super.debugFillProperties(properties);\n    properties.add(DiagnosticsProperty<bool>('p1', p1));\n  }\n}\n```\n\n## Common fixes\n\nIf there isn't on override of either the `debugFillProperties` or\n`debugDescribeChildren` method, then add one.\n\nAdd a description of the property in the `debugFillProperties` or\n`debugDescribeChildren` method:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const C({super.key}) extends Widget {\n  bool get p1 => true;\n\n  bool get p2 => false;\n\n  @override\n  void debugFillProperties(DiagnosticPropertiesBuilder properties) {\n    super.debugFillProperties(properties);\n    properties.add(DiagnosticsProperty<bool>('p1', p1));\n    properties.add(DiagnosticsProperty<bool>('p2', p2));\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -2327,7 +2341,7 @@
   {
     "id": "duplicate_field_formal_parameter",
     "description": "_The field '{0}' can't be initialized by multiple parameters in the same constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's more than one\ninitializing formal parameter for the same field in a constructor's\nparameter list. It isn't useful to assign a value that will immediately be\noverwritten.\n\n## Example\n\nThe following code produces this diagnostic because `this.f` appears twice\nin the parameter list:\n\n```dart\nclass C {\n  int f;\n\n  C(this.f, this.[!f!]) {}\n}\n```\n\n## Common fixes\n\nRemove one of the initializing formal parameters:\n\n```dart\nclass C {\n  int f;\n\n  C(this.f) {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's more than one\ninitializing formal parameter for the same field in a constructor's\nparameter list. It isn't useful to assign a value that will immediately be\noverwritten.\n\n## Example\n\nThe following code produces this diagnostic because `this.f` appears twice\nin the parameter list:\n\n```dart\nclass C {\n  int f;\n\n  C(this.f, this.[!f!]);\n}\n```\n\n## Common fixes\n\nRemove one of the initializing formal parameters:\n\n```dart\nclass C {\n  int f;\n\n  C(this.f);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -2468,9 +2482,9 @@
   {
     "id": "empty_container_bodies",
     "description": "_Empty {0} bodies should be written using a ';' rather than '{}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the block body of a class,\nenum, extension, extension type, or mixin is empty and can be replaced by\na semicolon.\n\n## Example\n\nThe following code produces this diagnostic because the body of the class\n`C` is empty:\n\n```dart\nclass C [!{}!]\n```\n\n## Common fixes\n\nIf the class needs to have members, then add them:\n\n```dart\nclass C {\n  String toString() => 'c';\n}\n```\n\nOtherwise, replace the body with a semicolon:\n\n```dart\nclass C;\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the block body of a class,\nenum, extension, extension type, or mixin is empty and can be replaced by\na semicolon.\n\n## Example\n\nThe following code produces this diagnostic because the body of the class\n`C` is empty:\n\n```dart\nclass C [!{}!]\n```\n\n## Common fixes\n\nIf the class needs to have members, then add them:\n\n```dart\nclass C {\n  @override\n  String toString() => 'c';\n}\n```\n\nOtherwise, replace the body with a semicolon:\n\n```dart\nclass C;\n```\n",
     "hasDocumentation": true,
-    "fromLint": false,
+    "fromLint": true,
     "previousNames": []
   },
   {
@@ -2489,6 +2503,14 @@
     "previousNames": []
   },
   {
+    "id": "empty_record_literal_with_comma",
+    "description": "_A record literal without fields can't have a trailing comma._",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record literal that has no\nfields has a trailing comma. Empty record literals can't contain a comma.\n\n## Example\n\nThe following code produces this diagnostic because the empty record\nliteral has a trailing comma:\n\n```dart\nvar r = ([!,!]);\n```\n\n## Common fixes\n\nIf the record is intended to be empty, then remove the comma:\n\n```dart\nvar r = ();\n```\n\nIf the record is intended to have one or more fields, then add the\nexpressions used to compute the values of those fields:\n\n```dart\nvar r = (3, 4);\n```\n",
+    "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "empty_record_type_named_fields_list",
     "description": "_The list of named fields in a record type can't be empty._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record type has an empty list\nof named fields.\n\n## Example\n\nThe following code produces this diagnostic because the record type has an\nempty list of named fields:\n\n```dart\nvoid f((int, int, {[!}!]) r) {}\n```\n\n## Common fixes\n\nIf the record is intended to have named fields, then add the types and\nnames of the fields:\n\n```dart\nvoid f((int, int, {int z}) r) {}\n```\n\nIf the record isn't intended to have named fields, then remove the curly\nbraces:\n\n```dart\nvoid f((int, int) r) {}\n```\n",
@@ -2497,9 +2519,17 @@
     "previousNames": []
   },
   {
+    "id": "empty_record_type_with_comma",
+    "description": "_A record type without fields can't have a trailing comma._",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record type that has no\nfields has a trailing comma. Empty record types can't contain a comma.\n\n## Example\n\nThe following code produces this diagnostic because the empty record type\nhas a trailing comma:\n\n```dart\nvoid f(([!,!]) r) {}\n```\n\n## Common fixes\n\nIf the record type is intended to be empty, then remove the comma:\n\n```dart\nvoid f(() r) {}\n```\n\nIf the record type is intended to have one or more fields, then add the\ntypes of those fields:\n\n```dart\nvoid f((int, int) r) {}\n```\n",
+    "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "empty_statements",
     "description": "_Unnecessary empty statement._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an empty statement is found.\n\n## Example\n\nThe following code produces this diagnostic because the statement\ncontrolled by the `while` loop is an empty statement:\n\n```dart\nvoid f(bool condition) {\n  while (condition)[!;!]\n    g();\n}\n\nvoid g() {}\n```\n\n## Common fixes\n\nIf there are no statements that need to be controlled, then remove both\nthe empty statement and the control structure it's part of (being careful\nthat any other code being removed doesn't have a side-effect that needs to\nbe preserved):\n\n```dart\nvoid f(bool condition) {\n  g();\n}\n\nvoid g() {}\n```\n\nIf there are no statements that need to be controlled but the control\nstructure is still required for other reasons, then replace the empty\nstatement with a block to make the structure of the code more obvious:\n\n```dart\nvoid f(bool condition) {\n  while (condition) {}\n  g();\n}\n\nvoid g() {}\n```\n\nIf there are statements that need to be controlled, remove the empty\nstatement and adjust the code so that the appropriate statements are being\ncontrolled, possibly adding a block:\n\n```dart\nvoid f(bool condition) {\n  while (condition) {\n    g();\n  }\n}\n\nvoid g() {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an empty statement is found.\n\n## Example\n\nThe following code produces this diagnostic because the statement\ncontrolled by the `while` loop is an empty statement:\n\n```dart\nvoid f(bool condition) {\n  while (condition) {\n    [!;!]\n  }\n  g();\n}\n\nvoid g() {}\n```\n\n## Common fixes\n\nIf there are no statements that need to be controlled, then remove both\nthe empty statement and the control structure it's part of (being careful\nthat any other code being removed doesn't have a side-effect that needs to\nbe preserved):\n\n```dart\nvoid f(bool condition) {\n  g();\n}\n\nvoid g() {}\n```\n\nIf there are no statements that need to be controlled but the control\nstructure is still required for other reasons, then replace the empty\nstatement with a block to make the structure of the code more obvious:\n\n```dart\nvoid f(bool condition) {\n  while (condition) {}\n  g();\n}\n\nvoid g() {}\n```\n\nIf there are statements that need to be controlled, remove the empty\nstatement and adjust the code so that the appropriate statements are being\ncontrolled, possibly adding a block:\n\n```dart\nvoid f(bool condition) {\n  while (condition) {\n    g();\n  }\n}\n\nvoid g() {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -2596,7 +2626,7 @@
   },
   {
     "id": "eol_at_end_of_file",
-    "description": "_Missing a newline at the end of the file._",
+    "description": "_Missing a newline at the end of the file._\n\n_Too many newlines at the end of the file._",
     "hasDocumentation": false,
     "fromLint": true,
     "previousNames": []
@@ -2658,15 +2688,9 @@
   {
     "id": "exhaustive_cases",
     "description": "_Missing case clauses for some constants in '{0}'._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a\n`switch` statement over an instance of an enum-like class is\nmissing a `case` clause for one or more of the class's constants and\ndoesn't have a `default` clause.\n\nEnum-like classes are non-abstract classes that have:\n\n- Only private, non-factory constructors.\n- Two or more `static const` fields whose type is the enclosing class.\n- No subclasses in the defining library.\n\n## Example\n\nThe following code produces this diagnostic because the\n`switch` statement is missing a `case` clause for the constant `C.c`:\n\n```dart\nclass const C._(final int i) {\n  static const C a = ._(1);\n  static const C b = ._(2);\n  static const C c = ._(3);\n}\n\nvoid f(C c) {\n  [!switch (c)!] {\n    case .a:\n      print('a');\n    case .b:\n      print('b');\n  }\n}\n```\n\n## Common fixes\n\nIf the missing constant needs to be handled separately,\nthen add a `case` clause for it:\n\n```dart\nclass const C._(final int i) {\n  static const C a = ._(1);\n  static const C b = ._(2);\n  static const C c = ._(3);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case .a:\n      print('a');\n    case .b:\n      print('b');\n    case .c:\n      print('c');\n  }\n}\n```\n\nIf the missing constant doesn't need to be handled specially,\nthen add a `default` clause to cover it:\n\n```dart\nclass const C._(final int i) {\n  static const C a = ._(1);\n  static const C b = ._(2);\n  static const C c = ._(3);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case .a:\n      print('a');\n    case .b:\n      print('b');\n    default:\n      print('other');\n  }\n}\n```\n",
+    "hasDocumentation": true,
     "fromLint": true,
-    "previousNames": []
-  },
-  {
-    "id": "expected_an_initializer",
-    "description": "_Expected an initializer._",
-    "hasDocumentation": false,
-    "fromLint": false,
     "previousNames": []
   },
   {
@@ -2778,13 +2802,6 @@
     "previousNames": []
   },
   {
-    "id": "expected_statement",
-    "description": "_Expected a statement._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "expected_string_literal",
     "description": "_Expected a string literal._",
     "hasDocumentation": false,
@@ -2843,7 +2860,7 @@
     "previousNames": []
   },
   {
-    "id": "export_after_part",
+    "id": "export_directive_after_part_directive",
     "description": "_Export directives must precede part directives._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -2852,7 +2869,7 @@
   {
     "id": "export_internal_library",
     "description": "_The library '{0}' is internal and can't be exported._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds an export whose `dart:`\nURI references an internal library.\n\n## Example\n\nThe following code produces this diagnostic because `_interceptors` is an\ninternal library:\n\n```dart\n[!export 'dart:_interceptors';!]\n```\n\n## Common fixes\n\nRemove the export directive.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds an export whose `dart:`\nURI references an internal library.\n\n## Example\n\nThe following code produces this diagnostic because `_internal` is an\ninternal library:\n\n```dart\n[!export 'dart:_internal';!]\n```\n\n## Common fixes\n\nRemove the export directive.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -2868,7 +2885,7 @@
   {
     "id": "export_of_non_library",
     "description": "_The exported library '{0}' can't have a part-of directive._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an export directive references a\npart rather than a library.\n\n## Example\n\nGiven a file `part.dart` containing\n\n```dart\npart of lib;\n```\n\nThe following code produces this diagnostic because the file `part.dart` is\na part, and only libraries can be exported:\n\n```dart\nlibrary lib;\n\nexport [!'part.dart'!];\n```\n\n## Common fixes\n\nEither remove the export directive, or change the URI to be the URI of the\nlibrary containing the part.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an export directive references a\npart rather than a library.\n\n## Example\n\nGiven a file `part.dart` containing\n\n```dart\npart of lib;\n```\n\nThe following code produces this diagnostic because the file `part.dart` is\na part, and only libraries can be exported:\n\n```dart\nexport [!'part.dart'!];\n```\n\n## Common fixes\n\nEither remove the export directive, or change the URI to be the URI of the\nlibrary containing the part.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3232,14 +3249,6 @@
     "previousNames": []
   },
   {
-    "id": "extraneous_modifier_in_extension",
-    "description": "_Can't have modifier '{0}' in an extension._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a member declared inside an\nextension uses the keyword `covariant` in the declaration of a parameter.\nExtensions aren't classes and don't have subclasses, so the keyword serves\nno purpose.\n\n## Example\n\nThe following code produces this diagnostic because `i` is marked as being\ncovariant:\n\n```dart\nextension E on String {\n  void a([!covariant!] int i) {}\n}\n```\n\n## Common fixes\n\nRemove the `covariant` keyword:\n\n```dart\nextension E on String {\n  void a(int i) {}\n}\n```\n",
-    "hasDocumentation": true,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "extraneous_modifier_in_extension_type",
     "description": "_Can't have modifier '{0}' in an extension type._",
     "hasDocumentation": false,
@@ -3594,6 +3603,14 @@
     "previousNames": []
   },
   {
+    "id": "future_sync_value",
+    "description": "_For synchronous values, `Future.syncValue` is more performant._",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the method `Future.value`\nis called with a non-`Future` value. This includes the type `Object`,\nbut not `dynamic` or `FutureOr`.\n\nThe constructor internally checks whether the argument is a `Future`.\nIf the argument is already known not to be a `Future`, the check is\nredundant and reduces performance.\n\n## Example\n\n```dart\nFuture<int> f() => Future.[!value!](1);\n```\n\n## Common fixes\n\nReplace the call to `Future.value` with a call to `Future.syncValue`:\n\n```dart\nFuture<int> f() => Future.syncValue(1);\n```\n",
+    "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "generic_function_type_cannot_be_bound",
     "description": "_Generic function types can't be used as type parameter bounds._",
     "hasDocumentation": false,
@@ -3669,7 +3686,7 @@
   {
     "id": "hash_and_equals",
     "description": "_Missing a corresponding override of '{0}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class or mixin either\noverrides the definition of `==` but doesn't override the definition of\n`hashCode`, or conversely overrides the definition of `hashCode` but\ndoesn't override the definition of `==`.\n\nBoth the `==` operator and the `hashCode` property of objects must be\nconsistent for a common hash map implementation to function properly. As a\nresult, when overriding either method, both should be overridden.\n\n## Example\n\nThe following code produces this diagnostic because the class `C`\noverrides the `==` operator but doesn't override the getter `hashCode`:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n\n  @override\n  bool operator [!==!](Object other) =>\n      other is C &&\n      other.runtimeType == runtimeType &&\n      other.value == value;\n}\n```\n\n## Common fixes\n\nIf you need to override one of the members, then add an override of the\nother:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n\n  @override\n  bool operator ==(Object other) =>\n      other is C &&\n      other.runtimeType == runtimeType &&\n      other.value == value;\n\n  @override\n  int get hashCode => value.hashCode;\n}\n```\n\nIf you don't need to override either of the members, then remove the\nunnecessary override:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class or mixin either\noverrides the definition of `==` but doesn't override the definition of\n`hashCode`, or conversely overrides the definition of `hashCode` but\ndoesn't override the definition of `==`.\n\nBoth the `==` operator and the `hashCode` property of objects must be\nconsistent for a common hash map implementation to function properly. As a\nresult, when overriding either method, both should be overridden.\n\n## Example\n\nThe following code produces this diagnostic because the class `C`\noverrides the `==` operator but doesn't override the getter `hashCode`:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n\n  @override\n  bool operator [!==!](Object other) =>\n      other is C && other.runtimeType == runtimeType && other.value == value;\n}\n```\n\n## Common fixes\n\nIf you need to override one of the members, then add an override of the\nother:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n\n  @override\n  bool operator ==(Object other) =>\n      other is C && other.runtimeType == runtimeType && other.value == value;\n\n  @override\n  int get hashCode => value.hashCode;\n}\n```\n\nIf you don't need to override either of the members, then remove the\nunnecessary override:\n\n```dart\nclass C {\n  final int value;\n\n  C(this.value);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -3714,7 +3731,7 @@
   {
     "id": "illegal_concrete_enum_member",
     "description": "_A concrete instance member named '{0}' can't be declared in a class that implements 'Enum'._\n\n_A concrete instance member named '{0}' can't be inherited from '{1}' in a class that implements 'Enum'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when either an enum declaration, a\nclass that implements `Enum`, or a mixin with a superclass constraint of\n`Enum`, declares or inherits a concrete instance member named either\n`index`, `hashCode`, or `==`.\n\n## Examples\n\nThe following code produces this diagnostic because the enum `E` declares\nan instance getter named `index`:\n\n```dart\nenum E {\n  v;\n\n  int get [!index!] => 0;\n}\n```\n\nThe following code produces this diagnostic because the class `C`, which\nimplements `Enum`, declares an instance field named `hashCode`:\n\n```dart\nabstract class C implements Enum {\n  int [!hashCode!] = 0;\n}\n```\n\nThe following code produces this diagnostic because the class `C`, which\nindirectly implements `Enum` through the class `A`, declares an instance\ngetter named `hashCode`:\n\n```dart\nabstract class A implements Enum {}\n\nabstract class C implements A {\n  int get [!hashCode!] => 0;\n}\n```\n\nThe following code produces this diagnostic because the mixin `M`, which\nhas `Enum` in the `on` clause, declares an explicit operator named `==`:\n\n```dart\nmixin M on Enum {\n  bool operator [!==!](Object other) => false;\n}\n```\n\n## Common fixes\n\nRename the conflicting member:\n\n```dart\nenum E {\n  v;\n\n  int get getIndex => 0;\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when either an enum declaration, a\nclass that implements `Enum`, or a mixin with a superclass constraint of\n`Enum`, declares or inherits a concrete instance member named either\n`index`, `hashCode`, or `==`.\n\n## Examples\n\nThe following code produces this diagnostic because the enum `E` declares\nan instance getter named `index`:\n\n```dart\nenum E {\n  v;\n\n  @override\n  int get [!index!] => 0;\n}\n```\n\nThe following code produces this diagnostic because the class `C`, which\nimplements `Enum`, declares an instance field named `hashCode`:\n\n```dart\nabstract class C implements Enum {\n  @override\n  int [!hashCode!] = 0;\n}\n```\n\nThe following code produces this diagnostic because the class `C`, which\nindirectly implements `Enum` through the class `A`, declares an instance\ngetter named `hashCode`:\n\n```dart\nabstract class A implements Enum {}\n\nabstract class C implements A {\n  @override\n  int get [!hashCode!] => 0;\n}\n```\n\nThe following code produces this diagnostic because the mixin `M`, which\nhas `Enum` in the `on` clause, declares an explicit operator named `==`:\n\n```dart\nmixin M on Enum {\n  @override\n  bool operator [!==!](Object other) => false;\n}\n```\n\n## Common fixes\n\nRename the conflicting member:\n\n```dart\nenum E {\n  v;\n\n  int get getIndex => 0;\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3795,7 +3812,7 @@
   {
     "id": "implements_non_class",
     "description": "_Classes and mixins can only implement other classes and mixins._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a name used in the `implements`\nclause of a class or mixin declaration is defined to be something other\nthan a class or mixin.\n\n## Example\n\nThe following code produces this diagnostic because `x` is a variable\nrather than a class or mixin:\n\n```dart\nvar x;\n\nclass C implements [!x!] {}\n```\n\n## Common fixes\n\nIf the name is the name of an existing class or mixin that's already being\nimported, then add a prefix to the import so that the local definition of\nthe name doesn't shadow the imported name.\n\nIf the name is the name of an existing class or mixin that isn't being\nimported, then add an import, with a prefix, for the library in which it's\ndeclared.\n\nOtherwise, either replace the name in the `implements` clause with the name\nof an existing class or mixin, or remove the name from the `implements`\nclause.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a name used in the `implements`\nclause of a class or mixin declaration is defined to be something other\nthan a class or mixin.\n\n## Example\n\nThe following code produces this diagnostic because `x` is a variable\nrather than a class or mixin:\n\n```dart\nvar x = 0;\n\nclass C implements [!x!] {}\n```\n\n## Common fixes\n\nIf the name is the name of an existing class or mixin that's already being\nimported, then add a prefix to the import so that the local definition of\nthe name doesn't shadow the imported name.\n\nIf the name is the name of an existing class or mixin that isn't being\nimported, then add an import, with a prefix, for the library in which it's\ndeclared.\n\nOtherwise, either replace the name in the `implements` clause with the name\nof an existing class or mixin, or remove the name from the `implements`\nclause.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3803,7 +3820,7 @@
   {
     "id": "implements_repeated",
     "description": "_'{0}' can only be implemented once._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a single class is specified more\nthan once in an `implements` clause.\n\n## Example\n\nThe following code produces this diagnostic because `A` is in the list\ntwice:\n\n```dart\nclass A {}\n\nclass B implements A, [!A!] {}\n```\n\n## Common fixes\n\nRemove all except one occurrence of the class name:\n\n```dart\nclass A {}\n\nclass B implements A {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a single class is specified more\nthan once in an `implements` clause.\n\n## Example\n\nThe following code produces this diagnostic because `A` is in the list\ntwice:\n\n```dart\n// @dart = 3.5\nclass A {}\n\nclass B implements A, [!A!] {}\n```\n\n## Common fixes\n\nRemove all except one occurrence of the class name:\n\n```dart\n// @dart = 3.5\nclass A {}\n\nclass B implements A {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3811,7 +3828,7 @@
   {
     "id": "implements_super_class",
     "description": "_'{0}' can't be used in both the 'extends' and 'implements' clauses._\n\n_'{0}' can't be used in both the 'extends' and 'with' clauses._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class is listed in the\n`extends` clause of a class declaration and also in either the\n`implements` or `with` clause of the same declaration.\n\n## Example\n\nThe following code produces this diagnostic because the class `A` is used\nin both the `extends` and `implements` clauses for the class `B`:\n\n```dart\nclass A {}\n\nclass B extends A implements [!A!] {}\n```\n\nThe following code produces this diagnostic because the class `A` is used\nin both the `extends` and `with` clauses for the class `B`:\n\n```dart\nmixin class A {}\n\nclass B extends A with [!A!] {}\n```\n\n## Common fixes\n\nIf you want to inherit the implementation from the class, then remove the\nclass from the `implements` clause:\n\n```dart\nclass A {}\n\nclass B extends A {}\n```\n\nIf you don't want to inherit the implementation from the class, then remove\nthe `extends` clause:\n\n```dart\nclass A {}\n\nclass B implements A {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class is listed in the\n`extends` clause of a class declaration and also in either the\n`implements` or `with` clause of the same declaration.\n\n## Example\n\nThe following code produces this diagnostic because the class `A` is used\nin both the `extends` and `implements` clauses for the class `B`:\n\n```dart\n// @dart = 3.5\nclass A {}\n\nclass B extends A implements [!A!] {}\n```\n\nThe following code produces this diagnostic because the class `A` is used\nin both the `extends` and `with` clauses for the class `B`:\n\n```dart\nmixin class A {}\n\nclass B extends A with [!A!] {}\n```\n\n## Common fixes\n\nIf you want to inherit the implementation from the class, then remove the\nclass from the `implements` clause:\n\n```dart\nclass A {}\n\nclass B extends A {}\n```\n\nIf you don't want to inherit the implementation from the class, then remove\nthe `extends` clause:\n\n```dart\nclass A {}\n\nclass B implements A {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3855,13 +3872,6 @@
     "previousNames": []
   },
   {
-    "id": "import_after_part",
-    "description": "_Import directives must precede part directives._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "import_deferred_library_with_load_function",
     "description": "_The imported library defines a top-level function named 'loadLibrary' that is hidden by deferring this library._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a library that declares a\nfunction named `loadLibrary` is imported using a deferred import. A\ndeferred import introduces an implicit function named `loadLibrary`. This\nfunction is used to load the contents of the deferred library, and the\nimplicit function hides the explicit declaration in the deferred library.\n\nFor more information, check out\n[Lazily loading a library](https://dart.dev/language/libraries#lazily-loading-a-library).\n\n## Example\n\nGiven a file `a.dart` that defines a function named `loadLibrary`:\n\n```dart\nvoid loadLibrary(Library library) {}\n\nclass Library {}\n```\n\nThe following code produces this diagnostic because the implicit\ndeclaration of `a.loadLibrary` is hiding the explicit declaration of\n`loadLibrary` in `a.dart`:\n\n```dart\n[!import 'a.dart' deferred as a;!]\n\nvoid f() {\n  a.Library();\n}\n```\n\n## Common fixes\n\nIf the imported library isn't required to be deferred, then remove the\nkeyword `deferred`:\n\n```dart\nimport 'a.dart' as a;\n\nvoid f() {\n  a.Library();\n}\n```\n\nIf the imported library is required to be deferred and you need to\nreference the imported function, then rename the function in the imported\nlibrary:\n\n```dart\nvoid populateLibrary(Library library) {}\n\nclass Library {}\n```\n\nIf the imported library is required to be deferred and you don't need to\nreference the imported function, then add a `hide` clause:\n\n```dart\nimport 'a.dart' deferred as a hide loadLibrary;\n\nvoid f() {\n  a.Library();\n}\n```\n",
@@ -3870,9 +3880,16 @@
     "previousNames": []
   },
   {
+    "id": "import_directive_after_part_directive",
+    "description": "_Import directives must precede part directives._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "import_internal_library",
     "description": "_The library '{0}' is internal and can't be imported._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds an import whose `dart:`\nURI references an internal library.\n\n## Example\n\nThe following code produces this diagnostic because `_interceptors` is an\ninternal library:\n\n```dart\nimport [!'dart:_interceptors'!];\n```\n\n## Common fixes\n\nRemove the import directive.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds an import whose `dart:`\nURI references an internal library.\n\n## Example\n\nThe following code produces this diagnostic because `_internal` is an\ninternal library:\n\n```dart\nimport [!'dart:_internal'!];\n```\n\n## Common fixes\n\nRemove the import directive.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3888,7 +3905,7 @@
   {
     "id": "import_of_non_library",
     "description": "_The imported library '{0}' can't have a part-of directive._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a [part file][] is imported\ninto a library.\n\n## Example\n\nGiven a [part file][] named `part.dart` containing the following:\n\n```dart\npart of lib;\n```\n\nThe following code produces this diagnostic because imported files can't\nhave a part-of directive:\n\n```dart\nlibrary lib;\n\nimport [!'part.dart'!];\n```\n\n## Common fixes\n\nImport the library that contains the [part file][] rather than the\n[part file][] itself.\n\n[part file]: /resources/glossary#part-file\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a [part file][] is imported\ninto a library.\n\n## Example\n\nGiven a [part file][] named `part.dart` containing the following:\n\n```dart\npart of lib;\n```\n\nThe following code produces this diagnostic because imported files can't\nhave a part-of directive:\n\n```dart\nimport [!'part.dart'!];\n```\n\n## Common fixes\n\nImport the library that contains the [part file][] rather than the\n[part file][] itself.\n\n[part file]: /resources/glossary#part-file\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -3929,6 +3946,13 @@
     "description": "_The rule '{0}' is incompatible with '{1}'._\n\n_The rule '{0}' is incompatible with {1}, which is included from {2} file{3}._\n\n_The rule '{0}' is incompatible with {1}._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when two specified lint rules are\nincompatible, such as when they enforce opposite styles.\n\n## Example\n\nThe following code produces this diagnostic because the rules\n`prefer_single_quotes` and `prefer_double_quotes` are incompatible with\neach other:\n\n```yaml\n// %uri=\"analysis_options.yaml\"\nlinter:\n  rules:\n    - prefer_single_quotes\n    - [!prefer_double_quotes!]\n```\n\n## Common fixes\n\nRemove all but one of the incompatible rules:\n\n```yaml\n// %uri=\"analysis_options.yaml\"\nlinter:\n  rules:\n    - prefer_single_quotes\n```\n",
     "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "incompatible_plugin_source",
+    "description": "_The plugin '{0}' is specified with a different source in '{1}'._",
+    "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
@@ -4057,7 +4081,7 @@
     "description": "_Field should be initialized in the field declaration._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a field initialized in either\nthe initializer list or body of a primary constructor can be initialized\nin the field declaration.\n\n## Example\n\nThe following code produces this diagnostic because the field `y` is\ninitialized in the primary constructor's initializer list, when it can be\ninitialized in the field declaration:\n\n```dart\nclass C(int x) {\n  this : [!y!] = x;\n\n  int y;\n}\n```\n\n## Common fixes\n\nInitialize the field in its declaration:\n\n```dart\nclass C(int x) {\n  int y = x;\n}\n```\n",
     "hasDocumentation": true,
-    "fromLint": false,
+    "fromLint": true,
     "previousNames": []
   },
   {
@@ -4080,6 +4104,13 @@
     "description": "_'{0}' is a static field in the enclosing class. Fields initialized in a constructor can't be static._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a static field is initialized\nin a constructor using either an initializing formal parameter or an\nassignment in the initializer list.\n\n## Example\n\nThe following code produces this diagnostic because the static field `a`\nis being initialized by the initializing formal parameter `this.a`:\n\n```dart\nclass C {\n  static int? a;\n  C([!this!].a);\n}\n```\n\n## Common fixes\n\nIf the field should be an instance field, then remove the keyword `static`:\n\n```dart\nclass C {\n  int? a;\n  C(this.a);\n}\n```\n\nIf you intended to initialize an instance field and typed the wrong name,\nthen correct the name of the field being initialized:\n\n```dart\nclass C {\n  static int? a;\n  int? b;\n  C(this.b);\n}\n```\n\nIf you really want to initialize the static field, then move the\ninitialization into the constructor body:\n\n```dart\nclass C {\n  static int? a;\n  C(int? c) {\n    a = c;\n  }\n}\n```\n",
     "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "initializing_declaring_parameter",
+    "description": "_Declaring parameters can't be initializing._",
+    "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
@@ -4118,7 +4149,7 @@
   {
     "id": "instantiate_abstract_class",
     "description": "_Abstract classes can't be instantiated._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds a constructor\ninvocation and the constructor is declared in an abstract class. Even\nthough you can't create an instance of an abstract class, abstract classes\ncan declare constructors that can be invoked by subclasses.\n\n## Example\n\nThe following code produces this diagnostic because `C` is an abstract\nclass:\n\n```dart\nabstract class C {}\n\nvar c = new [!C!]();\n```\n\n## Common fixes\n\nIf there's a concrete subclass of the abstract class that can be used, then\ncreate an instance of the concrete subclass.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it finds a constructor\ninvocation and the constructor is declared in an abstract class. Even\nthough you can't create an instance of an abstract class, abstract classes\ncan declare constructors that can be invoked by subclasses.\n\n## Example\n\nThe following code produces this diagnostic because `C` is an abstract\nclass:\n\n```dart\nabstract class C {}\n\nvar c = [!C!]();\n```\n\n## Common fixes\n\nIf there's a concrete subclass of the abstract class that can be used, then\ncreate an instance of the concrete subclass.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4195,7 +4226,7 @@
   {
     "id": "invalid_annotation_from_deferred_library",
     "description": "_Constant values from a deferred library can't be used as annotations._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constant from a library that\nis imported using a deferred import is used as an annotation. Annotations\nare evaluated at compile time, and constants from deferred libraries aren't\navailable at compile time.\n\nFor more information, check out\n[Lazily loading a library](https://dart.dev/language/libraries#lazily-loading-a-library).\n\n## Example\n\nThe following code produces this diagnostic because the constant `pi` is\nbeing used as an annotation when the library `dart:math` is imported as\n`deferred`:\n\n```dart\nimport 'dart:math' deferred as math;\n\n@[!math.pi!]\nvoid f() {}\n```\n\n## Common fixes\n\nIf you need to reference the constant as an annotation, then remove the\nkeyword `deferred` from the import:\n\n```dart\nimport 'dart:math' as math;\n\n@math.pi\nvoid f() {}\n```\n\nIf you can use a different constant as an annotation, then replace the\nannotation with a different constant:\n\n```dart\n@deprecated\nvoid f() {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constant from a library that\nis imported using a deferred import is used as an annotation. Annotations\nare evaluated at compile time, and constants from deferred libraries aren't\navailable at compile time.\n\nFor more information, check out\n[Lazily loading a library](https://dart.dev/language/libraries#lazily-loading-a-library).\n\n## Example\n\nThe following code produces this diagnostic because the constant `pi` is\nbeing used as an annotation when the library `dart:math` is imported as\n`deferred`:\n\n```dart\nimport 'dart:math' deferred as math;\n\n@[!math.pi!]\nvoid f() {}\n```\n\n## Common fixes\n\nIf you need to reference the constant as an annotation, then remove the\nkeyword `deferred` from the import:\n\n```dart\nimport 'dart:math' as math;\n\n@math.pi\nvoid f() {}\n```\n\nIf you can use a different constant as an annotation, then replace the\nannotation with a different constant:\n\n```dart\n@Deprecated('...')\nvoid f() {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4217,7 +4248,7 @@
     "previousNames": []
   },
   {
-    "id": "invalid_await_for",
+    "id": "invalid_await_in_for",
     "description": "_The keyword 'await' isn't allowed for a normal 'for' statement._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -4330,15 +4361,15 @@
     "previousNames": []
   },
   {
-    "id": "invalid_constant_pattern_binary",
-    "description": "_The binary operator {0} is not supported as a constant pattern._",
+    "id": "invalid_constant_const_prefix",
+    "description": "_The expression can't be prefixed by 'const' to form a constant pattern._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
   {
-    "id": "invalid_constant_pattern_const_prefix",
-    "description": "_The expression can't be prefixed by 'const' to form a constant pattern._",
+    "id": "invalid_constant_pattern_binary",
+    "description": "_The binary operator {0} is not supported as a constant pattern._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -4374,6 +4405,13 @@
   {
     "id": "invalid_constant_pattern_unary",
     "description": "_The unary operator {0} is not supported as a constant pattern._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "invalid_constructor_name",
+    "description": "_The name of a constructor must match the name of the enclosing class._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -4438,13 +4476,6 @@
     "description": "_The annotation '@Deprecated.subclass' can only be applied to subclassable classes and mixins._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when anything other than a\nsubclassable class or mixin is annotated with\n`@Deprecated.subclass`. A subclassable\nclass is a class not declared with the `final` or `sealed` keywords. A\nsubclassable mixin is a mixin not declared with the `base` keyword.\n\n## Example\n\nThe following code produces this diagnostic because the annotation is on a\nsealed class:\n\n```dart\n@[!Deprecated.subclass!]()\nsealed class C {}\n```\n\n## Common fixes\n\nRemove the annotation:\n\n```dart\nsealed class C {}\n```\n",
     "hasDocumentation": true,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "invalid_escape_started",
-    "description": "_The string '\\' can't stand alone._",
-    "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
@@ -4515,7 +4546,7 @@
   {
     "id": "invalid_field_type_in_struct",
     "description": "_Fields in struct classes can't have the type '{0}'. They can only be declared as 'int', 'double', 'Array', 'Pointer', or subtype of 'Struct' or 'Union'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a field in a subclass of\n`Struct` has a type other than `int`, `double`, `Array`, `Pointer`, or\nsubtype of `Struct` or `Union`.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the field `str` has\nthe type `String`, which isn't one of the allowed types for fields in a\nsubclass of `Struct`:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  external [!String!] s;\n\n  @Int32()\n  external int i;\n}\n```\n\n## Common fixes\n\nUse one of the allowed types for the field:\n\n```dart\nimport 'dart:ffi';\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  external Pointer<Utf8> s;\n\n  @Int32()\n  external int i;\n}\n```\n\n[ffi]: /interop/c-interop\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a field in a subclass of\n`Struct` has a type other than `int`, `double`, `Array`, `Pointer`, or\nsubtype of `Struct` or `Union`.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the field `str` has\nthe type `String`, which isn't one of the allowed types for fields in a\nsubclass of `Struct`:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  external [!String!] s;\n\n  @Int32()\n  external int i;\n}\n```\n\n## Common fixes\n\nUse one of the allowed types for the field:\n\n```dart\nimport 'dart:ffi';\n\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  external Pointer<Utf8> s;\n\n  @Int32()\n  external int i;\n}\n```\n\n[ffi]: /interop/c-interop\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4537,7 +4568,7 @@
   {
     "id": "invalid_implementation_override",
     "description": "_'{0}.{1}' ('{2}') isn't a valid concrete implementation of '{3}.{1}' ('{4}')._\n\n_The setter '{0}.{1}' ('{2}') isn't a valid concrete implementation of '{3}.{1}' ('{4}')._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when all of the following are true:\n\n- A class defines an abstract member.\n- There is a concrete implementation of that member in a superclass.\n- The concrete implementation isn't a valid implementation of the abstract\n  method.\n\nThe concrete implementation can be invalid because of incompatibilities in\neither the return type, the types of the method's parameters, or the type\nparameters.\n\n## Example\n\nThe following code produces this diagnostic because the method `A.add` has\na parameter of type `int`, and the overriding method `B.add` has a\ncorresponding parameter of type `num`:\n\n```dart\nclass A {\n  int add(int a) => a;\n}\nclass [!B!] extends A {\n  int add(num a);\n}\n```\n\nThis is a problem because in an invocation of `B.add` like the following:\n\n```dart\nvoid f(B b) {\n  b.add(3.4);\n}\n```\n\n`B.add` is expecting to be able to take, for example, a `double`, but when\nthe method `A.add` is executed (because it's the only concrete\nimplementation of `add`), a runtime exception will be thrown because a\n`double` can't be assigned to a parameter of type `int`.\n\n## Common fixes\n\nIf the method in the subclass can conform to the implementation in the\nsuperclass, then change the declaration in the subclass (or remove it if\nit's the same):\n\n```dart\nclass A {\n  int add(int a) => a;\n}\nclass B\textends A {\n  int add(int a);\n}\n```\n\nIf the method in the superclass can be generalized to be a valid\nimplementation of the method in the subclass, then change the superclass\nmethod:\n\n```dart\nclass A {\n  int add(num a) => a.floor();\n}\nclass B\textends A {\n  int add(num a);\n}\n```\n\nIf neither the method in the superclass nor the method in the subclass can\nbe changed, then provide a concrete implementation of the method in the\nsubclass:\n\n```dart\nclass A {\n  int add(int a) => a;\n}\nclass B\textends A {\n  int add(num a) => a.floor();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when all of the following are true:\n\n- A class defines an abstract member.\n- There is a concrete implementation of that member in a superclass.\n- The concrete implementation isn't a valid implementation of the abstract\n  method.\n\nThe concrete implementation can be invalid because of incompatibilities in\neither the return type, the types of the method's parameters, or the type\nparameters.\n\n## Example\n\nThe following code produces this diagnostic because the method `A.add` has\na parameter of type `int`, and the overriding method `B.add` has a\ncorresponding parameter of type `num`:\n\n```dart\nclass A {\n  int add(int a) => a;\n}\n\nclass [!B!] extends A {\n  int add(num a);\n}\n```\n\nThis is a problem because in an invocation of `B.add` like the following:\n\n```dart\nvoid f(B b) {\n  b.add(3.4);\n}\n```\n\n`B.add` is expecting to be able to take, for example, a `double`, but when\nthe method `A.add` is executed (because it's the only concrete\nimplementation of `add`), a runtime exception will be thrown because a\n`double` can't be assigned to a parameter of type `int`.\n\n## Common fixes\n\nIf the method in the subclass can conform to the implementation in the\nsuperclass, then change the declaration in the subclass (or remove it if\nit's the same):\n\n```dart\nclass A {\n  int add(int a) => a;\n}\n\nclass B extends A {\n  int add(int a);\n}\n```\n\nIf the method in the superclass can be generalized to be a valid\nimplementation of the method in the subclass, then change the superclass\nmethod:\n\n```dart\nclass A {\n  int add(num a) => a.floor();\n}\n\nclass B extends A {\n  int add(num a);\n}\n```\n\nIf neither the method in the superclass nor the method in the subclass can\nbe changed, then provide a concrete implementation of the method in the\nsubclass:\n\n```dart\nclass A {\n  int add(int a) => a;\n}\n\nclass B extends A {\n  int add(num a) => a.floor();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4567,7 +4598,7 @@
   {
     "id": "invalid_internal_annotation",
     "description": "_Only public elements in a package's private API can be annotated as being internal._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a declaration is annotated with\nthe [`internal`][meta-internal] annotation and that declaration is either\nin a [public library][] or has a private name.\n\n## Example\n\nThe following code, when in a [public library][], produces this diagnostic\nbecause the [`internal`][meta-internal] annotation can't be applied to\ndeclarations in a [public library][]:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@[!internal!]\nclass C {}\n```\n\nThe following code, whether in a public or internal library, produces this\ndiagnostic because the [`internal`][meta-internal] annotation can't be\napplied to declarations with private names:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@[!internal!]\nclass _C {}\n\nvoid f(_C c) {}\n```\n\n## Common fixes\n\nIf the declaration has a private name, then remove the annotation:\n\n```dart\nclass _C {}\n\nvoid f(_C c) {}\n```\n\nIf the declaration has a public name and is intended to be internal to the\npackage, then move the annotated declaration into an internal library (in\nother words, a library inside the `src` directory).\n\nOtherwise, remove the use of the annotation:\n\n```dart\nclass C {}\n```\n\n[meta-internal]: https://pub.dev/documentation/meta/latest/meta/internal-constant.html\n[public library]: /resources/glossary#public-library\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a declaration is annotated with\nthe [`internal`][meta-internal] annotation and that declaration is either\nin a [public library][] or has a private name.\n\n## Example\n\nThe following code, when in a [public library][], produces this diagnostic\nbecause the [`internal`][meta-internal] annotation can't be applied to\ndeclarations in a [public library][]:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@[!internal!]\nclass C {}\n```\n\nThe following code, whether in a public or internal library, produces this\ndiagnostic because the [`internal`][meta-internal] annotation can't be\napplied to declarations with private names:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@[!internal!]\nclass _C {}\n```\n\n## Common fixes\n\nIf the declaration has a private name, then remove the annotation:\n\n```dart\nclass _C {}\n```\n\nIf the declaration has a public name and is intended to be internal to the\npackage, then move the annotated declaration into an internal library (in\nother words, a library inside the `src` directory).\n\nOtherwise, remove the use of the annotation:\n\n```dart\nclass C {}\n```\n\n[meta-internal]: https://pub.dev/documentation/meta/latest/meta/internal-constant.html\n[public library]: /resources/glossary#public-library\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4590,7 +4621,7 @@
   {
     "id": "invalid_literal_annotation",
     "description": "_Only const constructors can have the `@literal` annotation._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the [`literal`][meta-literal]\nannotation is applied to anything other than a const constructor.\n\n## Examples\n\nThe following code produces this diagnostic because the constructor isn't\na `const` constructor:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  @[!literal!]\n  C();\n}\n```\n\n## Common fixes\n\nIf the annotation is on a constructor and the constructor should always be\ninvoked with `const`, when possible, then mark the constructor with the\n`const` keyword:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  @literal\n  const C();\n}\n```\n\nIf the constructor can't be marked as `const`, then remove the annotation.\n\nIf the annotation is on anything other than a constructor, then remove the\nannotation:\n\n```dart\nvar x;\n```\n\n[meta-literal]: https://pub.dev/documentation/meta/latest/meta/literal-constant.html\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the [`literal`][meta-literal]\nannotation is applied to anything other than a const constructor.\n\n## Examples\n\nThe following code produces this diagnostic because the constructor isn't\na `const` constructor:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  @[!literal!]\n  C();\n}\n```\n\n## Common fixes\n\nIf the annotation is on a constructor and the constructor should always be\ninvoked with `const`, when possible, then mark the constructor with the\n`const` keyword:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass C {\n  @literal\n  const C();\n}\n```\n\nIf the constructor can't be marked as `const`, then remove the annotation.\n\nIf the annotation is on anything other than a constructor, then remove the\nannotation:\n\n```dart\nvar x = 0;\n```\n\n[meta-literal]: https://pub.dev/documentation/meta/latest/meta/literal-constant.html\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4649,6 +4680,13 @@
     "previousNames": []
   },
   {
+    "id": "invalid_operator_questionmark_period_for_super",
+    "description": "_The operator '?.' cannot be used with 'super' because 'super' cannot be null._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "invalid_option",
     "description": "_Invalid option specified for '{0}': {1}_",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when an option is specified and the\nvalue of the option is invalid.\n\n## Example\n\nThe following code produces this diagnostic because `fail` isn't a valid\nseverity for a diagnostic:\n\n```yaml\n// %uri=\"analysis_options.yaml\"\nanalyzer:\n  errors:\n    dead_code: [!fail!]\n    prefer_single_quotes: warning\n```\n\n## Common fixes\n\nIf you specify the option, provide a valid value for it:\n\n```yaml\n// %uri=\"analysis_options.yaml\"\nanalyzer:\n  errors:\n    dead_code: error\n    prefer_single_quotes: warning\n```\n\nIf you don't need the option, remove it:\n\n```yaml\n// %uri=\"analysis_options.yaml\"\nanalyzer:\n  errors:\n    prefer_single_quotes: warning\n```\n",
@@ -4659,7 +4697,7 @@
   {
     "id": "invalid_override",
     "description": "_'{0}.{1}' ('{2}') isn't a valid override of '{3}.{1}' ('{4}')._\n\n_The setter '{0}.{1}' ('{2}') isn't a valid override of '{3}.{1}' ('{4}')._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a member of a class is found\nthat overrides a member from a supertype and the override isn't valid. An\noverride is valid if all of these are true:\n- It allows all of the arguments allowed by the overridden member.\n- It doesn't require any arguments that aren't required by the overridden\n  member.\n- The type of every parameter of the overridden member is assignable to the\n  corresponding parameter of the override.\n- The return type of the override is assignable to the return type of the\n  overridden member.\n\n## Example\n\nThe following code produces this diagnostic because the type of the\nparameter `s` (`String`) isn't assignable to the type of the parameter `i`\n(`int`):\n\n```dart\nclass A {\n  void m(int i) {}\n}\n\nclass B extends A {\n  void [!m!](String s) {}\n}\n```\n\n## Common fixes\n\nIf the invalid method is intended to override the method from the\nsuperclass, then change it to conform:\n\n```dart\nclass A {\n  void m(int i) {}\n}\n\nclass B extends A {\n  void m(int i) {}\n}\n```\n\nIf it isn't intended to override the method from the superclass, then\nrename it:\n\n```dart\nclass A {\n  void m(int i) {}\n}\n\nclass B extends A {\n  void m2(String s) {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a member of a class is found\nthat overrides a member from a supertype and the override isn't valid. An\noverride is valid if all of these are true:\n- It allows all of the arguments allowed by the overridden member.\n- It doesn't require any arguments that aren't required by the overridden\n  member.\n- The type of every parameter of the overridden member is assignable to the\n  corresponding parameter of the override.\n- The return type of the override is assignable to the return type of the\n  overridden member.\n\n## Example\n\nThe following code produces this diagnostic because the type of the\nparameter `s` (`String`) isn't assignable to the type of the parameter `i`\n(`int`):\n\n```dart\nclass A {\n  void m(int p) {}\n}\n\nclass B extends A {\n  @override\n  void [!m!](String p) {}\n}\n```\n\n## Common fixes\n\nIf the invalid method is intended to override the method from the\nsuperclass, then change it to conform:\n\n```dart\nclass A {\n  void m(int p) {}\n}\n\nclass B extends A {\n  @override\n  void m(int p) {}\n}\n```\n\nIf it isn't intended to override the method from the superclass, then\nrename it:\n\n```dart\nclass A {\n  void m(int p) {}\n}\n\nclass B extends A {\n  void m2(String p) {}\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -4811,6 +4849,13 @@
     "previousNames": []
   },
   {
+    "id": "invalid_unicode_escape_started",
+    "description": "_The string '\\' can't stand alone._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "invalid_unicode_escape_u_bracket",
     "description": "_An escape sequence starting with '\\u{' must be followed by 1 to 6 hexadecimal digits followed by a '}'._",
     "hasDocumentation": false,
@@ -4843,6 +4888,14 @@
     "id": "invalid_use_of_covariant",
     "description": "_The 'covariant' keyword can only be used for parameters in instance methods or before non-final instance fields._",
     "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "invalid_use_of_covariant_in_extension",
+    "description": "_Can't have modifier '{0}' in an extension._",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a member declared inside an\nextension uses the keyword `covariant` in the declaration of a parameter.\nExtensions aren't classes and don't have subclasses, so the keyword serves\nno purpose.\n\n## Example\n\nThe following code produces this diagnostic because `i` is marked as being\ncovariant:\n\n```dart\nextension E on String {\n  void a([!covariant!] int i) {}\n}\n```\n\n## Common fixes\n\nRemove the `covariant` keyword:\n\n```dart\nextension E on String {\n  void a(int i) {}\n}\n```\n",
+    "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
   },
@@ -4957,7 +5010,7 @@
   {
     "id": "invalid_widget_preview_application",
     "description": "_The '@Preview(...)' annotation can only be applied to public, statically accessible constructors and functions._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `@Preview(...)` annotation\nis applied to an invalid widget preview target. Widget previews can only\nbe applied to public, statically accessible, explicitly defined\nconstructors and functions.\n\n## Examples\n\nThe following code produces this diagnostic because `_myPrivatePreview`\nis private:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// Invalid application to private top-level function.\n@[!Preview!]()\n// ignore: unused_element\nWidget _myPrivatePreview() => Text('Foo');\n```\n\nThe following code produces this diagnostic because `myExternalPreview`\nis `external`:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// Invalid application to an external function.\n@[!Preview!]()\nexternal Widget myExternalPreview();\n```\n\nThe following code produces this diagnostic because `PublicWidget._()` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nclass PublicWidget extends StatelessWidget {\n  // Invalid application to a private constructor.\n  @[!Preview!]()\n  PublicWidget._();\n\n  @override\n  Widget build(BuildContext) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `instancePreview` is\nan instance method:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nclass PublicWidget extends StatelessWidget {\n  // Invalid application to a instance member.\n  @[!Preview!]()\n  Widget instancePreview() => PublicWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `_PrivateWidget` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// ignore: unused_element\nclass _PrivateWidget extends StatelessWidget {\n  // Invalid application to a constructor of a private class.\n  @[!Preview!]()\n  _PrivateWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `_PrivateWidget` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// ignore: unused_element\nclass _PrivateWidget extends StatelessWidget {\n  // Invalid application to a static method of a private class.\n  @[!Preview!]()\n  Widget privateStatic() => _PrivateWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `AbstractWidget` is\nan `abstract` class:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nabstract class AbstractWidget extends StatelessWidget {\n  // Invalid application to a constructor of an abstract class.\n  @[!Preview!]()\n  AbstractWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\n## Common fixes\n\nCreate a dedicated public, statically accessible, and explicitly defined\nconstructor, top-level function, or class member for use as a preview:\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `@Preview(...)` annotation\nis applied to an invalid widget preview target. Widget previews can only\nbe applied to public, statically accessible, explicitly defined\nconstructors and functions.\n\n## Examples\n\nThe following code produces this diagnostic because `_myPrivatePreview`\nis private:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// Invalid application to private top-level function.\n@[!Preview!]()\n// ignore: unused_element\nWidget _myPrivatePreview() => Text('Foo');\n```\n\nThe following code produces this diagnostic because `myExternalPreview`\nis `external`:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// Invalid application to an external function.\n@[!Preview!]()\nexternal Widget myExternalPreview();\n```\n\nThe following code produces this diagnostic because `PublicWidget._()` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nclass PublicWidget extends StatelessWidget {\n  // Invalid application to a private constructor.\n  @[!Preview!]()\n  const PublicWidget._();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `instancePreview` is\nan instance method:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nclass PublicWidget extends StatelessWidget {\n  const new();\n\n  // Invalid application to a instance member.\n  @[!Preview!]()\n  Widget instancePreview() => PublicWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `_PrivateWidget` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// ignore: unused_element\nclass _PrivateWidget extends StatelessWidget {\n  // Invalid application to a constructor of a private class.\n  @[!Preview!]()\n  const _PrivateWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `_PrivateWidget` is\nprivate:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\n// ignore: unused_element\nclass _PrivateWidget extends StatelessWidget {\n  const new();\n\n  // Invalid application to a static method of a private class.\n  @[!Preview!]()\n  Widget privateStatic() => _PrivateWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\nThe following code produces this diagnostic because `AbstractWidget` is\nan `abstract` class:\n\n```dart\nimport 'package:flutter/widgets.dart';\nimport 'package:flutter/widget_previews.dart';\n\nabstract class AbstractWidget extends StatelessWidget {\n  // Invalid application to a constructor of an abstract class.\n  @[!Preview!]()\n  AbstractWidget();\n\n  @override\n  Widget build(BuildContext context) => Text('Foo');\n}\n```\n\n## Common fixes\n\nCreate a dedicated public, statically accessible, and explicitly defined\nconstructor, top-level function, or class member for use as a preview:\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -5080,7 +5133,7 @@
   {
     "id": "library_annotations",
     "description": "_This annotation should be attached to a library directive._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an annotation that applies to\na whole library isn't associated with a `library` directive.\n\n## Example\n\nThe following code produces this diagnostic because the `TestOn`\nannotation, which applies to the whole library, is associated with an\n`import` directive rather than a `library` directive:\n\n```dart\n[!@TestOn('browser')!]\n\nimport 'package:test/test.dart';\n\nvoid main() {}\n```\n\n## Common fixes\n\nAssociate the annotation with a `library` directive, adding one if\nnecessary:\n\n```dart\n@TestOn('browser')\nlibrary;\n\nimport 'package:test/test.dart';\n\nvoid main() {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an annotation that applies to\na whole library isn't associated with a `library` directive.\n\n## Example\n\nThe following code produces this diagnostic because the `TestOn`\nannotation, which applies to the whole library, is associated with an\n`import` directive rather than a `library` directive:\n\n```dart\n[!@TestOn('browser')!]\nimport 'package:test/test.dart';\n\nvoid main() {}\n```\n\n## Common fixes\n\nAssociate the annotation with a `library` directive, adding one if\nnecessary:\n\n```dart\n@TestOn('browser')\nlibrary;\n\nimport 'package:test/test.dart';\n\nvoid main() {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -5238,29 +5291,15 @@
     "previousNames": []
   },
   {
-    "id": "member_with_same_name_as_class",
+    "id": "member_with_class_name",
     "description": "_A class member can't have the same name as the enclosing class._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
   {
-    "id": "metadata_space_before_parenthesis",
-    "description": "_Annotations can't have spaces or comments before the parenthesis._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "metadata_type_arguments",
-    "description": "_An annotation can't use type arguments._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "metadata_type_arguments_uninstantiated",
-    "description": "_An annotation with type arguments must be followed by an argument list._",
+    "id": "migrate_design_widgets",
+    "description": "_The '{0}' library is deprecated._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -5291,6 +5330,13 @@
   {
     "id": "missing_assignment_in_initializer",
     "description": "_Expected an assignment after the field name._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "missing_catch_or_finally",
+    "description": "_A try block must be followed by an 'on', 'catch', or 'finally' clause._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -5408,7 +5454,7 @@
   {
     "id": "missing_field_type_in_struct",
     "description": "_Fields in struct classes must have an explicitly declared type of 'int', 'double' or 'Pointer'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a field in a subclass of\n`Struct` or `Union` doesn't have a type annotation. Every field must have\nan explicit type, and the type must either be `int`, `double`, `Pointer`,\nor a subclass of either `Struct` or `Union`.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the field `str`\ndoesn't have a type annotation:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  external var [!str!];\n\n  @Int32()\n  external int i;\n}\n```\n\n## Common fixes\n\nExplicitly specify the type of the field:\n\n```dart\nimport 'dart:ffi';\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  external Pointer<Utf8> str;\n\n  @Int32()\n  external int i;\n}\n```\n\n[ffi]: /interop/c-interop\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a field in a subclass of\n`Struct` or `Union` doesn't have a type annotation. Every field must have\nan explicit type, and the type must either be `int`, `double`, `Pointer`,\nor a subclass of either `Struct` or `Union`.\n\nFor more information about FFI, see [C interop using dart:ffi][ffi].\n\n## Example\n\nThe following code produces this diagnostic because the field `str`\ndoesn't have a type annotation:\n\n```dart\nimport 'dart:ffi';\n\nfinal class C extends Struct {\n  external var [!str!];\n\n  @Int32()\n  external int i;\n}\n```\n\n## Common fixes\n\nExplicitly specify the type of the field:\n\n```dart\nimport 'dart:ffi';\n\nimport 'package:ffi/ffi.dart';\n\nfinal class C extends Struct {\n  external Pointer<Utf8> str;\n\n  @Int32()\n  external int i;\n}\n```\n\n[ffi]: /interop/c-interop\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -5456,8 +5502,22 @@
     "previousNames": []
   },
   {
+    "id": "missing_initializer",
+    "description": "_Expected an initializer._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "missing_key",
     "description": "_Missing the required key '{0}'._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "missing_keyword_operator",
+    "description": "_Operator declarations must be preceded by the keyword 'operator'._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -5509,13 +5569,6 @@
   {
     "id": "missing_one_of_multiple_keys",
     "description": "_Exactly one of the following keys must be provided: {0}._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "missing_operator_keyword",
-    "description": "_Operator declarations must be preceded by the keyword 'operator'._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -5596,6 +5649,13 @@
     "previousNames": []
   },
   {
+    "id": "missing_statement",
+    "description": "_Expected a statement._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "missing_template_end",
     "description": "_Missing the end brace for the template._",
     "hasDocumentation": false,
@@ -5648,7 +5708,7 @@
   {
     "id": "missing_whitespace_between_adjacent_strings",
     "description": "_Missing whitespace between adjacent strings._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic for a pair of adjacent string\nliterals unless either the left-hand string ends in whitespace or the\nright-hand string begins with whitespace.\n\n## Example\n\nThe following code produces this diagnostic because neither the left nor\nthe right string literal includes a space to separate the words that will\nbe joined:\n\n```dart\nvar s =\n  [!'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'!]\n  'do eiusmod tempor incididunt ut labore et dolore magna';\n```\n\n## Common fixes\n\nAdd whitespace at the end of the left-hand literal or at the beginning of\nthe right-hand literal:\n\n```dart\nvar s =\n  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed '\n  'do eiusmod tempor incididunt ut labore et dolore magna';\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic for a pair of adjacent string\nliterals unless either the left-hand string ends in whitespace or the\nright-hand string begins with whitespace.\n\n## Example\n\nThe following code produces this diagnostic because neither the left nor\nthe right string literal includes a space to separate the words that will\nbe joined:\n\n```dart\nvar s =\n    [!'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'!]\n    'do eiusmod tempor incididunt ut labore et dolore magna';\n```\n\n## Common fixes\n\nAdd whitespace at the end of the left-hand literal or at the beginning of\nthe right-hand literal:\n\n```dart\nvar s =\n    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed '\n    'do eiusmod tempor incididunt ut labore et dolore magna';\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -5678,7 +5738,7 @@
   {
     "id": "mixin_application_no_concrete_super_invoked_member",
     "description": "_The class doesn't have a concrete implementation of the super-invoked member '{0}'._\n\n_The class doesn't have a concrete implementation of the super-invoked setter '{0}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a [mixin application][] contains\nan invocation of a member from its superclass, and there's no concrete\nmember of that name in the mixin application's superclass.\n\n## Example\n\nThe following code produces this diagnostic because the mixin `M` contains\nthe invocation `super.m()`, and the class `A`, which is the superclass of\nthe [mixin application][] `A+M`, doesn't define a concrete implementation\nof `m`:\n\n```dart\nabstract class A {\n  void m();\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nabstract class B extends A with [!M!] {}\n```\n\n## Common fixes\n\nIf you intended to apply the mixin `M` to a different class, one that has a\nconcrete implementation of `m`, then change the superclass of `B` to that\nclass:\n\n```dart\nabstract class A {\n  void m();\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nclass C implements A {\n  void m() {}\n}\n\nabstract class B extends C with M {}\n```\n\nIf you need to make `B` a subclass of `A`, then add a concrete\nimplementation of `m` in `A`:\n\n```dart\nabstract class A {\n  void m() {}\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nabstract class B extends A with M {}\n```\n\n[mixin application]: /resources/glossary#mixin-application\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a [mixin application][] contains\nan invocation of a member from its superclass, and there's no concrete\nmember of that name in the mixin application's superclass.\n\n## Example\n\nThe following code produces this diagnostic because the mixin `M` contains\nthe invocation `super.m()`, and the class `A`, which is the superclass of\nthe [mixin application][] `A+M`, doesn't define a concrete implementation\nof `m`:\n\n```dart\nabstract class A {\n  void m();\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nabstract class B extends A with [!M!] {}\n```\n\n## Common fixes\n\nIf you intended to apply the mixin `M` to a different class, one that has a\nconcrete implementation of `m`, then change the superclass of `B` to that\nclass:\n\n```dart\nabstract class A {\n  void m();\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nclass C implements A {\n  @override\n  void m() {}\n}\n\nabstract class B extends C with M {}\n```\n\nIf you need to make `B` a subclass of `A`, then add a concrete\nimplementation of `m` in `A`:\n\n```dart\nabstract class A {\n  void m() {}\n}\n\nmixin M on A {\n  void bar() {\n    super.m();\n  }\n}\n\nabstract class B extends A with M {}\n```\n\n[mixin application]: /resources/glossary#mixin-application\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -5688,6 +5748,13 @@
     "description": "_'{0}' can't be mixed onto '{1}' because '{1}' doesn't implement '{2}'._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a mixin that has a superclass\nconstraint is used in a [mixin application][] with a superclass that\ndoesn't implement the required constraint.\n\n## Example\n\nThe following code produces this diagnostic because the mixin `M` requires\nthat the class to which it's applied be a subclass of `A`, but `Object`\nisn't a subclass of `A`:\n\n```dart\nclass A {}\n\nmixin M on A {}\n\nclass X = Object with [!M!];\n```\n\n## Common fixes\n\nIf you need to use the mixin, then change the superclass to be either the\nsame as or a subclass of the superclass constraint:\n\n```dart\nclass A {}\n\nmixin M on A {}\n\nclass X = A with M;\n```\n\n[mixin application]: /resources/glossary#mixin-application\n",
     "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "mixin_augmentation_has_on_clause",
+    "description": "_Mixin augmentations can't have 'on' clauses._",
+    "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
@@ -5718,7 +5785,7 @@
   {
     "id": "mixin_class_declares_non_trivial_generative_constructor",
     "description": "_The mixin class '{0}' can't declare a non-trivial generative constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a mixin class declares a non-trivial\ngenerative constructor. Trivial constructors are allowed, but non-trivial ones\n(those with parameters, bodies, or initializers) aren't.\n\n## Example\n\nThe following code produces this diagnostic because the `mixin class` `A`\ndefines a generative constructor with a body:\n\n```dart\nmixin class A {\n  [!A!]() {}\n}\n```\n\n## Common fixes\n\nIf you can remove the body or parameters of the constructor to make it trivial,\nthen do so:\n\n```dart\nmixin class A {\n  A(); // Trivial constructor\n}\n```\n\nIf the constructor can't be made trivial, then convert the `mixin class` to a\nregular `class` and extend or implement it, or separate the mixin capability:\n\n```dart\nclass A {\n  A() {}\n}\n\n// A separate mixin for mixing in behavior\nmixin class AM {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a mixin class declares a non-trivial\ngenerative constructor. Trivial constructors are allowed, but non-trivial ones\n(those with parameters, bodies, or initializers) aren't.\n\n## Example\n\nThe following code produces this diagnostic because the `mixin class` `A`\ndefines a generative constructor with a body:\n\n```dart\nmixin class A {\n  [!A!]() {}\n}\n```\n\n## Common fixes\n\nIf you can remove the body or parameters of the constructor to make it trivial,\nthen do so:\n\n```dart\nmixin class A {\n  A(); // Trivial constructor\n}\n```\n\nIf the constructor can't be made trivial, then convert the `mixin class` to a\nregular `class` and extend or implement it, or separate the mixin capability:\n\n```dart\nclass A {\n  A();\n}\n\n// A separate mixin for mixing in behavior\nmixin class AM {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -5830,7 +5897,7 @@
     "previousNames": []
   },
   {
-    "id": "multiple_extends",
+    "id": "multiple_extends_clauses",
     "description": "_Each class definition can have at most one extends clause._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -5860,6 +5927,13 @@
   {
     "id": "multiple_on_clauses",
     "description": "_Each mixin definition can have at most one on clause._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "multiple_part_of_directives",
+    "description": "_Only one part-of directive may be declared in a file._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
@@ -5924,7 +5998,7 @@
     "previousNames": []
   },
   {
-    "id": "multiple_with",
+    "id": "multiple_with_clauses",
     "description": "_Each class definition can have at most one with clause._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -5949,7 +6023,7 @@
   {
     "id": "must_be_immutable",
     "description": "_This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final: {0}_",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an immutable class defines one\nor more instance fields that aren't final. A class is immutable if it's\nmarked as being immutable using the annotation\n[`immutable`][meta-immutable] or if it's a subclass of an immutable class.\n\n## Example\n\nThe following code produces this diagnostic because the field `x` isn't\nfinal:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass [!C!] {\n  int x;\n\n  C(this.x);\n}\n```\n\n## Common fixes\n\nIf instances of the class should be immutable, then add the keyword `final`\nto all non-final field declarations:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final int x;\n\n  C(this.x);\n}\n```\n\nIf the instances of the class should be mutable, then remove the\nannotation, or choose a different superclass if the annotation is\ninherited:\n\n```dart\nclass C {\n  int x;\n\n  C(this.x);\n}\n```\n\n[meta-immutable]: https://pub.dev/documentation/meta/latest/meta/immutable-constant.html\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an immutable class defines one\nor more instance fields that aren't final. A class is immutable if it's\nmarked as being immutable using the annotation\n[`immutable`][meta-immutable] or if it's a subclass of an immutable class.\n\n## Example\n\nThe following code produces this diagnostic because the field `x` isn't\nfinal:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass [!C!] {\n  int x;\n\n  C(this.x);\n}\n```\n\n## Common fixes\n\nIf instances of the class should be immutable, then add the keyword `final`\nto all non-final field declarations:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final int x;\n\n  const C(this.x);\n}\n```\n\nIf the instances of the class should be mutable, then remove the\nannotation, or choose a different superclass if the annotation is\ninherited:\n\n```dart\nclass C {\n  int x;\n\n  C(this.x);\n}\n```\n\n[meta-immutable]: https://pub.dev/documentation/meta/latest/meta/immutable-constant.html\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -5957,7 +6031,7 @@
   {
     "id": "must_call_super",
     "description": "_This method overrides a method annotated as '@mustCallSuper' in '{0}', but doesn't invoke the overridden method._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a method that overrides a method\nthat is annotated as [`mustCallSuper`][meta-mustCallSuper] doesn't invoke\nthe overridden method as required.\n\n## Example\n\nThe following code produces this diagnostic because the method `m` in `B`\ndoesn't invoke the overridden method `m` in `A`:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass A {\n  @mustCallSuper\n  m() {}\n}\n\nclass B extends A {\n  @override\n  [!m!]() {}\n}\n```\n\n## Common fixes\n\nAdd an invocation of the overridden method in the overriding method:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass A {\n  @mustCallSuper\n  m() {}\n}\n\nclass B extends A {\n  @override\n  m() {\n    super.m();\n  }\n}\n```\n\n[meta-mustCallSuper]: https://pub.dev/documentation/meta/latest/meta/mustCallSuper-constant.html\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a method that overrides a method\nthat is annotated as [`mustCallSuper`][meta-mustCallSuper] doesn't invoke\nthe overridden method as required.\n\n## Example\n\nThe following code produces this diagnostic because the method `m` in `B`\ndoesn't invoke the overridden method `m` in `A`:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass A {\n  @mustCallSuper\n  m() {}\n}\n\nclass B extends A {\n  @override\n  [!m!]() {}\n}\n```\n\n## Common fixes\n\nAdd an invocation of the overridden method in the overriding method:\n\n```dart\nimport 'package:meta/meta.dart';\n\nclass A {\n  @mustCallSuper\n  void m() {}\n}\n\nclass B extends A {\n  @override\n  void m() {\n    super.m();\n  }\n}\n```\n\n[meta-mustCallSuper]: https://pub.dev/documentation/meta/latest/meta/mustCallSuper-constant.html\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -6099,7 +6173,7 @@
   {
     "id": "no_adjacent_strings_in_list",
     "description": "_Don't use adjacent strings in a list literal._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when two string literals are\nadjacent in a list literal. Adjacent strings in Dart are concatenated\ntogether to form a single string, but the intent might be for each string\nto be a separate element in the list.\n\n## Example\n\nThe following code produces this diagnostic because the strings `'a'` and\n`'b'` are adjacent:\n\n```dart\nList<String> list = [[!'a' 'b'!], 'c'];\n```\n\n## Common fixes\n\nIf the two strings are intended to be separate elements of the list, then\nadd a comma between them:\n\n```dart\nList<String> list = ['a', 'b', 'c'];\n```\n\nIf the two strings are intended to be a single concatenated string, then\neither manually merge the strings:\n\n```dart\nList<String> list = ['ab', 'c'];\n```\n\nOr use the `+` operator to concatenate the strings:\n\n```dart\nList<String> list = ['a' + 'b', 'c'];\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when two string literals are\nadjacent in a list literal. Adjacent strings in Dart are concatenated\ntogether to form a single string, but the intent might be for each string\nto be a separate element in the list.\n\n## Example\n\nThe following code produces this diagnostic because the strings `'a'` and\n`'b'` are adjacent:\n\n```dart\nList<String> list = [\n  [!'a'!]\n      [!'b'!],\n  'c',\n];\n```\n\n## Common fixes\n\nIf the two strings are intended to be separate elements of the list, then\nadd a comma between them:\n\n```dart\nList<String> list = ['a', 'b', 'c'];\n```\n\nIf the two strings are intended to be a single concatenated string, then\neither manually merge the strings:\n\n```dart\nList<String> list = ['ab', 'c'];\n```\n\nOr use the `+` operator to concatenate the strings:\n\n```dart\nList<String> list = ['a' + 'b', 'c'];\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -6107,7 +6181,7 @@
   {
     "id": "no_annotation_constructor_arguments",
     "description": "_Annotation creation must have arguments._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an annotation consists of a\nsingle identifier, but that identifier is the name of a class rather than a\nvariable. To create an instance of the class, the identifier must be\nfollowed by an argument list.\n\n## Example\n\nThe following code produces this diagnostic because `C` is a class, and a\nclass can't be used as an annotation without invoking a `const` constructor\nfrom the class:\n\n```dart\nclass C {\n  const C();\n}\n\n[!@C!]\nvar x;\n```\n\n## Common fixes\n\nAdd the missing argument list:\n\n```dart\nclass C {\n  const C();\n}\n\n@C()\nvar x;\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an annotation consists of a\nsingle identifier, but that identifier is the name of a class rather than a\nvariable. To create an instance of the class, the identifier must be\nfollowed by an argument list.\n\n## Example\n\nThe following code produces this diagnostic because `C` is a class, and a\nclass can't be used as an annotation without invoking a `const` constructor\nfrom the class:\n\n```dart\nclass C {\n  const C();\n}\n\n[!@C!]\nvar x = 0;\n```\n\n## Common fixes\n\nAdd the missing argument list:\n\n```dart\nclass C {\n  const C();\n}\n\n@C()\nvar x = 0;\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -6123,7 +6197,8 @@
   {
     "id": "no_default_cases",
     "description": "_Invalid use of 'default' member in a switch._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `switch` statement over an\nenum value or an instance of an enum-like class has a `default` clause.\n\nEnum-like classes are non-abstract classes that have:\n\n- Only private, non-factory constructors.\n- Two or more `static const` fields whose type is the enclosing class.\n- No subclasses in the defining library.\n\n## Examples\n\nThe following code produces this diagnostic because the\n`switch` statement over the enum value `e` has a `default` clause:\n\n```dart\nenum E { a, b, c }\n\nvoid f(E e) {\n  switch (e) {\n    case .a:\n      print('a');\n    [!default:!]\n      [!print('other');!]\n  }\n}\n```\n\nThe following code produces this diagnostic because the\n`switch` statement over `c`, an instance of the enum-like class `C`,\nhas a `default` clause:\n\n```dart\nclass const C._(final int i) {\n  static const C a = ._(1);\n  static const C b = ._(2);\n  static const C c = ._(3);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case .a:\n      print('a');\n    [!default:!]\n      [!print('other');!]\n  }\n}\n```\n\n## Common fixes\n\nIf the value is an `enum` value,\nreplace the `default` clause with `case` clauses for\nthe enum values that aren't already handled:\n\n```dart\nenum E { a, b, c }\n\nvoid f(E e) {\n  switch (e) {\n    case .a:\n      print('a');\n    case .b:\n    case .c:\n      print('other');\n  }\n}\n```\n\nIf the value is an instance of an enum-like class,\nreplace the `default` clause with `case` clauses for\nthe constants that aren't already handled:\n\n```dart\nclass const C._(final int i) {\n  static const C a = ._(1);\n  static const C b = ._(2);\n  static const C c = ._(3);\n}\n\nvoid f(C c) {\n  switch (c) {\n    case .a:\n      print('a');\n    case .b:\n    case .c:\n      print('other');\n  }\n}\n```\n",
+    "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
   },
@@ -6183,7 +6258,7 @@
   {
     "id": "no_logic_in_create_state",
     "description": "_Don't put any logic in 'createState'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an implementation of\n`createState` in a subclass of `StatefulWidget` contains any logic other\nthan the return of the result of invoking a zero argument constructor.\n\n## Examples\n\nThe following code produces this diagnostic because the constructor\ninvocation has arguments:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatefulWidget {\n  @override\n  MyState createState() => [!MyState(0)!];\n}\n\nclass MyState extends State {\n  int x;\n\n  MyState(this.x);\n\n  Widget build(BuildContext context) => MyWidget();\n}\n```\n\n## Common fixes\n\nRewrite the code so that `createState` doesn't contain any logic:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatefulWidget {\n  @override\n  MyState createState() => MyState();\n}\n\nclass MyState extends State {\n  int x = 0;\n\n  MyState();\n\n  Widget build(BuildContext context) => MyWidget();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an implementation of\n`createState` in a subclass of `StatefulWidget` contains any logic other\nthan the return of the result of invoking a zero argument constructor.\n\n## Examples\n\nThe following code produces this diagnostic because the constructor\ninvocation has arguments:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const MyWidget({super.key}) extends StatefulWidget {\n  @override\n  MyState createState() => [!MyState(0)!];\n}\n\nclass MyState extends State {\n  int x;\n\n  MyState(this.x);\n\n  @override\n  Widget build(BuildContext context) => MyWidget();\n}\n```\n\n## Common fixes\n\nRewrite the code so that `createState` doesn't contain any logic:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const MyWidget({super.key}) extends StatefulWidget {\n  @override\n  MyState createState() => MyState();\n}\n\nclass MyState extends State {\n  int x = 0;\n\n  MyState();\n\n  @override\n  Widget build(BuildContext context) => MyWidget();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -6191,7 +6266,7 @@
   {
     "id": "no_raw_types",
     "description": "_The generic type '{0}' should have explicit type arguments but doesn't._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a generic type is used without\nexplicit type arguments, meaning it is a raw type.\n\n## Example\n\nThe following code produces this diagnostic because the generic class `C`\nis used without a type argument:\n\n```dart\nclass C<T> {}\n[!C!] c = C<int>();\n```\n\n## Common fixes\n\nProvide explicit type arguments:\n\n```dart\nclass C<T> {}\nC<int> c = C<int>();\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a generic type is used without\nexplicit type arguments, meaning it is a raw type.\n\n## Example\n\nThe following code produces this diagnostic because the generic class `C`\nis used without a type argument:\n\n```dart\nclass C<T> {}\n\n[!C!] c = C<int>();\n```\n\n## Common fixes\n\nProvide explicit type arguments:\n\n```dart\nclass C<T> {}\n\nC<int> c = C<int>();\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -6242,7 +6317,7 @@
   {
     "id": "non_abstract_class_inherits_abstract_member",
     "description": "_Missing concrete implementation of '{0}'._\n\n_Missing concrete implementations of '{0}' and '{1}'._\n\n_Missing concrete implementations of '{0}', '{1}', '{2}', '{3}', and {4} more._\n\n_Missing concrete implementations of '{0}', '{1}', '{2}', and '{3}'._\n\n_Missing concrete implementations of '{0}', '{1}', and '{2}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a concrete class inherits one or\nmore abstract members, and doesn't provide or inherit an implementation for\nat least one of those abstract members.\n\n## Example\n\nThe following code produces this diagnostic because the class `B` doesn't\nhave a concrete implementation of `m`:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass [!B!] extends A {}\n```\n\n## Common fixes\n\nIf the subclass can provide a concrete implementation for some or all of\nthe abstract inherited members, then add the concrete implementations:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass B extends A {\n  void m() {}\n}\n```\n\nIf there is a mixin that provides an implementation of the inherited\nmethods, then apply the mixin to the subclass:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass B extends A with M {}\n\nmixin M {\n  void m() {}\n}\n```\n\nIf the subclass can't provide a concrete implementation for all of the\nabstract inherited members, then mark the subclass as being abstract:\n\n```dart\nabstract class A {\n  void m();\n}\n\nabstract class B extends A {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a concrete class inherits one or\nmore abstract members, and doesn't provide or inherit an implementation for\nat least one of those abstract members.\n\n## Example\n\nThe following code produces this diagnostic because the class `B` doesn't\nhave a concrete implementation of `m`:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass [!B!] extends A {}\n```\n\n## Common fixes\n\nIf the subclass can provide a concrete implementation for some or all of\nthe abstract inherited members, then add the concrete implementations:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass B extends A {\n  @override\n  void m() {}\n}\n```\n\nIf there is a mixin that provides an implementation of the inherited\nmethods, then apply the mixin to the subclass:\n\n```dart\nabstract class A {\n  void m();\n}\n\nclass B extends A with M {}\n\nmixin M {\n  void m() {}\n}\n```\n\nIf the subclass can't provide a concrete implementation for all of the\nabstract inherited members, then mark the subclass as being abstract:\n\n```dart\nabstract class A {\n  void m();\n}\n\nabstract class B extends A {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -6532,7 +6607,7 @@
   {
     "id": "non_redirecting_generative_constructor_with_primary",
     "description": "_Classes with primary constructors can't have non-redirecting generative constructors._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class that declares a primary\nconstructor also has a non-redirecting generative constructor.\n\n## Example\n\nThe following code produces this diagnostic because the class `C` declares\nboth a primary constructor and a non-redirecting generative constructor:\n\n```dart\nclass C(final String f) {\n  [!C.c!](Object p) : f = p.toString();\n}\n```\n\n## Common fixes\n\nIf the generative constructor can redirect to the primary constructor, then\nadd the redirection:\n\n```dart\nclass C(final String f) {\n  C.c(Object p) : this(p.toString());\n}\n```\n\nIf the generative constructor can be a factory constructor that uses the\nprimary constructor to create the instance, then make it a factory\nconstructor:\n\n```dart\nclass C(final String f) {\n  factory C.c(Object p) => C(p.toString());\n}\n```\n\nOtherwise, remove the generative constructor or convert the primary\nconstructor into a generative secondary constructor.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class that declares a primary\nconstructor also has a non-redirecting generative constructor.\n\n## Example\n\nThe following code produces this diagnostic because the class `C` declares\nboth a primary constructor and a non-redirecting generative constructor:\n\n```dart\nclass C(final String f) {\n  [!new c!](Object p) : f = p.toString();\n}\n```\n\n## Common fixes\n\nIf the generative constructor can redirect to the primary constructor, then\nadd the redirection:\n\n```dart\nclass C(final String f) {\n  new c(Object p) : this(p.toString());\n}\n```\n\nIf the generative constructor can be a factory constructor that uses the\nprimary constructor to create the instance, then make it a factory\nconstructor:\n\n```dart\nclass C(final String f) {\n  factory c(Object p) => C(p.toString());\n}\n```\n\nOtherwise, remove the generative constructor or convert the primary\nconstructor into a generative in-body constructor.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -6836,20 +6911,6 @@
     "previousNames": []
   },
   {
-    "id": "only_try",
-    "description": "_A try block must be followed by an 'on', 'catch', or 'finally' clause._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "operator_with_type_parameters",
-    "description": "_Types parameters aren't allowed when defining an operator._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "optional_parameter_in_operator",
     "description": "_Optional parameters aren't allowed when defining an operator._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when one or more of the parameters in\nan operator declaration are optional.\n\n## Example\n\nThe following code produces this diagnostic because the parameter `other`\nis an optional parameter:\n\n```dart\nclass C {\n  C operator +([[!C? other!]]) => this;\n}\n```\n\n## Common fixes\n\nMake all of the parameters be required parameters:\n\n```dart\nclass C {\n  C operator +(C other) => this;\n}\n```\n",
@@ -6959,13 +7020,6 @@
     "previousNames": []
   },
   {
-    "id": "part_of_twice",
-    "description": "_Only one part-of directive may be declared in a file._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "part_of_unnamed_library",
     "description": "_The library is unnamed. A URI is expected, not a library name '{0}', in the part-of directive._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a library that doesn't have a\n`library` directive (and hence has no name) contains a `part` directive\nand the `part of` directive in the [part file][] uses a name to specify\nthe library that it's a part of.\n\n## Example\n\nGiven a [part file][] named `part_file.dart` containing the following\ncode:\n\n```dart\npart of lib;\n```\n\nThe following code produces this diagnostic because the library including\nthe [part file][] doesn't have a name even though the [part file][] uses a\nname to specify which library it's a part of:\n\n```dart\npart [!'part_file.dart'!];\n```\n\n## Common fixes\n\nChange the `part of` directive in the [part file][] to specify its library\nby URI:\n\n```dart\npart of 'test.dart';\n```\n\n[part file]: /resources/glossary#part-file\n",
@@ -7039,7 +7093,7 @@
   {
     "id": "pattern_variable_assignment_inside_guard",
     "description": "_Pattern variables can't be assigned inside the guard of the enclosing guarded pattern._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a pattern variable is assigned\na value inside a guard (`when`) clause.\n\n## Example\n\nThe following code produces this diagnostic because the variable `a` is\nassigned a value inside the guard clause:\n\n```dart\nvoid f(int x) {\n  if (x case var a when ([!a!] = 1) > 0) {\n    print(a);\n  }\n}\n```\n\n## Common fixes\n\nIf there's a value you need to capture, then assign it to a different\nvariable:\n\n```dart\nvoid f(int x) {\n  var b;\n  if (x case var a when (b = 1) > 0) {\n    print(a + b);\n  }\n}\n```\n\nIf there isn't a value you need to capture, then remove the assignment:\n\n```dart\nvoid f(int x) {\n  if (x case var a when 1 > 0) {\n    print(a);\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a pattern variable is assigned\na value inside a guard (`when`) clause.\n\n## Example\n\nThe following code produces this diagnostic because the variable `a` is\nassigned a value inside the guard clause:\n\n```dart\nvoid f(int x) {\n  if (x case var a when ([!a!] = 1) > 0) {\n    print(a);\n  }\n}\n```\n\n## Common fixes\n\nIf there's a value you need to capture, then assign it to a different\nvariable:\n\n```dart\nvoid f(int x) {\n  var b = 0;\n  if (x case var a when (b = 1) > 0) {\n    print(a + b);\n  }\n}\n```\n\nIf there isn't a value you need to capture, then remove the assignment:\n\n```dart\nvoid f(int x) {\n  if (x case var a when 1 > 0) {\n    print(a);\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7099,7 +7153,7 @@
   {
     "id": "positional_super_formal_parameter_with_positional_argument",
     "description": "_Positional super parameters can't be used when the super constructor invocation has a positional argument._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when some, but not all, of the\npositional parameters provided to the constructor of the superclass are\nusing a super parameter.\n\nPositional super parameters are associated with positional parameters in\nthe super constructor by their index. That is, the first super parameter\nis associated with the first positional parameter in the super\nconstructor, the second with the second, and so on. The same is true for\npositional arguments. Having both positional super parameters and\npositional arguments means that there are two values associated with the\nsame parameter in the superclass's constructor, and hence isn't allowed.\n\n## Example\n\nThe following code produces this diagnostic because the constructor\n`B.new` is using a super parameter to pass one of the required positional\nparameters to the super constructor in `A`, but is explicitly passing the\nother in the super constructor invocation:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(int x, super.[!y!]) : super(x);\n}\n```\n\n## Common fixes\n\nIf all the positional parameters can be super parameters, then convert the\nnormal positional parameters to be super parameters:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(super.x, super.y);\n}\n```\n\nIf some positional parameters can't be super parameters, then convert the\nsuper parameters to be normal parameters:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(int x, int y) : super(x, y);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when some, but not all, of the\npositional parameters provided to the constructor of the superclass are\nusing a super parameter.\n\nPositional super parameters are associated with positional parameters in\nthe super constructor by their index. That is, the first super parameter\nis associated with the first positional parameter in the super\nconstructor, the second with the second, and so on. The same is true for\npositional arguments. Having both positional super parameters and\npositional arguments means that there are two values associated with the\nsame parameter in the superclass's constructor, and hence isn't allowed.\n\n## Example\n\nThe following code produces this diagnostic because the constructor\n`B.new` is using a super parameter to pass one of the required positional\nparameters to the super constructor in `A`, but is explicitly passing the\nother in the super constructor invocation:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(int x, super.[!y!]) : super(x);\n}\n```\n\n## Common fixes\n\nIf all the positional parameters can be super parameters, then convert the\nnormal positional parameters to be super parameters:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(super.x, super.y);\n}\n```\n\nIf some positional parameters can't be super parameters, then convert the\nsuper parameters to be normal parameters:\n\n```dart\nclass A {\n  A(int x, int y);\n}\n\nclass B extends A {\n  B(int x, int y) : super(x + 1, y);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7107,7 +7161,7 @@
   {
     "id": "prefer_adjacent_string_concatenation",
     "description": "_String literals shouldn't be concatenated by the '+' operator._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the `+` operator is used to\nconcatenate two string literals.\n\n## Example\n\nThe following code produces this diagnostic because two string literals\nare being concatenated by using the `+` operator:\n\n```dart\nvar s = 'a' [!+!] 'b';\n```\n\n## Common fixes\n\nRemove the operator:\n\n```dart\nvar s = 'a' 'b';\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the `+` operator is used to\nconcatenate two string literals.\n\n## Example\n\nThe following code produces this diagnostic because two string literals\nare being concatenated by using the `+` operator:\n\n```dart\nvar s = 'a' [!+!] 'b';\n```\n\n## Common fixes\n\nRemove the operator:\n\n```dart\nvar s =\n    'a'\n    'b';\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7162,7 +7216,7 @@
   {
     "id": "prefer_const_constructors_in_immutables",
     "description": "_Constructors in '@immutable' classes should be declared as 'const'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-`const` constructor is\nfound in a class that has the `@immutable` annotation.\n\n## Example\n\nThe following code produces this diagnostic because the constructor in `C`\nisn't declared as `const` even though `C` has the `@immutable` annotation:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  [!C!](this.f);\n}\n```\n\n## Common fixes\n\nIf the class really is intended to be immutable, then add the `const`\nmodifier to the constructor:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  const C(this.f);\n}\n```\n\nIf the class is mutable, then remove the `@immutable` annotation:\n\n```dart\nclass C {\n  final f;\n\n  C(this.f);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-`const` constructor is\nfound in a class that has the `@immutable` annotation.\n\n## Example\n\nThe following code produces this diagnostic because the constructor in `C`\nisn't declared as `const` even though `C` has the `@immutable` annotation:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final int f;\n\n  [!C!](this.f);\n}\n```\n\n## Common fixes\n\nIf the class really is intended to be immutable, then add the `const`\nmodifier to the constructor:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final int f;\n\n  const C(this.f);\n}\n```\n\nIf the class is mutable, then remove the `@immutable` annotation:\n\n```dart\nclass C {\n  final int f;\n\n  C(this.f);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7178,7 +7232,7 @@
   {
     "id": "prefer_const_literals_to_create_immutables",
     "description": "_Use 'const' literals as arguments to constructors of '@immutable' classes._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-const list, map, or set\nliteral is passed as an argument to a constructor declared in a class\nannotated with `@immutable`.\n\n## Example\n\nThe following code produces this diagnostic because the list literal\n(`[1]`) is being passed to a constructor in an immutable class but isn't\na constant list:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  const C(this.f);\n}\n\nC c = C([![1]!]);\n```\n\n## Common fixes\n\nIf the context can be made a [constant context][], then do so:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  const C(this.f);\n}\n\nconst C c = C([1]);\n```\n\nIf the context can't be made a [constant context][] but the constructor\ncan be invoked using `const`, then add `const` before the constructor\ninvocation:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  const C(this.f);\n}\n\nC c = const C([1]);\n```\n\nIf the context can't be made a [constant context][] and the constructor\ncan't be invoked using `const`, then add the keyword `const` before the\ncollection literal:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final f;\n\n  const C(this.f);\n}\n\nC c = C(const [1]);\n```\n\n[constant context]: /resources/glossary#constant-context\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a non-const list, map, or set\nliteral is passed as an argument to a constructor declared in a class\nannotated with `@immutable`.\n\n## Example\n\nThe following code produces this diagnostic because the list literal\n(`[1]`) is being passed to a constructor in an immutable class but isn't\na constant list:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final List<int> f;\n\n  const C(this.f);\n}\n\nC c = C([![1]!]);\n```\n\n## Common fixes\n\nIf the context can be made a [constant context][], then do so:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final List<int> f;\n\n  const C(this.f);\n}\n\nconst C c = C([1]);\n```\n\nIf the context can't be made a [constant context][] but the constructor\ncan be invoked using `const`, then add `const` before the constructor\ninvocation:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final List<int> f;\n\n  const C(this.f);\n}\n\nC c = const C([1]);\n```\n\nIf the context can't be made a [constant context][] and the constructor\ncan't be invoked using `const`, then add the keyword `const` before the\ncollection literal:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@immutable\nclass C {\n  final List<int> f;\n\n  const C(this.f);\n}\n\nC c = C(const [1]);\n```\n\n[constant context]: /resources/glossary#constant-context\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7257,7 +7311,7 @@
   {
     "id": "prefer_for_elements_to_map_fromiterable",
     "description": "_Use 'for' elements when building maps from iterables._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `Map.fromIterable` is used to\nbuild a map that could be built using the `for` element.\n\n## Example\n\nThe following code produces this diagnostic because `fromIterable` is\nbeing used to build a map that could be built using a `for` element:\n\n```dart\nvoid f(Iterable<String> data) {\n  [!Map<String, int>.fromIterable(!]\n    [!data,!]\n    [!key: (element) => element,!]\n    [!value: (element) => element.length,!]\n  [!)!];\n}\n```\n\n## Common fixes\n\nUse a `for` element to build the map:\n\n```dart\nvoid f(Iterable<String> data) {\n  <String, int>{\n    for (var element in data)\n      element: element.length\n  };\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `Map.fromIterable` is used to\nbuild a map that could be built using a `for` element.\n\n## Example\n\nThe following code produces this diagnostic because `fromIterable` is\nbeing used to build a map that could be built using a `for` element:\n\n```dart\nvoid f(Iterable<String> data) {\n  [!Map<String, int>.fromIterable(!]\n    [!data,!]\n    [!key: (element) => element,!]\n    [!value: (element) => element.length,!]\n  [!)!];\n}\n```\n\n## Common fixes\n\nUse a `for` element to build the map:\n\n```dart\nvoid f(Iterable<String> data) {\n  <String, int>{for (var element in data) element: element.length};\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7289,7 +7343,8 @@
   {
     "id": "prefer_if_elements_to_conditional_expressions",
     "description": "_Use an 'if' element to conditionally add elements._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a conditional expression\nis used as an element of a list or set literal and\nan `if` element could be used instead.\n\n## Example\n\nThe following code produces this diagnostic because a\nconditional expression is used to choose which of two values to\ninclude in the created list:\n\n```dart\nList<String> f(bool b) {\n  return ['a', [!b ? 'c' : 'd'!], 'e'];\n}\n```\n\n## Common fixes\n\nUse an `if` element to select the value:\n\n```dart\nList<String> f(bool b) {\n  return ['a', if (b) 'c' else 'd', 'e'];\n}\n```\n",
+    "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
   },
@@ -7304,7 +7359,7 @@
   {
     "id": "prefer_initializing_formals",
     "description": "_Use an initializing formal to assign a parameter to a field._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor parameter is used\nto initialize a field without modification.\n\n## Example\n\nThe following code produces this diagnostic because the parameter `c` is\nonly used to set the field `c`:\n\n```dart\nclass C {\n  int c;\n\n  C(int c) : [!this.c = c!];\n}\n```\n\n## Common fixes\n\nUse an initializing formal parameter to initialize the field:\n\n```dart\nclass C {\n  int c;\n\n  C(this.c);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor parameter is used\nto initialize a field without modification.\n\n## Example\n\nThe following code produces this diagnostic because the parameter `c` is\nonly used to set the field `c`:\n\n```dart\nclass C {\n  int c;\n\n  C(int c) : [!c = c!];\n}\n```\n\n## Common fixes\n\nUse an initializing formal parameter to initialize the field:\n\n```dart\nclass C {\n  int c;\n\n  C(this.c);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7406,7 +7461,8 @@
   {
     "id": "prefer_spread_collections",
     "description": "_The addition of multiple elements could be inlined._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `addAll` is used to\nadd the items of another collection to a list created by a list literal,\nin a situation where a spread element could be used instead.\n\n## Examples\n\nThe following code produces this diagnostic because the items of\nthe `numbers` list are added to a new list using `addAll`:\n\n```dart\nList<int> f(List<int> numbers) {\n  return [0, 1]..[!addAll!](numbers);\n}\n```\n\nThe following code produces this diagnostic because the items of\nthe nullable `numbers` list are added to a new list using `addAll`:\n\n```dart\nList<int> f(List<int>? numbers) {\n  return [0, 1]..[!addAll!](numbers ?? const []);\n}\n```\n\n## Common fixes\n\nIf the collection being added isn't nullable,\nthen use a spread element (`...`) to\ninclude its items in the new list:\n\n```dart\nList<int> f(List<int> numbers) {\n  return [0, 1, ...numbers];\n}\n```\n\nIf the collection being added is nullable,\nthen use a null-aware spread element (`...?`) to conditionally\ninclude its items in the new list if it's not `null`:\n\n```dart\nList<int> f(List<int>? numbers) {\n  return [0, 1, ...?numbers];\n}\n```\n",
+    "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
   },
@@ -7474,7 +7530,7 @@
   {
     "id": "primary_constructor_body_without_declaration",
     "description": "_A primary constructor body requires a primary constructor declaration._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class contains a primary\nconstructor body but doesn't declare a primary constructor.\n\n## Example\n\nThe following code produces this diagnostic because the class `C` contains\na primary constructor body but doesn't declare a primary constructor:\n\n```dart\nclass C {\n  [!this!] : assert(x > 0);\n}\n```\n\n## Common fixes\n\nIf the constructor is intended to be a primary constructor, then add\nparameter declarations to the class header:\n\n```dart\nclass C(int x) {\n  this : assert(x > 0);\n}\n```\n\nIf the constructor is intended to be a secondary constructor, then replace\nthe `this` with either the class name or `new` and declare the parameters in\nthe constructor declaration:\n\n```dart\nclass C {\n  C(int x) : assert(x > 0);\n}\n```\n\nIf the constructor isn't needed, then remove the body:\n\n```dart\nclass C {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a class contains a primary\nconstructor body but doesn't declare a primary constructor.\n\n## Example\n\nThe following code produces this diagnostic because the class `C` contains\na primary constructor body but doesn't declare a primary constructor:\n\n```dart\nclass C {\n  [!this!] : assert(x > 0);\n}\n```\n\n## Common fixes\n\nIf the constructor is intended to be a primary constructor, then add\nparameter declarations to the class header:\n\n```dart\nclass C(int x) {\n  this : assert(x > 0);\n}\n```\n\nIf the constructor is intended to be an in-body constructor, then replace\nthe `this` with either the class name or `new` and declare the parameters in\nthe constructor declaration:\n\n```dart\nclass C {\n  new(int x) : assert(x > 0);\n}\n```\n\nIf the constructor isn't needed, then remove the primary constructor body:\n\n```dart\nclass C {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7482,7 +7538,7 @@
   {
     "id": "primary_constructor_cannot_redirect",
     "description": "_A primary constructor can't be a redirecting constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a primary constructor redirects\nto another constructor.\n\n## Example\n\nThe following code produces this diagnostic because the primary\nconstructor has a redirect to the constructor `C.named`:\n\n```dart\nclass C(int x) {\n  C.named() : this(0);\n  this : assert(x > 0), [!this!].named();\n}\n```\n\n## Common fixes\n\nIf the redirection isn't necessary, then remove it:\n\n```dart\nclass C(int x) {\n  C.named() : this(0);\n  this : assert(x > 0);\n}\n```\n\nIf the redirection is necessary, then convert the primary constructor into\na secondary constructor, and rework other constructors as necessary:\n\n```dart\nclass C {\n  C.named();\n  C(int x) : this.named();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a primary constructor redirects\nto another constructor.\n\n## Example\n\nThe following code produces this diagnostic because the primary\nconstructor has a redirect to the constructor `C.named`:\n\n```dart\nclass C(int x) {\n  C.named() : this(0);\n  this : assert(x > 0), [!this!].named();\n}\n```\n\n## Common fixes\n\nIf the redirection isn't necessary, then remove it:\n\n```dart\nclass C(int x) {\n  new named() : this(0);\n  this : assert(x > 0);\n}\n```\n\nIf the redirection is necessary, then convert the primary constructor into\nan in-body constructor, and rework other constructors as necessary:\n\n```dart\nclass C {\n  new named();\n  new(int x) : this.named();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7506,7 +7562,7 @@
   {
     "id": "private_named_parameter_duplicate_public_name",
     "description": "_The corresponding public name '{0}' is already the name of another parameter._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a private named parameter\n(leading `_`) has a corresponding public name that conflicts with an\nexisting parameter name in the same parameter list.\n\n## Example\n\nThe following code produces this diagnostic because the private named\nparameter `_x`'s public name is `x`, which conflicts with the existing\nparameter named `x`:\n\n```dart\nclass C {\n  int? _x;\n  C({int? x, this.[!_x!]});\n  int? get x => _x;\n}\n```\n\n## Common fixes\n\nRename one of the two parameters.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a private named parameter\n(leading `_`) has a corresponding public name that conflicts with an\nexisting parameter name in the same parameter list.\n\n## Example\n\nThe following code produces this diagnostic because the private named\nparameter `_x`'s public name is `x`, which conflicts with the existing\nparameter named `x`:\n\n```dart\nclass C {\n  final int? _x;\n  C({int? x, this.[!_x!]});\n  int? get x => _x;\n}\n```\n\n## Common fixes\n\nRename one of the two parameters.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7567,7 +7623,7 @@
     "previousNames": []
   },
   {
-    "id": "record_literal_one_positional_field_no_trailing_comma",
+    "id": "record_literal_one_positional_no_trailing_comma",
     "description": "_A record literal with exactly one positional field requires a trailing comma._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record literal with a single\npositional field doesn't have a trailing comma after the field.\n\nIn some locations a record literal with a single positional field could\nalso be a parenthesized expression. A trailing comma is required to\ndisambiguate these two valid interpretations.\n\n## Example\n\nThe following code produces this diagnostic because the record literal has\none positional field but doesn't have a trailing comma:\n\n```dart\nvar r = const (1[!)!];\n```\n\n## Common fixes\n\nAdd a trailing comma:\n\n```dart\nvar r = const (1,);\n```\n",
     "hasDocumentation": true,
@@ -7575,32 +7631,9 @@
     "previousNames": []
   },
   {
-    "id": "record_literal_one_positional_no_trailing_comma",
-    "description": "_A record literal with exactly one positional field requires a trailing comma._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "record_literal_zero_fields_with_trailing_comma",
-    "description": "_A record literal without fields can't have a trailing comma._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record literal that has no\nfields has a trailing comma. Empty record literals can't contain a comma.\n\n## Example\n\nThe following code produces this diagnostic because the empty record\nliteral has a trailing comma:\n\n```dart\nvar r = ([!,!]);\n```\n\n## Common fixes\n\nIf the record is intended to be empty, then remove the comma:\n\n```dart\nvar r = ();\n```\n\nIf the record is intended to have one or more fields, then add the\nexpressions used to compute the values of those fields:\n\n```dart\nvar r = (3, 4);\n```\n",
-    "hasDocumentation": true,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "record_type_one_positional_field_no_trailing_comma",
+    "id": "record_type_one_positional_no_trailing_comma",
     "description": "_A record type with exactly one positional field requires a trailing comma._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record type annotation with a\nsingle positional field doesn't have a trailing comma after the field.\n\nIn some locations a record type with a single positional field could also\nbe a parenthesized expression. A trailing comma is required to\ndisambiguate these two valid interpretations.\n\n## Example\n\nThe following code produces this diagnostic because the record type has\none positional field, but doesn't have a trailing comma:\n\n```dart\nvoid f((int[!)!] r) {}\n```\n\n## Common fixes\n\nAdd a trailing comma:\n\n```dart\nvoid f((int,) r) {}\n```\n",
-    "hasDocumentation": true,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
-    "id": "record_type_zero_fields_but_trailing_comma",
-    "description": "_A record type without fields can't have a trailing comma._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a record type that has no\nfields has a trailing comma. Empty record types can't contain a comma.\n\n## Example\n\nThe following code produces this diagnostic because the empty record type\nhas a trailing comma:\n\n```dart\nvoid f(([!,!]) r) {}\n```\n\n## Common fixes\n\nIf the record type is intended to be empty, then remove the comma:\n\n```dart\nvoid f(() r) {}\n```\n\nIf the record type is intended to have one or more fields, then add the\ntypes of those fields:\n\n```dart\nvoid f((int, int) r) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7623,7 +7656,7 @@
   {
     "id": "recursive_constructor_redirect",
     "description": "_Constructors can't redirect to themselves either directly or indirectly._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor redirects to\nitself, either directly or indirectly, creating an infinite loop.\n\n## Examples\n\nThe following code produces this diagnostic because the generative\nconstructors `C.a` and `C.b` each redirect to the other:\n\n```dart\nclass C {\n  C.a() : [!this.b()!];\n  C.b() : [!this.a()!];\n}\n```\n\nThe following code produces this diagnostic because the factory\nconstructors `A` and `B` each redirect to the other:\n\n```dart\nabstract class A {\n  factory A() = [!B!];\n}\nclass B implements A {\n  factory B() = [!A!];\n  B.named();\n}\n```\n\n## Common fixes\n\nIn the case of generative constructors, break the cycle by finding defining\nat least one of the constructors to not redirect to another constructor:\n\n```dart\nclass C {\n  C.a() : this.b();\n  C.b();\n}\n```\n\nIn the case of factory constructors, break the cycle by defining at least\none of the factory constructors to do one of the following:\n\n- Redirect to a generative constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\nclass B implements A {\n  factory B() = B.named;\n  B.named();\n}\n```\n\n- Not redirect to another constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\nclass B implements A {\n  factory B() {\n    return B.named();\n  }\n\n  B.named();\n}\n```\n\n- Not be a factory constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\nclass B implements A {\n  B();\n  B.named();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor redirects to\nitself, either directly or indirectly, creating an infinite loop.\n\n## Examples\n\nThe following code produces this diagnostic because the generative\nconstructors `C.a` and `C.b` each redirect to the other:\n\n```dart\nclass C {\n  C.a() : [!this.b()!];\n  C.b() : [!this.a()!];\n}\n```\n\nThe following code produces this diagnostic because the factory\nconstructors `A` and `B` each redirect to the other:\n\n```dart\nabstract class A {\n  factory A() = [!B!];\n}\n\nclass B implements A {\n  factory B() = [!A!];\n  B.named();\n}\n```\n\n## Common fixes\n\nIn the case of generative constructors, break the cycle by finding defining\nat least one of the constructors to not redirect to another constructor:\n\n```dart\nclass C {\n  C.a() : this.b();\n  C.b();\n}\n```\n\nIn the case of factory constructors, break the cycle by defining at least\none of the factory constructors to do one of the following:\n\n- Redirect to a generative constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\n\nclass B implements A {\n  factory B() = B.named;\n  B.named();\n}\n```\n\n- Not redirect to another constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\n\nclass B implements A {\n  factory B() {\n    return B.named();\n  }\n\n  B.named();\n}\n```\n\n- Not be a factory constructor:\n\n```dart\nabstract class A {\n  factory A() = B;\n}\n\nclass B implements A {\n  B();\n  B.named();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7647,7 +7680,7 @@
   {
     "id": "recursive_interface_inheritance",
     "description": "_'{0}' can't be a superinterface of itself: {1}._\n\n_'{0}' can't extend itself._\n\n_'{0}' can't implement itself._\n\n_'{0}' can't use itself as a mixin._\n\n_'{0}' can't use itself as a superclass constraint._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's a circularity in the\ntype hierarchy. This happens when a type, either directly or indirectly,\nis declared to be a subtype of itself.\n\n## Example\n\nThe following code produces this diagnostic because the class `A` is\ndeclared to be a subtype of `B`, and `B` is a subtype of `A`:\n\n```dart\nclass [!A!] extends B {}\nclass B implements A {}\n```\n\n## Common fixes\n\nChange the type hierarchy so that there's no circularity.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's a circularity in the\ntype hierarchy. This happens when a type, either directly or indirectly,\nis declared to be a subtype of itself.\n\n## Example\n\nThe following code produces this diagnostic because the class `A` is\ndeclared to be a subtype of `B`, and `B` is a subtype of `A`:\n\n```dart\nclass [!A!] extends B {}\n\nclass B implements A {}\n```\n\n## Common fixes\n\nChange the type hierarchy so that there's no circularity.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7740,7 +7773,7 @@
     "previousNames": []
   },
   {
-    "id": "redirection_in_non_factory",
+    "id": "redirection_in_non_factory_constructor",
     "description": "_Only factory constructor can specify '=' redirection._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -7781,7 +7814,7 @@
   {
     "id": "remove_deprecations_in_breaking_versions",
     "description": "_Remove deprecated elements in breaking versions._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic in packages that have a \"breaking\"\nversion number (`x.0.0` or `0.x.0`) for every declaration that has a\n`@Deprecated` annotation.\n\n## Example\n\nGiven a package with a `pubspec.yaml` file containing:\n\n```yaml\nname: p\nversion: 2.0.0\nenvironment:\n  sdk: ^3.9.0\n```\n\nThe following code produces this diagnostic because the function `f` is\nannotated with `@deprecated`:\n\n```dart\n@[!deprecated!]\nvoid f() {}\n\nvoid g() {}\n```\n\n## Common fixes\n\nIf the declaration should be removed in the next release of the package,\nthen remove the declaration:\n\n```dart\nvoid g() {}\n```\n\nIf you are not making a breaking change, then use a\nminor or patch version increment for the package:\n\n```yaml\nname: p\nversion: 1.0.1\nenvironment:\n  sdk: ^3.9.0\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic in packages that have a \"breaking\"\nversion number (`x.0.0` or `0.x.0`) for every declaration that has a\n`@Deprecated` annotation.\n\n## Example\n\nGiven a package with a `pubspec.yaml` file containing:\n\n```yaml\nname: p\nversion: 2.0.0\nenvironment:\n  sdk: ^3.9.0\n```\n\nThe following code produces this diagnostic because the function `f` is\nannotated with `@deprecated`:\n\n```dart\n@[!Deprecated!]('...')\nvoid f() {}\n\nvoid g() {}\n```\n\n## Common fixes\n\nIf the declaration should be removed in the next release of the package,\nthen remove the declaration:\n\n```dart\nvoid g() {}\n```\n\nIf you are not making a breaking change, then use a\nminor or patch version increment for the package:\n\n```yaml\nname: p\nversion: 1.0.1\nenvironment:\n  sdk: ^3.9.0\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -7848,7 +7881,7 @@
   {
     "id": "rethrow_outside_catch",
     "description": "_A rethrow must be inside of a catch clause._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `rethrow` statement is outside\na `catch` clause. The `rethrow` statement is used to throw a caught\nexception again, but there's no caught exception outside of a `catch`\nclause.\n\n## Example\n\nThe following code produces this diagnostic because the `rethrow` statement\nis outside of a `catch` clause:\n\n```dart\nvoid f() {\n  [!rethrow!];\n}\n```\n\n## Common fixes\n\nIf you're trying to rethrow an exception, then wrap the `rethrow` statement\nin a `catch` clause:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (exception) {\n    rethrow;\n  }\n}\n```\n\nIf you're trying to throw a new exception, then replace the `rethrow`\nstatement with a `throw` expression:\n\n```dart\nvoid f() {\n  throw UnsupportedError('Not yet implemented');\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `rethrow` statement is outside\na `catch` clause. The `rethrow` statement is used to throw a caught\nexception again, but there's no caught exception outside of a `catch`\nclause.\n\n## Example\n\nThe following code produces this diagnostic because the\n`rethrow` statement is outside of a `catch` clause:\n\n```dart\nvoid f() {\n  [!rethrow!];\n}\n```\n\n## Common fixes\n\nIf you're trying to rethrow an exception, then wrap the `rethrow` statement\nin a `catch` clause:\n\n```dart\nvoid f() {\n  try {\n    // ...\n  } catch (exception) {\n    rethrow;\n  }\n}\n```\n\nIf you're trying to throw a new exception, then replace the `rethrow`\nstatement with a `throw` expression:\n\n```dart\nvoid f() {\n  throw UnsupportedError('Not yet implemented');\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -7856,7 +7889,7 @@
   {
     "id": "return_in_generative_constructor",
     "description": "_Constructors can't return values._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a generative constructor\ncontains a `return` statement that specifies a value to be returned.\nGenerative constructors always return the object that was created, and\ntherefore can't return a different object.\n\n## Example\n\nThe following code produces this diagnostic because the `return` statement\nhas an expression:\n\n```dart\nclass C {\n  C() {\n    return [!this!];\n  }\n}\n```\n\n## Common fixes\n\nIf the constructor should create a new instance, then remove either the\n`return` statement or the expression:\n\n```dart\nclass C {\n  C();\n}\n```\n\nIf the constructor shouldn't create a new instance, then convert it to be a\nfactory constructor:\n\n```dart\nclass C {\n  factory C() {\n    return _instance;\n  }\n\n  static C _instance = C._();\n\n  C._();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a generative constructor\ncontains a `return` statement that specifies a value to be returned.\nGenerative constructors always return the object that was created, and\ntherefore can't return a different object.\n\n## Example\n\nThe following code produces this diagnostic because the `return` statement\nhas an expression:\n\n```dart\nclass C {\n  C() {\n    return [!this!];\n  }\n}\n```\n\n## Common fixes\n\nIf the constructor should create a new instance, then remove either the\n`return` statement or the expression:\n\n```dart\nclass C {\n  C();\n}\n```\n\nIf the constructor shouldn't create a new instance, then convert it to be a\nfactory constructor:\n\n```dart\nclass C {\n  factory C() {\n    return _instance;\n  }\n\n  static final C _instance = C._();\n\n  C._();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -8097,7 +8130,7 @@
   {
     "id": "sized_box_for_whitespace",
     "description": "_Use a 'SizedBox' to add whitespace to a layout._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created using\nonly the `height` and/or `width` arguments.\n\n## Example\n\nThe following code produces this diagnostic because the `Container` has\nonly the `width` argument:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(\n    children: <Widget>[\n      const Text('...'),\n      [!Container!](\n        width: 4,\n        child: Text('...'),\n      ),\n      const Expanded(\n        child: Text('...'),\n      ),\n    ],\n  );\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `SizedBox` of the same dimensions:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(\n    children: <Widget>[\n      Text('...'),\n      SizedBox(\n        width: 4,\n        child: Text('...'),\n      ),\n      Expanded(\n        child: Text('...'),\n      ),\n    ],\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created using\nonly the `height` and/or `width` arguments.\n\n## Example\n\nThe following code produces this diagnostic because the `Container` has\nonly the `width` argument:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(\n    children: <Widget>[\n      const Text('...'),\n      [!Container!](width: 4, child: Text('...')),\n      const Expanded(child: Text('...')),\n    ],\n  );\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `SizedBox` of the same dimensions:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildRow() {\n  return Row(\n    children: <Widget>[\n      Text('...'),\n      SizedBox(width: 4, child: Text('...')),\n      Expanded(child: Text('...')),\n    ],\n  );\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -8105,7 +8138,7 @@
   {
     "id": "sized_box_shrink_expand",
     "description": "_Use 'SizedBox.{0}' to avoid needing to specify the 'height' and 'width'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `SizedBox` constructor\ninvocation specifies the values of both `height` and `width` as either\n`0.0` or `double.infinity`.\n\n## Examples\n\nThe following code produces this diagnostic because both the `height` and\n`width` are `0.0`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!SizedBox!](\n    height: 0.0,\n    width: 0.0,\n    child: const Text(''),\n  );\n}\n```\n\nThe following code produces this diagnostic because both the `height` and\n`width` are `double.infinity`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!SizedBox!](\n    height: double.infinity,\n    width: double.infinity,\n    child: const Text(''),\n  );\n}\n```\n\n## Common fixes\n\nIf both are `0.0`, then use `SizedBox.shrink`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return SizedBox.shrink(\n    child: const Text(''),\n  );\n}\n```\n\nIf both are `double.infinity`, then use `SizedBox.expand`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return SizedBox.expand(\n    child: const Text(''),\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `SizedBox` constructor\ninvocation specifies the values of both `height` and `width` as either\n`0.0` or `double.infinity`.\n\n## Examples\n\nThe following code produces this diagnostic because both the `height` and\n`width` are `0.0`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!SizedBox!](height: 0.0, width: 0.0, child: const Text(''));\n}\n```\n\nThe following code produces this diagnostic because both the `height` and\n`width` are `double.infinity`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!SizedBox!](\n    height: double.infinity,\n    width: double.infinity,\n    child: const Text(''),\n  );\n}\n```\n\n## Common fixes\n\nIf both are `0.0`, then use `SizedBox.shrink`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return SizedBox.shrink(child: const Text(''));\n}\n```\n\nIf both are `double.infinity`, then use `SizedBox.expand`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return SizedBox.expand(child: const Text(''));\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -8121,7 +8154,7 @@
   {
     "id": "sort_child_properties_last",
     "description": "_The '{0}' argument should be last in widget constructor invocations._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the `child` or `children`\nargument isn't the last argument in an invocation of a widget class'\nconstructor. An exception is made if all of the arguments after the\n`child` or `children` argument are function expressions.\n\n## Example\n\nThe following code produces this diagnostic because the `child` argument\nisn't the last argument in the invocation of the `Center` constructor:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget createWidget() {\n  return Center(\n    [!child: Text('...')!],\n    widthFactor: 0.5,\n  );\n}\n```\n\n## Common fixes\n\nMove the `child` or `children` argument to be last:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget createWidget() {\n  return Center(\n    widthFactor: 0.5,\n    child: Text('...'),\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the `child` or `children`\nargument isn't the last argument in an invocation of a widget class'\nconstructor. An exception is made if all of the arguments after the\n`child` or `children` argument are function expressions.\n\n## Example\n\nThe following code produces this diagnostic because the `child` argument\nisn't the last argument in the invocation of the `Center` constructor:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget createWidget() {\n  return Center([!child: Text('...')!], widthFactor: 0.5);\n}\n```\n\n## Common fixes\n\nMove the `child` or `children` argument to be last:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget createWidget() {\n  return Center(widthFactor: 0.5, child: Text('...'));\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -8355,21 +8388,21 @@
     "previousNames": []
   },
   {
+    "id": "super_initializing_declaring_parameter",
+    "description": "_Declaring parameters can't be super parameters._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
     "id": "super_invocation_not_last",
     "description": "_The superconstructor call must be last in an initializer list._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the initializer list of a\nconstructor contains an invocation of a constructor in the superclass, but\nthe invocation isn't the last item in the initializer list.\n\n## Example\n\nThe following code produces this diagnostic because the invocation of the\nsuperclass' constructor isn't the last item in the initializer list:\n\n```dart\nclass A {\n  A(int x);\n}\n\nclass B extends A {\n  B(int x) : [!super!](x), assert(x >= 0);\n}\n```\n\n## Common fixes\n\nMove the invocation of the superclass' constructor to the end of the\ninitializer list:\n\n```dart\nclass A {\n  A(int x);\n}\n\nclass B extends A {\n  B(int x) : assert(x >= 0), super(x);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the initializer list of a\nconstructor contains an invocation of a constructor in the superclass, but\nthe invocation isn't the last item in the initializer list.\n\n## Example\n\nThe following code produces this diagnostic because the invocation of the\nsuperclass' constructor isn't the last item in the initializer list:\n\n```dart\nclass A {\n  A(int x);\n}\n\nclass B extends A {\n  B(int x) : [!super!](x + 1), assert(x >= 0);\n}\n```\n\n## Common fixes\n\nMove the invocation of the superclass' constructor to the end of the\ninitializer list:\n\n```dart\nclass A {\n  A(int x);\n}\n\nclass B extends A {\n  B(int x) : assert(x >= 0), super(x + 1);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": [
       "invalid_super_invocation"
     ]
-  },
-  {
-    "id": "super_null_aware",
-    "description": "_The operator '?.' cannot be used with 'super' because 'super' cannot be null._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
   },
   {
     "id": "supertype_expands_to_type_parameter",
@@ -8396,14 +8429,14 @@
     "previousNames": []
   },
   {
-    "id": "switch_has_case_after_default",
+    "id": "switch_has_case_after_default_case",
     "description": "_The default case should be the last case in a switch statement._",
     "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
   {
-    "id": "switch_has_multiple_defaults",
+    "id": "switch_has_multiple_default_cases",
     "description": "_The 'default' case can only be declared once._",
     "hasDocumentation": false,
     "fromLint": false,
@@ -8503,13 +8536,6 @@
     "previousNames": []
   },
   {
-    "id": "type_after_var",
-    "description": "_Variables can't be declared using both 'var' and a type name._",
-    "hasDocumentation": false,
-    "fromLint": false,
-    "previousNames": []
-  },
-  {
     "id": "type_alias_cannot_reference_itself",
     "description": "_Typedefs can't reference themselves directly or recursively via another typedef._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a typedef refers to itself,\neither directly or indirectly.\n\n## Example\n\nThe following code produces this diagnostic because `F` depends on itself\nindirectly through `G`:\n\n```dart\ntypedef [!F!] = void Function(G);\ntypedef G = void Function(F);\n```\n\n## Common fixes\n\nChange one or more of the typedefs in the cycle so that none of them refer\nto themselves:\n\n```dart\ntypedef F = void Function(G);\ntypedef G = void Function(int);\n```\n",
@@ -8577,6 +8603,20 @@
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a type literal appears as a\npattern.\n\n## Example\n\nThe following code produces this diagnostic because a type literal is used\nas a constant pattern:\n\n```dart\nvoid f(Object? x) {\n  if (x case [!num!]) {\n    // ...\n  }\n}\n```\n\n## Common fixes\n\nIf the type literal is intended to match an object of the given type, then\nuse either a variable pattern:\n\n```dart\nvoid f(Object? x) {\n  if (x case num _) {\n    // ...\n  }\n}\n```\n\nOr an object pattern:\n\n```dart\nvoid f(Object? x) {\n  if (x case num()) {\n    // ...\n  }\n}\n```\n\nIf the type literal is intended to match the type literal, then write it\nas a constant pattern:\n\n```dart\nvoid f(Object? x) {\n  if (x case const (num)) {\n    // ...\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
+    "previousNames": []
+  },
+  {
+    "id": "type_parameter_on_constructor",
+    "description": "_Constructors can't have type parameters._",
+    "hasDocumentation": false,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "type_parameter_on_operator",
+    "description": "_Types parameters aren't allowed when defining an operator._",
+    "hasDocumentation": false,
+    "fromLint": false,
     "previousNames": []
   },
   {
@@ -8659,7 +8699,7 @@
   {
     "id": "undefined_annotation",
     "description": "_Undefined name '{0}' used as an annotation._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a name that isn't defined is\nused as an annotation.\n\n## Example\n\nThe following code produces this diagnostic because the name `undefined`\nisn't defined:\n\n```dart\n[!@undefined!]\nvoid f() {}\n```\n\n## Common fixes\n\nIf the name is correct, but it isn't declared yet, then declare the name as\na constant value:\n\n```dart\nconst undefined = 'undefined';\n\n@undefined\nvoid f() {}\n```\n\nIf the name is wrong, replace the name with the name of a valid constant:\n\n```dart\n@deprecated\nvoid f() {}\n```\n\nOtherwise, remove the annotation.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a name that isn't defined is\nused as an annotation.\n\n## Example\n\nThe following code produces this diagnostic because the name `undefined`\nisn't defined:\n\n```dart\n[!@undefined!]\nvoid f() {}\n```\n\n## Common fixes\n\nIf the name is correct, but it isn't declared yet, then declare the name as\na constant value:\n\n```dart\nconst undefined = 'undefined';\n\n@undefined\nvoid f() {}\n```\n\nIf the name is wrong, replace the name with the name of a valid constant:\n\n```dart\n@Deprecated('...')\nvoid f() {}\n```\n\nOtherwise, remove the annotation.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -8787,7 +8827,7 @@
   {
     "id": "undefined_named_parameter",
     "description": "_The named parameter '\\_{0}' should use the corresponding public name '{0}' at the callsite._\n\n_The named parameter '{0}' isn't defined._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a method or function invocation\nhas a named argument, but the method or function being invoked doesn't\ndefine a parameter with the same name.\n\n## Example\n\nThe following code produces this diagnostic because `m` doesn't declare a\nnamed parameter named `a`:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nvoid f(C c) {\n  c.m([!a!]: 1);\n}\n```\n\n## Common fixes\n\nIf the argument name is mistyped, then replace it with the correct name.\nThe example above can be fixed by changing `a` to `b`:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nvoid f(C c) {\n  c.m(b: 1);\n}\n```\n\nIf a subclass adds a parameter with the name in question, then cast the\nreceiver to the subclass:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nclass D extends C {\n  m({int? a, int? b}) {}\n}\n\nvoid f(C c) {\n  (c as D).m(a: 1);\n}\n```\n\nIf the parameter should be added to the function, then add it:\n\n```dart\nclass C {\n  m({int? a, int? b}) {}\n}\n\nvoid f(C c) {\n  c.m(a: 1);\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a method or function invocation\nhas a named argument, but the method or function being invoked doesn't\ndefine a parameter with the same name.\n\n## Example\n\nThe following code produces this diagnostic because `m` doesn't declare a\nnamed parameter named `a`:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nvoid f(C c) {\n  c.m([!a!]: 1);\n}\n```\n\n## Common fixes\n\nIf the argument name is mistyped, then replace it with the correct name.\nThe example above can be fixed by changing `a` to `b`:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nvoid f(C c) {\n  c.m(b: 1);\n}\n```\n\nIf a subclass adds a parameter with the name in question, then cast the\nreceiver to the subclass:\n\n```dart\nclass C {\n  m({int? b}) {}\n}\n\nclass D extends C {\n  @override\n  m({int? a, int? b}) {}\n}\n\nvoid f(C c) {\n  (c as D).m(a: 1);\n}\n```\n\nIf the parameter should be added to the function, then add it:\n\n```dart\nclass C {\n  m({int? a, int? b}) {}\n}\n\nvoid f(C c) {\n  c.m(a: 1);\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -8819,7 +8859,7 @@
   {
     "id": "undefined_setter",
     "description": "_The setter '{0}' isn't defined for the '{1}' function type._\n\n_The setter '{0}' isn't defined for the type '{1}'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it encounters an identifier that\nappears to be the name of a setter but either isn't defined or isn't\nvisible in the scope in which the identifier is being referenced.\n\n## Example\n\nThe following code produces this diagnostic because there isn't a setter\nnamed `z`:\n\n```dart\nclass C {\n  int x = 0;\n  void m(int y) {\n    this.[!z!] = y;\n  }\n}\n```\n\n## Common fixes\n\nIf the identifier isn't defined, then either define it or replace it with\nthe name of a setter that is defined. The example above can be corrected by\nfixing the spelling of the setter:\n\n```dart\nclass C {\n  int x = 0;\n  void m(int y) {\n    this.x = y;\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when it encounters an identifier that\nappears to be the name of a setter but either isn't defined or isn't\nvisible in the scope in which the identifier is being referenced.\n\n## Example\n\nThe following code produces this diagnostic because there isn't a setter\nnamed `z`:\n\n```dart\nclass C {\n  int x = 0;\n  void m(int y) {\n    this.[!z!] = y;\n  }\n}\n```\n\n## Common fixes\n\nIf the identifier isn't defined, then either define it or replace it with\nthe name of a setter that is defined. The example above can be corrected by\nfixing the spelling of the setter:\n\n```dart\nclass C {\n  int x = 0;\n  void m(int y) {\n    x = y;\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -8987,7 +9027,7 @@
   {
     "id": "unnecessary_const_in_enum_constructor",
     "description": "_Unnecessary 'const' keyword in an enum constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the keyword `const` is used in\na generative enum constructor. Generative enum constructors are implicitly\n`const`.\n\n## Examples\n\nThe following code produces this diagnostic because the keyword `const` in\nthe enum's primary constructor isn't needed:\n\n```dart\nenum [!const!] E(final int i) {\n  a(1), b(2);\n}\n```\n\nThe following code produces this diagnostic because the keyword `const` in\nthe enum's secondary constructor isn't needed:\n\n```dart\nenum E {\n  a(1), b(2);\n\n  [!const!] E(this.i);\n\n  final int i;\n}\n```\n\n## Common fixes\n\nRemove the unnecessary keyword:\n\n```dart\nenum E(final int i) {\n  a(1), b(2);\n}\n```\n\n```dart\nenum E {\n  a(1), b(2);\n\n  E(this.i);\n\n  final int i;\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the keyword `const` is used in\na generative enum constructor. Generative enum constructors are implicitly\n`const`.\n\n## Examples\n\nThe following code produces this diagnostic because the keyword `const` in\nthe enum's primary constructor isn't needed:\n\n```dart\nenum [!const!] E(final int i) {\n  a(1),\n  b(2);\n}\n```\n\nThe following code produces this diagnostic because the keyword `const` in\nthe enum's in-body constructor isn't needed:\n\n```dart\nenum E {\n  a(1),\n  b(2);\n\n  [!const!] E(this.i);\n\n  final int i;\n}\n```\n\n## Common fixes\n\nRemove the unnecessary keyword:\n\n```dart\nenum E(final int i) {\n  a(1),\n  b(2);\n}\n```\n\n```dart\nenum E {\n  a(1),\n  b(2);\n\n  new(this.i);\n\n  final int i;\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9091,7 +9131,7 @@
   {
     "id": "unnecessary_no_such_method",
     "description": "_Unnecessary 'noSuchMethod' declaration._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's a declaration of\n`noSuchMethod`, the only thing the declaration does is invoke the\noverridden declaration, and the overridden declaration isn't the\ndeclaration in `Object`.\n\nOverriding the implementation of `Object`'s `noSuchMethod` (no matter what\nthe implementation does) signals to the analyzer that it shouldn't flag any\ninherited abstract methods that aren't implemented in that class. This\nworks even if the overriding implementation is inherited from a superclass,\nso there's no value to declare it again in a subclass.\n\n## Example\n\nThe following code produces this diagnostic because the declaration of\n`noSuchMethod` in `A` makes the declaration of `noSuchMethod` in `B`\nunnecessary:\n\n```dart\nclass A {\n  @override\n  dynamic noSuchMethod(x) => super.noSuchMethod(x);\n}\n\nclass B extends A {\n  @override\n  dynamic [!noSuchMethod!](y) {\n    return super.noSuchMethod(y);\n  }\n}\n```\n\n## Common fixes\n\nRemove the unnecessary declaration:\n\n```dart\nclass A {\n  @override\n  dynamic noSuchMethod(x) => super.noSuchMethod(x);\n}\n\nclass B extends A {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when there's a declaration of\n`noSuchMethod`, the only thing the declaration does is invoke the\noverridden declaration, and the overridden declaration isn't the\ndeclaration in `Object`.\n\nOverriding the implementation of `Object`'s `noSuchMethod` (no matter what\nthe implementation does) signals to the analyzer that it shouldn't flag any\ninherited abstract methods that aren't implemented in that class. This\nworks even if the overriding implementation is inherited from a superclass,\nso there's no value to declare it again in a subclass.\n\n## Example\n\nThe following code produces this diagnostic because the declaration of\n`noSuchMethod` in `A` makes the declaration of `noSuchMethod` in `B`\nunnecessary:\n\n```dart\nclass A {\n  @override\n  dynamic noSuchMethod(invocation) => super.noSuchMethod(invocation);\n}\n\nclass B extends A {\n  @override\n  dynamic [!noSuchMethod!](invocation) {\n    return super.noSuchMethod(invocation);\n  }\n}\n```\n\n## Common fixes\n\nRemove the unnecessary declaration:\n\n```dart\nclass A {\n  @override\n  dynamic noSuchMethod(invocation) => super.noSuchMethod(invocation);\n}\n\nclass B extends A {}\n```\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -9115,7 +9155,7 @@
   {
     "id": "unnecessary_null_aware_assignments",
     "description": "_Unnecessary assignment of 'null'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the right-hand side of a\nnull-aware assignment is the `null` literal.\n\n## Example\n\nThe following code produces this diagnostic because the null aware\noperator is being used to assign `null` to `s` when `s` is already `null`:\n\n```dart\nvoid f(String? s) {\n  [!s ??= null!];\n}\n```\n\n## Common fixes\n\nIf a non-null value should be assigned to the left-hand operand, then\nchange the right-hand side:\n\n```dart\nvoid f(String? s) {\n  s ??= '';\n}\n```\n\nIf there is no non-null value to assign to the left-hand operand, then\nremove the assignment:\n\n```dart\nvoid f(String? s) {\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the right-hand side of a\nnull-aware assignment is the `null` literal.\n\n## Example\n\nThe following code produces this diagnostic because the null aware\noperator is being used to assign `null` to `s` when `s` is already `null`:\n\n```dart\nvoid f(String? s) {\n  [!s ??= null!];\n}\n```\n\n## Common fixes\n\nIf a non-null value should be assigned to the left-hand operand, then\nchange the right-hand side:\n\n```dart\nvoid f(String? s) {\n  s ??= '';\n}\n```\n\nIf there is no non-null value to assign to the left-hand operand, then\nremove the assignment:\n\n```dart\nvoid f(String? s) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9219,7 +9259,7 @@
   {
     "id": "unnecessary_statements",
     "description": "_Unnecessary statement._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an expression statement has no\nclear effect.\n\n## Example\n\nThe following code produces this diagnostic because the addition of the\nreturned values from the two invocations has no clear effect:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  [!first() + second()!];\n}\n```\n\n## Common fixes\n\nIf the expression doesn't need to be computed, then remove it:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n}\n```\n\nIf the value of the expression is needed, then make use of it, possibly\nassigning it to a local variable first:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  print(first() + second());\n}\n```\n\nIf portions of the expression need to be executed, then remove the\nunnecessary portions:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  first();\n  second();\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an expression statement has no\nclear effect.\n\n## Example\n\nThe following code produces this diagnostic because the addition of the\nreturned values from the two invocations has no clear effect:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  [!first() + second()!];\n}\n```\n\n## Common fixes\n\nIf the expression doesn't need to be computed, then remove it:\n\n```dart\nvoid f(int Function() first, int Function() second) {}\n```\n\nIf the value of the expression is needed, then make use of it, possibly\nassigning it to a local variable first:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  print(first() + second());\n}\n```\n\nIf portions of the expression need to be executed, then remove the\nunnecessary portions:\n\n```dart\nvoid f(int Function() first, int Function() second) {\n  first();\n  second();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9243,7 +9283,7 @@
   {
     "id": "unnecessary_this",
     "description": "_Unnecessary 'this.' qualifier._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the keyword `this` is used to\naccess a member that isn't shadowed.\n\n## Example\n\nThe following code produces this diagnostic because the use of `this` to\naccess the field `_f` isn't necessary:\n\n```dart\nclass C {\n  int _f = 2;\n\n  int get f => [!this!]._f;\n}\n```\n\n## Common fixes\n\nRemove the `this.`:\n\n```dart\nclass C {\n  int _f = 2;\n\n  int get f => _f;\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the keyword `this` is used to\naccess a member that isn't shadowed.\n\n## Example\n\nThe following code produces this diagnostic because the use of `this` to\naccess the field `_f` isn't necessary:\n\n```dart\nclass C {\n  final int _f = 2;\n\n  int get f => [!this!]._f;\n}\n```\n\n## Common fixes\n\nRemove the `this.`:\n\n```dart\nclass C {\n  final int _f = 2;\n\n  int get f => _f;\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9251,7 +9291,7 @@
   {
     "id": "unnecessary_to_list_in_spreads",
     "description": "_Unnecessary use of 'toList' in a spread._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `toList` is used to convert an\n`Iterable` to a `List` just before a spread operator is applied to the\nlist. The spread operator can be applied to any `Iterable`, so the\nconversion isn't necessary.\n\n## Example\n\nThe following code produces this diagnostic because `toList` is invoked on\nthe result of `map`, which is an `Iterable` that the spread operator could\nbe applied to directly:\n\n```dart\nList<String> toLowercase(List<String> strings) {\n  return [\n    ...strings.map((String s) => s.toLowerCase()).[!toList!](),\n  ];\n}\n```\n\n## Common fixes\n\nRemove the invocation of `toList`:\n\n```dart\nList<String> toLowercase(List<String> strings) {\n  return [\n    ...strings.map((String s) => s.toLowerCase()),\n  ];\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `toList` is used to convert an\n`Iterable` to a `List` just before a spread operator is applied to the\nlist. The spread operator can be applied to any `Iterable`, so the\nconversion isn't necessary.\n\n## Example\n\nThe following code produces this diagnostic because `toList` is invoked on\nthe result of `map`, which is an `Iterable` that the spread operator could\nbe applied to directly:\n\n```dart\nList<String> toLowercase(List<String> strings) {\n  return [...strings.map((String s) => s.toLowerCase()).[!toList!]()];\n}\n```\n\n## Common fixes\n\nRemove the invocation of `toList`:\n\n```dart\nList<String> toLowercase(List<String> strings) {\n  return [...strings.map((String s) => s.toLowerCase())];\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9267,7 +9307,7 @@
   {
     "id": "unnecessary_type_name_in_constructor",
     "description": "_Unnecessary type name in a constructor._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a secondary constructor\ndeclaration includes a type name.\n\n## Examples\n\nThe following code produces this diagnostic because the generative\nconstructor declaration includes the type name:\n\n```dart\nclass C {\n  [!C!]();\n}\n```\n\nThe following code produces this diagnostic because the factory\nconstructor declaration includes the type name:\n\n```dart\nclass C {\n  factory [!C!]() => C._();\n\n  new _() {}\n}\n```\n\n## Common fixes\n\nRemove the type name from the constructor. If the constructor is named,\nalso remove the period before the name:\n\n```dart\nclass C {\n  new ();\n}\n```\n\nor\n\n```dart\nclass C {\n  factory () => C._();\n\n  new _() {}\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an in-body constructor\ndeclaration includes a type name.\n\n## Examples\n\nThe following code produces this diagnostic because the generative\nconstructor declaration includes the type name:\n\n```dart\nclass C {\n  [!C!]();\n}\n```\n\nThe following code produces this diagnostic because the factory\nconstructor declaration includes the type name:\n\n```dart\nclass C {\n  factory [!C!]() => C._();\n\n  new _();\n}\n```\n\n## Common fixes\n\nRemove the type name from the constructor. If the constructor is named,\nalso remove the period before the name:\n\n```dart\nclass C {\n  new();\n}\n```\n\nor\n\n```dart\nclass C {\n  factory() => C._();\n\n  new _();\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9275,7 +9315,7 @@
   {
     "id": "unnecessary_unawaited",
     "description": "_Unnecessary use of 'unawaited'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `unawaited` is used to mark a\ncall to a function, method, or operator, or a reference to a field,\ngetter, or top-level variable as safely not being awaited, but the called\nmember is also annotated with `@awaitNotRequired`. This annotation itself\nsignals that wrapping with `unawaited` is unnecessary at any call site.\n\n## Example\n\nThe following code produces this diagnostic because `unawaited` is invoked\non a call to a function that's annotated with `@awaitNotRequired`:\n\n```dart\nimport 'dart:async';\nimport 'package:meta/meta.dart';\n\n@awaitNotRequired\nFuture<bool> log(String message) async => true;\n\nvoid f() {\n  [!unawaited!](log('Message.'));\n}\n```\n\n## Common fixes\n\nRemove the invocation of `unawaited`:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@awaitNotRequired\nFuture<bool> log(String message) async => true;\n\nvoid f() {\n  log('Message.');\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when `unawaited` is used to mark a\ncall to a function, method, or operator, or a reference to a field,\ngetter, or top-level variable as safely not being awaited, but the called\nmember is also annotated with `@awaitNotRequired`. This annotation itself\nsignals that wrapping with `unawaited` is unnecessary at any call site.\n\n## Example\n\nThe following code produces this diagnostic because `unawaited` is invoked\non a call to a function that's annotated with `@awaitNotRequired`:\n\n```dart\nimport 'dart:async';\n\nimport 'package:meta/meta.dart';\n\n@awaitNotRequired\nFuture<bool> log(String message) async => true;\n\nvoid f() {\n  [!unawaited!](log('Message.'));\n}\n```\n\n## Common fixes\n\nRemove the invocation of `unawaited`:\n\n```dart\nimport 'package:meta/meta.dart';\n\n@awaitNotRequired\nFuture<bool> log(String message) async => true;\n\nvoid f() {\n  log('Message.');\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9283,7 +9323,7 @@
   {
     "id": "unnecessary_underscores",
     "description": "_Unnecessary use of multiple underscores._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an unused variable is named\nwith multiple underscores (for example `__`). A single `_` wildcard variable\ncan be used instead.\n\n## Example\n\nThe following code produces this diagnostic because the `__` parameter is unused:\n\n```dart\nvoid function(int [!__!]) { }\n```\n\n## Common fixes\n\nReplace the name with a single underscore:\n\n```dart\nvoid function(int _) { }\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an unused variable is named\nwith multiple underscores (for example `__`). A single `_` wildcard variable\ncan be used instead.\n\n## Example\n\nThe following code produces this diagnostic because the `__` parameter is unused:\n\n```dart\nvoid function(int [!__!]) {}\n```\n\n## Common fixes\n\nReplace the name with a single underscore:\n\n```dart\nvoid function(int _) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9315,7 +9355,8 @@
   {
     "id": "unreachable_from_main",
     "description": "_Unreachable member '{0}' in an executable library._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a public declaration\nin an executable library isn't referenced, directly or indirectly,\nfrom an entry point of that library.\n\nAn executable library is a library that contains an entry point.\nAn entry point is a top-level function that is one of the following:\n\n- Named `main`.\n- Annotated with `@pragma('vm:entry-point')`.\n- Annotated with Flutter's widget preview annotation, `@Preview`.\n\nThe analyzer doesn't report declarations annotated with\n[`@visibleForTesting`][] from `package:meta` or\n[`@Preview`][] from Flutter.\n\n[`@Preview`]: https://api.flutter.dev/flutter/widget_previews/Preview-class.html\n\n## Examples\n\nThe following code produces this diagnostic because the function `f`\nis not referenced from the `main` function:\n\n```dart\nvoid main() {}\n\nvoid [!f!]() {}\n```\n\nThe following code produces this diagnostic because the method `m`\nis not referenced, even though its containing class `C` is:\n\n```dart\nvoid main() {\n  C();\n}\n\nclass C {\n  void [!m!]() {}\n}\n```\n\n## Common fixes\n\nIf the declaration is intended to be used,\nthen add the missing reference:\n\n```dart\nvoid main() {\n  f();\n}\n\nvoid f() {}\n```\n\nIf the declaration isn't needed, then remove it:\n\n```dart\nvoid main() {}\n```\n\nIf the declaration is public in order to be used by tests,\nthen add the [`@visibleForTesting`][] annotation:\n\n```dart\nimport 'package:meta/meta.dart';\n\nvoid main() {}\n\n@visibleForTesting\nvoid f() {}\n```\n\n[`@visibleForTesting`]: https://pub.dev/documentation/meta/latest/meta/visibleForTesting-constant.html\n",
+    "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
   },
@@ -9361,7 +9402,7 @@
   {
     "id": "unsafe_variance",
     "description": "_This type is unsafe: a type parameter occurs in a non-covariant position._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an instance member has a result\ntype which is [contravariant or invariant](https://dart.dev/resources/glossary#variance)\nin a type parameter of the enclosing declaration. The result type of a\nvariable is its type, and the result type of a getter or method is its\nreturn type. This lint warns against such members because they are likely\nto cause a failing type check at run time, with no static warning or error\nat the call site.\n\n## Example\n\nThe following code produces this diagnostic because `X` occurs\nas a parameter type in the type of `f`, which is a\ncontravariant occurrence of this type parameter:\n\n```dart\nclass C<X> {\n  bool Function([!X!]) f;\n  C(this.f);\n}\n```\n\nThis is unsafe: If `c` has static type `C<num>` and run-time type `C<int>`\nthen `c.f` will throw. Hence, every invocation `c.f(a)` will also throw,\neven in the case where `a` has a correct type as an argument to `c.f`.\n\n## Common fixes\n\nIf the linted member is or can be private then you may be able\nto enforce that it is never accessed on any other receiver than `this`.\nThis is sufficient to ensure that that the run-time type error does not\noccur. For example:\n\n```dart\nclass C<X> {\n  // NB: Ensure manually that `_f` is only accessed on `this`.\n  // ignore: unsafe_variance\n  bool Function(X) _f;\n\n  C(this._f);\n\n  // We can write a forwarding method to allow clients to call `_f`.\n  bool f(X x) => _f(x);\n}\n```\n\nYou can eliminate the unsafe variance by using a more general type for\nthe linted member. In this case you may need to check the run-time type\nand perform a downcast at call sites.\n\n```dart\nclass C<X> {\n  bool Function(Never) f;\n  C(this.f);\n}\n```\n\nIf `c` has static type `C<num>` then you may test the type. For example,\n`c.f is bool Function(num)`. You may safely call it with an argument of\ntype `num` if it has that type.\n\nYou can also eliminate the unsafe variance by using a much more general\ntype like `Function`, which is essentially the type `dynamic` for\nfunctions.\n\n```dart\nclass C<X> {\n  Function f;\n  C(this.f);\n}\n```\n\nThis will make `c.f(a)` dynamically safe: It will throw if and only if the\nargument `a` does not have the type required by the function. This is\nbetter than the original version because it will not throw because of a\nmismatched static type. It only throws when it _must_ throw for soundness\nreasons.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when an instance member has a result\ntype which is [contravariant or invariant](https://dart.dev/resources/glossary#variance)\nin a type parameter of the enclosing declaration. The result type of a\nvariable is its type, and the result type of a getter or method is its\nreturn type. This lint warns against such members because they are likely\nto cause a failing type check at run time, with no static warning or error\nat the call site.\n\n## Example\n\nThe following code produces this diagnostic because `X` occurs\nas a parameter type in the type of `f`, which is a\ncontravariant occurrence of this type parameter:\n\n```dart\nclass C<X> {\n  final bool Function([!X!]) f;\n  C(this.f);\n}\n```\n\nThis is unsafe: If `c` has static type `C<num>` and run-time type `C<int>`\nthen `c.f` will throw. Hence, every invocation `c.f(a)` will also throw,\neven in the case where `a` has a correct type as an argument to `c.f`.\n\n## Common fixes\n\nIf the linted member is or can be private then you may be able\nto enforce that it is never accessed on any other receiver than `this`.\nThis is sufficient to ensure that that the run-time type error does not\noccur. For example:\n\n```dart\nclass C<X> {\n  // NB: Ensure manually that `_f` is only accessed on `this`.\n  // ignore: unsafe_variance\n  final bool Function(X) _f;\n\n  C(this._f);\n\n  // We can write a forwarding method to allow clients to call `_f`.\n  bool f(X x) => _f(x);\n}\n```\n\nYou can eliminate the unsafe variance by using a more general type for\nthe linted member. In this case you may need to check the run-time type\nand perform a downcast at call sites.\n\n```dart\nclass C<X> {\n  final bool Function(Never) f;\n  C(this.f);\n}\n```\n\nIf `c` has static type `C<num>` then you may test the type. For example,\n`c.f is bool Function(num)`. You may safely call it with an argument of\ntype `num` if it has that type.\n\nYou can also eliminate the unsafe variance by using a much more general\ntype like `Function`, which is essentially the type `dynamic` for\nfunctions.\n\n```dart\nclass C<X> {\n  final Function f;\n  C(this.f);\n}\n```\n\nThis will make `c.f(a)` dynamically safe: It will throw if and only if the\nargument `a` does not have the type required by the function. This is\nbetter than the original version because it will not throw because of a\nmismatched static type. It only throws when it _must_ throw for soundness\nreasons.\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9481,7 +9522,7 @@
   {
     "id": "unused_field_from_primary_constructor",
     "description": "_The value of the field '{0}' isn't used._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a private field is declared in\na primary constructor but never read, even if it's written in one or more\nplaces.\n\n## Example\n\nThe following code produces this diagnostic because the field\n`_i` isn't read anywhere in the library:\n\n```dart\nclass C(final int [!_i!]);\n```\n\nThe primary constructor declares a field because the keyword `final` is\nused. (Using the `var` keyword also declares a field.)\n\n## Common fixes\n\nIf the parameter is still necessary, but the associated field is not, then\nremove the `final` or `var` keyword:\n\n```dart\nclass C(int _i);\n```\n\nIf the parameter is also unnecessary, then remove it (which also removes\nthe associated field).\n\n```dart\nclass C {}\n```\n\nIf the field was intended to be used, then add the missing code.\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a private field is declared in\na primary constructor but never read, even if it's written in one or more\nplaces.\n\n## Example\n\nThe following code produces this diagnostic because the field\n`_i` isn't read anywhere in the library:\n\n```dart\nclass C(final int [!_i!]);\n```\n\nThe primary constructor declares a field because the keyword `final` is\nused. (Using the `var` keyword also declares a field.)\n\n## Common fixes\n\nIf the parameter is still necessary, but the associated field is not, then\nremove the `final` or `var` keyword and use a wildcard in place of the\nparameter:\n\n```dart\nclass C(int _);\n```\n\nIf the parameter is also unnecessary, then remove it (which also removes\nthe associated field).\n\n```dart\nclass C();\n```\n\nIf the field was intended to be used, then add the missing code.\n",
     "hasDocumentation": true,
     "fromLint": false,
     "previousNames": []
@@ -9561,7 +9602,7 @@
   {
     "id": "use_build_context_synchronously",
     "description": "_Don't use 'BuildContext's across async gaps, guarded by an unrelated 'mounted' check._\n\n_Don't use 'BuildContext's across async gaps._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `BuildContext` is referenced\nby a `StatefulWidget` after an asynchronous gap without first checking the\n`mounted` property.\n\nStoring a `BuildContext` for later use can lead to difficult-to-diagnose\ncrashes. Asynchronous gaps implicitly store a `BuildContext`, making them\neasy to overlook for diagnosis.\n\n## Example\n\nThe following code produces this diagnostic because the `context` is\npassed to a constructor after the `await`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends Widget {\n  void onButtonTapped(BuildContext context) async {\n    await Future.delayed(const Duration(seconds: 1));\n    Navigator.of([!context!]).pop();\n  }\n}\n```\n\n## Common fixes\n\nIf you can remove the asynchronous gap, do so:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends Widget {\n  void onButtonTapped(BuildContext context) {\n    Navigator.of(context).pop();\n  }\n}\n```\n\nIf you can't remove the asynchronous gap, then use `mounted` to guard the\nuse of the `context`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends Widget {\n  void onButtonTapped(BuildContext context) async {\n    await Future.delayed(const Duration(seconds: 1));\n    if (context.mounted) {\n      Navigator.of(context).pop();\n    }\n  }\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `BuildContext` is referenced\nby a `StatefulWidget` after an asynchronous gap without first checking the\n`mounted` property.\n\nStoring a `BuildContext` for later use can lead to difficult-to-diagnose\ncrashes. Asynchronous gaps implicitly store a `BuildContext`, making them\neasy to overlook for diagnosis.\n\n## Example\n\nThe following code produces this diagnostic because the `context` is\npassed to a constructor after the `await`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const MyWidget({super.key}) extends Widget {\n  void onButtonTapped(BuildContext context) async {\n    await Future.delayed(const Duration(seconds: 1));\n    Navigator.of([!context!]).pop();\n  }\n}\n```\n\n## Common fixes\n\nIf you can remove the asynchronous gap, do so:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const MyWidget({super.key}) extends Widget {\n  void onButtonTapped(BuildContext context) {\n    Navigator.of(context).pop();\n  }\n}\n```\n\nIf you can't remove the asynchronous gap, then use `mounted` to guard the\nuse of the `context`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass const MyWidget({super.key}) extends Widget {\n  void onButtonTapped(BuildContext context) async {\n    await Future.delayed(const Duration(seconds: 1));\n    if (context.mounted) {\n      Navigator.of(context).pop();\n    }\n  }\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9569,7 +9610,7 @@
   {
     "id": "use_colored_box",
     "description": "_Use a 'ColoredBox' rather than a 'Container' with only a 'Color'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created that\nonly sets the color.\n\n## Example\n\nThe following code produces this diagnostic because the only attribute of\nthe container that is set is the `color`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!Container!](\n    color: Colors.red,\n    child: const Text('hello'),\n  );\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `ColoredBox`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return ColoredBox(\n    color: Colors.red,\n    child: const Text('hello'),\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created that\nonly sets the color.\n\n## Example\n\nThe following code produces this diagnostic because the only attribute of\nthe container that is set is the `color`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return [!Container!](color: Colors.red, child: const Text('hello'));\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `ColoredBox`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget build() {\n  return ColoredBox(color: Colors.red, child: const Text('hello'));\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9579,13 +9620,13 @@
     "description": "_Use a declaring parameter._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when a primary constructor has a\nparameter whose name matches a field of the same type in the class, and\nthe constructor assigns the value to the field without modifying it.\n\n## Example\n\nThe following code produces this diagnostic because the constructor\nassigns the parameter `i` to the field `i`:\n\n```dart\nclass C(int [!i!]) {\n  final int i;\n\n  this : i = i;\n}\n```\n\n## Common fixes\n\nConvert the parameter to a declaring parameter:\n\n```dart\nclass C(final int i);\n```\n",
     "hasDocumentation": true,
-    "fromLint": false,
+    "fromLint": true,
     "previousNames": []
   },
   {
     "id": "use_decorated_box",
     "description": "_Use 'DecoratedBox' rather than a 'Container' with only a 'Decoration'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created that\nonly sets the decoration.\n\n## Example\n\nThe following code produces this diagnostic because the only attribute of\nthe container that is set is the `decoration`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildArea() {\n  return [!Container!](\n    decoration: const BoxDecoration(\n      color: Colors.red,\n      borderRadius: BorderRadius.all(\n        Radius.circular(5),\n      ),\n    ),\n    child: const Text('...'),\n  );\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `DecoratedBox`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildArea() {\n  return DecoratedBox(\n    decoration: const BoxDecoration(\n      color: Colors.red,\n      borderRadius: BorderRadius.all(\n        Radius.circular(5),\n      ),\n    ),\n    child: const Text('...'),\n  );\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a `Container` is created that\nonly sets the decoration.\n\n## Example\n\nThe following code produces this diagnostic because the only attribute of\nthe container that is set is the `decoration`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildArea() {\n  return [!Container!](\n    decoration: const BoxDecoration(\n      color: Colors.red,\n      borderRadius: BorderRadius.all(Radius.circular(5)),\n    ),\n    child: const Text('...'),\n  );\n}\n```\n\n## Common fixes\n\nReplace the `Container` with a `DecoratedBox`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nWidget buildArea() {\n  return DecoratedBox(\n    decoration: const BoxDecoration(\n      color: Colors.red,\n      borderRadius: BorderRadius.all(Radius.circular(5)),\n    ),\n    child: const Text('...'),\n  );\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9624,14 +9665,15 @@
   {
     "id": "use_is_even_rather_than_modulo",
     "description": "_Use '{0}' rather than '% 2'._",
-    "hasDocumentation": false,
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when the result of\napplying the modulo operator `%` to an integer value,\nwith `2` as the right operand, is compared to `0` or `1` using `==`\nrather than using the `isEven` or `isOdd` getter.\n\n## Examples\n\nThe following code produces this diagnostic because the result of\n`x % 2` is compared to `0` to check whether `x` is even:\n\n```dart\nbool f(int x) => [!x % 2 == 0!];\n```\n\nThe following code produces this diagnostic because the result of\n`x % 2` is compared to `1` to check whether `x` is odd:\n\n```dart\nbool f(int x) => [!x % 2 == 1!];\n```\n\n## Common fixes\n\nIf you're checking whether a value is even,\nthen use the `isEven` getter:\n\n```dart\nbool f(int x) => x.isEven;\n```\n\nIf you're checking whether a value is odd,\nthen use the `isOdd` getter:\n\n```dart\nbool f(int x) => x.isOdd;\n```\n",
+    "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
   },
   {
     "id": "use_key_in_widget_constructors",
     "description": "_Constructors for public widgets should have a named 'key' parameter._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor in a subclass of\n`Widget` that isn't private to its library doesn't have a parameter named\n`key`.\n\n## Example\n\nThe following code produces this diagnostic because the constructor for\nthe class `MyWidget` doesn't have a parameter named `key`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatelessWidget {\n  [!MyWidget!]({required int height});\n}\n```\n\nThe following code produces this diagnostic because the default\nconstructor for the class `MyWidget` doesn't have a parameter named `key`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass [!MyWidget!] extends StatelessWidget {}\n```\n\n## Common fixes\n\nAdd a parameter named `key` to the constructor, explicitly declaring the\nconstructor if necessary:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatelessWidget {\n  MyWidget({super.key, required int height});\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a constructor in a subclass of\n`Widget` that isn't private to its library doesn't have a parameter named\n`key`.\n\n## Example\n\nThe following code produces this diagnostic because the constructor for\nthe class `MyWidget` doesn't have a parameter named `key`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatelessWidget {\n  const [!MyWidget!]({required int height});\n}\n```\n\nThe following code produces this diagnostic because the default\nconstructor for the class `MyWidget` doesn't have a parameter named `key`:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass [!MyWidget!] extends StatelessWidget {}\n```\n\n## Common fixes\n\nAdd a parameter named `key` to the constructor, explicitly declaring the\nconstructor if necessary:\n\n```dart\nimport 'package:flutter/material.dart';\n\nclass MyWidget extends StatelessWidget {\n  const MyWidget({super.key, required int height});\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9655,7 +9697,7 @@
   {
     "id": "use_null_aware_elements",
     "description": "_Use the null-aware marker '?' rather than a null check via an 'if'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a null check is used instead\nof a null-aware marker inside of a collection literal.\n\n## Example\n\nThe following code produces this diagnostic because a null check is used\nto decide whether `x` should be inserted into the list, while the\nnull-aware marker '?' would be less brittle and less verbose.\n\n```dart\nf(int? x) => [[!if!] (x != null) x];\n```\n\n## Common fixes\n\nReplace the null-check with the null-aware marker '?':\n\n```dart\nf(int? x) => [?x];\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a null check is used instead\nof a null-aware marker inside of a collection literal.\n\n## Example\n\nThe following code produces this diagnostic because a null check is used\nto decide whether `x` should be inserted into the list, while the\nnull-aware marker '?' would be less brittle and less verbose.\n\n```dart\nvoid f(int? x) => [[!if!] (x != null) x];\n```\n\n## Common fixes\n\nReplace the null-check with the null-aware marker '?':\n\n```dart\nvoid f(int? x) => [?x];\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9680,7 +9722,7 @@
     "id": "use_primary_constructors",
     "description": "_Use a primary constructor._",
     "hasDocumentation": false,
-    "fromLint": false,
+    "fromLint": true,
     "previousNames": []
   },
   {
@@ -9726,7 +9768,7 @@
   {
     "id": "use_super_parameters",
     "description": "_Parameter '{0}' could be a super parameter._\n\n_Parameters '{0}' could be super parameters._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a parameter to a constructor is\npassed to a super constructor without being referenced or modified and a\n`super` parameter isn't used.\n\n## Example\n\nThe following code produces this diagnostic because the parameters of the\nconstructor for `B` are only used as arguments to the super constructor:\n\n```dart\nclass A {\n  A({int? x, int? y});\n}\nclass B extends A {\n  [!B!]({int? x, int? y}) : super(x: x, y: y);\n}\n```\n\n## Common fixes\n\nUse a `super` parameter to pass the arguments:\n\n```dart\nclass A {\n  A({int? x, int? y});\n}\nclass B extends A {\n  B({super.x, super.y});\n}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a parameter to a constructor is\npassed to a super constructor without being referenced or modified and a\n`super` parameter isn't used.\n\n## Example\n\nThe following code produces this diagnostic because the parameters of the\nconstructor for `B` are only used as arguments to the super constructor:\n\n```dart\nclass A {\n  A({int? x, int? y});\n}\n\nclass B extends A {\n  [!B!]({int? x, int? y}) : super(x: x, y: y);\n}\n```\n\n## Common fixes\n\nUse a `super` parameter to pass the arguments:\n\n```dart\nclass A {\n  A({int? x, int? y});\n}\n\nclass B extends A {\n  B({super.x, super.y});\n}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []
@@ -9766,6 +9808,13 @@
     "description": "_A member named 'values' can't be declared in an enum._",
     "documentation": "## Description\n\nThe analyzer produces this diagnostic when an enum declaration defines a\nmember named `values`, whether the member is an enum value, an instance\nmember, or a static member.\n\nAny such member conflicts with the implicit declaration of the static\ngetter named `values` that returns a list containing all the enum\nconstants.\n\n## Example\n\nThe following code produces this diagnostic because the enum `E` defines\nan instance member named `values`:\n\n```dart\nenum E {\n  v;\n\n  void [!values!]() {}\n}\n```\n\n## Common fixes\n\nChange the name of the conflicting member:\n\n```dart\nenum E {\n  v;\n\n  void getValues() {}\n}\n```\n",
     "hasDocumentation": true,
+    "fromLint": false,
+    "previousNames": []
+  },
+  {
+    "id": "var_and_type",
+    "description": "_Variables can't be declared using both 'var' and a type name._",
+    "hasDocumentation": false,
     "fromLint": false,
     "previousNames": []
   },
@@ -9846,7 +9895,7 @@
   {
     "id": "void_checks",
     "description": "_Assignment to a variable of type 'void'._",
-    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a value is assigned to a\nvariable of type `void`.\n\nIt isn't possible to access the value of such a variable, so the\nassignment has no value.\n\n## Example\n\nThe following code produces this diagnostic because the field `value` has\nthe type `void`, but a value is being assigned to it:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<void> a) {\n  [!a.value = 1!];\n}\n```\n\nThe following code produces this diagnostic because the type of the\nparameter `p` in the method `m` is `void`, but a value is being assigned\nto it in the invocation:\n\n```dart\nclass A<T> {\n  void m(T p) { }\n}\n\nvoid f(A<void> a) {\n  a.m([!1!]);\n}\n```\n\n## Common fixes\n\nIf the type of the variable is incorrect, then change the type of the\nvariable:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<int> a) {\n  a.value = 1;\n}\n```\n\nIf the type of the variable is correct, then remove the assignment:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<void> a) {}\n```\n",
+    "documentation": "## Description\n\nThe analyzer produces this diagnostic when a value is assigned to a\nvariable of type `void`.\n\nIt isn't possible to access the value of such a variable, so the\nassignment has no value.\n\n## Example\n\nThe following code produces this diagnostic because the field `value` has\nthe type `void`, but a value is being assigned to it:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<void> a) {\n  [!a.value = 1!];\n}\n```\n\nThe following code produces this diagnostic because the type of the\nparameter `p` in the method `m` is `void`, but a value is being assigned\nto it in the invocation:\n\n```dart\nclass A<T> {\n  void m(T p) {}\n}\n\nvoid f(A<void> a) {\n  a.m([!1!]);\n}\n```\n\n## Common fixes\n\nIf the type of the variable is incorrect, then change the type of the\nvariable:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<int> a) {\n  a.value = 1;\n}\n```\n\nIf the type of the variable is correct, then remove the assignment:\n\n```dart\nclass A<T> {\n  T? value;\n}\n\nvoid f(A<void> a) {}\n```\n",
     "hasDocumentation": true,
     "fromLint": true,
     "previousNames": []

--- a/tool/dash_site/lib/src/diagnostics/diagnostics.dart
+++ b/tool/dash_site/lib/src/diagnostics/diagnostics.dart
@@ -199,7 +199,10 @@ final class DocumentationGenerator {
       _extractAllDocs(classEntry.key, classEntry.value);
     }
 
-    _extractAllDocs('FrontEnd', messages.sharedMessages);
+    _extractAllDocs(
+      'ParserErrorCode',
+      messages.cfeToAnalyzerErrorCodeTables.analyzerCodeToInfo,
+    );
   }
 
   /// Writes the condenses data representation of

--- a/tool/dash_site/lib/src/diagnostics/error_code_info.dart
+++ b/tool/dash_site/lib/src/diagnostics/error_code_info.dart
@@ -237,6 +237,8 @@ class CfeToAnalyzerErrorCodeTables {
         analyzerCode = analyzerCodeLong.substring(
           'CompileTimeErrorCode.'.length,
         );
+      } else if (!analyzerCodeLong.contains('.')) {
+        analyzerCode = analyzerCodeLong;
       } else {
         // Ignore error codes that start with other types.
         continue;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/7406

**Staged diagnostic page now with correct name:** https://dart-dev--pr7407-fix-analyzer-codes-qrwnx43t.web.app/tools/diagnostics/record_literal_one_positional_no_trailing_comma