### PR TITLE
Migrate site skill validation to published skills_lint package

### DIFF
--- a/site/pubspec.yaml
+++ b/site/pubspec.yaml
@@ -42,17 +42,13 @@ dev_dependencies:
       ref: 6d50799f4dc347398863b83f5dc46d1da8f6c5cd
   build_runner: ^2.15.1
   build_web_compilers: ^4.8.5
-  dart_skills_lint:
-    git:
-      url: https://github.com/flutter/skills
-      path: tool/dart_skills_lint
-      ref: 3d375fed1b5f6bfe2881a601a4b6d91588594ff6
   jaspr_builder: ^0.23.1
   jaspr_test: ^0.23.1
   lints: ^6.1.0
   logging: ^1.3.0
   sass: ^1.102.0
   sass_builder: ^2.4.0+1
+  skills_lint: ^0.5.1
   test: ^1.31.1
 
 jaspr:

--- a/site/skills_lint.yaml
+++ b/site/skills_lint.yaml
@@ -1,4 +1,4 @@
-dart_skills_lint:
+skills_lint:
   rules:
     check-relative-paths: error
     check-absolute-paths: error

--- a/site/test/lint_skills_test.dart
+++ b/site/test/lint_skills_test.dart
@@ -3,13 +3,13 @@ library;
 
 import 'dart:io';
 
-import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
+import 'package:skills_lint/skills_lint.dart';
 import 'package:test/test.dart';
 
 final String _configFilePath = Directory.current.path.endsWith('site')
-    ? 'dart_skills_lint.yaml'
-    : 'site/dart_skills_lint.yaml';
+    ? 'skills_lint.yaml'
+    : 'site/skills_lint.yaml';
 
 void main() {
   test('Run skills linter', () async {

--- a/src/content/security.md
+++ b/src/content/security.md
@@ -68,7 +68,7 @@ Dart does not have a bug bounty program.
 ## Receiving security updates
 
 Depending on the issue and the fix release, an announcement will be made to
-[dart-announce](https://groups.google.com/a/dartlang.org/g/announce) 
+[dart-announce]({{site.announce}}) 
 mailing list.
 
 ## Best practices


### PR DESCRIPTION
skills_lint is published. The changes are because the new location also changed the package name. 
- @reidbaker 

Agent authored description
---
Migrates the \`site\` skill validation tooling from the legacy \`dart_skills_lint\` repository dependency to the official published [\`skills_lint: ^0.5.1\`](https://pub.dev/packages/skills_lint) package on pub.dev.

### Summary of Changes
- Updated \`site/pubspec.yaml\` to depend on \`skills_lint: ^0.5.1\`.
- Renamed \`site/dart_skills_lint.yaml\` to \`site/skills_lint.yaml\` and updated the root configuration key.
- Updated \`site/test/lint_skills_test.dart\` imports and configuration filename.
- Verified with \`dart pub get\`, \`dart analyze --fatal-infos\`, and \`dart test\`.