### PR TITLE
Fix callout container syntax in dart:core library overview

### DIFF
--- a/src/content/libraries/dart-core.md
+++ b/src/content/libraries/dart-core.md
@@ -159,7 +159,7 @@ var codeUnitList = 'Never odd or even'.codeUnits.toList();
 assert(codeUnitList[0] == 78);
 ```
 
-:::
+:::note
 In many cases, you want to work with
 Unicode grapheme clusters
 as opposed to pure code units.


### PR DESCRIPTION
Fixes missing `note` alert type on the Unicode grapheme clusters callout container in `src/content/libraries/dart-core.md`.

Closes #7345

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

<details>
  <summary>Contribution guidelines:</summary><br>

  - See our [contributor guide](https://github.com/dart-lang/site-www/blob/main/CONTRIBUTING.md) for general expectations for PRs.
  - Larger or significant changes should be discussed in an issue before creating a PR.
  - Code changes should generally follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
  - Updates to [code excerpts](https://github.com/flutter/website/tree/main/packages/excerpter) indicated by `<?code-excerpt` need to be updated in their source `.dart` file as well.
</details>
