### PR TITLE
Remove aggressive wording in effective-dart

### DIFF
--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -226,11 +226,8 @@ class RadioButtonWidget extends Widget {
 }
 ```
 
-If you really don't have anything interesting to say
-that can't be inferred from the declaration itself,
-then omit the doc comment.
-It's better to say nothing
-than waste a reader's time telling them something they already know.
+Only add doc comments when providing context, caveats, or usage details not immediately obvious
+from the surrounding context.
 
 <a id="prefer-starting-function-or-method-comments-with-third-person-verbs" aria-hidden="true"></a>
 

--- a/src/content/effective-dart/documentation.md
+++ b/src/content/effective-dart/documentation.md
@@ -226,8 +226,8 @@ class RadioButtonWidget extends Widget {
 }
 ```
 
-Only add doc comments when providing context, caveats, or usage details not immediately obvious
-from the surrounding context.
+Only add doc comments when providing context, caveats, or usage details
+not immediately obvious from the surrounding context.
 
 <a id="prefer-starting-function-or-method-comments-with-third-person-verbs" aria-hidden="true"></a>
 


### PR DESCRIPTION
Effective dart contains the a paragraph that can come off as passive aggressive:

`If you really don't have anything interesting to say...` feels personal and condescending, as if evaluating the author's intelligence or value rather than the code style.

`...waste a reader's time telling them something they already know.` uses accusatory language ("waste") that makes the author feel defensive.

As the guidelines in the doc are often cited verbatim, it's important that the wording doesn't come off hostile so people can collaborate better :)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
