### PR TITLE
Restore continuity and execution steps in logging tutorial

### DIFF
--- a/src/content/learn/tutorial/async.md
+++ b/src/content/learn/tutorial/async.md
@@ -81,7 +81,7 @@ dependency to your project.
 Now that you've added the `http` package,
 you need to import it into your Dart file to use its functionalities.
 
-1.  Open the `dartpedia/bin/cli.dart` file.
+1.  Open the `cli/bin/cli.dart` file.
 1.  Add the following `import` statement at the top of the file,
     along with the existing `dart:io` import:
 

--- a/src/content/learn/tutorial/fetch-data.md
+++ b/src/content/learn/tutorial/fetch-data.md
@@ -337,6 +337,7 @@ items:
 
 ## Next lesson
 
-In the next lesson, you'll complete the CLI by
-integrating the `wikipedia` package with the `cli` package.
-You'll implement the command logic and display the results to the user.
+In the next lesson, you'll complete your CLI application by
+integrating the `wikipedia` package commands with the `cli` package
+and adding logging for debugging and error monitoring.
+

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -170,12 +170,12 @@ creating a new file for the logger and setting up the necessary imports.
     -   It listens for log records and writes them to the log file.
 
 1. Create a new file called `cli/lib/cli.dart` and export `logger.dart`.
-   This makes the `initFileLogger` available to other parts of your app.
+   This makes `initFileLogger` available to other parts of your app.
+   (You'll add exports for the CLI commands in the following tasks once they're created).
 
    ```dart title="cli/lib/cli.dart"
-    export 'src/commands/get_article.dart';
-    export 'src/commands/search.dart';
-    export 'src/logger.dart';
+   // ...
+   export 'src/logger.dart';
    ```
 
 ### Task 3: Use the logger in `cli.dart`
@@ -574,15 +574,33 @@ uses a `try/catch` block to handle potential network or data errors.
       handle network errors (`HttpException`) and
       data parsing errors (`FormatException`), logging them for debugging.
 
+3.  Now update `cli/lib/cli.dart` to export your new command files:
+
+    ```dart title="cli/lib/cli.dart"
+    export 'src/commands/get_article.dart';
+    export 'src/commands/search.dart';
+    export 'src/logger.dart';
+    ```
 
 ### Task 6: Run the application and check the logs
 
-Now that you've added logging to your application,
-run it and check the log file to see the results.
+Now that you've implemented the CLI commands, wired up `CommandRunner` in `bin/cli.dart`, and configured logging, test your application from the terminal.
 
-1.  Run the application with a command that might produce an error.
-    For example, try searching for an article that
-    doesn't exist or that causes a `FormatException`.
+1.  Run the CLI application to search for an article:
+
+    ```bash
+    dart run bin/cli.dart search "Dart programming"
+    ```
+
+    You should see terminal output listing Wikipedia articles matching your search term.
+
+1.  Try running the command with the `--im-feeling-lucky` flag:
+
+    ```bash
+    dart run bin/cli.dart search "Dart" --im-feeling-lucky
+    ```
+
+1.  Run the application with a query that produces an error or warning to test logging:
 
     ```bash
     dart run bin/cli.dart search blahblahblahblah
@@ -591,7 +609,7 @@ run it and check the log file to see the results.
 1.  Check the `logs` directory in your project.
     You should see a file with the current date and the name `errors.txt`.
 
-1.  Open the log file and verify that the error message is logged.
+1.  Open the log file and verify that the error message is logged:
 
     ```text
     [2025-02-20 16:23:45.678 - errors] WARNING: HttpException: HttpException: , uri = https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=blahblahblahblah

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -33,33 +33,36 @@ Before you begin this chapter, ensure you:
 
 ## Tasks
 
-In this chapter, you'll add logging to the `dartpedia` CLI application to
+In this chapter, you'll complete the `dartpedia` CLI application by
+integrating the `wikipedia` package commands and adding logging to
 help track errors and monitor its behavior.
-This will involve adding the `logging` package,
-creating a `Logger` instance, and writing log messages to a file.
+This will involve adding package dependencies,
+creating the CLI commands, configuring a `Logger` instance,
+and running your complete application.
 
-### Task 1: Add the `logging` package
+### Task 1: Add dependencies to the `cli` package
 
-First, add the `logging` package to your project's dependencies.
+First, add the `wikipedia` package (which you built in the previous chapters)
+and the `logging` package to your CLI project's dependencies.
 
 1.  Open the `cli/pubspec.yaml` file.
 
 1.  Locate the `dependencies` section.
 
-1.  Add the `logging` package to your dependencies:
+1.  Add the `wikipedia` and `logging` packages to your dependencies:
 
     ```yaml
     dependencies:
       http: ^1.3.0
       command_runner:
         path: ../command_runner
+      # Add the following lines
       wikipedia:
         path: ../wikipedia
-      # Add the following line
       logging: ^1.2.0
     ```
 
-1.  Run `dart pub get` in the `cli` directory to fetch the new dependency.
+1.  Run `dart pub get` in the `cli` directory to fetch the new dependencies.
 
 ### Task 2: Create a logger
 
@@ -169,77 +172,13 @@ creating a new file for the logger and setting up the necessary imports.
         `Level.INFO` or `Level.WARNING` in production.
     -   It listens for log records and writes them to the log file.
 
-1. Create a new file called `cli/lib/cli.dart` and export `logger.dart`.
-   This makes `initFileLogger` available to other parts of your app.
-   (You'll add exports for the CLI commands in the following tasks once they're created).
-
-   ```dart title="cli/lib/cli.dart"
-   // ...
-   export 'src/logger.dart';
-   ```
-
-### Task 3: Use the logger in `cli.dart`
-
-Now, use the `initFileLogger` function in `cli/bin/cli.dart` to
-create a logger instance and log messages to a file.
-
-1.  Open the `cli/bin/cli.dart` file.
-
-1.  Add the import for the logger:
-
-    ```dart title="cli/bin/cli.dart"
-    import 'package:cli/cli.dart';
-    import 'package:command_runner/command_runner.dart';
-    ```
-
-1.  Modify the `main` function to initialize the logger and
-    pass it to the commands:
-
-    ```dart title="cli/bin/cli.dart"
-    import 'package:cli/cli.dart';
-    import 'package:command_runner/command_runner.dart';
-
-    void main(List<String> arguments) async {
-      final errorLogger = initFileLogger('errors');
-      final app =
-          CommandRunner(
-              onOutput: (String output) async {
-                await write(output);
-              },
-              onError: (Object error) {
-                if (error is Error) {
-                  errorLogger.severe(
-                    '[Error] ${error.toString()}\n${error.stackTrace}',
-                  );
-                  throw error;
-                }
-                if (error is Exception) {
-                  errorLogger.warning(error);
-                  print(error);
-                }
-              },
-            )
-            ..addCommand(HelpCommand())
-            ..addCommand(SearchCommand(logger: errorLogger))
-            ..addCommand(GetArticleCommand(logger: errorLogger));
-
-      app.run(arguments);
-    }
-    ```
-
-    This code does the following:
-
-    -   It initializes a `Logger` instance using `initFileLogger('errors')`.
-    -   It passes the `logger` instance to `CommandRunner` and
-        individual commands.
-
-### Task 4: Create the SearchCommand command
+### Task 3: Create the SearchCommand command
 
 The core functionality of the CLI lives in its commands.
 Create the `SearchCommand` and `GetArticleCommand` files and
-add the necessary code, including the logging and error handling.
+add the necessary code, including logging and error handling.
 
-1.  Create a new file named `/cli/lib/src/commands/search.dart`.
+1.  Create a new file named `cli/lib/src/commands/search.dart`.
 
 1.  Add the imports and a basic class structure.
     This `SearchCommand` class extends `Command`, and
@@ -249,101 +188,7 @@ add the necessary code, including the logging and error handling.
     which allows the command to log events without
     needing to create its own logger.
 
-    ```dart
-    import 'dart:async';
-    import 'dart:io';
-
-    import 'package:command_runner/command_runner.dart';
-    import 'package:logging/logging.dart';
-    import 'package:wikipedia/wikipedia.dart';
-
-    class SearchCommand extends Command {
-      SearchCommand({required this.logger});
-
-      final Logger logger;
-
-      @override
-      String get description => 'Search for Wikipedia articles.';
-
-      @override
-      bool get requiresArgument => true;
-
-      @override
-      String get name => 'search';
-
-      @override
-      String get valueHelp => 'STRING';
-
-      @override
-      String get help =>
-          'Prints a list of links to Wikipedia articles that match the given term.';
-
-      @override
-      FutureOr<String> run(ArgResults args) async {
-        // The rest of the function will be added below.
-        // ...
-      }
-    }
-    ```
-
-1.  Now, add the core logic to the `run` method.
-    This code checks for a valid argument,
-    calls the `search()` function from the `wikipedia` package,
-    formats the results, and returns the results as a string.
-
-    ```dart
-    import 'dart:async';
-    import 'dart:io';
-
-    import 'package:command_runner/command_runner.dart';
-    import 'package:logging/logging.dart';
-    import 'package:wikipedia/wikipedia.dart';
-
-    class SearchCommand extends Command {
-      SearchCommand({required this.logger});
-
-      final Logger logger;
-
-      @override
-      String get description => 'Search for Wikipedia articles.';
-
-      @override
-      bool get requiresArgument => true;
-
-      @override
-      String get name => 'search';
-
-      @override
-      String get valueHelp => 'STRING';
-
-      @override
-      String get help =>
-          'Prints a list of links to Wikipedia articles that match the given term.';
-
-      @override
-      FutureOr<String> run(ArgResults args) async {
-        if (requiresArgument &&
-            (args.commandArg == null || args.commandArg!.isEmpty)) {
-          throw ArgumentException('Please include a search term', name);
-        }
-
-        final buffer = StringBuffer('Search results:\n');
-        final SearchResults results = await search(args.commandArg!);
-
-        for (var result in results.results) {
-          buffer.writeln('${result.title} - ${result.url}');
-        }
-        return buffer.toString();
-      }
-    }
-    ```
-
-1.  Next, add the "I'm feeling lucky" feature by
-    adding a flag to the constructor. Then, in the `run` method,
-    add the logic to check if the flag is set and, if so,
-    get the summary of the top search result.
-
-    ```dart
+    ```dart title="cli/lib/src/commands/search.dart"
     import 'dart:async';
     import 'dart:io';
 
@@ -380,6 +225,19 @@ add the necessary code, including the logging and error handling.
 
       @override
       FutureOr<String> run(ArgResults args) async {
+        // Command logic will be added below.
+        // ...
+        return '';
+      }
+    }
+    ```
+
+1.  Implement the command logic to search Wikipedia and format the results.
+
+    ```dart
+    // ...
+      @override
+      FutureOr<String> run(ArgResults args) async {
         if (requiresArgument &&
             (args.commandArg == null || args.commandArg!.isEmpty)) {
           throw ArgumentException('Please include a search term', name);
@@ -406,7 +264,7 @@ add the necessary code, including the logging and error handling.
         }
         return buffer.toString();
       }
-    }
+    // ...
     ```
 
 1.  Finally, wrap the main logic in a `try/catch` block.
@@ -414,7 +272,7 @@ add the necessary code, including the logging and error handling.
     could arise from network issues or data formatting problems.
     You'll use the injected `logger` to record these errors to the log file.
 
-    ```dart
+    ```dart title="cli/lib/src/commands/search.dart"
     import 'dart:async';
     import 'dart:io';
 
@@ -494,17 +352,17 @@ add the necessary code, including the logging and error handling.
     }
     ```
 
-### Task 5: Create the GetArticleCommand command
+### Task 4: Create the GetArticleCommand command
 
 Now, create the `GetArticleCommand` file and add the necessary code.
 The code is similar to the previous `SearchCommand`, as it also
 uses a `try/catch` block to handle potential network or data errors.
 
-1.  Create a new file named cli/lib/src/commands/get_article.dart.
+1.  Create a new file named `cli/lib/src/commands/get_article.dart`.
 
-1.  Add the following code to `get_article.dart`.
+1.  Add the following code to `get_article.dart`:
 
-    ```dart
+    ```dart title="cli/lib/src/commands/get_article.dart"
     import 'dart:async';
     import 'dart:io';
 
@@ -574,7 +432,14 @@ uses a `try/catch` block to handle potential network or data errors.
       handle network errors (`HttpException`) and
       data parsing errors (`FormatException`), logging them for debugging.
 
-3.  Now update `cli/lib/cli.dart` to export your new command files:
+### Task 5: Export commands and wire up `cli.dart`
+
+Now, export the logger and commands from the `cli` library,
+then wire them up in `cli/bin/cli.dart` to
+create the complete CLI application.
+
+1.  Create a new file called `cli/lib/cli.dart` and
+    export your logger and commands:
 
     ```dart title="cli/lib/cli.dart"
     export 'src/commands/get_article.dart';
@@ -582,9 +447,64 @@ uses a `try/catch` block to handle potential network or data errors.
     export 'src/logger.dart';
     ```
 
+    This makes `initFileLogger`, `SearchCommand`, and `GetArticleCommand`
+    available to other parts of your application.
+
+1.  Open the `cli/bin/cli.dart` file.
+
+1.  Add the imports for `cli` and `command_runner`:
+
+    ```dart title="cli/bin/cli.dart"
+    import 'package:cli/cli.dart';
+    import 'package:command_runner/command_runner.dart';
+    ```
+
+1.  Modify the `main` function to initialize the logger and
+    register the commands with `CommandRunner`:
+
+    ```dart title="cli/bin/cli.dart"
+    import 'package:cli/cli.dart';
+    import 'package:command_runner/command_runner.dart';
+
+    void main(List<String> arguments) async {
+      final errorLogger = initFileLogger('errors');
+      final app =
+          CommandRunner(
+              onOutput: (String output) async {
+                await write(output);
+              },
+              onError: (Object error) {
+                if (error is Error) {
+                  errorLogger.severe(
+                    '[Error] ${error.toString()}\n${error.stackTrace}',
+                  );
+                  throw error;
+                }
+                if (error is Exception) {
+                  errorLogger.warning(error);
+                  print(error);
+                }
+              },
+            )
+            ..addCommand(HelpCommand())
+            ..addCommand(SearchCommand(logger: errorLogger))
+            ..addCommand(GetArticleCommand(logger: errorLogger));
+
+      app.run(arguments);
+    }
+    ```
+
+    This code does the following:
+
+    -   Initializes a `Logger` instance using `initFileLogger('errors')`.
+    -   Passes the logger instance to `SearchCommand` and `GetArticleCommand`.
+    -   Registers all commands with `CommandRunner`.
+
 ### Task 6: Run the application and check the logs
 
-Now that you've implemented the CLI commands, wired up `CommandRunner` in `bin/cli.dart`, and configured logging, test your application from the terminal.
+Now that you've implemented the CLI commands,
+wired up `CommandRunner` in `bin/cli.dart`, and configured logging,
+test your application from the terminal.
 
 1.  Run the CLI application to search for an article:
 
@@ -592,7 +512,8 @@ Now that you've implemented the CLI commands, wired up `CommandRunner` in `bin/c
     dart run bin/cli.dart search "Dart programming"
     ```
 
-    You should see terminal output listing Wikipedia articles matching your search term.
+    You should see terminal output listing Wikipedia articles
+    matching your search term.
 
 1.  Try running the command with the `--im-feeling-lucky` flag:
 
@@ -600,14 +521,16 @@ Now that you've implemented the CLI commands, wired up `CommandRunner` in `bin/c
     dart run bin/cli.dart search "Dart" --im-feeling-lucky
     ```
 
-1.  Run the application with a query that produces an error or warning to test logging:
+1.  Run the application with a query that produces an error or
+    warning to test logging:
 
     ```bash
     dart run bin/cli.dart search blahblahblahblah
     ```
 
-1.  Check the `logs` directory in your project.
-    You should see a file with the current date and the name `errors.txt`.
+1.  Check the `cli/logs` directory in your project.
+    You should see a file named with the current date,
+    such as `<year>_<month>_<day>_errors.txt`.
 
 1.  Open the log file and verify that the error message is logged:
 

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -36,7 +36,7 @@ Before you begin this chapter, ensure you:
 In this chapter, you'll complete the `dartpedia` CLI application by
 integrating the `wikipedia` package commands and adding logging to
 help track errors and monitor its behavior.
-This will involve adding package dependencies,
+This involves adding package dependencies,
 creating the CLI commands, configuring a `Logger` instance,
 and running your complete application.
 

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -438,8 +438,8 @@ Now, export the logger and commands from the `cli` library,
 then wire them up in `cli/bin/cli.dart` to
 create the complete CLI application.
 
-1.  Create a new file called `cli/lib/cli.dart` and
-    export your logger and commands:
+1.  Open the `cli/lib/cli.dart` file.
+    Replace its placeholder content with exports for your logger and commands:
 
     ```dart title="cli/lib/cli.dart"
     export 'src/commands/get_article.dart';
@@ -447,8 +447,9 @@ create the complete CLI application.
     export 'src/logger.dart';
     ```
 
-    This makes `initFileLogger`, `SearchCommand`, and `GetArticleCommand`
-    available to other parts of your application.
+    This file acts as the library's public interface,
+    exporting `initFileLogger`, `SearchCommand`, and `GetArticleCommand`
+    so that `cli/bin/cli.dart` can import them from `package:cli/cli.dart`.
 
 1.  Open the `cli/bin/cli.dart` file.
 
@@ -505,6 +506,8 @@ create the complete CLI application.
 Now that you've implemented the CLI commands,
 wired up `CommandRunner` in `bin/cli.dart`, and configured logging,
 test your application from the terminal.
+Make sure you run these commands from your `cli` directory
+(`/dartpedia/cli`).
 
 1.  Run the CLI application to search for an article:
 
@@ -550,6 +553,50 @@ test your application from the terminal.
     are also logged to this file as `WARNING` level entries,
     followed by an `INFO` entry with command usage.
     :::
+
+1.  Verify that your workspace structure matches the completed project:
+
+    ```text
+    dartpedia/
+    ├── pubspec.yaml               # Workspace root configuration
+    ├── cli/
+    │   ├── bin/
+    │   │   └── cli.dart           # Application entrypoint
+    │   ├── lib/
+    │   │   ├── cli.dart           # Library exports
+    │   │   └── src/
+    │   │       ├── commands/
+    │   │       │   ├── get_article.dart
+    │   │       │   └── search.dart
+    │   │       └── logger.dart    # Logging configuration
+    │   ├── logs/
+    │   │   └── <date>_errors.txt  # Generated error logs
+    │   └── pubspec.yaml
+    ├── command_runner/
+    │   ├── lib/
+    │   │   ├── command_runner.dart
+    │   │   └── src/
+    │   │       ├── arguments.dart
+    │   │       ├── command_runner_base.dart
+    │   │       ├── console.dart
+    │   │       ├── exceptions.dart
+    │   │       └── help_command.dart
+    │   └── pubspec.yaml
+    └── wikipedia/
+        ├── lib/
+        │   ├── wikipedia.dart
+        │   └── src/
+        │       ├── api/
+        │       │   ├── get_article.dart
+        │       │   ├── search.dart
+        │       │   └── summary.dart
+        │       └── model/
+        │           ├── article.dart
+        │           ├── search_results.dart
+        │           ├── summary.dart
+        │           └── title_set.dart
+        └── pubspec.yaml
+    ```
 
 ## Review
 

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -521,11 +521,17 @@ test your application from the terminal.
     dart run bin/cli.dart search "Dart" --im-feeling-lucky
     ```
 
-1.  Run the application with a query that produces an error or
-    warning to test logging:
+1.  Run the application without the required search argument to test
+    error logging:
 
     ```bash
-    dart run bin/cli.dart search blahblahblahblah
+    dart run bin/cli.dart search
+    ```
+
+    You should see the error printed to the terminal:
+
+    ```console
+    ArgumentException: Please include a search term
     ```
 
 1.  Check the `cli/logs` directory in your project.
@@ -535,9 +541,15 @@ test your application from the terminal.
 1.  Open the log file and verify that the error message is logged:
 
     ```text
-    [2025-02-20 16:23:45.678 - errors] WARNING: HttpException: HttpException: , uri = https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=blahblahblahblah
-    [2025-02-20 16:23:45.678 - errors] INFO: Usage: dart bin/cli.dart <command> [commandArg?] [...options?]
+    [2025-02-20 16:23:45.678 - errors] WARNING: ArgumentException: Please include a search term
     ```
+
+    :::note
+    Network errors caught by `SearchCommand` or `GetArticleCommand`
+    (such as when your device is offline or Wikipedia is unreachable)
+    are also logged to this file as `WARNING` level entries,
+    followed by an `INFO` entry with command usage.
+    :::
 
 ## Review
 


### PR DESCRIPTION
### Summary

Resolves tutorial continuity, dependency, and command execution issues across the tutorial (Chapters 3, 11, and 12).

- **Chapter 3 (`async.md`):** Fixed path typo from `dartpedia/bin/cli.dart` to `cli/bin/cli.dart`.
- **Chapter 11 (`fetch-data.md`):** Updated the "Next lesson" transition to cleanly bridge into Chapter 12's command implementation and logging.
- **Chapter 12 (`logging.md`):**
  - Added missing `wikipedia: path: ../wikipedia` dependency to `cli/pubspec.yaml`.
  - Reordered tasks so `logger.dart`, `SearchCommand`, and `GetArticleCommand` are created before being exported and wired into `bin/cli.dart`.
  - Updated `cli/lib/cli.dart` instruction to open and replace the placeholder file created in Chapter 1, clarifying the library export pattern.
  - Replaced the non-failing Wikipedia search test command with `dart run bin/cli.dart search` (omitting the search argument), deterministically triggering `ArgumentException` and verifying the generated log file in `cli/logs/`.
  - Added working directory guidance (`/dartpedia/cli`) and a complete workspace structure tree to Task 6.

Fixes #7188
Fixes #7213
Fixes #7224
Fixes #7239
