### PR TITLE
[pub] Add SemVer compatibility and breaking changes reference guide

### DIFF
--- a/src/content/tools/pub/publishing.md
+++ b/src/content/tools/pub/publishing.md
@@ -65,6 +65,10 @@ Beyond these conventions, you must follow these requirements:
   These restrictions ensure that dependencies of your packages
   can be found and accessed in the future.
 
+* Choose a version number that adheres to [Semantic Versioning (SemVer)][semver].
+  To understand what API changes require a major, minor, or patch bump,
+  consult the [SemVer compatibility rules][semver-rules] guide.
+
 * Own a [Google Account][]. Pub uses a Google account to manage package
   upload permissions. Your Google Account can be associated with
   a Gmail address or any other email address.
@@ -537,6 +541,7 @@ If you change your mind, you can remove the discontinued mark at any time.
 [`dart pub publish`]: /tools/pub/cmd/pub-lish
 [pubspec]: /tools/pub/pubspec
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html
+[semver-rules]: /tools/pub/semver-rules
 [verified publisher]: /tools/pub/verified-publishers
 [git-ignore-format]: https://git-scm.com/docs/gitignore#_pattern_format
 [pubignore-when]: https://stackoverflow.com/a/69767697

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -180,8 +180,11 @@ Once that's been done, consider it hermetically sealed: you can't touch it
 anymore. To make more changes, you'll need a new version.
 
 When you select a version, follow [semantic versioning.][semantic versioning]
+For a reference on which API changes in Dart require major, minor, or patch
+version bumps, see [SemVer compatibility rules][semver-rules].
 
 [semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html
+[semver-rules]: /tools/pub/semver-rules
 
 ### Description
 

--- a/src/content/tools/pub/pubspec.md
+++ b/src/content/tools/pub/pubspec.md
@@ -181,7 +181,7 @@ anymore. To make more changes, you'll need a new version.
 
 When you select a version, follow [semantic versioning.][semantic versioning]
 For a reference on which API changes in Dart require major, minor, or patch
-version bumps, see [SemVer compatibility rules][semver-rules].
+version bumps, check out [SemVer compatibility rules][semver-rules].
 
 [semantic versioning]: https://semver.org/spec/v2.0.0-rc.1.html
 [semver-rules]: /tools/pub/semver-rules

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -1,5 +1,5 @@
 ---
-title: SemVer compatibility and breaking changes
+title: API versioning guidelines
 breadcrumb: SemVer rules
 description: >-
   A comprehensive guide to what changes are breaking (major), non-breaking
@@ -79,9 +79,19 @@ Renaming a public symbol is functionally equivalent to removing the original nam
 
 Moving a declaration from the public `lib/` root to `lib/src/` (without an `export` in a public library file) makes it inaccessible to external packages, breaking all existing consumers.
 
-### MAJOR: Change the type of a top-level variable or constant
+### MAJOR: Widen or change the type of a `const` or `final` variable
 
-Changing the static type of a top-level variable or constant causes type errors for any callers expecting the previous type.
+Changing a `const` or `final` variable to a broader type (for example, `const int maxRetries` to `const num maxRetries`) or to an incompatible type breaks callers expecting members of the more specific type.
+
+### MINOR: Narrow the type of a `const` or `final` variable
+
+Narrowing the static type of a read-only `const` or `final` variable to a more specific subtype (for example, `const num timeout` to `const int timeout`, or `const Object key` to `const String key`) is backward-compatible. Because consumers only read the value, a more specific subtype satisfies all existing type expectations while providing additional type safety.
+
+### MAJOR: Change the type of a mutable (`var`) top-level variable
+
+For mutable variables (which can be both read from and written to), changing the static type in either direction is a breaking change:
+* Narrowing the type (e.g., `num` to `int`) breaks callers assigning a `double` into the variable.
+* Widening the type (e.g., `int` to `num`) breaks callers expecting `int` methods when reading the variable.
 
 ### MAJOR: Change a top-level variable from `var` to `final`
 
@@ -93,7 +103,41 @@ Making a mutable variable `final` breaks any consumer assigning values to that v
 
 Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, and `mixin`), allowing package authors to explicitly define how classes can be used by consumers. The SemVer impact of adding or modifying members depends on these modifiers.
 
-### Unmodified classes (`class` and `abstract class`)
+### Changing modifiers on existing classes
+
+Changing the modifier on an already-published class alters what external packages are permitted to do with it:
+
+#### MAJOR: Change a concrete class to an abstract class
+
+Changing a concrete class to `abstract class` prevents external consumers from instantiating the class directly (`new MyClass()`), causing compile errors.
+
+#### MINOR: Change an abstract class to a concrete class
+
+Making an abstract class concrete enables external instantiation without breaking existing subclasses or implementers.
+
+#### MAJOR: Add the `base` modifier to an existing class
+
+Prevents external consumers from implementing the class (`implements MyClass`), breaking all existing external implementers.
+
+#### MAJOR: Add the `interface` modifier to an existing class
+
+Prevents external consumers from extending the class (`extends MyClass`), breaking all existing external subclasses.
+
+#### MAJOR: Add the `final` or `sealed` modifier to an existing class
+
+Prevents external consumers from extending, implementing, or mixing in the class, breaking all existing external subtypes.
+
+#### MAJOR: Remove the `mixin` modifier from a `mixin class`
+
+Prevents external consumers from using the class as a mixin (`with MyClass`).
+
+#### MINOR: Remove `base`, `interface`, or `final` from a class
+
+Loosens restrictions on consumers, granting new capabilities without invalidating existing code.
+
+---
+
+### Unmodified classes: `class` and `abstract class`
 
 An unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
 
@@ -225,6 +269,31 @@ Restricting the superclass requirements (for example, from `on Object` to `on Wi
 
 ---
 
+## Type aliases (`typedef`)
+
+Type aliases (`typedef`) define names for function types, records, or existing class types.
+
+### MINOR: Add a new type alias
+
+Adding a new public `typedef` exposes a new type name without affecting existing code.
+
+### MAJOR: Remove or rename a type alias
+
+Any downstream code referencing the removed `typedef` name will fail to compile.
+
+### MAJOR: Change the aliased type in a type alias
+
+Changing the underlying type that a type alias references (for example, changing `typedef Callback = void Function(int);` to `typedef Callback = void Function(String);`) alters the expected type everywhere the alias is used, breaking consumers.
+
+### MAJOR: Replace a `typedef` with a class or vice versa
+
+Replacing a type alias with a class (or class with a type alias) of the same name is a breaking change:
+
+* **Function type alias $\rightarrow$ class:** In Dart, closure literals are function types, not class instances. Code assigning a closure (`Callback cb = (x) => ...;`) will fail to compile against `class Callback`.
+* **Class type alias $\rightarrow$ subclass:** If `typedef A = B;` is replaced with `class A extends B {}`, `B` is no longer assignable to `A` ($B \not\le A$), and bidirectional type identity is lost.
+
+---
+
 ## Constructors
 
 ### MINOR: Add a new public constructor or factory
@@ -265,7 +334,7 @@ If a class previously had the default implicit constructor `MyClass()`, adding `
 
 Existing call sites omitting the parameter will fail to compile.
 
-#### MINOR: Add an optional parameter (positional or named)
+#### MINOR: Add an optional parameter
 
 Existing call sites can omit the new optional parameter without issue.
 
@@ -285,16 +354,16 @@ Call sites passing `func(paramName: value)` will fail to compile when `paramName
 
 Reordering positional parameters changes the expected argument positions at call sites. Even if the parameter types are identical, it causes callers to pass arguments to the wrong parameters, altering behavior or causing compile-time type errors.
 
-#### MAJOR: Narrow a parameter type (more specific / subtype)
+#### MAJOR: Narrow a parameter type
 
 Changing a parameter from `num` to `int` breaks callers that passed `double`.
 
-#### MINOR / MAJOR: Widen a parameter type (more general / supertype)
+#### Widen a parameter type
 
-* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs.
+* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs (for example, widening a parameter from `Future<T>` to `FutureOr<T>` or from `int` to `num`).
 * **MAJOR** for methods on an implementable class, because it changes the signature required for external overrides.
 
-#### PATCH / MINOR: Change the default value of an optional parameter
+#### MINOR: Change the default value of an optional parameter
 
 Does not break compilation or static type checks, but alters runtime behavior for callers omitting the argument.
 
@@ -302,38 +371,47 @@ Does not break compilation or static type checks, but alters runtime behavior fo
 
 ### Return types
 
-#### MINOR / MAJOR: Narrow a return type (more specific / subtype)
+Return types in Dart are **covariant**: callers expect a return value conforming to at least the declared type, while subclasses overriding a method must return a subtype of the superclass method's return type.
 
-* **MINOR** for callers of top-level functions and `final` class methods (for example, returning `int` instead of `num` is covariant and safe for callers).
-* **MAJOR** if the method is overridden in external subclasses or implementers.
+#### Narrow a return type
+
+Moving down the type lattice to a more specific subtype (e.g., `num` $\rightarrow$ `int`, `Object?` $\rightarrow$ `String`, `void` $\rightarrow$ `T`, or `T` $\rightarrow$ `Never`):
+
+* **MINOR for callers of top-level functions and `final` class methods:**
+  * **Direct invocations:** Callers receive a more specific type with additional available members and tighter type safety.
+  * **Top types (`void` $\rightarrow$ `T`):** Changing a return type from `void` to a specific type is a form of narrowing from the top type. Callers ignoring the return value continue to work, and callbacks passed to `void Function(...)` continue to compile because Dart treats `T Function(...)` as a subtype of `void Function(...)` for any type `T`.
+  * **Bottom type (`T` $\rightarrow$ `Never`):** For functions that unconditionally throw or exit, narrowing the return type to `Never` is backward-compatible because `Never` is a universal subtype of all Dart types.
+* **MAJOR if the method is overridden in external subclasses or implementers:**
+  * External subclasses that declared the previous wider return type (e.g., `@override num method()` or `@override void method()`) will fail to compile with an override error, because the subclass's wider return type is not a valid subtype of the new narrower return type.
 
 #### MAJOR: Widen a return type (more general / supertype)
 
-Changing a return type from `int` to `num` breaks callers expecting `int` methods and properties on the returned object.
+Moving up the type lattice to a broader supertype (e.g., `int` $\rightarrow$ `num`, `Future<T>` $\rightarrow$ `FutureOr<T>`, or specific type `T` $\rightarrow$ `void`):
 
-#### MINOR: Change return type from `void` to a specific type
-
-Existing callers ignoring the return value continue to work.
-
-#### MAJOR: Change return type from a specific type to `void`
-
-Callers using the return value will fail to compile.
+* **MAJOR for callers:**
+  * Callers expecting specific members on the returned object (such as `int` methods, or `.then()` on a `Future<T>`) will fail to compile.
+  * Changing a return type from a specific type `T` to `void` is a form of widening to the top type, breaking any callers attempting to read or use the returned value.
+* Subclasses that already returned a narrower subtype remain valid overrides.
 
 ---
 
 ### Generics and type parameters
 
-#### MAJOR: Add a type parameter without a default bound
+#### MAJOR: Add a bound to an unconstrained type parameter
 
-Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
+Adding a type parameter constraint (for example, changing `class Store<T>` to `class Store<T extends State>`) breaks existing consumers using type arguments that do not conform to the new bound (such as `Store<String>`).
 
 #### MAJOR: Tighten a type parameter bound
 
 Changing `<T extends Object>` to `<T extends num>` breaks callers using non-number type arguments.
 
-#### MINOR: Loosen a type parameter bound
+#### MINOR: Loosen or remove a type parameter bound
 
-Changing `<T extends int>` to `<T extends num>` permits more types while remaining compatible with existing valid usages.
+Changing `<T extends int>` to `<T extends num>` or removing a bound permits more types while remaining compatible with existing valid usages.
+
+#### MAJOR: Add a type parameter without a default bound
+
+Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
 
 ---
 
@@ -346,6 +424,10 @@ Adding a value to an `enum` breaks exhaustive `switch` statements and pattern ma
 ### MAJOR: Remove or rename an enum value
 
 Any code referencing `MyEnum.oldValue` will fail to compile.
+
+### MAJOR: Reorder enum values
+
+Reordering enum declarations does not cause static compilation errors, but alters each value's `.index` property at runtime. If your package or downstream users serialize enums by index (such as in databases or network protocols), reordering values is a breaking runtime change.
 
 ### MINOR: Add a member to an enhanced enum
 
@@ -364,6 +446,14 @@ Adding extension methods is backward-compatible. (In rare cases, static ambiguit
 #### MAJOR: Remove or rename an extension method
 
 Call sites invoking the extension member will fail to compile.
+
+#### MAJOR: Change the extended type (`on` clause)
+
+Changing the target type of an extension (for example, `extension Helpers on String` to `extension Helpers on int`) removes the extension members from instances of the original type, breaking all existing call sites.
+
+#### MINOR: Widen the extended type
+
+Widening the extended type (for example, from `on int` to `on num`) allows the extension to be used on more types while preserving all existing call sites.
 
 ---
 

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -77,8 +77,14 @@ constant is backward-compatible. Existing consumer code will continue to compile
 and function as before.
 
 ```dart tag=good
-// Added to lib/my_package.dart in a minor release:
-void newHelperFunction() {}
+// Before (v1.0.0):
+// lib/my_package.dart
+void calculateTotal() {}
+
+// After (v1.1.0 - MINOR):
+// lib/my_package.dart
+void calculateTotal() {}
+void calculateTax() {} // Added: safe because existing callers are unaffected.
 ```
 
 *Note:* While introducing a new top-level name can theoretically create a naming
@@ -90,11 +96,27 @@ downstream code, SemVer treats top-level additions as non-breaking.
 Removing any public top-level declaration is a breaking change. Any downstream
 code referencing the removed symbol will fail to compile.
 
+```dart tag=bad
+// Before (v1.0.0):
+void calculateTax() {}
+
+// After (v2.0.0 - MAJOR):
+// `calculateTax` was removed. Existing callers fail to compile.
+```
+
 ### MAJOR: Rename a public top-level declaration
 
 Renaming a public symbol is functionally equivalent to removing the original
 name and introducing a new one. Downstream code referencing the original name
 will break.
+
+```dart tag=bad
+// Before (v1.0.0):
+void performTask() {}
+
+// After (v2.0.0 - MAJOR):
+void executeTask() {} // Renamed: callers referencing `performTask` fail to compile.
+```
 
 ### MAJOR: Move a declaration to `lib/src/` without re-exporting
 
@@ -102,11 +124,29 @@ Moving a declaration from the public `lib/` root to `lib/src/`, without an
 `export` in a public library file, makes it inaccessible to external packages,
 breaking all existing consumers.
 
+```dart tag=bad
+// Before (v1.0.0):
+// lib/my_package.dart
+export 'src/engine.dart';
+
+// After (v2.0.0 - MAJOR):
+// lib/my_package.dart
+// `src/engine.dart` is no longer exported: callers importing `package:my_package/my_package.dart` fail to access engine symbols.
+```
+
 ### MAJOR: Widen or change the type of a `const` or `final` variable
 
 Changing a `const` or `final` variable to a broader type, such as changing
 `const int maxRetries` to `const num maxRetries`, or to an incompatible type
 breaks callers expecting members of the more specific type.
+
+```dart tag=bad
+// Before (v1.0.0):
+const int maxRetries = 3;
+
+// After (v2.0.0 - MAJOR):
+const num maxRetries = 3; // Widened: callers expecting `int` methods break.
+```
 
 ### MINOR: Narrow the type of a `const` or `final` variable
 
@@ -115,6 +155,14 @@ specific subtype, such as changing `const num timeout` to `const int timeout` or
 `const Object key` to `const String key`, is backward-compatible. Because
 consumers only read the value, a more specific subtype satisfies all existing
 type expectations while providing additional type safety.
+
+```dart tag=good
+// Before (v1.0.0):
+const num timeout = 30;
+
+// After (v1.1.0 - MINOR):
+const int timeout = 30; // Narrowed: consumers only read the value, receiving a more specific subtype.
+```
 
 ### MAJOR: Change the type of a mutable top-level variable
 
@@ -125,10 +173,26 @@ the static type in either direction is a breaking change:
 * Widening the type, such as `int` to `num`, breaks callers expecting `int`
   methods when reading the variable.
 
+```dart tag=bad
+// Before (v1.0.0):
+num threshold = 10.5;
+
+// After (v2.0.0 - MAJOR):
+int threshold = 10; // Narrowed: callers assigning a double (e.g. `threshold = 1.5;`) fail to compile.
+```
+
 ### MAJOR: Change a top-level variable from `var` to `final`
 
 Making a mutable variable `final` breaks any consumer assigning values to that
 variable.
+
+```dart tag=bad
+// Before (v1.0.0):
+String globalConfig = 'default';
+
+// After (v2.0.0 - MAJOR):
+final String globalConfig = 'default'; // Callers assigning `globalConfig = 'custom';` fail to compile.
+```
 
 ---
 
@@ -149,35 +213,106 @@ packages are permitted to do with it:
 Changing a concrete class to `abstract class` prevents external consumers from
 instantiating the class directly using `new MyClass()`, causing compile errors.
 
+```dart tag=bad
+// Before (v1.0.0):
+class Formatter {}
+
+// Downstream package:
+final formatter = Formatter();
+
+// After (v2.0.0 - MAJOR):
+abstract class Formatter {} // Breaks: `Formatter()` can no longer be directly instantiated.
+```
+
 #### MINOR: Change an abstract class to a concrete class
 
 Making an abstract class concrete enables external instantiation without
 breaking existing subclasses or implementers.
+
+```dart tag=good
+// Before (v1.0.0):
+abstract class Formatter {}
+
+// After (v1.1.0 - MINOR):
+class Formatter {} // Safe: allows direct instantiation without breaking existing subtypes.
+```
 
 #### MAJOR: Add the `base` modifier to an existing class
 
 Prevents external consumers from implementing the class using `implements
 MyClass`, breaking all existing external implementers.
 
+```dart tag=bad
+// Before (v1.0.0):
+class Worker {}
+
+// Downstream package:
+class CustomWorker implements Worker {}
+
+// After (v2.0.0 - MAJOR):
+base class Worker {} // Breaks: downstream implementers (`implements Worker`) fail to compile.
+```
+
 #### MAJOR: Add the `interface` modifier to an existing class
 
 Prevents external consumers from extending the class using `extends MyClass`,
 breaking all existing external subclasses.
+
+```dart tag=bad
+// Before (v1.0.0):
+class Service {}
+
+// Downstream package:
+class CustomService extends Service {}
+
+// After (v2.0.0 - MAJOR):
+interface class Service {} // Breaks: downstream subclasses (`extends Service`) fail to compile.
+```
 
 #### MAJOR: Add the `final` or `sealed` modifier to an existing class
 
 Prevents external consumers from extending, implementing, or mixing in the
 class, breaking all existing external subtypes.
 
+```dart tag=bad
+// Before (v1.0.0):
+class Database {}
+
+// Downstream package:
+class MockDatabase extends Database {}
+
+// After (v2.0.0 - MAJOR):
+final class Database {} // Breaks: downstream subclasses fail to compile.
+```
+
 #### MAJOR: Remove the `mixin` modifier from a `mixin class`
 
 Prevents external consumers from using the class as a mixin using `with
 MyClass`.
 
+```dart tag=bad
+// Before (v1.0.0):
+mixin class TaskRunner {}
+
+// Downstream package:
+class Worker with TaskRunner {}
+
+// After (v2.0.0 - MAJOR):
+class TaskRunner {} // Breaks: downstream mixin uses (`with TaskRunner`) fail to compile.
+```
+
 #### MINOR: Remove `base`, `interface`, or `final` from a class
 
 Loosens restrictions on consumers, granting new capabilities without
 invalidating existing code.
+
+```dart tag=good
+// Before (v1.0.0):
+final class Database {}
+
+// After (v1.1.0 - MINOR):
+class Database {} // Safe: loosens restrictions and allows consumers to extend or implement.
+```
 
 ---
 
@@ -194,10 +329,21 @@ to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing
 implementers due to missing overrides.
 
 ```dart tag=bad
-// In package:foo (v1.1.0) - BREAKING for external implementers:
+// Before (v1.0.0):
 abstract class HttpClient {
   void get(String url);
-  void post(String url, Object body); // External `implements HttpClient` fails!
+}
+
+// Downstream package (v1.0.0):
+class MockHttpClient implements HttpClient {
+  @override
+  void get(String url) {}
+}
+
+// After (v2.0.0 - MAJOR, or broken if released as MINOR):
+abstract class HttpClient {
+  void get(String url);
+  void post(String url, Object body); // Added: MockHttpClient fails to compile due to missing `post`.
 }
 ```
 
@@ -206,14 +352,51 @@ abstract class HttpClient {
 Removing or renaming an instance method, getter, setter, or field breaks all
 callers, extenders, and implementers.
 
+```dart tag=bad
+// Before (v1.0.0):
+class Account {
+  void close() {}
+}
+
+// After (v2.0.0 - MAJOR):
+class Account {
+  // `close()` was removed or renamed: existing callers fail to compile.
+}
+```
+
 #### MINOR: Add a static member to a class
 
 Static members are namespaced to the class, such as `Class.member`, and do not
 affect subclasses or external implementations.
 
+```dart tag=good
+// Before (v1.0.0):
+class MathUtils {
+  static double add(double a, double b) => a + b;
+}
+
+// After (v1.1.0 - MINOR):
+class MathUtils {
+  static double add(double a, double b) => a + b;
+  static double multiply(double a, double b) => a * b; // Safe: namespaced static member addition.
+}
+```
+
 #### MAJOR: Remove or rename a static member
 
 Breaks call sites referencing `Class.staticMember`.
+
+```dart tag=bad
+// Before (v1.0.0):
+class MathUtils {
+  static double multiply(double a, double b) => a * b;
+}
+
+// After (v2.0.0 - MAJOR):
+class MathUtils {
+  // `multiply` was removed: call sites referencing `MathUtils.multiply` fail to compile.
+}
+```
 
 ---
 
@@ -229,19 +412,42 @@ instance methods, getters, setters, or fields is completely backward-compatible.
 Consumers only call existing members and cannot be broken by added members.
 
 ```dart tag=good
-// Safe to add in a minor release:
+// Before (v1.0.0):
+final class Config {
+  final String host;
+  final int port;
+  Config(this.host, this.port);
+}
+
+// After (v1.1.0 - MINOR):
 final class Config {
   final String host;
   final int port;
   Config(this.host, this.port);
 
-  bool get isSecure => port == 443;
+  bool get isSecure => port == 443; // Added: safe because consumers cannot implement or extend Config.
 }
 ```
 
 #### MAJOR: Remove or rename an instance member of a final class
 
 Existing callers referencing the removed member will fail to compile.
+
+```dart tag=bad
+// Before (v1.0.0):
+final class Config {
+  final String host;
+  final int port;
+  Config(this.host, this.port);
+}
+
+// After (v2.0.0 - MAJOR):
+final class Config {
+  final String host;
+  // `port` removed: callers referencing `config.port` fail to compile.
+  Config(this.host);
+}
+```
 
 ---
 
@@ -256,10 +462,45 @@ Because external libraries can only extend rather than implement a `base class`,
 subclasses automatically inherit the new default implementation without needing
 to override it.
 
+```dart tag=good
+// Before (v1.0.0):
+base class Controller {
+  void start() {}
+}
+
+// Downstream package:
+class AppController extends Controller {}
+
+// After (v1.1.0 - MINOR):
+base class Controller {
+  void start() {}
+  void stop() {} // Added: AppController automatically inherits the concrete implementation.
+}
+```
+
 #### MAJOR: Add an abstract member to a base class
 
 Subclasses in external libraries will fail to compile because they do not
 provide an implementation for the new abstract member.
+
+```dart tag=bad
+// Before (v1.0.0):
+abstract base class Controller {
+  void start();
+}
+
+// Downstream package:
+class AppController extends Controller {
+  @override
+  void start() {}
+}
+
+// After (v2.0.0 - MAJOR):
+abstract base class Controller {
+  void start();
+  void stop(); // Added abstract: AppController fails to compile (missing `stop`).
+}
+```
 
 #### MAJOR: Remove or rename an instance member of a base class
 
@@ -277,6 +518,25 @@ extended using `extends`.
 External classes can implement an `interface class`. Adding any new method,
 getter, setter, or field requires implementers to provide the new member,
 breaking compilation.
+
+```dart tag=bad
+// Before (v1.0.0):
+interface class Repository {
+  void fetch();
+}
+
+// Downstream package:
+class CustomRepository implements Repository {
+  @override
+  void fetch() {}
+}
+
+// After (v2.0.0 - MAJOR):
+interface class Repository {
+  void fetch();
+  void save(); // Added: CustomRepository fails to compile due to missing `save()` implementation.
+}
+```
 
 #### MAJOR: Remove or rename an instance member of an interface class
 
@@ -296,22 +556,38 @@ exhaustive `switch` statements or pattern matches in consumer code that do not
 have a wildcard `_` or `default` case will fail to compile.
 
 ```dart tag=bad
+// Before (v1.0.0):
 sealed class Result {}
 class Success extends Result {}
 class Failure extends Result {}
 
-// Adding `class Pending extends Result {}` breaks exhaustive switches:
-// switch (result) {
-//   case Success(): ...
-//   case Failure(): ...
-//   // Error: Switch is no longer exhaustive!
-// }
+// Downstream package:
+String describe(Result result) => switch (result) {
+  Success() => 'Success',
+  Failure() => 'Failure',
+};
+
+// After (v2.0.0 - MAJOR):
+sealed class Result {}
+class Success extends Result {}
+class Failure extends Result {}
+class Pending extends Result {} // Added: downstream `describe` switch is no longer exhaustive and fails to compile.
 ```
 
 #### MINOR: Add a member to a sealed class
 
 External code cannot implement or extend a `sealed` class, so adding instance or
 static members is non-breaking.
+
+```dart tag=good
+// Before (v1.0.0):
+sealed class Result {}
+
+// After (v1.1.0 - MINOR):
+sealed class Result {
+  bool get isSuccess => this is Success; // Added: safe because consumers cannot implement or extend sealed classes.
+}
+```
 
 ---
 
@@ -325,16 +601,59 @@ Classes using `with MyMixin` automatically receive the concrete implementation.
 `implements MyMixin`, but the standard and intended usage of mixins is with the
 `with` keyword.
 
+```dart tag=good
+// Before (v1.0.0):
+mixin Logger {
+  void log(String message) => print(message);
+}
+
+// After (v1.1.0 - MINOR):
+mixin Logger {
+  void log(String message) => print(message);
+  void logError(String error) => log('ERROR: $error'); // Added: classes using `with Logger` inherit the method.
+}
+```
+
 #### MAJOR: Add an abstract member to a mixin
 
 Requires all classes applying the mixin to supply an implementation for the new
 abstract member.
+
+```dart tag=bad
+// Before (v1.0.0):
+mixin Serializer {
+  String serialize();
+}
+
+// Downstream package:
+class User with Serializer {
+  @override
+  String serialize() => '{}';
+}
+
+// After (v2.0.0 - MAJOR):
+mixin Serializer {
+  String serialize();
+  void deserialize(String json); // Added abstract: User fails to compile due to missing `deserialize`.
+}
+```
 
 #### MAJOR: Tighten the `on` constraint on a mixin
 
 Restricting the superclass requirements, such as from `on Object` to `on
 Widget`, prevents existing classes that do not meet the new requirement from
 mixing it in.
+
+```dart tag=bad
+// Before (v1.0.0):
+mixin Lifecycle on Object {}
+
+// Downstream package:
+class Service with Lifecycle {}
+
+// After (v2.0.0 - MAJOR):
+mixin Lifecycle on State {} // Breaks: Service does not extend State and fails to compile.
+```
 
 ---
 
@@ -347,9 +666,26 @@ Type aliases define names for function types, records, or existing class types.
 Adding a new public `typedef` exposes a new type name without affecting existing
 code.
 
+```dart tag=good
+// Before (v1.0.0):
+void process(void Function(int) callback) {}
+
+// After (v1.1.0 - MINOR):
+typedef NumberCallback = void Function(int);
+void process(NumberCallback callback) {} // Safe: adds type alias without altering contract.
+```
+
 ### MAJOR: Remove or rename a type alias
 
 Any downstream code referencing the removed `typedef` name will fail to compile.
+
+```dart tag=bad
+// Before (v1.0.0):
+typedef DataHandler = void Function(String);
+
+// After (v2.0.0 - MAJOR):
+// `DataHandler` was removed. Downstream code referencing `DataHandler` fails to compile.
+```
 
 ### MAJOR: Change the aliased type in a type alias
 
@@ -357,6 +693,14 @@ Changing the underlying type that a type alias references, such as changing
 `typedef Callback = void Function(int);` to `typedef Callback = void
 Function(String);`, alters the expected type everywhere the alias is used,
 breaking consumers.
+
+```dart tag=bad
+// Before (v1.0.0):
+typedef Callback = void Function(int count);
+
+// After (v2.0.0 - MAJOR):
+typedef Callback = void Function(String message); // Changed type: downstream callbacks expecting `int` fail to compile.
+```
 
 ### MAJOR: Replace a `typedef` with a class or vice versa
 
@@ -370,6 +714,19 @@ name, is a breaking change:
   with `class A extends B {}`, `B` is no longer assignable to `A`, and
   bidirectional type identity is lost.
 
+```dart tag=bad
+// Before (v1.0.0):
+typedef Callback = void Function();
+
+// Downstream package:
+Callback cb = () => print('done');
+
+// After (v2.0.0 - MAJOR):
+abstract class Callback {
+  void call();
+} // Function literals are not instances of class Callback: downstream `cb = () => ...` fails to compile.
+```
+
 ---
 
 ## Constructors
@@ -380,33 +737,131 @@ Adding named constructors, such as `MyClass.named()`, or factories to an
 instantiable class provides new construction options without affecting existing
 callers.
 
+```dart tag=good
+// Before (v1.0.0):
+class Request {
+  Request(String url);
+}
+
+// After (v1.1.0 - MINOR):
+class Request {
+  Request(String url);
+  Request.json(String url); // Added: provides a new constructor without breaking existing callers.
+}
+```
+
 ### MAJOR: Remove or rename a constructor
 
 Breaks call sites that invoked the removed constructor.
+
+```dart tag=bad
+// Before (v1.0.0):
+class Request {
+  Request.named(String url);
+}
+
+// After (v2.0.0 - MAJOR):
+class Request {
+  // `Request.named` was removed: callers using `Request.named(...)` fail to compile.
+}
+```
 
 ### MAJOR: Add a required parameter to a constructor
 
 Existing constructor invocations that omit the new parameter will fail to
 compile.
 
+```dart tag=bad
+// Before (v1.0.0):
+class User {
+  final String name;
+  User(this.name);
+}
+
+// After (v2.0.0 - MAJOR):
+class User {
+  final String name;
+  final String email;
+  User(this.name, {required this.email}); // Existing `User('Alice')` calls fail to compile.
+}
+```
+
 ### MINOR: Add an optional parameter to a constructor
 
 Call sites can omit optional parameters, both positional and named.
 
+```dart tag=good
+// Before (v1.0.0):
+class User {
+  final String name;
+  User(this.name);
+}
+
+// After (v1.1.0 - MINOR):
+class User {
+  final String name;
+  final String? email;
+  User(this.name, {this.email}); // Safe: existing `User('Alice')` calls continue to compile.
+}
+```
+
 ### MAJOR: Change a `const` constructor to non-`const`
 
 Breaks any call site using `const MyClass(...)`.
+
+```dart tag=bad
+// Before (v1.0.0):
+class Point {
+  final int x;
+  const Point(this.x);
+}
+
+// Downstream package:
+const origin = Point(0);
+
+// After (v2.0.0 - MAJOR):
+class Point {
+  final int x;
+  Point(this.x); // Removed `const`: `const Point(0)` fails to compile.
+}
+```
 
 ### MINOR: Change a non-`const` constructor to `const`
 
 Adding `const` capability does not break existing non-const call sites using
 `MyClass(...)`.
 
+```dart tag=good
+// Before (v1.0.0):
+class Point {
+  final int x;
+  Point(this.x);
+}
+
+// After (v1.1.0 - MINOR):
+class Point {
+  final int x;
+  const Point(this.x); // Safe: non-const invocations `Point(0)` remain valid.
+}
+```
+
 ### MAJOR: Add a private constructor to a class with only a default constructor
 
 If a class previously had the default implicit constructor `MyClass()`, adding
 `MyClass._()` removes the default public constructor and prevents external
 instantiation or subclassing.
+
+```dart tag=bad
+// Before (v1.0.0):
+class AppUtils {
+  // Implicit public default constructor `AppUtils()`
+}
+
+// After (v2.0.0 - MAJOR):
+class AppUtils {
+  AppUtils._(); // Replaces public constructor: callers using `AppUtils()` fail to compile.
+}
+```
 
 ---
 
@@ -418,9 +873,25 @@ instantiation or subclassing.
 
 Existing call sites omitting the parameter will fail to compile.
 
+```dart tag=bad
+// Before (v1.0.0):
+void logMessage(String message) {}
+
+// After (v2.0.0 - MAJOR):
+void logMessage(String message, {required String level}) {} // Callers using `logMessage('data')` fail to compile.
+```
+
 #### MINOR: Add an optional parameter
 
 Existing call sites can omit the new optional parameter without issue.
+
+```dart tag=good
+// Before (v1.0.0):
+void logMessage(String message) {}
+
+// After (v1.1.0 - MINOR):
+void logMessage(String message, [String level = 'INFO']) {} // Safe: existing calls `logMessage('data')` continue to compile.
+```
 
 :::note Tear-offs and optional parameters
 In Dart, tearing off a method like `final fn = obj.myMethod;` produces a
@@ -435,10 +906,26 @@ primary contract relies on exact function signatures.
 
 Call sites passing the removed argument will fail to compile.
 
+```dart tag=bad
+// Before (v1.0.0):
+void connect(String host, int port) {}
+
+// After (v2.0.0 - MAJOR):
+void connect(String host) {} // Callers passing two arguments fail to compile.
+```
+
 #### MAJOR: Rename a named parameter
 
 Call sites passing `func(paramName: value)` will fail to compile when
 `paramName` is changed.
+
+```dart tag=bad
+// Before (v1.0.0):
+void fetchData({int timeoutSeconds = 30}) {}
+
+// After (v2.0.0 - MAJOR):
+void fetchData({int timeout = 30}) {} // Callers passing `fetchData(timeoutSeconds: 10)` fail to compile.
+```
 
 #### MAJOR: Reorder positional parameters
 
@@ -447,9 +934,25 @@ sites. Even if the parameter types are identical, it causes callers to pass
 arguments to the wrong parameters, altering behavior or causing compile-time
 type errors.
 
+```dart tag=bad
+// Before (v1.0.0):
+void setDimensions(double width, double height) {}
+
+// After (v2.0.0 - MAJOR):
+void setDimensions(double height, double width) {} // Callers pass width as height and height as width.
+```
+
 #### MAJOR: Narrow a parameter type
 
 Changing a parameter from `num` to `int` breaks callers that passed `double`.
+
+```dart tag=bad
+// Before (v1.0.0):
+void setPadding(num padding) {}
+
+// After (v2.0.0 - MAJOR):
+void setPadding(int padding) {} // Callers passing a double (`setPadding(8.5)`) fail to compile.
+```
 
 #### Widen a parameter type
 
@@ -459,10 +962,26 @@ Changing a parameter from `num` to `int` breaks callers that passed `double`.
 * **MAJOR** for methods on an implementable class, because it changes the
   signature required for external overrides.
 
+```dart tag=good
+// Before (v1.0.0):
+void setPadding(int padding) {}
+
+// After (v1.1.0 - MINOR for top-level functions and final class methods):
+void setPadding(num padding) {} // Safe: callers can now pass int or double without breaking existing callers.
+```
+
 #### MINOR: Change the default value of an optional parameter
 
 Does not break compilation or static type checks, but alters runtime behavior
 for callers omitting the argument.
+
+```dart tag=good
+// Before (v1.0.0):
+void connect([int timeoutSeconds = 10]) {}
+
+// After (v1.1.0 - MINOR):
+void connect([int timeoutSeconds = 30]) {} // Compiles without error; changes default runtime behavior.
+```
 
 ---
 
@@ -494,6 +1013,14 @@ Moving down the type lattice to a more specific subtype, such as `num` to `int`,
     with an override error, because the subclass's wider return type is not a
     valid subtype of the new narrower return type.
 
+```dart tag=good
+// Before (v1.0.0):
+num getScale() => 1;
+
+// After (v1.1.0 - MINOR for top-level functions and final class methods):
+int getScale() => 1; // Safe: callers expecting `num` continue to work, while callers can access `int` methods.
+```
+
 #### MAJOR: Widen a return type
 
 Moving up the type lattice to a broader supertype, such as `int` to `num`,
@@ -507,6 +1034,14 @@ Moving up the type lattice to a broader supertype, such as `int` to `num`,
     returned value.
 * Subclasses that already returned a narrower subtype remain valid overrides.
 
+```dart tag=bad
+// Before (v1.0.0):
+int getCount() => 42;
+
+// After (v2.0.0 - MAJOR):
+num getCount() => 42.0; // Callers expecting `int` (e.g. `int count = getCount();`) fail to compile.
+```
+
 ---
 
 ### Generics and type parameters
@@ -517,15 +1052,39 @@ Adding a type parameter constraint, such as changing `class Store<T>` to `class
 Store<T extends State>`, breaks existing consumers using type arguments that do
 not conform to the new bound, like `Store<String>`.
 
+```dart tag=bad
+// Before (v1.0.0):
+class Store<T> {}
+
+// After (v2.0.0 - MAJOR):
+class Store<T extends State> {} // Existing uses like `Store<String>` fail to compile.
+```
+
 #### MAJOR: Tighten a type parameter bound
 
 Changing `<T extends Object>` to `<T extends num>` breaks callers using
 non-number type arguments.
 
+```dart tag=bad
+// Before (v1.0.0):
+class NumericList<T extends Object> {}
+
+// After (v2.0.0 - MAJOR):
+class NumericList<T extends num> {} // Existing uses like `NumericList<String>` fail to compile.
+```
+
 #### MINOR: Loosen or remove a type parameter bound
 
 Changing `<T extends int>` to `<T extends num>` or removing a bound permits more
 types while remaining compatible with existing valid usages.
+
+```dart tag=good
+// Before (v1.0.0):
+class NumericList<T extends int> {}
+
+// After (v1.1.0 - MINOR):
+class NumericList<T extends num> {} // Safe: existing `NumericList<int>` remains valid, and `NumericList<double>` is now supported.
+```
 
 #### MAJOR: Add a type parameter without a default bound
 
@@ -541,9 +1100,48 @@ change type inference behavior.
 Adding a value to an `enum` breaks exhaustive `switch` statements and pattern
 matches in consumer code that do not include a `default` or wildcard `_` clause.
 
+```dart tag=bad
+// Before (v1.0.0):
+enum Status {
+  pending,
+  success,
+  failure,
+}
+
+// Downstream package:
+String label(Status status) => switch (status) {
+  Status.pending => 'Pending',
+  Status.success => 'Success',
+  Status.failure => 'Failure',
+};
+
+// After (v2.0.0 - MAJOR):
+enum Status {
+  pending,
+  success,
+  failure,
+  cancelled, // Added: downstream `label` switch is no longer exhaustive and fails to compile.
+}
+```
+
 ### MAJOR: Remove or rename an enum value
 
 Any code referencing `MyEnum.oldValue` will fail to compile.
+
+```dart tag=bad
+// Before (v1.0.0):
+enum Status {
+  pending,
+  success,
+  failure,
+}
+
+// After (v2.0.0 - MAJOR):
+enum Status {
+  pending,
+  success, // `failure` was removed or renamed: callers referencing `Status.failure` fail to compile.
+}
+```
 
 ### MAJOR: Reorder enum values
 
@@ -552,10 +1150,42 @@ alters each value's `.index` property at runtime. If your package or downstream
 users serialize enums by index, like in databases or network protocols,
 reordering values is a breaking runtime change.
 
+```dart tag=bad
+// Before (v1.0.0):
+enum Priority {
+  low,    // index: 0
+  medium, // index: 1
+  high,   // index: 2
+}
+
+// After (v2.0.0 - MAJOR runtime break for serialized indices):
+enum Priority {
+  high,   // index: 0 (changed!)
+  medium, // index: 1
+  low,    // index: 2 (changed!)
+}
+```
+
 ### MINOR: Add a member to an enhanced enum
 
 Enums cannot be extended or implemented, so adding members to an enhanced enum
 is safe for consumers.
+
+```dart tag=good
+// Before (v1.0.0):
+enum Status {
+  pending,
+  success;
+}
+
+// After (v1.1.0 - MINOR):
+enum Status {
+  pending,
+  success;
+
+  bool get isDone => this == Status.success; // Safe: consumers only call existing members and cannot implement enums.
+}
+```
 
 ---
 
@@ -569,9 +1199,34 @@ Adding extension methods is backward-compatible. Static ambiguity can
 occasionally occur if consumer code already has another extension in scope with
 the same method name.
 
+```dart tag=good
+// Before (v1.0.0):
+extension StringUtils on String {
+  bool get isBlank => trim().isEmpty;
+}
+
+// After (v1.1.0 - MINOR):
+extension StringUtils on String {
+  bool get isBlank => trim().isEmpty;
+  bool get isNotBlank => !isBlank; // Added: backward-compatible new extension member.
+}
+```
+
 #### MAJOR: Remove or rename an extension method
 
 Call sites invoking the extension member will fail to compile.
+
+```dart tag=bad
+// Before (v1.0.0):
+extension StringUtils on String {
+  bool get isBlank => trim().isEmpty;
+}
+
+// After (v2.0.0 - MAJOR):
+extension StringUtils on String {
+  // `isBlank` was removed: callers invoking `'text'.isBlank` fail to compile.
+}
+```
 
 #### MAJOR: Change the extended type: the `on` clause
 
@@ -579,10 +1234,34 @@ Changing the target type of an extension, such as changing `extension Helpers on
 String` to `extension Helpers on int`, removes the extension members from
 instances of the original type, breaking all existing call sites.
 
+```dart tag=bad
+// Before (v1.0.0):
+extension Formatter on String {
+  String format() => trim();
+}
+
+// After (v2.0.0 - MAJOR):
+extension Formatter on StringBuffer { // Changed from `on String` to `on StringBuffer`: existing `'text'.format()` calls fail to compile.
+  String format() => toString().trim();
+}
+```
+
 #### MINOR: Widen the extended type
 
 Widening the extended type, such as from `on int` to `on num`, allows the
 extension to be used on more types while preserving all existing call sites.
+
+```dart tag=good
+// Before (v1.0.0):
+extension NumberUtils on int {
+  num doubleValue() => this * 2;
+}
+
+// After (v1.1.0 - MINOR):
+extension NumberUtils on num { // Widened from `on int` to `on num`: all existing `int` call sites continue to work.
+  num doubleValue() => this * 2;
+}
+```
 
 ---
 
@@ -592,14 +1271,44 @@ extension to be used on more types while preserving all existing call sites.
 
 Changes the underlying type contract and implicit constructors.
 
+```dart tag=bad
+// Before (v1.0.0):
+extension type Id(int value) {}
+
+// After (v2.0.0 - MAJOR):
+extension type Id(String value) {} // Breaks callers passing `int` to `Id(...)`.
+```
+
 #### MINOR: Add a member to an extension type
 
 Extension types cannot be implemented or extended with subtyping, so adding
 members is non-breaking.
 
+```dart tag=good
+// Before (v1.0.0):
+extension type Id(int value) {}
+
+// After (v1.1.0 - MINOR):
+extension type Id(int value) {
+  bool get isValid => value > 0; // Added: safe because extension types cannot be subclassed or implemented.
+}
+```
+
 #### MAJOR: Remove or rename a member of an extension type
 
 Breaks call sites referencing the member.
+
+```dart tag=bad
+// Before (v1.0.0):
+extension type Id(int value) {
+  bool get isValid => value > 0;
+}
+
+// After (v2.0.0 - MAJOR):
+extension type Id(int value) {
+  // `isValid` removed: callers using `id.isValid` fail to compile.
+}
+```
 
 ---
 
@@ -622,11 +1331,42 @@ Changing the thrown exception, such as throwing `SecurityException` instead of
 `AuthException`, breaks downstream code with `try ... on AuthException catch
 (e)` handlers. The new exception will bypass the handler and crash at runtime.
 
+```dart tag=bad
+// Before (v1.0.0):
+/// Throws [AuthException] on invalid credentials.
+void authenticate(String token) {
+  throw AuthException('Invalid token');
+}
+
+// Downstream package:
+// try { authenticate(token); } on AuthException catch (e) { ... }
+
+// After (v2.0.0 - MAJOR):
+/// Throws [SecurityException] on invalid credentials.
+void authenticate(String token) {
+  throw SecurityException('Invalid token'); // Breaks: `on AuthException` no longer catches this error.
+}
+```
+
 #### MINOR: Throw a subtype of the documented exception
 
 Throwing a more specific subtype, such as throwing `ExpiredTokenException
 extends AuthException`, is backward-compatible. Existing callers catching `on
 AuthException` continue to catch the new subtype without changes.
+
+```dart tag=good
+// Before (v1.0.0):
+/// Throws [AuthException] on invalid credentials.
+void authenticate(String token) {
+  throw AuthException('Invalid token');
+}
+
+// After (v1.1.0 - MINOR):
+/// Throws [ExpiredTokenException] on invalid credentials.
+void authenticate(String token) {
+  throw ExpiredTokenException('Token expired'); // Safe: `ExpiredTokenException extends AuthException`, so `on AuthException` still catches it.
+}
+```
 
 #### MAJOR: Throw an exception on previously succeeding inputs or states
 

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -12,7 +12,7 @@ and predictable package ecosystem.
 
 This guide provides a detailed reference on how various changes to your Dart
 code affect the public API surface of your package and what version bump
-(`major`, `minor`, or `patch`) is required.
+(`MAJOR`, `MINOR`, or `PATCH`) is required.
 
 :::tip
 For a conceptual overview of pub's version solving algorithm and lockfiles,
@@ -34,38 +34,34 @@ consumers of your package:
 
 ## Top-level declarations
 
-### Add a new top-level declaration `[minor]`
+### MINOR: Add a new top-level declaration
 
 Adding a new public top-level function, class, typedef, enum, extension, or constant is backward-compatible. Existing consumer code will continue to compile and function as before.
 
-```dart
+```dart tag=good
 // Added to lib/my_package.dart in a minor release:
 void newHelperFunction() {}
 ```
 
 *Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import (`import 'package:foo/foo.dart';`) in downstream code, SemVer treats top-level additions as non-breaking.
 
-### Remove a public top-level declaration `[major]`
+### MAJOR: Remove a public top-level declaration
 
 Removing any public top-level declaration is a breaking change. Any downstream code referencing the removed symbol will fail to compile.
 
-### Rename a public top-level declaration `[major]`
+### MAJOR: Rename a public top-level declaration
 
 Renaming a public symbol is functionally equivalent to removing the original name and introducing a new one. Downstream code referencing the original name will break.
 
-### Move a declaration to `lib/src/` without re-exporting `[major]`
+### MAJOR: Move a declaration to `lib/src/` without re-exporting
 
 Moving a declaration from the public `lib/` root to `lib/src/` (without an `export` in a public library file) makes it inaccessible to external packages, breaking all existing consumers.
 
-### Change the type of a top-level variable or constant `[major]`
+### MAJOR: Change the type of a top-level variable or constant
 
 Changing the static type of a top-level variable or constant causes type errors for any callers expecting the previous type.
 
-### Change a top-level variable from `final` to `var` `[minor]`
-
-Allowing reassignment of a previously read-only top-level variable is backward-compatible for existing readers.
-
-### Change a top-level variable from `var` to `final` `[major]`
+### MAJOR: Change a top-level variable from `var` to `final`
 
 Making a mutable variable `final` breaks any consumer assigning values to that variable.
 
@@ -73,38 +69,33 @@ Making a mutable variable `final` breaks any consumer assigning values to that v
 
 ## Classes, mixins, and class modifiers
 
-Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, and `mixin`), allowing package authors to explicitly define how classes can be used by external consumers. The SemVer impact of adding or modifying members depends heavily on these modifiers.
+Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, and `mixin`), allowing package authors to explicitly define how classes can be used by consumers. The SemVer impact of adding or modifying members depends on these modifiers.
 
 ### Unmodified classes (`class` and `abstract class`)
 
-By default, an unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
+An unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
 
-#### Add an instance member to an unmodified class `[major]`
+#### MAJOR: Add an instance member to an unmodified class
 
 Adding any instance method, getter, setter, or field to an unmodified `class` or `abstract class` is a breaking change. Because external libraries are permitted to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing implementers due to missing overrides.
 
-```dart
-// In package:foo (v1.0.0)
-class HttpClient {
-  void get(String url) {}
-}
-
-// In package:foo (v1.1.0) - BREAKING for implementers!
-class HttpClient {
-  void get(String url) {}
-  void post(String url, Object body) {} // External `implements HttpClient` fails!
+```dart tag=bad
+// In package:foo (v1.1.0) - BREAKING for external implementers:
+abstract class HttpClient {
+  void get(String url);
+  void post(String url, Object body); // External `implements HttpClient` fails!
 }
 ```
 
-#### Remove or rename an instance member `[major]`
+#### MAJOR: Remove or rename an instance member
 
 Removing or renaming an instance method, getter, setter, or field breaks all callers, extenders, and implementers.
 
-#### Add a static member to a class `[minor]`
+#### MINOR: Add a static member to a class
 
 Static members are namespaced to the class (`Class.member`) and do not affect subclasses or external implementations.
 
-#### Remove or rename a static member `[major]`
+#### MAJOR: Remove or rename a static member
 
 Breaks call sites referencing `Class.staticMember`.
 
@@ -112,25 +103,24 @@ Breaks call sites referencing `Class.staticMember`.
 
 ### `final class` and `abstract final class`
 
-A `final` class cannot be extended, implemented, or mixed in outside of the defining library. Consumers can only construct it (if not abstract) and call its members.
+A `final` class cannot be extended, implemented, or mixed in outside of the defining library.
 
-#### Add an instance member to a final class `[minor]`
+#### MINOR: Add an instance member to a final class
 
 Since external code cannot `extend` or `implement` a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
 
-```dart
-// Non-breaking in a final class:
+```dart tag=good
+// Safe to add in a minor release:
 final class Config {
   final String host;
   final int port;
   Config(this.host, this.port);
 
-  // Safe to add in a minor release:
   bool get isSecure => port == 443;
 }
 ```
 
-#### Remove or rename an instance member of a final class `[major]`
+#### MAJOR: Remove or rename an instance member of a final class
 
 Existing callers referencing the removed member will fail to compile.
 
@@ -140,15 +130,15 @@ Existing callers referencing the removed member will fail to compile.
 
 A `base` class can be extended (`extends`) outside the library, but cannot be implemented (`implements`).
 
-#### Add a concrete instance member to a base class `[minor]`
+#### MINOR: Add a concrete instance member to a base class
 
 Because external libraries can only `extend` (not `implement`) a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
 
-#### Add an abstract member to a base class `[major]`
+#### MAJOR: Add an abstract member to a base class
 
 Subclasses in external libraries will fail to compile because they do not provide an implementation for the new abstract member.
 
-#### Remove or rename an instance member of a base class `[major]`
+#### MAJOR: Remove or rename an instance member of a base class
 
 Breaks both callers and extending subclasses.
 
@@ -158,11 +148,11 @@ Breaks both callers and extending subclasses.
 
 An `interface` class can be implemented (`implements`) outside the library, but cannot be extended (`extends`).
 
-#### Add any member to an interface class `[major]`
+#### MAJOR: Add any member to an interface class
 
 External classes can `implement` an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
 
-#### Remove or rename an instance member of an interface class `[major]`
+#### MAJOR: Remove or rename an instance member of an interface class
 
 Breaks callers and implementers.
 
@@ -172,11 +162,11 @@ Breaks callers and implementers.
 
 A `sealed` class is implicitly abstract and cannot be extended, implemented, or mixed in outside the library. It is designed for exhaustive pattern matching.
 
-#### Add a direct subtype to a sealed class family `[major]`
+#### MAJOR: Add a direct subtype to a sealed class family
 
 Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard (`_`) or `default` case will fail to compile.
 
-```dart
+```dart tag=bad
 sealed class Result {}
 class Success extends Result {}
 class Failure extends Result {}
@@ -189,7 +179,7 @@ class Failure extends Result {}
 // }
 ```
 
-#### Add a member to a sealed class `[minor]`
+#### MINOR: Add a member to a sealed class
 
 External code cannot implement or extend a `sealed` class, so adding instance or static members is non-breaking.
 
@@ -197,17 +187,17 @@ External code cannot implement or extend a `sealed` class, so adding instance or
 
 ### `mixin` and `mixin class`
 
-#### Add a concrete member to a mixin `[minor]`
+#### MINOR: Add a concrete member to a mixin
 
 Classes using `with MyMixin` automatically receive the concrete implementation.
 
 *Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with `with`.
 
-#### Add an abstract member to a mixin `[major]`
+#### MAJOR: Add an abstract member to a mixin
 
 Requires all classes applying the mixin to supply an implementation for the new abstract member.
 
-#### Tighten the `on` constraint on a mixin `[major]`
+#### MAJOR: Tighten the `on` constraint on a mixin
 
 Restricting the superclass requirements (for example, from `on Object` to `on Widget`) prevents existing classes that do not meet the new requirement from mixing it in.
 
@@ -215,31 +205,31 @@ Restricting the superclass requirements (for example, from `on Object` to `on Wi
 
 ## Constructors
 
-### Add a new public constructor or factory `[minor]`
+### MINOR: Add a new public constructor or factory
 
 Adding named constructors (`MyClass.named()`) or factories to an instantiable class provides new construction options without affecting existing callers.
 
-### Remove or rename a constructor `[major]`
+### MAJOR: Remove or rename a constructor
 
 Breaks call sites that invoked the removed constructor.
 
-### Add a required parameter to a constructor `[major]`
+### MAJOR: Add a required parameter to a constructor
 
 Existing constructor invocations that omit the new parameter will fail to compile.
 
-### Add an optional parameter to a constructor `[minor]`
+### MINOR: Add an optional parameter to a constructor
 
 Call sites can omit optional parameters (both positional and named).
 
-### Change a `const` constructor to non-`const` `[major]`
+### MAJOR: Change a `const` constructor to non-`const`
 
 Breaks any call site using `const MyClass(...)`.
 
-### Change a non-`const` constructor to `const` `[minor]`
+### MINOR: Change a non-`const` constructor to `const`
 
 Adding `const` capability does not break existing non-const call sites (`MyClass(...)`).
 
-### Add a private constructor to a class with only the default constructor `[major]`
+### MAJOR: Add a private constructor to a class with only the default constructor
 
 If a class previously had the default implicit constructor `MyClass()`, adding `MyClass._()` removes the default public constructor and prevents external instantiation or subclassing.
 
@@ -249,36 +239,36 @@ If a class previously had the default implicit constructor `MyClass()`, adding `
 
 ### Parameters
 
-#### Add a required positional or named parameter `[major]`
+#### MAJOR: Add a required positional or named parameter
 
 Existing call sites omitting the parameter will fail to compile.
 
-#### Add an optional parameter (positional or named) `[minor]`
+#### MINOR: Add an optional parameter (positional or named)
 
 Existing call sites can omit the new optional parameter without issue.
 
 :::note Tear-offs and optional parameters
-In Dart, tearing off a method (`final fn = obj.myMethod;`) produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `Minor` releases unless a package's primary contract relies on exact function signatures.
+In Dart, tearing off a method (`final fn = obj.myMethod;`) produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `MINOR` releases unless a package's primary contract relies on exact function signatures.
 :::
 
-#### Remove any parameter `[major]`
+#### MAJOR: Remove any parameter
 
 Call sites passing the removed argument will fail to compile.
 
-#### Rename a named parameter `[major]`
+#### MAJOR: Rename a named parameter
 
 Call sites passing `func(paramName: value)` will fail to compile when `paramName` is changed.
 
-#### Narrow a parameter type (more specific / subtype) `[major]`
+#### MAJOR: Narrow a parameter type (more specific / subtype)
 
 Changing a parameter from `num` to `int` breaks callers that passed `double`.
 
-#### Widen a parameter type (more general / supertype) `[minor / major]`
+#### MINOR / MAJOR: Widen a parameter type (more general / supertype)
 
-* **Minor** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs.
-* **Major** for methods on an implementable class, because it changes the signature required for external overrides.
+* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs.
+* **MAJOR** for methods on an implementable class, because it changes the signature required for external overrides.
 
-#### Change the default value of an optional parameter `[patch / minor]`
+#### PATCH / MINOR: Change the default value of an optional parameter
 
 Does not break compilation or static type checks, but alters runtime behavior for callers omitting the argument.
 
@@ -286,20 +276,20 @@ Does not break compilation or static type checks, but alters runtime behavior fo
 
 ### Return types
 
-#### Narrow a return type (more specific / subtype) `[minor / major]`
+#### MINOR / MAJOR: Narrow a return type (more specific / subtype)
 
-* **Minor** for callers of top-level functions and `final` class methods (for example, returning `int` instead of `num` is covariant and safe for callers).
-* **Major** if the method is overridden in external subclasses or implementers.
+* **MINOR** for callers of top-level functions and `final` class methods (for example, returning `int` instead of `num` is covariant and safe for callers).
+* **MAJOR** if the method is overridden in external subclasses or implementers.
 
-#### Widen a return type (more general / supertype) `[major]`
+#### MAJOR: Widen a return type (more general / supertype)
 
 Changing a return type from `int` to `num` breaks callers expecting `int` methods and properties on the returned object.
 
-#### Change return type from `void` to a specific type `[minor]`
+#### MINOR: Change return type from `void` to a specific type
 
 Existing callers ignoring the return value continue to work.
 
-#### Change return type from a specific type to `void` `[major]`
+#### MAJOR: Change return type from a specific type to `void`
 
 Callers using the return value will fail to compile.
 
@@ -307,15 +297,15 @@ Callers using the return value will fail to compile.
 
 ### Generics and type parameters
 
-#### Add a type parameter without a default bound `[major]`
+#### MAJOR: Add a type parameter without a default bound
 
 Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
 
-#### Tighten a type parameter bound `[major]`
+#### MAJOR: Tighten a type parameter bound
 
 Changing `<T extends Object>` to `<T extends num>` breaks callers using non-number type arguments.
 
-#### Loosen a type parameter bound `[minor]`
+#### MINOR: Loosen a type parameter bound
 
 Changing `<T extends int>` to `<T extends num>` permits more types while remaining compatible with existing valid usages.
 
@@ -323,15 +313,15 @@ Changing `<T extends int>` to `<T extends num>` permits more types while remaini
 
 ## Enums
 
-### Add a new enum value `[major]`
+### MAJOR: Add a new enum value
 
 Adding a value to an `enum` breaks exhaustive `switch` statements and pattern matches in consumer code that do not include a `default` or wildcard `_` clause.
 
-### Remove or rename an enum value `[major]`
+### MAJOR: Remove or rename an enum value
 
 Any code referencing `MyEnum.oldValue` will fail to compile.
 
-### Add a member to an enhanced enum `[minor]`
+### MINOR: Add a member to an enhanced enum
 
 Enums cannot be extended or implemented, so adding members to an enhanced enum is safe for consumers.
 
@@ -341,11 +331,11 @@ Enums cannot be extended or implemented, so adding members to an enhanced enum i
 
 ### Extension methods (`extension on ...`)
 
-#### Add an extension or extension method `[minor]`
+#### MINOR: Add an extension or extension method
 
 Adding extension methods is backward-compatible. (In rare cases, static ambiguity can occur if consumer code has another extension with the same method name in scope).
 
-#### Remove or rename an extension method `[major]`
+#### MAJOR: Remove or rename an extension method
 
 Call sites invoking the extension member will fail to compile.
 
@@ -353,15 +343,15 @@ Call sites invoking the extension member will fail to compile.
 
 ### Extension types (`extension type ...`)
 
-#### Change the underlying representation type `[major]`
+#### MAJOR: Change the underlying representation type
 
 Changes the underlying type contract and implicit constructors.
 
-#### Add a member to an extension type `[minor]`
+#### MINOR: Add a member to an extension type
 
 Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking.
 
-#### Remove or rename a member of an extension type `[major]`
+#### MAJOR: Remove or rename a member of an extension type
 
 Breaks call sites referencing the member.
 
@@ -369,19 +359,19 @@ Breaks call sites referencing the member.
 
 ## Dependencies and SDK constraints
 
-### Increase the Dart SDK constraint lower bound `[minor]`
+### MINOR: Increase the Dart SDK constraint lower bound
 
 Increasing the SDK constraint (for example, `sdk: ^3.5.0` to `sdk: ^3.6.0`) is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
 
-### Export a new dependency `[minor]`
+### MINOR: Export a new dependency
 
 Re-exporting another package's library (`export 'package:foo/foo.dart';`) exposes new public API surface.
 
-### Remove an exported dependency `[major]`
+### MAJOR: Remove an exported dependency
 
 Consumers relying on your package re-exporting those symbols will fail to compile.
 
-### Update dependencies within existing constraint ranges `[patch / minor]`
+### PATCH / MINOR: Update dependencies within existing constraint ranges
 
 Normal maintenance as long as your package's own public API surface is unchanged.
 

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -1,18 +1,18 @@
 ---
-title: API versioning guidelines
+title: SemVer compatibility and breaking changes
 breadcrumb: SemVer rules
 description: >-
-  A comprehensive guide to what changes are breaking (major), non-breaking
-  features (minor), or bug fixes (patch) in Dart packages.
+  A comprehensive guide to what changes are breaking major changes, non-breaking
+  minor features, or patch bug fixes in Dart packages.
 ---
 
 When developing and publishing Dart packages, adhering to
-[Semantic Versioning (SemVer)][semver] is essential for maintaining a healthy
+[Semantic Versioning][semver] is essential for maintaining a healthy
 and predictable package ecosystem.
 
 This guide provides a detailed reference on how various changes to your Dart
 code affect the public API surface of your package and what version bump
-(`MAJOR`, `MINOR`, or `PATCH`) is required.
+is required.
 
 :::tip
 For a conceptual overview of pub's version solving algorithm and lockfiles,
@@ -23,7 +23,7 @@ see the [Package versioning](/tools/pub/versioning) guide.
 
 Dart's package manager, pub, follows [Semantic Versioning 2.0.0][semver] as implemented by [`package:pub_semver`][pub_semver].
 
-A standard version number is formatted as `MAJOR.MINOR.PATCH` (for example, `1.2.3`):
+A standard version number is formatted as `MAJOR.MINOR.PATCH`, such as `1.2.3`:
 
 * **`MAJOR`**: Incompatible breaking changes to the public API.
 * **`MINOR`**: Backward-compatible new functionality or features.
@@ -31,14 +31,14 @@ A standard version number is formatted as `MAJOR.MINOR.PATCH` (for example, `1.2
 
 ### Pre-1.0.0 versions
 
-While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and [`pub_semver`][pub_semver] enforce a stricter convention so that consumers can safely depend on pre-1.0.0 packages using [caret syntax](/tools/pub/dependencies#caret-syntax) (`^`):
+While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and [`pub_semver`][pub_semver] enforce a stricter convention so that consumers can safely depend on pre-1.0.0 packages using [caret syntax](/tools/pub/dependencies#caret-syntax):
 
-* **`0.y.z` (where $y > 0$, for example `0.2.0`):**
-  * Bumping `y` (`0.2.0` $\rightarrow$ `0.3.0`) is treated as a **breaking change** (equivalent to a major bump).
-  * Bumping `z` (`0.2.0` $\rightarrow$ `0.2.1`) is treated as a **backward-compatible change** (equivalent to a minor or patch bump).
+* **`0.y.z` versions where $y > 0$, such as `0.2.0`:**
+  * Bumping `y` from `0.2.0` to `0.3.0` is treated as a **breaking change**, which is equivalent to a major bump.
+  * Bumping `z` from `0.2.0` to `0.2.1` is treated as a **backward-compatible change**, which is equivalent to a minor or patch bump.
   * Caret syntax `^0.2.0` allows `>=0.2.0 <0.3.0`.
-* **`0.0.z` (for example `0.0.1`):**
-  * Bumping `z` (`0.0.1` $\rightarrow$ `0.0.2`) is treated as a **breaking change**.
+* **`0.0.z` versions, such as `0.0.1`:**
+  * Bumping `z` from `0.0.1` to `0.0.2` is treated as a **breaking change**.
   * Caret syntax `^0.0.1` allows only `>=0.0.1 <0.0.2`.
 
 ## The public API boundary
@@ -46,9 +46,9 @@ While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and [`
 In Dart packages, the **public API** comprises all declarations accessible to
 consumers of your package:
 
-* **Public:** Any library directly inside `lib/` (e.g., `lib/my_package.dart`)
+* **Public:** Any library directly inside `lib/`, such as `lib/my_package.dart`,
   and any declarations re-exported through `export` directives.
-* **Private / Internal:** Any file inside `lib/src/` that is **not**
+* **Private and internal:** Any file inside `lib/src/` that is **not**
   re-exported by a public library in `lib/`. Changes to unexported files in
   `lib/src/` are considered internal and do not affect the public SemVer contract.
 
@@ -65,7 +65,7 @@ Adding a new public top-level function, class, typedef, enum, extension, or cons
 void newHelperFunction() {}
 ```
 
-*Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import (`import 'package:foo/foo.dart';`) in downstream code, SemVer treats top-level additions as non-breaking.
+*Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import like `import 'package:foo/foo.dart';` in downstream code, SemVer treats top-level additions as non-breaking.
 
 ### MAJOR: Remove a public top-level declaration
 
@@ -77,21 +77,21 @@ Renaming a public symbol is functionally equivalent to removing the original nam
 
 ### MAJOR: Move a declaration to `lib/src/` without re-exporting
 
-Moving a declaration from the public `lib/` root to `lib/src/` (without an `export` in a public library file) makes it inaccessible to external packages, breaking all existing consumers.
+Moving a declaration from the public `lib/` root to `lib/src/`, without an `export` in a public library file, makes it inaccessible to external packages, breaking all existing consumers.
 
 ### MAJOR: Widen or change the type of a `const` or `final` variable
 
-Changing a `const` or `final` variable to a broader type (for example, `const int maxRetries` to `const num maxRetries`) or to an incompatible type breaks callers expecting members of the more specific type.
+Changing a `const` or `final` variable to a broader type, such as changing `const int maxRetries` to `const num maxRetries`, or to an incompatible type breaks callers expecting members of the more specific type.
 
 ### MINOR: Narrow the type of a `const` or `final` variable
 
-Narrowing the static type of a read-only `const` or `final` variable to a more specific subtype (for example, `const num timeout` to `const int timeout`, or `const Object key` to `const String key`) is backward-compatible. Because consumers only read the value, a more specific subtype satisfies all existing type expectations while providing additional type safety.
+Narrowing the static type of a read-only `const` or `final` variable to a more specific subtype, such as changing `const num timeout` to `const int timeout` or `const Object key` to `const String key`, is backward-compatible. Because consumers only read the value, a more specific subtype satisfies all existing type expectations while providing additional type safety.
 
-### MAJOR: Change the type of a mutable (`var`) top-level variable
+### MAJOR: Change the type of a mutable top-level variable
 
-For mutable variables (which can be both read from and written to), changing the static type in either direction is a breaking change:
-* Narrowing the type (e.g., `num` to `int`) breaks callers assigning a `double` into the variable.
-* Widening the type (e.g., `int` to `num`) breaks callers expecting `int` methods when reading the variable.
+For mutable `var` variables that can be both read from and written to, changing the static type in either direction is a breaking change:
+* Narrowing the type, such as `num` to `int`, breaks callers assigning a `double` into the variable.
+* Widening the type, such as `int` to `num`, breaks callers expecting `int` methods when reading the variable.
 
 ### MAJOR: Change a top-level variable from `var` to `final`
 
@@ -101,7 +101,7 @@ Making a mutable variable `final` breaks any consumer assigning values to that v
 
 ## Classes, mixins, and class modifiers
 
-Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, and `mixin`), allowing package authors to explicitly define how classes can be used by consumers. The SemVer impact of adding or modifying members depends on these modifiers.
+Dart 3 introduced class modifiers: `final`, `base`, `interface`, `sealed`, and `mixin`. These allow package authors to explicitly define how classes can be used by consumers. The SemVer impact of adding or modifying members depends on these modifiers.
 
 ### Changing modifiers on existing classes
 
@@ -109,7 +109,7 @@ Changing the modifier on an already-published class alters what external package
 
 #### MAJOR: Change a concrete class to an abstract class
 
-Changing a concrete class to `abstract class` prevents external consumers from instantiating the class directly (`new MyClass()`), causing compile errors.
+Changing a concrete class to `abstract class` prevents external consumers from instantiating the class directly using `new MyClass()`, causing compile errors.
 
 #### MINOR: Change an abstract class to a concrete class
 
@@ -117,11 +117,11 @@ Making an abstract class concrete enables external instantiation without breakin
 
 #### MAJOR: Add the `base` modifier to an existing class
 
-Prevents external consumers from implementing the class (`implements MyClass`), breaking all existing external implementers.
+Prevents external consumers from implementing the class using `implements MyClass`, breaking all existing external implementers.
 
 #### MAJOR: Add the `interface` modifier to an existing class
 
-Prevents external consumers from extending the class (`extends MyClass`), breaking all existing external subclasses.
+Prevents external consumers from extending the class using `extends MyClass`, breaking all existing external subclasses.
 
 #### MAJOR: Add the `final` or `sealed` modifier to an existing class
 
@@ -129,7 +129,7 @@ Prevents external consumers from extending, implementing, or mixing in the class
 
 #### MAJOR: Remove the `mixin` modifier from a `mixin class`
 
-Prevents external consumers from using the class as a mixin (`with MyClass`).
+Prevents external consumers from using the class as a mixin using `with MyClass`.
 
 #### MINOR: Remove `base`, `interface`, or `final` from a class
 
@@ -139,7 +139,7 @@ Loosens restrictions on consumers, granting new capabilities without invalidatin
 
 ### Unmodified classes: `class` and `abstract class`
 
-An unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
+An unmodified class in Dart allows external packages to construct, extend using `extends`, and implement using `implements`.
 
 #### MAJOR: Add an instance member to an unmodified class
 
@@ -159,7 +159,7 @@ Removing or renaming an instance method, getter, setter, or field breaks all cal
 
 #### MINOR: Add a static member to a class
 
-Static members are namespaced to the class (`Class.member`) and do not affect subclasses or external implementations.
+Static members are namespaced to the class, such as `Class.member`, and do not affect subclasses or external implementations.
 
 #### MAJOR: Remove or rename a static member
 
@@ -173,7 +173,7 @@ A `final` class cannot be extended, implemented, or mixed in outside of the defi
 
 #### MINOR: Add an instance member to a final class
 
-Since external code cannot `extend` or `implement` a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
+Since external code cannot extend or implement a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
 
 ```dart tag=good
 // Safe to add in a minor release:
@@ -194,11 +194,11 @@ Existing callers referencing the removed member will fail to compile.
 
 ### `base class`
 
-A `base` class can be extended (`extends`) outside the library, but cannot be implemented (`implements`).
+A `base` class can be extended outside the library, but cannot be implemented using `implements`.
 
 #### MINOR: Add a concrete instance member to a base class
 
-Because external libraries can only `extend` (not `implement`) a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
+Because external libraries can only extend rather than implement a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
 
 #### MAJOR: Add an abstract member to a base class
 
@@ -212,11 +212,11 @@ Breaks both callers and extending subclasses.
 
 ### `interface class` and `abstract interface class`
 
-An `interface` class can be implemented (`implements`) outside the library, but cannot be extended (`extends`).
+An `interface` class can be implemented outside the library, but cannot be extended using `extends`.
 
 #### MAJOR: Add any member to an interface class
 
-External classes can `implement` an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
+External classes can implement an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
 
 #### MAJOR: Remove or rename an instance member of an interface class
 
@@ -230,7 +230,7 @@ A `sealed` class is implicitly abstract and cannot be extended, implemented, or 
 
 #### MAJOR: Add a direct subtype to a sealed class family
 
-Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard (`_`) or `default` case will fail to compile.
+Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard `_` or `default` case will fail to compile.
 
 ```dart tag=bad
 sealed class Result {}
@@ -257,7 +257,7 @@ External code cannot implement or extend a `sealed` class, so adding instance or
 
 Classes using `with MyMixin` automatically receive the concrete implementation.
 
-*Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with `with`.
+*Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with the `with` keyword.
 
 #### MAJOR: Add an abstract member to a mixin
 
@@ -265,13 +265,13 @@ Requires all classes applying the mixin to supply an implementation for the new 
 
 #### MAJOR: Tighten the `on` constraint on a mixin
 
-Restricting the superclass requirements (for example, from `on Object` to `on Widget`) prevents existing classes that do not meet the new requirement from mixing it in.
+Restricting the superclass requirements, such as from `on Object` to `on Widget`, prevents existing classes that do not meet the new requirement from mixing it in.
 
 ---
 
-## Type aliases (`typedef`)
+## Type aliases: `typedef`
 
-Type aliases (`typedef`) define names for function types, records, or existing class types.
+Type aliases define names for function types, records, or existing class types.
 
 ### MINOR: Add a new type alias
 
@@ -283,14 +283,14 @@ Any downstream code referencing the removed `typedef` name will fail to compile.
 
 ### MAJOR: Change the aliased type in a type alias
 
-Changing the underlying type that a type alias references (for example, changing `typedef Callback = void Function(int);` to `typedef Callback = void Function(String);`) alters the expected type everywhere the alias is used, breaking consumers.
+Changing the underlying type that a type alias references, such as changing `typedef Callback = void Function(int);` to `typedef Callback = void Function(String);`, alters the expected type everywhere the alias is used, breaking consumers.
 
 ### MAJOR: Replace a `typedef` with a class or vice versa
 
-Replacing a type alias with a class (or class with a type alias) of the same name is a breaking change:
+Replacing a type alias with a class, or a class with a type alias of the same name, is a breaking change:
 
-* **Function type alias $\rightarrow$ class:** In Dart, closure literals are function types, not class instances. Code assigning a closure (`Callback cb = (x) => ...;`) will fail to compile against `class Callback`.
-* **Class type alias $\rightarrow$ subclass:** If `typedef A = B;` is replaced with `class A extends B {}`, `B` is no longer assignable to `A` ($B \not\le A$), and bidirectional type identity is lost.
+* **Function type alias $\rightarrow$ class:** In Dart, closure literals are function types, not class instances. Code assigning a closure like `Callback cb = (x) => ...;` will fail to compile against `class Callback`.
+* **Class type alias $\rightarrow$ subclass:** If `typedef A = B;` is replaced with `class A extends B {}`, `B` is no longer assignable to `A`, and bidirectional type identity is lost.
 
 ---
 
@@ -298,7 +298,7 @@ Replacing a type alias with a class (or class with a type alias) of the same nam
 
 ### MINOR: Add a new public constructor or factory
 
-Adding named constructors (`MyClass.named()`) or factories to an instantiable class provides new construction options without affecting existing callers.
+Adding named constructors, such as `MyClass.named()`, or factories to an instantiable class provides new construction options without affecting existing callers.
 
 ### MAJOR: Remove or rename a constructor
 
@@ -310,7 +310,7 @@ Existing constructor invocations that omit the new parameter will fail to compil
 
 ### MINOR: Add an optional parameter to a constructor
 
-Call sites can omit optional parameters (both positional and named).
+Call sites can omit optional parameters, both positional and named.
 
 ### MAJOR: Change a `const` constructor to non-`const`
 
@@ -318,7 +318,7 @@ Breaks any call site using `const MyClass(...)`.
 
 ### MINOR: Change a non-`const` constructor to `const`
 
-Adding `const` capability does not break existing non-const call sites (`MyClass(...)`).
+Adding `const` capability does not break existing non-const call sites using `MyClass(...)`.
 
 ### MAJOR: Add a private constructor to a class with only the default constructor
 
@@ -339,7 +339,7 @@ Existing call sites omitting the parameter will fail to compile.
 Existing call sites can omit the new optional parameter without issue.
 
 :::note Tear-offs and optional parameters
-In Dart, tearing off a method (`final fn = obj.myMethod;`) produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `MINOR` releases unless a package's primary contract relies on exact function signatures.
+In Dart, tearing off a method like `final fn = obj.myMethod;` produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `MINOR` releases unless a package's primary contract relies on exact function signatures.
 :::
 
 #### MAJOR: Remove any parameter
@@ -360,7 +360,7 @@ Changing a parameter from `num` to `int` breaks callers that passed `double`.
 
 #### Widen a parameter type
 
-* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs (for example, widening a parameter from `Future<T>` to `FutureOr<T>` or from `int` to `num`).
+* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs, such as widening a parameter from `Future<T>` to `FutureOr<T>` or from `int` to `num`.
 * **MAJOR** for methods on an implementable class, because it changes the signature required for external overrides.
 
 #### MINOR: Change the default value of an optional parameter
@@ -375,21 +375,21 @@ Return types in Dart are **covariant**: callers expect a return value conforming
 
 #### Narrow a return type
 
-Moving down the type lattice to a more specific subtype (e.g., `num` $\rightarrow$ `int`, `Object?` $\rightarrow$ `String`, `void` $\rightarrow$ `T`, or `T` $\rightarrow$ `Never`):
+Moving down the type lattice to a more specific subtype, such as `num` to `int`, `Object?` to `String`, `void` to a specific type, or any type to `Never`:
 
 * **MINOR for callers of top-level functions and `final` class methods:**
   * **Direct invocations:** Callers receive a more specific type with additional available members and tighter type safety.
-  * **Top types (`void` $\rightarrow$ `T`):** Changing a return type from `void` to a specific type is a form of narrowing from the top type. Callers ignoring the return value continue to work, and callbacks passed to `void Function(...)` continue to compile because Dart treats `T Function(...)` as a subtype of `void Function(...)` for any type `T`.
-  * **Bottom type (`T` $\rightarrow$ `Never`):** For functions that unconditionally throw or exit, narrowing the return type to `Never` is backward-compatible because `Never` is a universal subtype of all Dart types.
+  * **Top types:** Changing a return type from `void` to a specific type `T` is a form of narrowing from the top type. Callers ignoring the return value continue to work, and callbacks passed to `void Function(...)` continue to compile because Dart treats `T Function(...)` as a subtype of `void Function(...)` for any type `T`.
+  * **Bottom type:** For functions that unconditionally throw or exit, narrowing the return type to `Never` is backward-compatible because `Never` is a universal subtype of all Dart types.
 * **MAJOR if the method is overridden in external subclasses or implementers:**
-  * External subclasses that declared the previous wider return type (e.g., `@override num method()` or `@override void method()`) will fail to compile with an override error, because the subclass's wider return type is not a valid subtype of the new narrower return type.
+  * External subclasses that declared the previous wider return type, such as `@override num method()` or `@override void method()`, will fail to compile with an override error, because the subclass's wider return type is not a valid subtype of the new narrower return type.
 
-#### MAJOR: Widen a return type (more general / supertype)
+#### MAJOR: Widen a return type
 
-Moving up the type lattice to a broader supertype (e.g., `int` $\rightarrow$ `num`, `Future<T>` $\rightarrow$ `FutureOr<T>`, or specific type `T` $\rightarrow$ `void`):
+Moving up the type lattice to a broader supertype, such as `int` to `num`, `Future<T>` to `FutureOr<T>`, or a specific type `T` to `void`:
 
 * **MAJOR for callers:**
-  * Callers expecting specific members on the returned object (such as `int` methods, or `.then()` on a `Future<T>`) will fail to compile.
+  * Callers expecting specific members on the returned object, like `int` methods or `.then()` on a `Future<T>`, will fail to compile.
   * Changing a return type from a specific type `T` to `void` is a form of widening to the top type, breaking any callers attempting to read or use the returned value.
 * Subclasses that already returned a narrower subtype remain valid overrides.
 
@@ -399,7 +399,7 @@ Moving up the type lattice to a broader supertype (e.g., `int` $\rightarrow$ `nu
 
 #### MAJOR: Add a bound to an unconstrained type parameter
 
-Adding a type parameter constraint (for example, changing `class Store<T>` to `class Store<T extends State>`) breaks existing consumers using type arguments that do not conform to the new bound (such as `Store<String>`).
+Adding a type parameter constraint, such as changing `class Store<T>` to `class Store<T extends State>`, breaks existing consumers using type arguments that do not conform to the new bound, like `Store<String>`.
 
 #### MAJOR: Tighten a type parameter bound
 
@@ -427,7 +427,7 @@ Any code referencing `MyEnum.oldValue` will fail to compile.
 
 ### MAJOR: Reorder enum values
 
-Reordering enum declarations does not cause static compilation errors, but alters each value's `.index` property at runtime. If your package or downstream users serialize enums by index (such as in databases or network protocols), reordering values is a breaking runtime change.
+Reordering enum declarations does not cause static compilation errors, but alters each value's `.index` property at runtime. If your package or downstream users serialize enums by index, like in databases or network protocols, reordering values is a breaking runtime change.
 
 ### MINOR: Add a member to an enhanced enum
 
@@ -437,27 +437,27 @@ Enums cannot be extended or implemented, so adding members to an enhanced enum i
 
 ## Extension methods and extension types
 
-### Extension methods (`extension on ...`)
+### Extension methods: `extension on`
 
 #### MINOR: Add an extension or extension method
 
-Adding extension methods is backward-compatible. (In rare cases, static ambiguity can occur if consumer code has another extension with the same method name in scope).
+Adding extension methods is backward-compatible. Static ambiguity can occasionally occur if consumer code already has another extension in scope with the same method name.
 
 #### MAJOR: Remove or rename an extension method
 
 Call sites invoking the extension member will fail to compile.
 
-#### MAJOR: Change the extended type (`on` clause)
+#### MAJOR: Change the extended type: the `on` clause
 
-Changing the target type of an extension (for example, `extension Helpers on String` to `extension Helpers on int`) removes the extension members from instances of the original type, breaking all existing call sites.
+Changing the target type of an extension, such as changing `extension Helpers on String` to `extension Helpers on int`, removes the extension members from instances of the original type, breaking all existing call sites.
 
 #### MINOR: Widen the extended type
 
-Widening the extended type (for example, from `on int` to `on num`) allows the extension to be used on more types while preserving all existing call sites.
+Widening the extended type, such as from `on int` to `on num`, allows the extension to be used on more types while preserving all existing call sites.
 
 ---
 
-### Extension types (`extension type ...`)
+### Extension types: `extension type`
 
 #### MAJOR: Change the underlying representation type
 
@@ -475,19 +475,19 @@ Breaks call sites referencing the member.
 
 ## Errors and exceptions
 
-In Dart, all errors and exceptions are unchecked at compile time (functions do not declare a `throws` clause in their signature). Determining the SemVer impact of changing thrown errors or exceptions depends on the distinction between [programmatic errors][effective_dart_errors] and [runtime exceptions][effective_dart_errors], as well as your documented API contract.
+In Dart, all errors and exceptions are unchecked at compile time, meaning functions do not declare a `throws` clause in their signature. Determining the SemVer impact of changing thrown errors or exceptions depends on the distinction between [programmatic errors][effective_dart_errors] and [runtime exceptions][effective_dart_errors], as well as your documented API contract.
 
 ### Documented exceptions
 
-When a library explicitly documents that a function or method throws a specific exception (for example, `/// Throws [AuthException] on invalid credentials.`):
+When a library explicitly documents that a function or method throws a specific exception, such as `/// Throws [AuthException] on invalid credentials.`:
 
 #### MAJOR: Change or remove a documented exception type
 
-Changing the thrown exception (for example, throwing `SecurityException` instead of `AuthException`) breaks downstream code with `try ... on AuthException catch (e)` handlers. The new exception will bypass the handler and crash at runtime.
+Changing the thrown exception, such as throwing `SecurityException` instead of `AuthException`, breaks downstream code with `try ... on AuthException catch (e)` handlers. The new exception will bypass the handler and crash at runtime.
 
 #### MINOR: Throw a subtype of the documented exception
 
-Throwing a more specific subtype (for example, throwing `ExpiredTokenException extends AuthException`) is backward-compatible. Existing callers catching `on AuthException` continue to catch the new subtype without changes.
+Throwing a more specific subtype, such as throwing `ExpiredTokenException extends AuthException`, is backward-compatible. Existing callers catching `on AuthException` continue to catch the new subtype without changes.
 
 #### MAJOR: Throw an exception on previously succeeding inputs or states
 
@@ -501,7 +501,7 @@ Handling an edge case or providing a fallback so that a function succeeds instea
 
 ### Programmatic errors: `Error` subclasses
 
-Subclasses of `Error` (such as `ArgumentError`, `StateError`, `RangeError`, and `AssertionError`) indicate a bug in the caller's code (contract violations or invalid arguments). Consumers should not catch `Error` types in application logic.
+Subclasses of `Error`, such as `ArgumentError`, `StateError`, `RangeError`, and `AssertionError`, indicate a bug in the caller's code, representing contract violations or invalid arguments. Consumers should not catch `Error` types in application logic.
 
 #### MAJOR: Throw an `ArgumentError` or `StateError` on previously valid inputs
 
@@ -509,11 +509,11 @@ Throwing an error for inputs or states that were previously valid and supported 
 
 #### PATCH: Add or refine `Error` checks for invalid arguments
 
-Throwing a clear `ArgumentError` or `StateError` on invalid inputs that previously caused undefined behavior, corrupted state, or internal unhandled exceptions (such as `TypeError` or `NoSuchMethodError`) is a bug fix or hardening improvement.
+Throwing a clear `ArgumentError` or `StateError` on invalid inputs that previously caused undefined behavior, corrupted state, or internal unhandled exceptions, such as `TypeError` or `NoSuchMethodError`, is a bug fix or hardening improvement.
 
 #### MINOR: Support previously invalid arguments without throwing an `Error`
 
-Expanding the acceptable input domain (for example, accepting negative numbers or null values where previously an `ArgumentError` was thrown) is a backward-compatible feature addition.
+Expanding the acceptable input domain, such as accepting negative numbers or null values where an `ArgumentError` was previously thrown, is a backward-compatible feature addition.
 
 ---
 
@@ -521,17 +521,17 @@ Expanding the acceptable input domain (for example, accepting negative numbers o
 
 ### MINOR: Increase the Dart SDK constraint lower bound
 
-Increasing the SDK constraint (for example, `sdk: ^3.5.0` to `sdk: ^3.6.0`) is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
+Increasing the SDK constraint, such as from `sdk: ^3.5.0` to `sdk: ^3.6.0`, is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
 
 ### MINOR: Export a new dependency
 
-Re-exporting another package's library (`export 'package:foo/foo.dart';`) exposes new public API surface.
+Re-exporting another package's library using `export 'package:foo/foo.dart';` exposes new public API surface.
 
 ### MAJOR: Remove an exported dependency
 
 Consumers relying on your package re-exporting those symbols will fail to compile.
 
-### PATCH / MINOR: Update dependencies within existing constraint ranges
+### PATCH: Update dependencies within existing constraint ranges
 
 Normal maintenance as long as your package's own public API surface is unchanged.
 

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -34,8 +34,7 @@ consumers of your package:
 
 ## Top-level declarations
 
-### Add a new top-level declaration
-**Minor: Non-breaking**
+### Add a new top-level declaration `[minor]`
 
 Adding a new public top-level function, class, typedef, enum, extension, or constant is backward-compatible. Existing consumer code will continue to compile and function as before.
 
@@ -46,33 +45,27 @@ void newHelperFunction() {}
 
 *Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import (`import 'package:foo/foo.dart';`) in downstream code, SemVer treats top-level additions as non-breaking.
 
-### Remove a public top-level declaration
-**Major: Breaking**
+### Remove a public top-level declaration `[major]`
 
 Removing any public top-level declaration is a breaking change. Any downstream code referencing the removed symbol will fail to compile.
 
-### Rename a public top-level declaration
-**Major: Breaking**
+### Rename a public top-level declaration `[major]`
 
 Renaming a public symbol is functionally equivalent to removing the original name and introducing a new one. Downstream code referencing the original name will break.
 
-### Move a declaration to `lib/src/` without re-exporting
-**Major: Breaking**
+### Move a declaration to `lib/src/` without re-exporting `[major]`
 
 Moving a declaration from the public `lib/` root to `lib/src/` (without an `export` in a public library file) makes it inaccessible to external packages, breaking all existing consumers.
 
-### Change the type of a top-level variable or constant
-**Major: Breaking**
+### Change the type of a top-level variable or constant `[major]`
 
 Changing the static type of a top-level variable or constant causes type errors for any callers expecting the previous type.
 
-### Change a top-level variable from `final` to `var`
-**Minor: Non-breaking**
+### Change a top-level variable from `final` to `var` `[minor]`
 
 Allowing reassignment of a previously read-only top-level variable is backward-compatible for existing readers.
 
-### Change a top-level variable from `var` to `final`
-**Major: Breaking**
+### Change a top-level variable from `var` to `final` `[major]`
 
 Making a mutable variable `final` breaks any consumer assigning values to that variable.
 
@@ -86,8 +79,7 @@ Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, a
 
 By default, an unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
 
-#### Add an instance member to an unmodified class
-**Major: Breaking**
+#### Add an instance member to an unmodified class `[major]`
 
 Adding any instance method, getter, setter, or field to an unmodified `class` or `abstract class` is a breaking change. Because external libraries are permitted to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing implementers due to missing overrides.
 
@@ -104,18 +96,15 @@ class HttpClient {
 }
 ```
 
-#### Remove or rename an instance member
-**Major: Breaking**
+#### Remove or rename an instance member `[major]`
 
 Removing or renaming an instance method, getter, setter, or field breaks all callers, extenders, and implementers.
 
-#### Add a static member to a class
-**Minor: Non-breaking**
+#### Add a static member to a class `[minor]`
 
 Static members are namespaced to the class (`Class.member`) and do not affect subclasses or external implementations.
 
-#### Remove or rename a static member
-**Major: Breaking**
+#### Remove or rename a static member `[major]`
 
 Breaks call sites referencing `Class.staticMember`.
 
@@ -125,8 +114,7 @@ Breaks call sites referencing `Class.staticMember`.
 
 A `final` class cannot be extended, implemented, or mixed in outside of the defining library. Consumers can only construct it (if not abstract) and call its members.
 
-#### Add an instance member to a final class
-**Minor: Non-breaking**
+#### Add an instance member to a final class `[minor]`
 
 Since external code cannot `extend` or `implement` a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
 
@@ -142,8 +130,7 @@ final class Config {
 }
 ```
 
-#### Remove or rename an instance member of a final class
-**Major: Breaking**
+#### Remove or rename an instance member of a final class `[major]`
 
 Existing callers referencing the removed member will fail to compile.
 
@@ -153,18 +140,15 @@ Existing callers referencing the removed member will fail to compile.
 
 A `base` class can be extended (`extends`) outside the library, but cannot be implemented (`implements`).
 
-#### Add a concrete instance member to a base class
-**Minor: Non-breaking**
+#### Add a concrete instance member to a base class `[minor]`
 
 Because external libraries can only `extend` (not `implement`) a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
 
-#### Add an abstract member to a base class
-**Major: Breaking**
+#### Add an abstract member to a base class `[major]`
 
 Subclasses in external libraries will fail to compile because they do not provide an implementation for the new abstract member.
 
-#### Remove or rename an instance member of a base class
-**Major: Breaking**
+#### Remove or rename an instance member of a base class `[major]`
 
 Breaks both callers and extending subclasses.
 
@@ -174,13 +158,11 @@ Breaks both callers and extending subclasses.
 
 An `interface` class can be implemented (`implements`) outside the library, but cannot be extended (`extends`).
 
-#### Add any member to an interface class
-**Major: Breaking**
+#### Add any member to an interface class `[major]`
 
 External classes can `implement` an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
 
-#### Remove or rename an instance member of an interface class
-**Major: Breaking**
+#### Remove or rename an instance member of an interface class `[major]`
 
 Breaks callers and implementers.
 
@@ -190,8 +172,7 @@ Breaks callers and implementers.
 
 A `sealed` class is implicitly abstract and cannot be extended, implemented, or mixed in outside the library. It is designed for exhaustive pattern matching.
 
-#### Add a direct subtype to a sealed class family
-**Major: Breaking**
+#### Add a direct subtype to a sealed class family `[major]`
 
 Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard (`_`) or `default` case will fail to compile.
 
@@ -208,8 +189,7 @@ class Failure extends Result {}
 // }
 ```
 
-#### Add a member to a sealed class
-**Minor: Non-breaking**
+#### Add a member to a sealed class `[minor]`
 
 External code cannot implement or extend a `sealed` class, so adding instance or static members is non-breaking.
 
@@ -217,20 +197,17 @@ External code cannot implement or extend a `sealed` class, so adding instance or
 
 ### `mixin` and `mixin class`
 
-#### Add a concrete member to a mixin
-**Minor: Non-breaking**
+#### Add a concrete member to a mixin `[minor]`
 
 Classes using `with MyMixin` automatically receive the concrete implementation.
 
 *Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with `with`.
 
-#### Add an abstract member to a mixin
-**Major: Breaking**
+#### Add an abstract member to a mixin `[major]`
 
 Requires all classes applying the mixin to supply an implementation for the new abstract member.
 
-#### Tighten the `on` constraint on a mixin
-**Major: Breaking**
+#### Tighten the `on` constraint on a mixin `[major]`
 
 Restricting the superclass requirements (for example, from `on Object` to `on Widget`) prevents existing classes that do not meet the new requirement from mixing it in.
 
@@ -238,38 +215,31 @@ Restricting the superclass requirements (for example, from `on Object` to `on Wi
 
 ## Constructors
 
-### Add a new public constructor or factory
-**Minor: Non-breaking**
+### Add a new public constructor or factory `[minor]`
 
 Adding named constructors (`MyClass.named()`) or factories to an instantiable class provides new construction options without affecting existing callers.
 
-### Remove or rename a constructor
-**Major: Breaking**
+### Remove or rename a constructor `[major]`
 
 Breaks call sites that invoked the removed constructor.
 
-### Add a required parameter to a constructor
-**Major: Breaking**
+### Add a required parameter to a constructor `[major]`
 
 Existing constructor invocations that omit the new parameter will fail to compile.
 
-### Add an optional parameter to a constructor
-**Minor: Non-breaking**
+### Add an optional parameter to a constructor `[minor]`
 
 Call sites can omit optional parameters (both positional and named).
 
-### Change a `const` constructor to non-`const`
-**Major: Breaking**
+### Change a `const` constructor to non-`const` `[major]`
 
 Breaks any call site using `const MyClass(...)`.
 
-### Change a non-`const` constructor to `const`
-**Minor: Non-breaking**
+### Change a non-`const` constructor to `const` `[minor]`
 
 Adding `const` capability does not break existing non-const call sites (`MyClass(...)`).
 
-### Add a private constructor to a class with only the default constructor
-**Major: Breaking**
+### Add a private constructor to a class with only the default constructor `[major]`
 
 If a class previously had the default implicit constructor `MyClass()`, adding `MyClass._()` removes the default public constructor and prevents external instantiation or subclassing.
 
@@ -279,13 +249,11 @@ If a class previously had the default implicit constructor `MyClass()`, adding `
 
 ### Parameters
 
-#### Add a required positional or named parameter
-**Major: Breaking**
+#### Add a required positional or named parameter `[major]`
 
 Existing call sites omitting the parameter will fail to compile.
 
-#### Add an optional parameter (positional or named)
-**Minor: Non-breaking**
+#### Add an optional parameter (positional or named) `[minor]`
 
 Existing call sites can omit the new optional parameter without issue.
 
@@ -293,29 +261,24 @@ Existing call sites can omit the new optional parameter without issue.
 In Dart, tearing off a method (`final fn = obj.myMethod;`) produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `Minor` releases unless a package's primary contract relies on exact function signatures.
 :::
 
-#### Remove any parameter
-**Major: Breaking**
+#### Remove any parameter `[major]`
 
 Call sites passing the removed argument will fail to compile.
 
-#### Rename a named parameter
-**Major: Breaking**
+#### Rename a named parameter `[major]`
 
 Call sites passing `func(paramName: value)` will fail to compile when `paramName` is changed.
 
-#### Narrow a parameter type (more specific / subtype)
-**Major: Breaking**
+#### Narrow a parameter type (more specific / subtype) `[major]`
 
 Changing a parameter from `num` to `int` breaks callers that passed `double`.
 
-#### Widen a parameter type (more general / supertype)
-**Minor / Major**
+#### Widen a parameter type (more general / supertype) `[minor / major]`
 
 * **Minor** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs.
 * **Major** for methods on an implementable class, because it changes the signature required for external overrides.
 
-#### Change the default value of an optional parameter
-**Patch / Minor**
+#### Change the default value of an optional parameter `[patch / minor]`
 
 Does not break compilation or static type checks, but alters runtime behavior for callers omitting the argument.
 
@@ -323,24 +286,20 @@ Does not break compilation or static type checks, but alters runtime behavior fo
 
 ### Return types
 
-#### Narrow a return type (more specific / subtype)
-**Minor / Major**
+#### Narrow a return type (more specific / subtype) `[minor / major]`
 
 * **Minor** for callers of top-level functions and `final` class methods (for example, returning `int` instead of `num` is covariant and safe for callers).
 * **Major** if the method is overridden in external subclasses or implementers.
 
-#### Widen a return type (more general / supertype)
-**Major: Breaking**
+#### Widen a return type (more general / supertype) `[major]`
 
 Changing a return type from `int` to `num` breaks callers expecting `int` methods and properties on the returned object.
 
-#### Change return type from `void` to a specific type
-**Minor: Non-breaking**
+#### Change return type from `void` to a specific type `[minor]`
 
 Existing callers ignoring the return value continue to work.
 
-#### Change return type from a specific type to `void`
-**Major: Breaking**
+#### Change return type from a specific type to `void` `[major]`
 
 Callers using the return value will fail to compile.
 
@@ -348,18 +307,15 @@ Callers using the return value will fail to compile.
 
 ### Generics and type parameters
 
-#### Add a type parameter without a default bound
-**Major: Breaking**
+#### Add a type parameter without a default bound `[major]`
 
 Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
 
-#### Tighten a type parameter bound
-**Major: Breaking**
+#### Tighten a type parameter bound `[major]`
 
 Changing `<T extends Object>` to `<T extends num>` breaks callers using non-number type arguments.
 
-#### Loosen a type parameter bound
-**Minor: Non-breaking**
+#### Loosen a type parameter bound `[minor]`
 
 Changing `<T extends int>` to `<T extends num>` permits more types while remaining compatible with existing valid usages.
 
@@ -367,18 +323,15 @@ Changing `<T extends int>` to `<T extends num>` permits more types while remaini
 
 ## Enums
 
-### Add a new enum value
-**Major: Breaking**
+### Add a new enum value `[major]`
 
 Adding a value to an `enum` breaks exhaustive `switch` statements and pattern matches in consumer code that do not include a `default` or wildcard `_` clause.
 
-### Remove or rename an enum value
-**Major: Breaking**
+### Remove or rename an enum value `[major]`
 
 Any code referencing `MyEnum.oldValue` will fail to compile.
 
-### Add a method, getter, or field to an enhanced enum
-**Minor: Non-breaking**
+### Add a member to an enhanced enum `[minor]`
 
 Enums cannot be extended or implemented, so adding members to an enhanced enum is safe for consumers.
 
@@ -388,13 +341,11 @@ Enums cannot be extended or implemented, so adding members to an enhanced enum i
 
 ### Extension methods (`extension on ...`)
 
-#### Add an extension or extension method
-**Minor: Non-breaking**
+#### Add an extension or extension method `[minor]`
 
 Adding extension methods is backward-compatible. (In rare cases, static ambiguity can occur if consumer code has another extension with the same method name in scope).
 
-#### Remove or rename an extension method
-**Major: Breaking**
+#### Remove or rename an extension method `[major]`
 
 Call sites invoking the extension member will fail to compile.
 
@@ -402,18 +353,15 @@ Call sites invoking the extension member will fail to compile.
 
 ### Extension types (`extension type ...`)
 
-#### Change the underlying representation type
-**Major: Breaking**
+#### Change the underlying representation type `[major]`
 
 Changes the underlying type contract and implicit constructors.
 
-#### Add a member to an extension type
-**Minor: Non-breaking**
+#### Add a member to an extension type `[minor]`
 
 Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking.
 
-#### Remove or rename a member of an extension type
-**Major: Breaking**
+#### Remove or rename a member of an extension type `[major]`
 
 Breaks call sites referencing the member.
 
@@ -421,23 +369,19 @@ Breaks call sites referencing the member.
 
 ## Dependencies and SDK constraints
 
-### Increase the Dart SDK constraint lower bound
-**Minor: Non-breaking**
+### Increase the Dart SDK constraint lower bound `[minor]`
 
 Increasing the SDK constraint (for example, `sdk: ^3.5.0` to `sdk: ^3.6.0`) is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
 
-### Export a new dependency
-**Minor: Non-breaking**
+### Export a new dependency `[minor]`
 
 Re-exporting another package's library (`export 'package:foo/foo.dart';`) exposes new public API surface.
 
-### Remove an exported dependency
-**Major: Breaking**
+### Remove an exported dependency `[major]`
 
 Consumers relying on your package re-exporting those symbols will fail to compile.
 
-### Update dependencies within existing constraint ranges
-**Patch / Minor**
+### Update dependencies within existing constraint ranges `[patch / minor]`
 
 Normal maintenance as long as your package's own public API surface is unchanged.
 

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -7,12 +7,22 @@ description: >-
 ---
 
 When developing and publishing Dart packages, adhering to
-[Semantic Versioning][semver] is essential for maintaining a healthy
+[Semantic Versioning][semver] helps creating a healthy
 and predictable package ecosystem.
 
-This guide provides a detailed reference on how various changes to your Dart
-code affect the public API surface of your package and what version bump
-is required.
+Any Dart package provides a set of features - but with that comes also a
+contract that the user can rely on this set of features to continue working.
+Packages sometimes get changed, and there are two categories of changes:
+Adding or removing functionality. Some changes do one or the other, some do
+both.
+While removing functionality may sometimes be necessary, doing so violates the
+contract with the user. To accomodate for this, Dart uses semantic versioning
+to help a user in recognizing whether a new version of a package adheres to the
+old or is presenting a new contract.
+
+This guide provides a detailed reference on which changes to your Dart code
+affect the public API surface of your package and what version bump is
+required.
 
 :::tip
 For a conceptual overview of pub's version solving algorithm and lockfiles,
@@ -21,7 +31,8 @@ see the [Package versioning](/tools/pub/versioning) guide.
 
 ## Semantic versioning and `package:pub_semver`
 
-Dart's package manager, pub, follows [Semantic Versioning 2.0.0][semver] as implemented by [`package:pub_semver`][pub_semver].
+Dart's package manager, pub, follows [Semantic Versioning 2.0.0][semver] as
+implemented by [`package:pub_semver`][pub_semver].
 
 A standard version number is formatted as `MAJOR.MINOR.PATCH`, such as `1.2.3`:
 
@@ -31,11 +42,17 @@ A standard version number is formatted as `MAJOR.MINOR.PATCH`, such as `1.2.3`:
 
 ### Pre-1.0.0 versions
 
-While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and [`pub_semver`][pub_semver] enforce a stricter convention so that consumers can safely depend on pre-1.0.0 packages using [caret syntax](/tools/pub/dependencies#caret-syntax):
+While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and
+[`pub_semver`][pub_semver] enforce a stricter convention so that consumers can
+safely depend on pre-1.0.0 packages using
+[caret syntax](/tools/pub/dependencies#caret-syntax):
 
 * **`0.y.z` versions where $y > 0$, such as `0.2.0`:**
-  * Bumping `y` from `0.2.0` to `0.3.0` is treated as a **breaking change**, which is equivalent to a major bump.
-  * Bumping `z` from `0.2.0` to `0.2.1` is treated as a **backward-compatible change**, which is equivalent to a minor or patch bump.
+  * Bumping `y` from `0.2.0` to `0.3.0` is treated as a **breaking change**,
+    which is equivalent to a major bump.
+  * Bumping `z` from `0.2.0` to `0.2.1` is treated as a
+    **backward-compatible change**, which is equivalent to a minor or patch
+    bump.
   * Caret syntax `^0.2.0` allows `>=0.2.0 <0.3.0`.
 * **`0.0.z` versions, such as `0.0.1`:**
   * Bumping `z` from `0.0.1` to `0.0.2` is treated as a **breaking change**.

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -19,6 +19,28 @@ For a conceptual overview of pub's version solving algorithm and lockfiles,
 see the [Package versioning](/tools/pub/versioning) guide.
 :::
 
+## Semantic versioning and `package:pub_semver`
+
+Dart's package manager, pub, follows [Semantic Versioning 2.0.0][semver] as implemented by [`package:pub_semver`][pub_semver].
+
+A standard version number is formatted as `MAJOR.MINOR.PATCH` (for example, `1.2.3`):
+
+* **`MAJOR`**: Incompatible breaking changes to the public API.
+* **`MINOR`**: Backward-compatible new functionality or features.
+* **`PATCH`**: Backward-compatible bug fixes.
+
+### Pre-1.0.0 versions
+
+While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and [`pub_semver`][pub_semver] enforce a stricter convention so that consumers can safely depend on pre-1.0.0 packages using [caret syntax](/tools/pub/dependencies#caret-syntax) (`^`):
+
+* **`0.y.z` (where $y > 0$, for example `0.2.0`):**
+  * Bumping `y` (`0.2.0` $\rightarrow$ `0.3.0`) is treated as a **breaking change** (equivalent to a major bump).
+  * Bumping `z` (`0.2.0` $\rightarrow$ `0.2.1`) is treated as a **backward-compatible change** (equivalent to a minor or patch bump).
+  * Caret syntax `^0.2.0` allows `>=0.2.0 <0.3.0`.
+* **`0.0.z` (for example `0.0.1`):**
+  * Bumping `z` (`0.0.1` $\rightarrow$ `0.0.2`) is treated as a **breaking change**.
+  * Caret syntax `^0.0.1` allows only `>=0.0.1 <0.0.2`.
+
 ## The public API boundary
 
 In Dart packages, the **public API** comprises all declarations accessible to
@@ -379,4 +401,5 @@ Consumers relying on your package re-exporting those symbols will fail to compil
 
 Normal maintenance as long as your package's own public API surface is unchanged.
 
+[pub_semver]: {{site.pub-pkg}}/pub_semver
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -34,100 +34,244 @@ consumers of your package:
 
 ## Top-level declarations
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a new top-level declaration** (function, class, typedef, enum, extension, constant) | `Minor` | Adding new public symbols is backward-compatible. (While potential name conflicts with wildcard imports exist, SemVer treats this as non-breaking). |
-| **Remove a public top-level declaration** | `Major` | Any code referencing the removed symbol will fail to compile. |
-| **Rename a public top-level declaration** | `Major` | Equivalent to removing the old name and adding a new one. |
-| **Move a declaration to `lib/src/` without re-exporting** | `Major` | Makes a previously public symbol private/inaccessible. |
-| **Change the type of a top-level variable or constant** | `Major` | Callers expecting the old type will encounter type errors. |
-| **Change a top-level variable from `final` to `var`** | `Minor` | Making a read-only variable mutable is backward-compatible for existing readers. |
-| **Change a top-level variable from `var` to `final`** | `Major` | Code assigning to the variable will fail to compile. |
+### Add a new top-level declaration
+**Minor: Non-breaking**
+
+Adding a new public top-level function, class, typedef, enum, extension, or constant is backward-compatible. Existing consumer code will continue to compile and function as before.
+
+```dart
+// Added to lib/my_package.dart in a minor release:
+void newHelperFunction() {}
+```
+
+*Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import (`import 'package:foo/foo.dart';`) in downstream code, SemVer treats top-level additions as non-breaking.
+
+### Remove a public top-level declaration
+**Major: Breaking**
+
+Removing any public top-level declaration is a breaking change. Any downstream code referencing the removed symbol will fail to compile.
+
+### Rename a public top-level declaration
+**Major: Breaking**
+
+Renaming a public symbol is functionally equivalent to removing the original name and introducing a new one. Downstream code referencing the original name will break.
+
+### Move a declaration to `lib/src/` without re-exporting
+**Major: Breaking**
+
+Moving a declaration from the public `lib/` root to `lib/src/` (without an `export` in a public library file) makes it inaccessible to external packages, breaking all existing consumers.
+
+### Change the type of a top-level variable or constant
+**Major: Breaking**
+
+Changing the static type of a top-level variable or constant causes type errors for any callers expecting the previous type.
+
+### Change a top-level variable from `final` to `var`
+**Minor: Non-breaking**
+
+Allowing reassignment of a previously read-only top-level variable is backward-compatible for existing readers.
+
+### Change a top-level variable from `var` to `final`
+**Major: Breaking**
+
+Making a mutable variable `final` breaks any consumer assigning values to that variable.
 
 ---
 
 ## Classes, mixins, and class modifiers
 
-Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`,
-and `mixin`), allowing package authors to explicitly define how classes can be
-used by external consumers. The SemVer impact of adding or modifying members
-depends heavily on these modifiers.
+Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`, and `mixin`), allowing package authors to explicitly define how classes can be used by external consumers. The SemVer impact of adding or modifying members depends heavily on these modifiers.
 
 ### Unmodified classes (`class` and `abstract class`)
 
-By default, an unmodified class in Dart allows external packages to construct,
-extend (`extends`), and implement (`implements`) it.
+By default, an unmodified class in Dart allows external packages to construct, extend (`extends`), and implement (`implements`) it.
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add any instance method, getter, setter, or field** | `Major` | **Breaking!** Because external code could have written `class MyImpl implements Foo`, any new member in `Foo` causes existing implementations to fail compilation due to missing overrides. |
-| **Remove or rename an instance member** | `Major` | Existing callers and subclasses will fail. |
-| **Add a static member** | `Minor` | Static members are namespaced to the class and do not affect implementations or subclasses. |
-| **Remove a static member** | `Major` | Breaks call sites referencing `Class.member`. |
+#### Add an instance member to an unmodified class
+**Major: Breaking**
+
+Adding any instance method, getter, setter, or field to an unmodified `class` or `abstract class` is a breaking change. Because external libraries are permitted to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing implementers due to missing overrides.
+
+```dart
+// In package:foo (v1.0.0)
+class HttpClient {
+  void get(String url) {}
+}
+
+// In package:foo (v1.1.0) - BREAKING for implementers!
+class HttpClient {
+  void get(String url) {}
+  void post(String url, Object body) {} // External `implements HttpClient` fails!
+}
+```
+
+#### Remove or rename an instance member
+**Major: Breaking**
+
+Removing or renaming an instance method, getter, setter, or field breaks all callers, extenders, and implementers.
+
+#### Add a static member to a class
+**Minor: Non-breaking**
+
+Static members are namespaced to the class (`Class.member`) and do not affect subclasses or external implementations.
+
+#### Remove or rename a static member
+**Major: Breaking**
+
+Breaks call sites referencing `Class.staticMember`.
+
+---
 
 ### `final class` and `abstract final class`
 
-A `final` class cannot be extended, implemented, or mixed in outside of the
-defining library. Consumers can only construct it (if not abstract) and call its
-members.
+A `final` class cannot be extended, implemented, or mixed in outside of the defining library. Consumers can only construct it (if not abstract) and call its members.
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add an instance method, getter, setter, or field** | `Minor` | **Non-breaking!** Since no external code can `implement` or `extend` a `final` class, adding new members is safe for consumers. |
-| **Remove or rename an instance member** | `Major` | Existing callers will break. |
+#### Add an instance member to a final class
+**Minor: Non-breaking**
+
+Since external code cannot `extend` or `implement` a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
+
+```dart
+// Non-breaking in a final class:
+final class Config {
+  final String host;
+  final int port;
+  Config(this.host, this.port);
+
+  // Safe to add in a minor release:
+  bool get isSecure => port == 443;
+}
+```
+
+#### Remove or rename an instance member of a final class
+**Major: Breaking**
+
+Existing callers referencing the removed member will fail to compile.
+
+---
 
 ### `base class`
 
-A `base` class can be extended (`extends`) outside the library, but cannot be
-implemented (`implements`).
+A `base` class can be extended (`extends`) outside the library, but cannot be implemented (`implements`).
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a concrete instance method, getter, or field** | `Minor` | **Non-breaking!** External subclasses inherit the new default implementation automatically without needing to override it. |
-| **Add an abstract method or getter** | `Major` | Existing subclasses will fail to compile because they do not implement the new abstract member. |
-| **Remove or rename an instance member** | `Major` | Breaks callers and subclasses. |
+#### Add a concrete instance member to a base class
+**Minor: Non-breaking**
+
+Because external libraries can only `extend` (not `implement`) a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
+
+#### Add an abstract member to a base class
+**Major: Breaking**
+
+Subclasses in external libraries will fail to compile because they do not provide an implementation for the new abstract member.
+
+#### Remove or rename an instance member of a base class
+**Major: Breaking**
+
+Breaks both callers and extending subclasses.
+
+---
 
 ### `interface class` and `abstract interface class`
 
-An `interface` class can be implemented (`implements`) outside the library, but
-cannot be extended (`extends`).
+An `interface` class can be implemented (`implements`) outside the library, but cannot be extended (`extends`).
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add any method, getter, setter, or field** | `Major` | **Breaking!** External implementers will be missing the required implementation. |
-| **Remove or rename an instance member** | `Major` | Breaks callers and implementers. |
+#### Add any member to an interface class
+**Major: Breaking**
+
+External classes can `implement` an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
+
+#### Remove or rename an instance member of an interface class
+**Major: Breaking**
+
+Breaks callers and implementers.
+
+---
 
 ### `sealed class`
 
-A `sealed` class is implicitly abstract and cannot be extended, implemented, or
-mixed in outside the library. It is designed for exhaustive pattern matching.
+A `sealed` class is implicitly abstract and cannot be extended, implemented, or mixed in outside the library. It is designed for exhaustive pattern matching.
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a new direct subtype to a sealed family** | `Major` | **Breaking!** Any external exhaustive `switch` expression or statement on the sealed class will fail to compile due to missing cases. |
-| **Add a member to the sealed class** | `Minor` | Non-breaking because external code cannot implement or extend it. |
+#### Add a direct subtype to a sealed class family
+**Major: Breaking**
+
+Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard (`_`) or `default` case will fail to compile.
+
+```dart
+sealed class Result {}
+class Success extends Result {}
+class Failure extends Result {}
+
+// Adding `class Pending extends Result {}` breaks exhaustive switches:
+// switch (result) {
+//   case Success(): ...
+//   case Failure(): ...
+//   // Error: Switch is no longer exhaustive!
+// }
+```
+
+#### Add a member to a sealed class
+**Minor: Non-breaking**
+
+External code cannot implement or extend a `sealed` class, so adding instance or static members is non-breaking.
+
+---
 
 ### `mixin` and `mixin class`
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a concrete method or field to a `mixin`** | `Minor`* | Non-breaking for consumers using `with Mixin`. (*Note: technically breaking if a consumer used `implements Mixin`). |
-| **Add an abstract member to a `mixin`** | `Major` | Requires all applications of the mixin to provide an implementation. |
-| **Add or change the `on` type constraint** | `Major` | Tightening the `on` constraint restricts where the mixin can be applied. |
+#### Add a concrete member to a mixin
+**Minor: Non-breaking**
+
+Classes using `with MyMixin` automatically receive the concrete implementation.
+
+*Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with `with`.
+
+#### Add an abstract member to a mixin
+**Major: Breaking**
+
+Requires all classes applying the mixin to supply an implementation for the new abstract member.
+
+#### Tighten the `on` constraint on a mixin
+**Major: Breaking**
+
+Restricting the superclass requirements (for example, from `on Object` to `on Widget`) prevents existing classes that do not meet the new requirement from mixing it in.
 
 ---
 
 ## Constructors
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a new public named constructor or factory** | `Minor` | Adding new ways to instantiate a class is backward-compatible. |
-| **Remove or rename a constructor** | `Major` | Breaks code calling `MyClass.named()`. |
-| **Add a required positional or named parameter** | `Major` | Existing construction sites will fail to compile. |
-| **Add an optional positional or named parameter** | `Minor` | Existing construction sites continue to work. |
-| **Change a `const` constructor to non-`const`** | `Major` | Breaks call sites using `const MyClass(...)`. |
-| **Change a non-`const` constructor to `const`** | `Minor` | Backward-compatible; existing non-const call sites continue to work. |
-| **Add a private constructor `Class._()` to a class with only default constructor** | `Major` | Prevents external instantiation or subclassing if no other public constructors exist. |
+### Add a new public constructor or factory
+**Minor: Non-breaking**
+
+Adding named constructors (`MyClass.named()`) or factories to an instantiable class provides new construction options without affecting existing callers.
+
+### Remove or rename a constructor
+**Major: Breaking**
+
+Breaks call sites that invoked the removed constructor.
+
+### Add a required parameter to a constructor
+**Major: Breaking**
+
+Existing constructor invocations that omit the new parameter will fail to compile.
+
+### Add an optional parameter to a constructor
+**Minor: Non-breaking**
+
+Call sites can omit optional parameters (both positional and named).
+
+### Change a `const` constructor to non-`const`
+**Major: Breaking**
+
+Breaks any call site using `const MyClass(...)`.
+
+### Change a non-`const` constructor to `const`
+**Minor: Non-breaking**
+
+Adding `const` capability does not break existing non-const call sites (`MyClass(...)`).
+
+### Add a private constructor to a class with only the default constructor
+**Major: Breaking**
+
+If a class previously had the default implicit constructor `MyClass()`, adding `MyClass._()` removes the default public constructor and prevents external instantiation or subclassing.
 
 ---
 
@@ -135,104 +279,166 @@ mixed in outside the library. It is designed for exhaustive pattern matching.
 
 ### Parameters
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a required positional parameter** | `Major` | Existing call sites without the argument will fail to compile. |
-| **Add a required named parameter** | `Major` | Existing call sites without the named argument will fail to compile. |
-| **Add an optional positional parameter** | `Minor`* | Callers can omit it. (*Note: technically breaking if the function was torn off and assigned to an exact function type). |
-| **Add an optional named parameter** | `Minor`* | Callers can omit it. (*Note: see tear-off nuance below). |
-| **Remove any parameter (required or optional)** | `Major` | Breaks call sites passing that argument. |
-| **Rename a named parameter** | `Major` | Breaks call sites passing the argument by name (`foo: value`). |
-| **Change a parameter type to a more specific type (subtype)** | `Major` | Narrowing accepted types (e.g. from `num` to `int`) breaks callers passing other valid inputs (e.g. `double`). |
-| **Change a parameter type to a more general type (supertype)** | `Minor` / `Major` | **Minor** for callers (accepts more inputs), but **Major** if the method belongs to an interface/class that external code implements or overrides. |
-| **Change the default value of an optional parameter** | `Patch` / `Minor` | Behavioral change; does not break compilation, but callers relying on previous default behavior may be affected. |
+#### Add a required positional or named parameter
+**Major: Breaking**
+
+Existing call sites omitting the parameter will fail to compile.
+
+#### Add an optional parameter (positional or named)
+**Minor: Non-breaking**
+
+Existing call sites can omit the new optional parameter without issue.
 
 :::note Tear-offs and optional parameters
-In Dart, tearing off a method (e.g. `final fn = obj.myMethod;`) produces a
-function whose static type reflects its exact signature. Adding an optional
-parameter changes the static type of the tear-off, which can cause a type
-mismatch if the consumer assigned it to a specific `typedef`. In practice,
-adding optional parameters is standard for `Minor` releases unless a package's
-primary contract relies on specific function signatures.
+In Dart, tearing off a method (`final fn = obj.myMethod;`) produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `Minor` releases unless a package's primary contract relies on exact function signatures.
 :::
+
+#### Remove any parameter
+**Major: Breaking**
+
+Call sites passing the removed argument will fail to compile.
+
+#### Rename a named parameter
+**Major: Breaking**
+
+Call sites passing `func(paramName: value)` will fail to compile when `paramName` is changed.
+
+#### Narrow a parameter type (more specific / subtype)
+**Major: Breaking**
+
+Changing a parameter from `num` to `int` breaks callers that passed `double`.
+
+#### Widen a parameter type (more general / supertype)
+**Minor / Major**
+
+* **Minor** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs.
+* **Major** for methods on an implementable class, because it changes the signature required for external overrides.
+
+#### Change the default value of an optional parameter
+**Patch / Minor**
+
+Does not break compilation or static type checks, but alters runtime behavior for callers omitting the argument.
+
+---
 
 ### Return types
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Change return type to a more specific type (subtype)** | `Minor` / `Major` | **Minor** for callers (e.g. `num` to `int` is covariant and safe for callers), but **Major** if the method is overridden in external subclasses or implementers. |
-| **Change return type to a more general type (supertype)** | `Major` | Breaks callers expecting the narrower type (e.g. changing `int` to `num`). |
-| **Change return type from `void` to a specific type** | `Minor` | Callers ignoring the return value continue to work. |
-| **Change return type from a specific type to `void`** | `Major` | Callers using the return value will fail to compile. |
+#### Narrow a return type (more specific / subtype)
+**Minor / Major**
+
+* **Minor** for callers of top-level functions and `final` class methods (for example, returning `int` instead of `num` is covariant and safe for callers).
+* **Major** if the method is overridden in external subclasses or implementers.
+
+#### Widen a return type (more general / supertype)
+**Major: Breaking**
+
+Changing a return type from `int` to `num` breaks callers expecting `int` methods and properties on the returned object.
+
+#### Change return type from `void` to a specific type
+**Minor: Non-breaking**
+
+Existing callers ignoring the return value continue to work.
+
+#### Change return type from a specific type to `void`
+**Major: Breaking**
+
+Callers using the return value will fail to compile.
+
+---
 
 ### Generics and type parameters
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a type parameter with no default / bound** | `Major` | Existing call sites or type annotations lacking the type argument may fail or change behavior. |
-| **Tighten a type parameter bound** (e.g. `<T>` to `<T extends num>`) | `Major` | Callers using type arguments outside the new bound will fail. |
-| **Loosen a type parameter bound** (e.g. `<T extends int>` to `<T extends num>`) | `Minor` | Permits a wider range of types without breaking existing valid arguments. |
+#### Add a type parameter without a default bound
+**Major: Breaking**
+
+Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
+
+#### Tighten a type parameter bound
+**Major: Breaking**
+
+Changing `<T extends Object>` to `<T extends num>` breaks callers using non-number type arguments.
+
+#### Loosen a type parameter bound
+**Minor: Non-breaking**
+
+Changing `<T extends int>` to `<T extends num>` permits more types while remaining compatible with existing valid usages.
 
 ---
 
 ## Enums
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a new enum value** | `Major` | **Breaking!** Exhaustive `switch` statements and pattern matches on the enum without a `default` or wildcard `_` case will fail to compile. |
-| **Remove or rename an enum value** | `Major` | Any code referencing `MyEnum.oldValue` will break. |
-| **Add a method, getter, or field to an enhanced enum** | `Minor` | Enums cannot be extended or implemented, so adding members is safe. |
+### Add a new enum value
+**Major: Breaking**
+
+Adding a value to an `enum` breaks exhaustive `switch` statements and pattern matches in consumer code that do not include a `default` or wildcard `_` clause.
+
+### Remove or rename an enum value
+**Major: Breaking**
+
+Any code referencing `MyEnum.oldValue` will fail to compile.
+
+### Add a method, getter, or field to an enhanced enum
+**Minor: Non-breaking**
+
+Enums cannot be extended or implemented, so adding members to an enhanced enum is safe for consumers.
 
 ---
 
-## Extensions and extension types
+## Extension methods and extension types
 
 ### Extension methods (`extension on ...`)
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Add a new extension or extension method** | `Minor` | Non-breaking. (In rare cases, can introduce ambiguity if a consumer has another extension with the same name in scope). |
-| **Remove or rename an extension method** | `Major` | Call sites using the extension member will fail. |
+#### Add an extension or extension method
+**Minor: Non-breaking**
+
+Adding extension methods is backward-compatible. (In rare cases, static ambiguity can occur if consumer code has another extension with the same method name in scope).
+
+#### Remove or rename an extension method
+**Major: Breaking**
+
+Call sites invoking the extension member will fail to compile.
+
+---
 
 ### Extension types (`extension type ...`)
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Change the underlying representation type** | `Major` | Breaks all type conversions and compatibility with the underlying representation. |
-| **Add a method, getter, or setter** | `Minor` | Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking. |
-| **Remove or rename a member** | `Major` | Breaks callers referencing the member. |
+#### Change the underlying representation type
+**Major: Breaking**
+
+Changes the underlying type contract and implicit constructors.
+
+#### Add a member to an extension type
+**Minor: Non-breaking**
+
+Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking.
+
+#### Remove or rename a member of an extension type
+**Major: Breaking**
+
+Breaks call sites referencing the member.
 
 ---
 
 ## Dependencies and SDK constraints
 
-| Change | SemVer Bump | Notes |
-| :--- | :--- | :--- |
-| **Increase the Dart SDK constraint lower bound** | `Minor` | Safe for a minor release if within the current major Dart SDK line, provided your users have access to that SDK version. |
-| **Export a new dependency** (`export 'package:foo/foo.dart'`) | `Minor` | Adds new public API surface to your package. |
-| **Remove an exported dependency** | `Major` | Breaks consumers relying on your package re-exporting those symbols. |
-| **Update dependencies within existing constraint ranges** | `Patch` / `Minor` | Normal maintenance as long as your package's own public API is unchanged. |
+### Increase the Dart SDK constraint lower bound
+**Minor: Non-breaking**
 
----
+Increasing the SDK constraint (for example, `sdk: ^3.5.0` to `sdk: ^3.6.0`) is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
 
-## Summary quick reference
+### Export a new dependency
+**Minor: Non-breaking**
 
-| Change | SemVer Bump |
-| :--- | :--- |
-| Add new top-level class, function, enum, or extension | **Minor** |
-| Remove or rename any public top-level declaration | **Major** |
-| Add member to unmodified `class` or `abstract class` | **Major** |
-| Add member to `final class` or `sealed class` | **Minor** |
-| Add concrete member to `base class` | **Minor** |
-| Add abstract member to `base class` | **Major** |
-| Add member to `interface class` | **Major** |
-| Add new subtype to `sealed class` | **Major** |
-| Add required parameter to function, method, or constructor | **Major** |
-| Add optional parameter to function, method, or constructor | **Minor** |
-| Rename named parameter | **Major** |
-| Add value to an `enum` | **Major** |
-| Remove or rename `enum` value | **Major** |
-| Change `const` constructor to non-`const` | **Major** |
-| Tighten type bounds or parameter types | **Major** |
+Re-exporting another package's library (`export 'package:foo/foo.dart';`) exposes new public API surface.
+
+### Remove an exported dependency
+**Major: Breaking**
+
+Consumers relying on your package re-exporting those symbols will fail to compile.
+
+### Update dependencies within existing constraint ranges
+**Patch / Minor**
+
+Normal maintenance as long as your package's own public API surface is unchanged.
 
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -1,0 +1,238 @@
+---
+title: SemVer compatibility and breaking changes
+breadcrumb: SemVer rules
+description: >-
+  A comprehensive guide to what changes are breaking (major), non-breaking
+  features (minor), or bug fixes (patch) in Dart packages.
+---
+
+When developing and publishing Dart packages, adhering to
+[Semantic Versioning (SemVer)][semver] is essential for maintaining a healthy
+and predictable package ecosystem.
+
+This guide provides a detailed reference on how various changes to your Dart
+code affect the public API surface of your package and what version bump
+(`major`, `minor`, or `patch`) is required.
+
+:::tip
+For a conceptual overview of pub's version solving algorithm and lockfiles,
+see the [Package versioning](/tools/pub/versioning) guide.
+:::
+
+## The public API boundary
+
+In Dart packages, the **public API** comprises all declarations accessible to
+consumers of your package:
+
+* **Public:** Any library directly inside `lib/` (e.g., `lib/my_package.dart`)
+  and any declarations re-exported through `export` directives.
+* **Private / Internal:** Any file inside `lib/src/` that is **not**
+  re-exported by a public library in `lib/`. Changes to unexported files in
+  `lib/src/` are considered internal and do not affect the public SemVer contract.
+
+---
+
+## Top-level declarations
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a new top-level declaration** (function, class, typedef, enum, extension, constant) | `Minor` | Adding new public symbols is backward-compatible. (While potential name conflicts with wildcard imports exist, SemVer treats this as non-breaking). |
+| **Remove a public top-level declaration** | `Major` | Any code referencing the removed symbol will fail to compile. |
+| **Rename a public top-level declaration** | `Major` | Equivalent to removing the old name and adding a new one. |
+| **Move a declaration to `lib/src/` without re-exporting** | `Major` | Makes a previously public symbol private/inaccessible. |
+| **Change the type of a top-level variable or constant** | `Major` | Callers expecting the old type will encounter type errors. |
+| **Change a top-level variable from `final` to `var`** | `Minor` | Making a read-only variable mutable is backward-compatible for existing readers. |
+| **Change a top-level variable from `var` to `final`** | `Major` | Code assigning to the variable will fail to compile. |
+
+---
+
+## Classes, mixins, and class modifiers
+
+Dart 3 introduced **class modifiers** (`final`, `base`, `interface`, `sealed`,
+and `mixin`), allowing package authors to explicitly define how classes can be
+used by external consumers. The SemVer impact of adding or modifying members
+depends heavily on these modifiers.
+
+### Unmodified classes (`class` and `abstract class`)
+
+By default, an unmodified class in Dart allows external packages to construct,
+extend (`extends`), and implement (`implements`) it.
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add any instance method, getter, setter, or field** | `Major` | **Breaking!** Because external code could have written `class MyImpl implements Foo`, any new member in `Foo` causes existing implementations to fail compilation due to missing overrides. |
+| **Remove or rename an instance member** | `Major` | Existing callers and subclasses will fail. |
+| **Add a static member** | `Minor` | Static members are namespaced to the class and do not affect implementations or subclasses. |
+| **Remove a static member** | `Major` | Breaks call sites referencing `Class.member`. |
+
+### `final class` and `abstract final class`
+
+A `final` class cannot be extended, implemented, or mixed in outside of the
+defining library. Consumers can only construct it (if not abstract) and call its
+members.
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add an instance method, getter, setter, or field** | `Minor` | **Non-breaking!** Since no external code can `implement` or `extend` a `final` class, adding new members is safe for consumers. |
+| **Remove or rename an instance member** | `Major` | Existing callers will break. |
+
+### `base class`
+
+A `base` class can be extended (`extends`) outside the library, but cannot be
+implemented (`implements`).
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a concrete instance method, getter, or field** | `Minor` | **Non-breaking!** External subclasses inherit the new default implementation automatically without needing to override it. |
+| **Add an abstract method or getter** | `Major` | Existing subclasses will fail to compile because they do not implement the new abstract member. |
+| **Remove or rename an instance member** | `Major` | Breaks callers and subclasses. |
+
+### `interface class` and `abstract interface class`
+
+An `interface` class can be implemented (`implements`) outside the library, but
+cannot be extended (`extends`).
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add any method, getter, setter, or field** | `Major` | **Breaking!** External implementers will be missing the required implementation. |
+| **Remove or rename an instance member** | `Major` | Breaks callers and implementers. |
+
+### `sealed class`
+
+A `sealed` class is implicitly abstract and cannot be extended, implemented, or
+mixed in outside the library. It is designed for exhaustive pattern matching.
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a new direct subtype to a sealed family** | `Major` | **Breaking!** Any external exhaustive `switch` expression or statement on the sealed class will fail to compile due to missing cases. |
+| **Add a member to the sealed class** | `Minor` | Non-breaking because external code cannot implement or extend it. |
+
+### `mixin` and `mixin class`
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a concrete method or field to a `mixin`** | `Minor`* | Non-breaking for consumers using `with Mixin`. (*Note: technically breaking if a consumer used `implements Mixin`). |
+| **Add an abstract member to a `mixin`** | `Major` | Requires all applications of the mixin to provide an implementation. |
+| **Add or change the `on` type constraint** | `Major` | Tightening the `on` constraint restricts where the mixin can be applied. |
+
+---
+
+## Constructors
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a new public named constructor or factory** | `Minor` | Adding new ways to instantiate a class is backward-compatible. |
+| **Remove or rename a constructor** | `Major` | Breaks code calling `MyClass.named()`. |
+| **Add a required positional or named parameter** | `Major` | Existing construction sites will fail to compile. |
+| **Add an optional positional or named parameter** | `Minor` | Existing construction sites continue to work. |
+| **Change a `const` constructor to non-`const`** | `Major` | Breaks call sites using `const MyClass(...)`. |
+| **Change a non-`const` constructor to `const`** | `Minor` | Backward-compatible; existing non-const call sites continue to work. |
+| **Add a private constructor `Class._()` to a class with only default constructor** | `Major` | Prevents external instantiation or subclassing if no other public constructors exist. |
+
+---
+
+## Functions, methods, and parameters
+
+### Parameters
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a required positional parameter** | `Major` | Existing call sites without the argument will fail to compile. |
+| **Add a required named parameter** | `Major` | Existing call sites without the named argument will fail to compile. |
+| **Add an optional positional parameter** | `Minor`* | Callers can omit it. (*Note: technically breaking if the function was torn off and assigned to an exact function type). |
+| **Add an optional named parameter** | `Minor`* | Callers can omit it. (*Note: see tear-off nuance below). |
+| **Remove any parameter (required or optional)** | `Major` | Breaks call sites passing that argument. |
+| **Rename a named parameter** | `Major` | Breaks call sites passing the argument by name (`foo: value`). |
+| **Change a parameter type to a more specific type (subtype)** | `Major` | Narrowing accepted types (e.g. from `num` to `int`) breaks callers passing other valid inputs (e.g. `double`). |
+| **Change a parameter type to a more general type (supertype)** | `Minor` / `Major` | **Minor** for callers (accepts more inputs), but **Major** if the method belongs to an interface/class that external code implements or overrides. |
+| **Change the default value of an optional parameter** | `Patch` / `Minor` | Behavioral change; does not break compilation, but callers relying on previous default behavior may be affected. |
+
+:::note Tear-offs and optional parameters
+In Dart, tearing off a method (e.g. `final fn = obj.myMethod;`) produces a
+function whose static type reflects its exact signature. Adding an optional
+parameter changes the static type of the tear-off, which can cause a type
+mismatch if the consumer assigned it to a specific `typedef`. In practice,
+adding optional parameters is standard for `Minor` releases unless a package's
+primary contract relies on specific function signatures.
+:::
+
+### Return types
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Change return type to a more specific type (subtype)** | `Minor` / `Major` | **Minor** for callers (e.g. `num` to `int` is covariant and safe for callers), but **Major** if the method is overridden in external subclasses or implementers. |
+| **Change return type to a more general type (supertype)** | `Major` | Breaks callers expecting the narrower type (e.g. changing `int` to `num`). |
+| **Change return type from `void` to a specific type** | `Minor` | Callers ignoring the return value continue to work. |
+| **Change return type from a specific type to `void`** | `Major` | Callers using the return value will fail to compile. |
+
+### Generics and type parameters
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a type parameter with no default / bound** | `Major` | Existing call sites or type annotations lacking the type argument may fail or change behavior. |
+| **Tighten a type parameter bound** (e.g. `<T>` to `<T extends num>`) | `Major` | Callers using type arguments outside the new bound will fail. |
+| **Loosen a type parameter bound** (e.g. `<T extends int>` to `<T extends num>`) | `Minor` | Permits a wider range of types without breaking existing valid arguments. |
+
+---
+
+## Enums
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a new enum value** | `Major` | **Breaking!** Exhaustive `switch` statements and pattern matches on the enum without a `default` or wildcard `_` case will fail to compile. |
+| **Remove or rename an enum value** | `Major` | Any code referencing `MyEnum.oldValue` will break. |
+| **Add a method, getter, or field to an enhanced enum** | `Minor` | Enums cannot be extended or implemented, so adding members is safe. |
+
+---
+
+## Extensions and extension types
+
+### Extension methods (`extension on ...`)
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Add a new extension or extension method** | `Minor` | Non-breaking. (In rare cases, can introduce ambiguity if a consumer has another extension with the same name in scope). |
+| **Remove or rename an extension method** | `Major` | Call sites using the extension member will fail. |
+
+### Extension types (`extension type ...`)
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Change the underlying representation type** | `Major` | Breaks all type conversions and compatibility with the underlying representation. |
+| **Add a method, getter, or setter** | `Minor` | Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking. |
+| **Remove or rename a member** | `Major` | Breaks callers referencing the member. |
+
+---
+
+## Dependencies and SDK constraints
+
+| Change | SemVer Bump | Notes |
+| :--- | :--- | :--- |
+| **Increase the Dart SDK constraint lower bound** | `Minor` | Safe for a minor release if within the current major Dart SDK line, provided your users have access to that SDK version. |
+| **Export a new dependency** (`export 'package:foo/foo.dart'`) | `Minor` | Adds new public API surface to your package. |
+| **Remove an exported dependency** | `Major` | Breaks consumers relying on your package re-exporting those symbols. |
+| **Update dependencies within existing constraint ranges** | `Patch` / `Minor` | Normal maintenance as long as your package's own public API is unchanged. |
+
+---
+
+## Summary quick reference
+
+| Change | SemVer Bump |
+| :--- | :--- |
+| Add new top-level class, function, enum, or extension | **Minor** |
+| Remove or rename any public top-level declaration | **Major** |
+| Add member to unmodified `class` or `abstract class` | **Major** |
+| Add member to `final class` or `sealed class` | **Minor** |
+| Add concrete member to `base class` | **Minor** |
+| Add abstract member to `base class` | **Major** |
+| Add member to `interface class` | **Major** |
+| Add new subtype to `sealed class` | **Major** |
+| Add required parameter to function, method, or constructor | **Major** |
+| Add optional parameter to function, method, or constructor | **Minor** |
+| Rename named parameter | **Major** |
+| Add value to an `enum` | **Major** |
+| Remove or rename `enum` value | **Major** |
+| Change `const` constructor to non-`const` | **Major** |
+| Tighten type bounds or parameter types | **Major** |
+
+[semver]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -473,6 +473,50 @@ Breaks call sites referencing the member.
 
 ---
 
+## Errors and exceptions
+
+In Dart, all errors and exceptions are unchecked at compile time (functions do not declare a `throws` clause in their signature). Determining the SemVer impact of changing thrown errors or exceptions depends on the distinction between [programmatic errors][effective_dart_errors] and [runtime exceptions][effective_dart_errors], as well as your documented API contract.
+
+### Documented exceptions
+
+When a library explicitly documents that a function or method throws a specific exception (for example, `/// Throws [AuthException] on invalid credentials.`):
+
+#### MAJOR: Change or remove a documented exception type
+
+Changing the thrown exception (for example, throwing `SecurityException` instead of `AuthException`) breaks downstream code with `try ... on AuthException catch (e)` handlers. The new exception will bypass the handler and crash at runtime.
+
+#### MINOR: Throw a subtype of the documented exception
+
+Throwing a more specific subtype (for example, throwing `ExpiredTokenException extends AuthException`) is backward-compatible. Existing callers catching `on AuthException` continue to catch the new subtype without changes.
+
+#### MAJOR: Throw an exception on previously succeeding inputs or states
+
+Throwing an exception in scenarios where the function previously succeeded alters control flow and breaks working consumer code.
+
+#### MINOR: Stop throwing an exception by succeeding instead
+
+Handling an edge case or providing a fallback so that a function succeeds instead of throwing is backward-compatible. Existing `try-catch` blocks will simply not be triggered.
+
+---
+
+### Programmatic errors: `Error` subclasses
+
+Subclasses of `Error` (such as `ArgumentError`, `StateError`, `RangeError`, and `AssertionError`) indicate a bug in the caller's code (contract violations or invalid arguments). Consumers should not catch `Error` types in application logic.
+
+#### MAJOR: Throw an `ArgumentError` or `StateError` on previously valid inputs
+
+Throwing an error for inputs or states that were previously valid and supported narrows the acceptable input domain, breaking existing callers.
+
+#### PATCH: Add or refine `Error` checks for invalid arguments
+
+Throwing a clear `ArgumentError` or `StateError` on invalid inputs that previously caused undefined behavior, corrupted state, or internal unhandled exceptions (such as `TypeError` or `NoSuchMethodError`) is a bug fix or hardening improvement.
+
+#### MINOR: Support previously invalid arguments without throwing an `Error`
+
+Expanding the acceptable input domain (for example, accepting negative numbers or null values where previously an `ArgumentError` was thrown) is a backward-compatible feature addition.
+
+---
+
 ## Dependencies and SDK constraints
 
 ### MINOR: Increase the Dart SDK constraint lower bound
@@ -491,5 +535,6 @@ Consumers relying on your package re-exporting those symbols will fail to compil
 
 Normal maintenance as long as your package's own public API surface is unchanged.
 
+[effective_dart_errors]: /effective-dart/usage#error-handling
 [pub_semver]: {{site.pub-pkg}}/pub_semver
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -6,27 +6,24 @@ description: >-
   minor features, or patch bug fixes in Dart packages.
 ---
 
-When developing and publishing Dart packages, adhering to
-[Semantic Versioning][semver] helps creating a healthy
-and predictable package ecosystem.
+When developing and publishing Dart packages, adhering to [Semantic
+Versioning][semver] helps creating a healthy and predictable package ecosystem.
 
 Any Dart package provides a set of features - but with that comes also a
 contract that the user can rely on this set of features to continue working.
-Packages sometimes get changed, and there are two categories of changes:
-Adding or removing functionality. Some changes do one or the other, some do
-both.
-While removing functionality may sometimes be necessary, doing so violates the
-contract with the user. To accomodate for this, Dart uses semantic versioning
-to help a user in recognizing whether a new version of a package adheres to the
-old or is presenting a new contract.
+Packages sometimes get changed, and there are two categories of changes: Adding
+or removing functionality. Some changes do one or the other, some do both. While
+removing functionality may sometimes be necessary, doing so violates the
+contract with the user. To accomodate for this, Dart uses semantic versioning to
+help a user in recognizing whether a new version of a package adheres to the old
+or is presenting a new contract.
 
 This guide provides a detailed reference on which changes to your Dart code
-affect the public API surface of your package and what version bump is
-required.
+affect the public API surface of your package and what version bump is required.
 
 :::tip
-For a conceptual overview of pub's version solving algorithm and lockfiles,
-see the [Package versioning](/tools/pub/versioning) guide.
+For a conceptual overview of pub's version solving algorithm and lockfiles, see
+the [Package versioning](/tools/pub/versioning) guide.
 :::
 
 ## Semantic versioning and `package:pub_semver`
@@ -44,15 +41,14 @@ A standard version number is formatted as `MAJOR.MINOR.PATCH`, such as `1.2.3`:
 
 While standard SemVer 2.0.0 allows any change before version `1.0.0`, pub and
 [`pub_semver`][pub_semver] enforce a stricter convention so that consumers can
-safely depend on pre-1.0.0 packages using
-[caret syntax](/tools/pub/dependencies#caret-syntax):
+safely depend on pre-1.0.0 packages using [caret
+syntax](/tools/pub/dependencies#caret-syntax):
 
 * **`0.y.z` versions where $y > 0$, such as `0.2.0`:**
   * Bumping `y` from `0.2.0` to `0.3.0` is treated as a **breaking change**,
     which is equivalent to a major bump.
-  * Bumping `z` from `0.2.0` to `0.2.1` is treated as a
-    **backward-compatible change**, which is equivalent to a minor or patch
-    bump.
+  * Bumping `z` from `0.2.0` to `0.2.1` is treated as a **backward-compatible
+    change**, which is equivalent to a minor or patch bump.
   * Caret syntax `^0.2.0` allows `>=0.2.0 <0.3.0`.
 * **`0.0.z` versions, such as `0.0.1`:**
   * Bumping `z` from `0.0.1` to `0.0.2` is treated as a **breaking change**.
@@ -67,7 +63,8 @@ consumers of your package:
   and any declarations re-exported through `export` directives.
 * **Private and internal:** Any file inside `lib/src/` that is **not**
   re-exported by a public library in `lib/`. Changes to unexported files in
-  `lib/src/` are considered internal and do not affect the public SemVer contract.
+  `lib/src/` are considered internal and do not affect the public SemVer
+  contract.
 
 ---
 
@@ -75,92 +72,126 @@ consumers of your package:
 
 ### MINOR: Add a new top-level declaration
 
-Adding a new public top-level function, class, typedef, enum, extension, or constant is backward-compatible. Existing consumer code will continue to compile and function as before.
+Adding a new public top-level function, class, typedef, enum, extension, or
+constant is backward-compatible. Existing consumer code will continue to compile
+and function as before.
 
 ```dart tag=good
 // Added to lib/my_package.dart in a minor release:
 void newHelperFunction() {}
 ```
 
-*Note:* While introducing a new top-level name can theoretically create a naming conflict with a wildcard import like `import 'package:foo/foo.dart';` in downstream code, SemVer treats top-level additions as non-breaking.
+*Note:* While introducing a new top-level name can theoretically create a naming
+conflict with a wildcard import like `import 'package:foo/foo.dart';` in
+downstream code, SemVer treats top-level additions as non-breaking.
 
 ### MAJOR: Remove a public top-level declaration
 
-Removing any public top-level declaration is a breaking change. Any downstream code referencing the removed symbol will fail to compile.
+Removing any public top-level declaration is a breaking change. Any downstream
+code referencing the removed symbol will fail to compile.
 
 ### MAJOR: Rename a public top-level declaration
 
-Renaming a public symbol is functionally equivalent to removing the original name and introducing a new one. Downstream code referencing the original name will break.
+Renaming a public symbol is functionally equivalent to removing the original
+name and introducing a new one. Downstream code referencing the original name
+will break.
 
 ### MAJOR: Move a declaration to `lib/src/` without re-exporting
 
-Moving a declaration from the public `lib/` root to `lib/src/`, without an `export` in a public library file, makes it inaccessible to external packages, breaking all existing consumers.
+Moving a declaration from the public `lib/` root to `lib/src/`, without an
+`export` in a public library file, makes it inaccessible to external packages,
+breaking all existing consumers.
 
 ### MAJOR: Widen or change the type of a `const` or `final` variable
 
-Changing a `const` or `final` variable to a broader type, such as changing `const int maxRetries` to `const num maxRetries`, or to an incompatible type breaks callers expecting members of the more specific type.
+Changing a `const` or `final` variable to a broader type, such as changing
+`const int maxRetries` to `const num maxRetries`, or to an incompatible type
+breaks callers expecting members of the more specific type.
 
 ### MINOR: Narrow the type of a `const` or `final` variable
 
-Narrowing the static type of a read-only `const` or `final` variable to a more specific subtype, such as changing `const num timeout` to `const int timeout` or `const Object key` to `const String key`, is backward-compatible. Because consumers only read the value, a more specific subtype satisfies all existing type expectations while providing additional type safety.
+Narrowing the static type of a read-only `const` or `final` variable to a more
+specific subtype, such as changing `const num timeout` to `const int timeout` or
+`const Object key` to `const String key`, is backward-compatible. Because
+consumers only read the value, a more specific subtype satisfies all existing
+type expectations while providing additional type safety.
 
 ### MAJOR: Change the type of a mutable top-level variable
 
-For mutable `var` variables that can be both read from and written to, changing the static type in either direction is a breaking change:
-* Narrowing the type, such as `num` to `int`, breaks callers assigning a `double` into the variable.
-* Widening the type, such as `int` to `num`, breaks callers expecting `int` methods when reading the variable.
+For mutable `var` variables that can be both read from and written to, changing
+the static type in either direction is a breaking change:
+* Narrowing the type, such as `num` to `int`, breaks callers assigning a
+  `double` into the variable.
+* Widening the type, such as `int` to `num`, breaks callers expecting `int`
+  methods when reading the variable.
 
 ### MAJOR: Change a top-level variable from `var` to `final`
 
-Making a mutable variable `final` breaks any consumer assigning values to that variable.
+Making a mutable variable `final` breaks any consumer assigning values to that
+variable.
 
 ---
 
 ## Classes, mixins, and class modifiers
 
-Dart 3 introduced class modifiers: `final`, `base`, `interface`, `sealed`, and `mixin`. These allow package authors to explicitly define how classes can be used by consumers. The SemVer impact of adding or modifying members depends on these modifiers.
+Dart 3 introduced class modifiers: `final`, `base`, `interface`, `sealed`, and
+`mixin`. These allow package authors to explicitly define how classes can be
+used by consumers. The SemVer impact of adding or modifying members depends on
+these modifiers.
 
 ### Changing modifiers on existing classes
 
-Changing the modifier on an already-published class alters what external packages are permitted to do with it:
+Changing the modifier on an already-published class alters what external
+packages are permitted to do with it:
 
 #### MAJOR: Change a concrete class to an abstract class
 
-Changing a concrete class to `abstract class` prevents external consumers from instantiating the class directly using `new MyClass()`, causing compile errors.
+Changing a concrete class to `abstract class` prevents external consumers from
+instantiating the class directly using `new MyClass()`, causing compile errors.
 
 #### MINOR: Change an abstract class to a concrete class
 
-Making an abstract class concrete enables external instantiation without breaking existing subclasses or implementers.
+Making an abstract class concrete enables external instantiation without
+breaking existing subclasses or implementers.
 
 #### MAJOR: Add the `base` modifier to an existing class
 
-Prevents external consumers from implementing the class using `implements MyClass`, breaking all existing external implementers.
+Prevents external consumers from implementing the class using `implements
+MyClass`, breaking all existing external implementers.
 
 #### MAJOR: Add the `interface` modifier to an existing class
 
-Prevents external consumers from extending the class using `extends MyClass`, breaking all existing external subclasses.
+Prevents external consumers from extending the class using `extends MyClass`,
+breaking all existing external subclasses.
 
 #### MAJOR: Add the `final` or `sealed` modifier to an existing class
 
-Prevents external consumers from extending, implementing, or mixing in the class, breaking all existing external subtypes.
+Prevents external consumers from extending, implementing, or mixing in the
+class, breaking all existing external subtypes.
 
 #### MAJOR: Remove the `mixin` modifier from a `mixin class`
 
-Prevents external consumers from using the class as a mixin using `with MyClass`.
+Prevents external consumers from using the class as a mixin using `with
+MyClass`.
 
 #### MINOR: Remove `base`, `interface`, or `final` from a class
 
-Loosens restrictions on consumers, granting new capabilities without invalidating existing code.
+Loosens restrictions on consumers, granting new capabilities without
+invalidating existing code.
 
 ---
 
 ### Unmodified classes: `class` and `abstract class`
 
-An unmodified class in Dart allows external packages to construct, extend using `extends`, and implement using `implements`.
+An unmodified class in Dart allows external packages to construct, extend using
+`extends`, and implement using `implements`.
 
 #### MAJOR: Add an instance member to an unmodified class
 
-Adding any instance method, getter, setter, or field to an unmodified `class` or `abstract class` is a breaking change. Because external libraries are permitted to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing implementers due to missing overrides.
+Adding any instance method, getter, setter, or field to an unmodified `class` or
+`abstract class` is a breaking change. Because external libraries are permitted
+to write `class MyImpl implements Foo`, any new member in `Foo` breaks existing
+implementers due to missing overrides.
 
 ```dart tag=bad
 // In package:foo (v1.1.0) - BREAKING for external implementers:
@@ -172,11 +203,13 @@ abstract class HttpClient {
 
 #### MAJOR: Remove or rename an instance member
 
-Removing or renaming an instance method, getter, setter, or field breaks all callers, extenders, and implementers.
+Removing or renaming an instance method, getter, setter, or field breaks all
+callers, extenders, and implementers.
 
 #### MINOR: Add a static member to a class
 
-Static members are namespaced to the class, such as `Class.member`, and do not affect subclasses or external implementations.
+Static members are namespaced to the class, such as `Class.member`, and do not
+affect subclasses or external implementations.
 
 #### MAJOR: Remove or rename a static member
 
@@ -186,11 +219,14 @@ Breaks call sites referencing `Class.staticMember`.
 
 ### `final class` and `abstract final class`
 
-A `final` class cannot be extended, implemented, or mixed in outside of the defining library.
+A `final` class cannot be extended, implemented, or mixed in outside of the
+defining library.
 
 #### MINOR: Add an instance member to a final class
 
-Since external code cannot extend or implement a `final class`, adding new instance methods, getters, setters, or fields is completely backward-compatible. Consumers only call existing members and cannot be broken by added members.
+Since external code cannot extend or implement a `final class`, adding new
+instance methods, getters, setters, or fields is completely backward-compatible.
+Consumers only call existing members and cannot be broken by added members.
 
 ```dart tag=good
 // Safe to add in a minor release:
@@ -211,15 +247,19 @@ Existing callers referencing the removed member will fail to compile.
 
 ### `base class`
 
-A `base` class can be extended outside the library, but cannot be implemented using `implements`.
+A `base` class can be extended outside the library, but cannot be implemented
+using `implements`.
 
 #### MINOR: Add a concrete instance member to a base class
 
-Because external libraries can only extend rather than implement a `base class`, subclasses automatically inherit the new default implementation without needing to override it.
+Because external libraries can only extend rather than implement a `base class`,
+subclasses automatically inherit the new default implementation without needing
+to override it.
 
 #### MAJOR: Add an abstract member to a base class
 
-Subclasses in external libraries will fail to compile because they do not provide an implementation for the new abstract member.
+Subclasses in external libraries will fail to compile because they do not
+provide an implementation for the new abstract member.
 
 #### MAJOR: Remove or rename an instance member of a base class
 
@@ -229,11 +269,14 @@ Breaks both callers and extending subclasses.
 
 ### `interface class` and `abstract interface class`
 
-An `interface` class can be implemented outside the library, but cannot be extended using `extends`.
+An `interface` class can be implemented outside the library, but cannot be
+extended using `extends`.
 
 #### MAJOR: Add any member to an interface class
 
-External classes can implement an `interface class`. Adding any new method, getter, setter, or field requires implementers to provide the new member, breaking compilation.
+External classes can implement an `interface class`. Adding any new method,
+getter, setter, or field requires implementers to provide the new member,
+breaking compilation.
 
 #### MAJOR: Remove or rename an instance member of an interface class
 
@@ -243,11 +286,14 @@ Breaks callers and implementers.
 
 ### `sealed class`
 
-A `sealed` class is implicitly abstract and cannot be extended, implemented, or mixed in outside the library. It is designed for exhaustive pattern matching.
+A `sealed` class is implicitly abstract and cannot be extended, implemented, or
+mixed in outside the library. It is designed for exhaustive pattern matching.
 
 #### MAJOR: Add a direct subtype to a sealed class family
 
-Adding a new subclass to a `sealed` class is a breaking change because exhaustive `switch` statements or pattern matches in consumer code that do not have a wildcard `_` or `default` case will fail to compile.
+Adding a new subclass to a `sealed` class is a breaking change because
+exhaustive `switch` statements or pattern matches in consumer code that do not
+have a wildcard `_` or `default` case will fail to compile.
 
 ```dart tag=bad
 sealed class Result {}
@@ -264,7 +310,8 @@ class Failure extends Result {}
 
 #### MINOR: Add a member to a sealed class
 
-External code cannot implement or extend a `sealed` class, so adding instance or static members is non-breaking.
+External code cannot implement or extend a `sealed` class, so adding instance or
+static members is non-breaking.
 
 ---
 
@@ -274,15 +321,20 @@ External code cannot implement or extend a `sealed` class, so adding instance or
 
 Classes using `with MyMixin` automatically receive the concrete implementation.
 
-*Note:* Adding a member is technically breaking if an external consumer used `implements MyMixin`, but the standard and intended usage of mixins is with the `with` keyword.
+*Note:* Adding a member is technically breaking if an external consumer used
+`implements MyMixin`, but the standard and intended usage of mixins is with the
+`with` keyword.
 
 #### MAJOR: Add an abstract member to a mixin
 
-Requires all classes applying the mixin to supply an implementation for the new abstract member.
+Requires all classes applying the mixin to supply an implementation for the new
+abstract member.
 
 #### MAJOR: Tighten the `on` constraint on a mixin
 
-Restricting the superclass requirements, such as from `on Object` to `on Widget`, prevents existing classes that do not meet the new requirement from mixing it in.
+Restricting the superclass requirements, such as from `on Object` to `on
+Widget`, prevents existing classes that do not meet the new requirement from
+mixing it in.
 
 ---
 
@@ -292,7 +344,8 @@ Type aliases define names for function types, records, or existing class types.
 
 ### MINOR: Add a new type alias
 
-Adding a new public `typedef` exposes a new type name without affecting existing code.
+Adding a new public `typedef` exposes a new type name without affecting existing
+code.
 
 ### MAJOR: Remove or rename a type alias
 
@@ -300,14 +353,22 @@ Any downstream code referencing the removed `typedef` name will fail to compile.
 
 ### MAJOR: Change the aliased type in a type alias
 
-Changing the underlying type that a type alias references, such as changing `typedef Callback = void Function(int);` to `typedef Callback = void Function(String);`, alters the expected type everywhere the alias is used, breaking consumers.
+Changing the underlying type that a type alias references, such as changing
+`typedef Callback = void Function(int);` to `typedef Callback = void
+Function(String);`, alters the expected type everywhere the alias is used,
+breaking consumers.
 
 ### MAJOR: Replace a `typedef` with a class or vice versa
 
-Replacing a type alias with a class, or a class with a type alias of the same name, is a breaking change:
+Replacing a type alias with a class, or a class with a type alias of the same
+name, is a breaking change:
 
-* **Function type alias $\rightarrow$ class:** In Dart, closure literals are function types, not class instances. Code assigning a closure like `Callback cb = (x) => ...;` will fail to compile against `class Callback`.
-* **Class type alias $\rightarrow$ subclass:** If `typedef A = B;` is replaced with `class A extends B {}`, `B` is no longer assignable to `A`, and bidirectional type identity is lost.
+* **Function type alias $\rightarrow$ class:** In Dart, closure literals are
+  function types, not class instances. Code assigning a closure like `Callback
+  cb = (x) => ...;` will fail to compile against `class Callback`.
+* **Class type alias $\rightarrow$ subclass:** If `typedef A = B;` is replaced
+  with `class A extends B {}`, `B` is no longer assignable to `A`, and
+  bidirectional type identity is lost.
 
 ---
 
@@ -315,7 +376,9 @@ Replacing a type alias with a class, or a class with a type alias of the same na
 
 ### MINOR: Add a new public constructor or factory
 
-Adding named constructors, such as `MyClass.named()`, or factories to an instantiable class provides new construction options without affecting existing callers.
+Adding named constructors, such as `MyClass.named()`, or factories to an
+instantiable class provides new construction options without affecting existing
+callers.
 
 ### MAJOR: Remove or rename a constructor
 
@@ -323,7 +386,8 @@ Breaks call sites that invoked the removed constructor.
 
 ### MAJOR: Add a required parameter to a constructor
 
-Existing constructor invocations that omit the new parameter will fail to compile.
+Existing constructor invocations that omit the new parameter will fail to
+compile.
 
 ### MINOR: Add an optional parameter to a constructor
 
@@ -335,11 +399,14 @@ Breaks any call site using `const MyClass(...)`.
 
 ### MINOR: Change a non-`const` constructor to `const`
 
-Adding `const` capability does not break existing non-const call sites using `MyClass(...)`.
+Adding `const` capability does not break existing non-const call sites using
+`MyClass(...)`.
 
-### MAJOR: Add a private constructor to a class with only the default constructor
+### MAJOR: Add a private constructor to a class with only a default constructor
 
-If a class previously had the default implicit constructor `MyClass()`, adding `MyClass._()` removes the default public constructor and prevents external instantiation or subclassing.
+If a class previously had the default implicit constructor `MyClass()`, adding
+`MyClass._()` removes the default public constructor and prevents external
+instantiation or subclassing.
 
 ---
 
@@ -356,7 +423,12 @@ Existing call sites omitting the parameter will fail to compile.
 Existing call sites can omit the new optional parameter without issue.
 
 :::note Tear-offs and optional parameters
-In Dart, tearing off a method like `final fn = obj.myMethod;` produces a function whose static type reflects its exact signature. Adding an optional parameter changes the static type of the tear-off, which can cause a type mismatch if the consumer assigned it to a specific `typedef`. In practice, adding optional parameters is standard for `MINOR` releases unless a package's primary contract relies on exact function signatures.
+In Dart, tearing off a method like `final fn = obj.myMethod;` produces a
+function whose static type reflects its exact signature. Adding an optional
+parameter changes the static type of the tear-off, which can cause a type
+mismatch if the consumer assigned it to a specific `typedef`. In practice,
+adding optional parameters is standard for `MINOR` releases unless a package's
+primary contract relies on exact function signatures.
 :::
 
 #### MAJOR: Remove any parameter
@@ -365,11 +437,15 @@ Call sites passing the removed argument will fail to compile.
 
 #### MAJOR: Rename a named parameter
 
-Call sites passing `func(paramName: value)` will fail to compile when `paramName` is changed.
+Call sites passing `func(paramName: value)` will fail to compile when
+`paramName` is changed.
 
 #### MAJOR: Reorder positional parameters
 
-Reordering positional parameters changes the expected argument positions at call sites. Even if the parameter types are identical, it causes callers to pass arguments to the wrong parameters, altering behavior or causing compile-time type errors.
+Reordering positional parameters changes the expected argument positions at call
+sites. Even if the parameter types are identical, it causes callers to pass
+arguments to the wrong parameters, altering behavior or causing compile-time
+type errors.
 
 #### MAJOR: Narrow a parameter type
 
@@ -377,37 +453,58 @@ Changing a parameter from `num` to `int` breaks callers that passed `double`.
 
 #### Widen a parameter type
 
-* **MINOR** for top-level functions and `final` class methods, because callers can pass a wider variety of inputs, such as widening a parameter from `Future<T>` to `FutureOr<T>` or from `int` to `num`.
-* **MAJOR** for methods on an implementable class, because it changes the signature required for external overrides.
+* **MINOR** for top-level functions and `final` class methods, because callers
+  can pass a wider variety of inputs, such as widening a parameter from
+  `Future<T>` to `FutureOr<T>` or from `int` to `num`.
+* **MAJOR** for methods on an implementable class, because it changes the
+  signature required for external overrides.
 
 #### MINOR: Change the default value of an optional parameter
 
-Does not break compilation or static type checks, but alters runtime behavior for callers omitting the argument.
+Does not break compilation or static type checks, but alters runtime behavior
+for callers omitting the argument.
 
 ---
 
 ### Return types
 
-Return types in Dart are **covariant**: callers expect a return value conforming to at least the declared type, while subclasses overriding a method must return a subtype of the superclass method's return type.
+Return types in Dart are **covariant**: callers expect a return value conforming
+to at least the declared type, while subclasses overriding a method must return
+a subtype of the superclass method's return type.
 
 #### Narrow a return type
 
-Moving down the type lattice to a more specific subtype, such as `num` to `int`, `Object?` to `String`, `void` to a specific type, or any type to `Never`:
+Moving down the type lattice to a more specific subtype, such as `num` to `int`,
+`Object?` to `String`, `void` to a specific type, or any type to `Never`:
 
 * **MINOR for callers of top-level functions and `final` class methods:**
-  * **Direct invocations:** Callers receive a more specific type with additional available members and tighter type safety.
-  * **Top types:** Changing a return type from `void` to a specific type `T` is a form of narrowing from the top type. Callers ignoring the return value continue to work, and callbacks passed to `void Function(...)` continue to compile because Dart treats `T Function(...)` as a subtype of `void Function(...)` for any type `T`.
-  * **Bottom type:** For functions that unconditionally throw or exit, narrowing the return type to `Never` is backward-compatible because `Never` is a universal subtype of all Dart types.
+  * **Direct invocations:** Callers receive a more specific type with additional
+    available members and tighter type safety.
+  * **Top types:** Changing a return type from `void` to a specific type `T` is
+    a form of narrowing from the top type. Callers ignoring the return value
+    continue to work, and callbacks passed to `void Function(...)` continue to
+    compile because Dart treats `T Function(...)` as a subtype of `void
+    Function(...)` for any type `T`.
+  * **Bottom type:** For functions that unconditionally throw or exit, narrowing
+    the return type to `Never` is backward-compatible because `Never` is a
+    universal subtype of all Dart types.
 * **MAJOR if the method is overridden in external subclasses or implementers:**
-  * External subclasses that declared the previous wider return type, such as `@override num method()` or `@override void method()`, will fail to compile with an override error, because the subclass's wider return type is not a valid subtype of the new narrower return type.
+  * External subclasses that declared the previous wider return type, such as
+    `@override num method()` or `@override void method()`, will fail to compile
+    with an override error, because the subclass's wider return type is not a
+    valid subtype of the new narrower return type.
 
 #### MAJOR: Widen a return type
 
-Moving up the type lattice to a broader supertype, such as `int` to `num`, `Future<T>` to `FutureOr<T>`, or a specific type `T` to `void`:
+Moving up the type lattice to a broader supertype, such as `int` to `num`,
+`Future<T>` to `FutureOr<T>`, or a specific type `T` to `void`:
 
 * **MAJOR for callers:**
-  * Callers expecting specific members on the returned object, like `int` methods or `.then()` on a `Future<T>`, will fail to compile.
-  * Changing a return type from a specific type `T` to `void` is a form of widening to the top type, breaking any callers attempting to read or use the returned value.
+  * Callers expecting specific members on the returned object, like `int`
+    methods or `.then()` on a `Future<T>`, will fail to compile.
+  * Changing a return type from a specific type `T` to `void` is a form of
+    widening to the top type, breaking any callers attempting to read or use the
+    returned value.
 * Subclasses that already returned a narrower subtype remain valid overrides.
 
 ---
@@ -416,19 +513,24 @@ Moving up the type lattice to a broader supertype, such as `int` to `num`, `Futu
 
 #### MAJOR: Add a bound to an unconstrained type parameter
 
-Adding a type parameter constraint, such as changing `class Store<T>` to `class Store<T extends State>`, breaks existing consumers using type arguments that do not conform to the new bound, like `Store<String>`.
+Adding a type parameter constraint, such as changing `class Store<T>` to `class
+Store<T extends State>`, breaks existing consumers using type arguments that do
+not conform to the new bound, like `Store<String>`.
 
 #### MAJOR: Tighten a type parameter bound
 
-Changing `<T extends Object>` to `<T extends num>` breaks callers using non-number type arguments.
+Changing `<T extends Object>` to `<T extends num>` breaks callers using
+non-number type arguments.
 
 #### MINOR: Loosen or remove a type parameter bound
 
-Changing `<T extends int>` to `<T extends num>` or removing a bound permits more types while remaining compatible with existing valid usages.
+Changing `<T extends int>` to `<T extends num>` or removing a bound permits more
+types while remaining compatible with existing valid usages.
 
 #### MAJOR: Add a type parameter without a default bound
 
-Call sites or type annotations lacking the type argument may fail to compile or change type inference behavior.
+Call sites or type annotations lacking the type argument may fail to compile or
+change type inference behavior.
 
 ---
 
@@ -436,7 +538,8 @@ Call sites or type annotations lacking the type argument may fail to compile or 
 
 ### MAJOR: Add a new enum value
 
-Adding a value to an `enum` breaks exhaustive `switch` statements and pattern matches in consumer code that do not include a `default` or wildcard `_` clause.
+Adding a value to an `enum` breaks exhaustive `switch` statements and pattern
+matches in consumer code that do not include a `default` or wildcard `_` clause.
 
 ### MAJOR: Remove or rename an enum value
 
@@ -444,11 +547,15 @@ Any code referencing `MyEnum.oldValue` will fail to compile.
 
 ### MAJOR: Reorder enum values
 
-Reordering enum declarations does not cause static compilation errors, but alters each value's `.index` property at runtime. If your package or downstream users serialize enums by index, like in databases or network protocols, reordering values is a breaking runtime change.
+Reordering enum declarations does not cause static compilation errors, but
+alters each value's `.index` property at runtime. If your package or downstream
+users serialize enums by index, like in databases or network protocols,
+reordering values is a breaking runtime change.
 
 ### MINOR: Add a member to an enhanced enum
 
-Enums cannot be extended or implemented, so adding members to an enhanced enum is safe for consumers.
+Enums cannot be extended or implemented, so adding members to an enhanced enum
+is safe for consumers.
 
 ---
 
@@ -458,7 +565,9 @@ Enums cannot be extended or implemented, so adding members to an enhanced enum i
 
 #### MINOR: Add an extension or extension method
 
-Adding extension methods is backward-compatible. Static ambiguity can occasionally occur if consumer code already has another extension in scope with the same method name.
+Adding extension methods is backward-compatible. Static ambiguity can
+occasionally occur if consumer code already has another extension in scope with
+the same method name.
 
 #### MAJOR: Remove or rename an extension method
 
@@ -466,11 +575,14 @@ Call sites invoking the extension member will fail to compile.
 
 #### MAJOR: Change the extended type: the `on` clause
 
-Changing the target type of an extension, such as changing `extension Helpers on String` to `extension Helpers on int`, removes the extension members from instances of the original type, breaking all existing call sites.
+Changing the target type of an extension, such as changing `extension Helpers on
+String` to `extension Helpers on int`, removes the extension members from
+instances of the original type, breaking all existing call sites.
 
 #### MINOR: Widen the extended type
 
-Widening the extended type, such as from `on int` to `on num`, allows the extension to be used on more types while preserving all existing call sites.
+Widening the extended type, such as from `on int` to `on num`, allows the
+extension to be used on more types while preserving all existing call sites.
 
 ---
 
@@ -482,7 +594,8 @@ Changes the underlying type contract and implicit constructors.
 
 #### MINOR: Add a member to an extension type
 
-Extension types cannot be implemented or extended with subtyping, so adding members is non-breaking.
+Extension types cannot be implemented or extended with subtyping, so adding
+members is non-breaking.
 
 #### MAJOR: Remove or rename a member of an extension type
 
@@ -492,45 +605,66 @@ Breaks call sites referencing the member.
 
 ## Errors and exceptions
 
-In Dart, all errors and exceptions are unchecked at compile time, meaning functions do not declare a `throws` clause in their signature. Determining the SemVer impact of changing thrown errors or exceptions depends on the distinction between [programmatic errors][effective_dart_errors] and [runtime exceptions][effective_dart_errors], as well as your documented API contract.
+In Dart, all errors and exceptions are unchecked at compile time, meaning
+functions do not declare a `throws` clause in their signature. Determining the
+SemVer impact of changing thrown errors or exceptions depends on the distinction
+between [programmatic errors][effective_dart_errors] and [runtime
+exceptions][effective_dart_errors], as well as your documented API contract.
 
 ### Documented exceptions
 
-When a library explicitly documents that a function or method throws a specific exception, such as `/// Throws [AuthException] on invalid credentials.`:
+When a library explicitly documents that a function or method throws a specific
+exception, such as `/// Throws [AuthException] on invalid credentials.`:
 
 #### MAJOR: Change or remove a documented exception type
 
-Changing the thrown exception, such as throwing `SecurityException` instead of `AuthException`, breaks downstream code with `try ... on AuthException catch (e)` handlers. The new exception will bypass the handler and crash at runtime.
+Changing the thrown exception, such as throwing `SecurityException` instead of
+`AuthException`, breaks downstream code with `try ... on AuthException catch
+(e)` handlers. The new exception will bypass the handler and crash at runtime.
 
 #### MINOR: Throw a subtype of the documented exception
 
-Throwing a more specific subtype, such as throwing `ExpiredTokenException extends AuthException`, is backward-compatible. Existing callers catching `on AuthException` continue to catch the new subtype without changes.
+Throwing a more specific subtype, such as throwing `ExpiredTokenException
+extends AuthException`, is backward-compatible. Existing callers catching `on
+AuthException` continue to catch the new subtype without changes.
 
 #### MAJOR: Throw an exception on previously succeeding inputs or states
 
-Throwing an exception in scenarios where the function previously succeeded alters control flow and breaks working consumer code.
+Throwing an exception in scenarios where the function previously succeeded
+alters control flow and breaks working consumer code.
 
 #### MINOR: Stop throwing an exception by succeeding instead
 
-Handling an edge case or providing a fallback so that a function succeeds instead of throwing is backward-compatible. Existing `try-catch` blocks will simply not be triggered.
+Handling an edge case or providing a fallback so that a function succeeds
+instead of throwing is backward-compatible. Existing `try-catch` blocks will
+simply not be triggered.
 
 ---
 
 ### Programmatic errors: `Error` subclasses
 
-Subclasses of `Error`, such as `ArgumentError`, `StateError`, `RangeError`, and `AssertionError`, indicate a bug in the caller's code, representing contract violations or invalid arguments. Consumers should not catch `Error` types in application logic.
+Subclasses of `Error`, such as `ArgumentError`, `StateError`, `RangeError`, and
+`AssertionError`, indicate a bug in the caller's code, representing contract
+violations or invalid arguments. Consumers should not catch `Error` types in
+application logic.
 
 #### MAJOR: Throw an `ArgumentError` or `StateError` on previously valid inputs
 
-Throwing an error for inputs or states that were previously valid and supported narrows the acceptable input domain, breaking existing callers.
+Throwing an error for inputs or states that were previously valid and supported
+narrows the acceptable input domain, breaking existing callers.
 
 #### PATCH: Add or refine `Error` checks for invalid arguments
 
-Throwing a clear `ArgumentError` or `StateError` on invalid inputs that previously caused undefined behavior, corrupted state, or internal unhandled exceptions, such as `TypeError` or `NoSuchMethodError`, is a bug fix or hardening improvement.
+Throwing a clear `ArgumentError` or `StateError` on invalid inputs that
+previously caused undefined behavior, corrupted state, or internal unhandled
+exceptions, such as `TypeError` or `NoSuchMethodError`, is a bug fix or
+hardening improvement.
 
 #### MINOR: Support previously invalid arguments without throwing an `Error`
 
-Expanding the acceptable input domain, such as accepting negative numbers or null values where an `ArgumentError` was previously thrown, is a backward-compatible feature addition.
+Expanding the acceptable input domain, such as accepting negative numbers or
+null values where an `ArgumentError` was previously thrown, is a
+backward-compatible feature addition.
 
 ---
 
@@ -538,19 +672,24 @@ Expanding the acceptable input domain, such as accepting negative numbers or nul
 
 ### MINOR: Increase the Dart SDK constraint lower bound
 
-Increasing the SDK constraint, such as from `sdk: ^3.5.0` to `sdk: ^3.6.0`, is standard for minor releases to adopt new language features, provided consumers on supported SDKs can resolve it.
+Increasing the SDK constraint, such as from `sdk: ^3.5.0` to `sdk: ^3.6.0`, is
+standard for minor releases to adopt new language features, provided consumers
+on supported SDKs can resolve it.
 
 ### MINOR: Export a new dependency
 
-Re-exporting another package's library using `export 'package:foo/foo.dart';` exposes new public API surface.
+Re-exporting another package's library using `export 'package:foo/foo.dart';`
+exposes new public API surface.
 
 ### MAJOR: Remove an exported dependency
 
-Consumers relying on your package re-exporting those symbols will fail to compile.
+Consumers relying on your package re-exporting those symbols will fail to
+compile.
 
 ### PATCH: Update dependencies within existing constraint ranges
 
-Normal maintenance as long as your package's own public API surface is unchanged.
+Normal maintenance as long as your package's own public API surface is
+unchanged.
 
 [effective_dart_errors]: /effective-dart/usage#error-handling
 [pub_semver]: {{site.pub-pkg}}/pub_semver

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -259,6 +259,10 @@ Call sites passing the removed argument will fail to compile.
 
 Call sites passing `func(paramName: value)` will fail to compile when `paramName` is changed.
 
+#### MAJOR: Reorder positional parameters
+
+Reordering positional parameters changes the expected argument positions at call sites. Even if the parameter types are identical, it causes callers to pass arguments to the wrong parameters, altering behavior or causing compile-time type errors.
+
 #### MAJOR: Narrow a parameter type (more specific / subtype)
 
 Changing a parameter from `num` to `int` breaks callers that passed `double`.

--- a/src/content/tools/pub/semver-rules.md
+++ b/src/content/tools/pub/semver-rules.md
@@ -970,6 +970,15 @@ void setPadding(int padding) {}
 void setPadding(num padding) {} // Safe: callers can now pass int or double without breaking existing callers.
 ```
 
+:::note Tear-offs and widened parameter types
+Widening a parameter type changes the static type of a tear-off. Because
+function parameters are contravariant, tearing off a function with a widened
+parameter type (like `void Function(Object)`) can prevent assigning narrower
+callbacks into an inferred variable (like `var callback = doStuff; callback =
+(String s) {};`). In practice, such situations are rare, and widening parameter
+types on top-level functions is treated as non-breaking.
+:::
+
 #### MINOR: Change the default value of an optional parameter
 
 Does not break compilation or static type checks, but alters runtime behavior
@@ -1262,6 +1271,18 @@ extension NumberUtils on num { // Widened from `on int` to `on num`: all existin
   num doubleValue() => this * 2;
 }
 ```
+
+:::note Extension ambiguity and name collisions
+Widening an extension's target type (or adding a new extension) can
+occasionally introduce static ambiguity if a downstream consumer already has
+another extension with the same member name in scope, because Dart's extension
+resolution rules may now rank them with equal specificity.
+
+In SemVer, potential naming collisions and resolution ambiguities in downstream
+wildcard scopes are treated as non-breaking (`MINOR`), because consumers can
+disambiguate them using explicit extension invocation syntax (such as
+`NumberUtils(x).doubleValue()`) or `hide` directives.
+:::
 
 ---
 

--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -11,6 +11,8 @@ approach to it.
 Consider this to be advanced information.
 To learn _why_ pub was designed the way it was, keep reading.
 If you want to _use_ pub, consult the [other docs][pub].
+For a reference guide on which API changes require major, minor, or patch version bumps,
+see [SemVer compatibility rules][semver-rules].
 
 Modern software development, especially web development, leans heavily on
 reusing lots and lots of existing code. That includes code _you_ wrote in the

--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -194,7 +194,7 @@ For simplicity's sake, avoid using `+` after the version reaches `1.0.0`.
 
 :::tip
 For a detailed guide on what constitutes a breaking change versus a minor
-or patch update across Dart language features, see
+or patch update across Dart language features, check out
 [SemVer compatibility and breaking changes][semver-rules].
 :::
 

--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -190,6 +190,12 @@ slot: going from `0.1.2` to `0.2.0` indicates a breaking change, going to
 doesn't affect the public API.
 For simplicity's sake, avoid using `+` after the version reaches `1.0.0`.
 
+:::tip
+For a detailed guide on what constitutes a breaking change versus a minor
+or patch update across Dart language features, see
+[SemVer compatibility and breaking changes][semver-rules].
+:::
+
 We've got almost all of the pieces we need to deal with versioning and API
 evolution now. Let's see how they play together and what pub does.
 
@@ -470,6 +476,7 @@ consult the [PubGrub][pubgrub] article on Medium.
 [bundler]: https://bundler.io
 [caret-syntax]: /tools/pub/dependencies#caret-syntax
 [semver]: https://semver.org/spec/v2.0.0-rc.1.html
+[semver-rules]: /tools/pub/semver-rules
 [lockfile]: /resources/glossary#lockfile
 [content hash]: /resources/glossary#pub-content-hash
 [pubgrub]: https://medium.com/@nex3/pubgrub-2fb6470504f

--- a/src/content/tools/pub/versioning.md
+++ b/src/content/tools/pub/versioning.md
@@ -12,7 +12,7 @@ Consider this to be advanced information.
 To learn _why_ pub was designed the way it was, keep reading.
 If you want to _use_ pub, consult the [other docs][pub].
 For a reference guide on which API changes require major, minor, or patch version bumps,
-see [SemVer compatibility rules][semver-rules].
+check out [SemVer compatibility rules][semver-rules].
 
 Modern software development, especially web development, leans heavily on
 reusing lots and lots of existing code. That includes code _you_ wrote in the

--- a/src/data/sidenav/default.yml
+++ b/src/data/sidenav/default.yml
@@ -182,6 +182,8 @@
           permalink: /tools/pub/security-advisories
         - title: Versioning
           permalink: /tools/pub/versioning
+        - title: SemVer rules
+          permalink: /tools/pub/semver-rules
         - title: Custom package repositories
           permalink: /tools/pub/custom-package-repositories
         - title: What not to commit


### PR DESCRIPTION
This PR adds a comprehensive SemVer compatibility and breaking changes reference guide for Dart packages (similar to [Cargo's SemVer reference](https://doc.rust-lang.org/cargo/reference/semver.html)).

Related to discussion in https://github.com/dart-lang/sdk/issues/63970.

This is a first draft - AI generated and then manually reviewed and wordsmithed a bit.

The current state can be viewed at https://dart-dev--pr7433-semver-rules-doc-3cv6edzw.web.app/tools/pub/semver-rules

cc @sigurdm @brianquinlan @devmil