### PR TITLE
Fix incorrect example in `future_sync_value`

### DIFF
--- a/src/data/linter_rules.json
+++ b/src/data/linter_rules.json
@@ -1224,7 +1224,7 @@
     "incompatible": [],
     "sets": [],
     "fixStatus": "hasFix",
-    "details": "**DO** use `Future.syncValue` when the argument is synchronous.\n\n**BAD:**\n```dart\nFuture<int> f() => Future.value(1);\n```\n\n**GOOD:**\n```dart\nFuture<int> f() => Future.value(1);\n```",
+    "details": "**DO** use `Future.syncValue` when the argument is synchronous.\n\n**BAD:**\n```dart\nFuture<int> f() => Future.value(1);\n```\n\n**GOOD:**\n```dart\nFuture<int> f() => Future.syncValue(1);\n```",
     "sinceDartSdk": "3.14"
   },
   {


### PR DESCRIPTION
Updates the example in the `future_sync_value` lint to use the expected `Future.syncValue` instead of `Future.value`.

Fixes https://github.com/dart-lang/site-www/issues/7446

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
