### PR TITLE
Add Publy to the package repositories service list

### DIFF
--- a/site/web/assets/img/tools/publy.svg
+++ b/site/web/assets/img/tools/publy.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="28" height="28" rx="6" fill="#0a161f"/>
+  <circle cx="9" cy="20" r="2.5" fill="#22d3ee"/>
+  <path d="M9 20L20 9M20 9H14M20 9V15" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/content/tools/pub/custom-package-repositories.md
+++ b/src/content/tools/pub/custom-package-repositories.md
@@ -235,6 +235,12 @@ your own custom package repository:
   </a>
 </li>
 <li>
+  <a href="https://publy.dev/docs/getting-started">
+    <img src="/assets/img/tools/publy.svg" alt="Publy logo">
+    <span>Publy</span>
+  </a>
+</li>
+<li>
   <a href="https://glpub.dev/">
     <img src="/assets/img/tools/glpub.png" alt="GLPub logo">
     <span>GLPub.dev</span>


### PR DESCRIPTION
Adds [Publy](https://publy.dev) to the "Dart package repositories as a service" list.

Publy is a private Dart & Flutter package registry that implements the [pub hosted repository spec v2](https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md) with token authentication (`dart pub token add`) — `dart pub publish` and `dart pub get` work against it unmodified. Docs: https://publy.dev/docs/getting-started

Same shape as previous vendor additions (#4580, #6009, #7106): the SVG logo committed next to the other logos, plus one list entry (placed after OnePub, keeping alphabetical order).