### PR TITLE
Update package-layout.md to include skills directory

### DIFF
--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -315,9 +315,8 @@ in there and organize it with subdirectories however you like.
 
 ## Public Agent Skills
 
-Guides or other skills for AI Agents should be placed under the `skills`
-directory, using the normal [Agent Skills](https://agentskills.io/)
-structure.
+Place skills and instructions for AI agents in the `skills` directory,
+following the [Agent Skills specification][agentskills].
 
 When users run the [`skills` CLI]({{site.pub-pkg}}/skills),
 it searches this directory and surfaces available skills to install.

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -319,10 +319,12 @@ Guides or other skills for AI Agents should be placed under the `skills`
 directory, using the normal [Agent Skills](https://agentskills.io/)
 structure.
 
-When users run the [skills cli]({{site.pub-pkg}}/skills) it will
-search in this directory and surface all your skills for them to install.
-This makes it trivial to distribute your official skills, matched up to the
-specific version of your package that your users are actually using.
+When users run the [`skills` CLI]({{site.pub-pkg}}/skills),
+it searches this directory and surfaces available skills to install.
+This makes it easy to distribute official skills
+matched to the specific package version users have installed.
+
+[agentskills]: https://agentskills.io
 
 
 ## Implementation files

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -319,7 +319,7 @@ Guides or other skills for AI Agents should be placed under the `skills`
 directory, using the normal [Agent Skills](https://agentskills.io/)
 structure.
 
-When users run the [skills cli](https://pub.dev/packages/skills) it will
+When users run the [skills cli]({{site.pub-pkg}}/skills) it will
 search in this directory and surface all your skills for them to install.
 This makes it trivial to distribute your official skills, matched up to the
 specific version of your package that your users are actually using.

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -47,7 +47,8 @@ might look like:
       - beans.dart
       - queso.dart
   - skills/
-    - some-skill/SKILL.md
+   - some-skill/
+      - SKILL.md
   - test/
     - enchilada_test.dart
     - tortilla_test.dart
@@ -313,7 +314,7 @@ These go in the top-level `lib` directory. You can put any kind of file
 in there and organize it with subdirectories however you like.
 
 
-## Public Agent Skills
+### Public agent skills
 
 Place skills and instructions for AI agents in the `skills` directory,
 following the [Agent Skills specification][agentskills].

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -202,8 +202,8 @@ Change all calls to `sayHello()` to instead be to `sayHi()`.
 
 ## Public directories
 
-Three directories in your package are public to other packages: `lib` and
-`bin`. You place [public libraries](#public-libraries) in `lib`,
+Three directories in your package are public to other packages: `lib`, `bin`,
+and `skills`. You place [public libraries](#public-libraries) in `lib`,
 [public tools](#public-tools) in `bin`, and
 [Agent Skills](https://agentskills.io/) in `skills`.
 
@@ -319,7 +319,7 @@ Guides or other skills for AI Agents should be placed under the `skills`
 directory, using the normal [Agent Skills](https://agentskills.io/)
 structure.
 
-When you users run the [skills cli](https://pub.dev/packages/skills) it will
+When users run the [skills cli](https://pub.dev/packages/skills) it will
 search in this directory and surface all your skills for them to install.
 This makes it trivial to distribute your official skills, matched up to the
 specific version of your package that your users are actually using.

--- a/src/content/tools/pub/package-layout.md
+++ b/src/content/tools/pub/package-layout.md
@@ -46,6 +46,8 @@ might look like:
     - src/
       - beans.dart
       - queso.dart
+  - skills/
+    - some-skill/SKILL.md
   - test/
     - enchilada_test.dart
     - tortilla_test.dart
@@ -200,9 +202,10 @@ Change all calls to `sayHello()` to instead be to `sayHi()`.
 
 ## Public directories
 
-Two directories in your package are public to other packages: `lib` and
-`bin`. You place [public libraries](#public-libraries) in `lib` and
-[public tools](#public-tools) in `bin`.
+Three directories in your package are public to other packages: `lib` and
+`bin`. You place [public libraries](#public-libraries) in `lib`,
+[public tools](#public-tools) in `bin`, and
+[Agent Skills](https://agentskills.io/) in `skills`.
 
 ### Public libraries
 
@@ -308,6 +311,18 @@ for consumers of the package to use.
 
 These go in the top-level `lib` directory. You can put any kind of file
 in there and organize it with subdirectories however you like.
+
+
+## Public Agent Skills
+
+Guides or other skills for AI Agents should be placed under the `skills`
+directory, using the normal [Agent Skills](https://agentskills.io/)
+structure.
+
+When you users run the [skills cli](https://pub.dev/packages/skills) it will
+search in this directory and surface all your skills for them to install.
+This makes it trivial to distribute your official skills, matched up to the
+specific version of your package that your users are actually using.
 
 
 ## Implementation files


### PR DESCRIPTION
Added information about the new 'skills' directory for AI Agent Skills and updated the public directories section to include it. This directory is read by the `skills` CLI - an official Dart team CLI for installing skills shipped with packages.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.