### PR TITLE
Document no longer supporting final/var non-declaring parameters

### DIFF
--- a/src/content/resources/breaking-changes.md
+++ b/src/content/resources/breaking-changes.md
@@ -99,7 +99,7 @@ don't include the section header.
 - Type promotion in inner generator functions has been [adjusted][62889].
 
 [62889]: {{site.repo.dart.sdk}}/issues/62889
-[primary constructors]: /language/primary-constructors
+[primary constructors]: /language/primary-constructors#field-declarations-in-parameters
 [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
 
 ### Libraries

--- a/src/content/resources/breaking-changes.md
+++ b/src/content/resources/breaking-changes.md
@@ -89,9 +89,18 @@ don't include the section header.
 
 ### Language
 
+- {{versioned}}
+  You can no longer use `final` or `var` on non-declaring parameters.
+  Dart now reserves both for
+  [declaring parameters in primary constructors][primary constructors].
+  Remove `final` or `var` from affected parameter declarations.
+  If you still want to avoid flag parameter reassignment,
+  you can use the [`parameter_assignments`][] lint rule.
 - Type promotion in inner generator functions has been [adjusted][62889].
 
 [62889]: {{site.repo.dart.sdk}}/issues/62889
+[primary constructors]: /language/primary-constructors
+[`parameter_assignments`]: /tools/linter-rules/parameter_assignments
 
 ### Libraries
 

--- a/src/content/resources/breaking-changes.md
+++ b/src/content/resources/breaking-changes.md
@@ -94,7 +94,7 @@ don't include the section header.
   Dart now reserves both for
   [declaring parameters in primary constructors][primary constructors].
   Remove `final` or `var` from affected parameter declarations.
-  If you still want to avoid flag parameter reassignment,
+  If you still want to prevent parameter reassignment,
   you can use the [`parameter_assignments`][] lint rule.
 - Type promotion in inner generator functions has been [adjusted][62889].
 

--- a/src/data/changelog.yml
+++ b/src/data/changelog.yml
@@ -21,7 +21,7 @@
     You can no longer use `final` or `var` on non-declaring parameters.
     Dart now reserves both for declaring parameters in primary constructors.
     Remove `final` or `var` from affected parameter declarations.
-    If you still want to avoid flag parameter reassignment,
+    If you still want to prevent parameter reassignment,
     you can use the [`parameter_assignments`][] lint rule.
 
     [`parameter_assignments`]: /tools/linter-rules/parameter_assignments

--- a/src/data/changelog.yml
+++ b/src/data/changelog.yml
@@ -16,6 +16,22 @@
 - version: 3.13.0
   releaseDate: 2026-08-12
   area: Language
+  subArea: Parameter declarations
+  description: |
+    You can no longer use `final` or `var` on non-declaring parameters.
+    Dart now reserves both for declaring parameters in primary constructors.
+    Remove `final` or `var` from affected parameter declarations.
+    If you still want to avoid flag parameter reassignment,
+    you can use the [`parameter_assignments`][] lint rule.
+
+    [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
+  tags:
+    - versioned
+  link: 'https://dart.dev/language/primary-constructors#field-declarations-in-parameters'
+# --------------------------------------------------
+- version: 3.13.0
+  releaseDate: 2026-08-12
+  area: Language
   subArea: Type promotion
   description: |
     **Breaking change**:


### PR DESCRIPTION
Add an entry to the site's [changelog](https://dart.dev/changelog) and [breaking change index](https://dart.dev/resources/breaking-changes) about dropping support for `var` and `final` on non-declaring formal parameters. This change was made to improve consistency for primary constructors and is language versioned, not breaking.

Contributes to https://github.com/dart-lang/sdk/issues/64151

