### PR TITLE
Highlight parameter modifier restriction in primary constructors doc

### DIFF
--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -9,6 +9,14 @@ class User(String name);
 
 // #enddocregion declaring-parameters
 
+// #docregion declaring-parameters-error
+// Valid: Primary constructor declaring parameter.
+class PointFinal(final int x, final int y);
+
+// Compile-time error in Dart 3.13+ (extraneous_modifier):
+void printValue(int x) => print(x);
+// #enddocregion declaring-parameters-error
+
 // #docregion initializer-scope
 class DeltaPoint(final int x, int delta) {
   // Accesses 'x' and 'delta' parameters directly!

--- a/examples/language/lib/primary_constructors/primary_constructors.dart
+++ b/examples/language/lib/primary_constructors/primary_constructors.dart
@@ -13,7 +13,7 @@ class User(String name);
 // Valid: Primary constructor declaring parameter.
 class PointFinal(final int x, final int y);
 
-// Compile-time error in Dart 3.13+ (extraneous_modifier):
+// Compile-time error (extraneous_modifier):
 void printValue(int x) => print(x);
 // #enddocregion declaring-parameters-error
 

--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -220,7 +220,7 @@ a compile-time error (`extraneous_modifier`).
 For code examples and migration steps, see
 [Parameter modifier restrictions][].
 
-To enforce immutable parameters as a style choice,
+To enforce non-reassignable parameters as a style choice,
 use the [`parameter_assignments`][] lint rule instead.
 
 ## The main() function {:#main}

--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -213,14 +213,15 @@ assert(say('Bob', 'Howdy') == 'Bob says Howdy with a carrier pigeon');
 
 ### Parameter modifiers
 
-In Dart 3.13 and later,
-you can't use modifiers like `final` or `var` for normal function parameters.
-These keywords are now reserved exclusively for
+The `final` and `var` parameter modifiers are reserved exclusively for
 [primary constructors][] to declare instance fields.
+Using them on formal parameters in any other declaration produces
+a compile-time error (`extraneous_modifier`).
+For code examples and migration steps, see
+[Parameter modifier restrictions][].
 
-If you wish to enforce immutability for function parameters,
-use lints like [`parameter_assignments`][] instead
-of the `final` keyword in the signature.
+To enforce immutable parameters as a style choice,
+use the [`parameter_assignments`][] lint rule instead.
 
 ## The main() function {:#main}
 
@@ -706,5 +707,6 @@ is not `final`) an external setter.
 [trailing commas]: /language/collections#lists
 [primary constructors]: /language/primary-constructors
 [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
+[Parameter modifier restrictions]: /language/primary-constructors#parameter-modifier-restrictions
 
 

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -82,9 +82,26 @@ class Point(var int x, var int y);
 class User(String name);
 ```
 
-Because `final` and `var` modifiers on parameters are reserved exclusively
-for declaring parameters in primary constructors,
-you can't use them on parameters in other kinds of functions.
+:::warning Breaking change: Parameter modifiers
+In Dart 3.13 and later, `final` and `var` parameter modifiers are
+reserved exclusively for declaring parameters in primary constructors.
+Using `final` or `var` on formal parameters in any other declaration—including
+top-level functions, methods, closures, and in-body constructors—produces
+a compile-time error (`extraneous_modifier`).
+
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters-error)" replace="/PointFinal/Point/g; /void printValue\(int x\)/void printValue(final int x)/g"?>
+```dart
+// Valid: Primary constructor declaring parameter.
+class Point(final int x, final int y);
+
+// Compile-time error in Dart 3.13+ (extraneous_modifier):
+void printValue(final int x) => print(x);
+```
+
+To fix this error, remove the modifier or run [`dart fix`][].
+To enforce immutable parameters as a style choice in Dart 3.13 and later,
+use the [`parameter_assignments`][] lint rule instead.
+:::
 
 For extension types, the primary constructor must have exactly one parameter.
 This parameter is always a declaring parameter, even if you omit the modifier.
@@ -363,14 +380,16 @@ when using primary constructors:
 *   **Restriction on `final` and `var` in normal function parameters**:
     With primary constructors,
     using `final` or `var` on formal parameters in normal functions
-    becomes a compile-time error.
+    becomes a compile-time error (`extraneous_modifier`).
     They are reserved exclusively for
     declaring parameters in primary constructors.
+    To migrate your code, remove `final` or `var` from affected parameters,
+    or run [`dart fix`][].
     Note that the lints `avoid_final_parameters` and
     `var_with_no_type_annotation` only work with
     a [language version][] of 3.12 or lower.
     To enforce immutable parameters as a style choice in Dart 3.13 and later,
-    use the [`parameter_assignments`][] linter rule.
+    use the [`parameter_assignments`][] lint rule.
 *   **The `factory` method edge case**:
     If you have a method named `factory` with no return type
     (for example, `factory() {}`),
@@ -380,6 +399,7 @@ when using primary constructors:
     to avoid this conflict.
 :::
 
+[`dart fix`]: /tools/dart-fix
 [language version]: /language/versioning
 [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
 [potentially constant]: /resources/glossary#potentially-constant

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -358,6 +358,12 @@ when using primary constructors:
     You can only use the `covariant` modifier on a
     primary constructor parameter if it's a
     mutable declaring parameter (uses the `var` modifier).
+*   **The `factory` method edge case**:
+    If you have a method named `factory` with no return type
+    (for example, `factory() {}`),
+    the compiler parses it as a concise factory constructor.
+    Make sure such methods have an explicit return type
+    (for example, `void factory() {}`) to avoid this conflict.
 
 ### Parameter modifier restrictions {:#parameter-modifier-restrictions}
 
@@ -384,7 +390,6 @@ If you are on a [language version][] of 3.12 or lower,
 you can enable the [`avoid_final_parameters`][] and
 [`var_with_no_type_annotation`][] lint rules to proactively find and
 remove these modifiers ahead of upgrading to Dart 3.13.
-
 
 [`avoid_final_parameters`]: /tools/linter-rules/avoid_final_parameters
 [`dart fix`]: /tools/dart-fix

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -84,30 +84,17 @@ class User(String name);
 
 For extension types, the primary constructor must have exactly one parameter.
 This parameter is always a declaring parameter, even if you omit the modifier.
-You can use the `final` modifier, but it's an error to use `var`.
 
 Mixin classes can only have a primary constructor
 with no parameters, body, or initializer list.
 
-:::warning Breaking change: Parameter modifiers
-The `final` and `var` parameter modifiers are
-reserved exclusively for declaring parameters in primary constructors.
-Using `final` or `var` on formal parameters in any other declaration
-(such as top-level functions, methods, closures, and in-body constructors)
-produces a compile-time error (`extraneous_modifier`).
-
-<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters-error)" replace="/PointFinal/Point/g; /void printValue\(int x\)/void printValue(final int x)/g"?>
-```dart
-// Valid: Primary constructor declaring parameter.
-class Point(final int x, final int y);
-
-// Compile-time error (extraneous_modifier):
-void printValue(final int x) => print(x);
-```
-
-To fix this error, remove the modifier or run [`dart fix`][].
-To enforce immutable parameters as a style choice,
-use the [`parameter_assignments`][] lint rule instead.
+:::warning
+**Breaking change: Parameter modifiers**
+Because `final` and `var` on parameters are now reserved for
+declaring parameters in primary constructors,
+you can't use them on parameters in other declarations.
+For code examples and migration guidance, see
+[Parameter modifier restrictions](#parameter-modifier-restrictions).
 :::
 
 <a id="primary-initializer-scope" aria-hidden="true"></a>
@@ -371,35 +358,37 @@ when using primary constructors:
     You can only use the `covariant` modifier on a
     primary constructor parameter if it's a
     mutable declaring parameter (uses the `var` modifier).
-    Using `covariant` on `final` or non-declaring parameters is a
-    compile-time error because they don't induce a setter.
 
-:::warning
-**Important breaking changes and edge cases:**
+### Parameter modifier restrictions {:#parameter-modifier-restrictions}
 
-*   **Restriction on `final` and `var` in normal function parameters**:
-    With primary constructors,
-    using `final` or `var` on formal parameters in normal functions
-    becomes a compile-time error (`extraneous_modifier`).
-    They are reserved exclusively for
-    declaring parameters in primary constructors.
-    To migrate your code, remove `final` or `var` from affected parameters,
-    or run [`dart fix`][].
-    Note that the lints `avoid_final_parameters` and
-    `var_with_no_type_annotation` only work with
-    a [language version][] of 3.12 or lower.
-    To enforce immutable parameters as a style choice,
-    use the [`parameter_assignments`][] lint rule.
-*   **The `factory` method edge case**:
-    If you have a method named `factory` with no return type
-    (for example, `factory() {}`),
-    the compiler parses it as a factory constructor
-    after primary constructors ship.
-    Make sure such methods have explicit return types
-    to avoid this conflict.
-:::
+The `final` and `var` parameter modifiers are reserved exclusively for
+declaring parameters in primary constructors.
+Using `final` or `var` on formal parameters in any other declaration
+(such as top-level functions, methods, closures, and in-body constructors)
+produces a compile-time error (`extraneous_modifier`).
 
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters-error)" replace="/PointFinal/Point/g; /printValue\(/printValue(final /g"?>
+```dart
+// Valid: Primary constructor declaring parameter.
+class Point(final int x, final int y);
+
+// Compile-time error (extraneous_modifier):
+void printValue(final int x) => print(x);
+```
+
+To fix this error, remove the modifier or run [`dart fix`][].
+To enforce immutable parameters as a style choice,
+use the [`parameter_assignments`][] lint rule instead.
+
+If you are on a [language version][] of 3.12 or lower,
+you can enable the [`avoid_final_parameters`][] and
+[`var_with_no_type_annotation`][] lint rules to proactively find and
+remove these modifiers ahead of upgrading to Dart 3.13.
+
+
+[`avoid_final_parameters`]: /tools/linter-rules/avoid_final_parameters
 [`dart fix`]: /tools/dart-fix
 [language version]: /language/versioning
 [`parameter_assignments`]: /tools/linter-rules/parameter_assignments
 [potentially constant]: /resources/glossary#potentially-constant
+[`var_with_no_type_annotation`]: /tools/linter-rules/var_with_no_type_annotation

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -88,8 +88,7 @@ This parameter is always a declaring parameter, even if you omit the modifier.
 Mixin classes can only have a primary constructor
 with no parameters, body, or initializer list.
 
-:::warning
-**Breaking change: Parameter modifiers**
+:::warning New parameter modifier restrictions
 Because `final` and `var` on parameters are now reserved for
 declaring parameters in primary constructors,
 you can't use them on parameters in other declarations.

--- a/src/content/language/primary-constructors.md
+++ b/src/content/language/primary-constructors.md
@@ -82,33 +82,33 @@ class Point(var int x, var int y);
 class User(String name);
 ```
 
-:::warning Breaking change: Parameter modifiers
-In Dart 3.13 and later, `final` and `var` parameter modifiers are
-reserved exclusively for declaring parameters in primary constructors.
-Using `final` or `var` on formal parameters in any other declaration—including
-top-level functions, methods, closures, and in-body constructors—produces
-a compile-time error (`extraneous_modifier`).
-
-<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters-error)" replace="/PointFinal/Point/g; /void printValue\(int x\)/void printValue(final int x)/g"?>
-```dart
-// Valid: Primary constructor declaring parameter.
-class Point(final int x, final int y);
-
-// Compile-time error in Dart 3.13+ (extraneous_modifier):
-void printValue(final int x) => print(x);
-```
-
-To fix this error, remove the modifier or run [`dart fix`][].
-To enforce immutable parameters as a style choice in Dart 3.13 and later,
-use the [`parameter_assignments`][] lint rule instead.
-:::
-
 For extension types, the primary constructor must have exactly one parameter.
 This parameter is always a declaring parameter, even if you omit the modifier.
 You can use the `final` modifier, but it's an error to use `var`.
 
 Mixin classes can only have a primary constructor
 with no parameters, body, or initializer list.
+
+:::warning Breaking change: Parameter modifiers
+The `final` and `var` parameter modifiers are
+reserved exclusively for declaring parameters in primary constructors.
+Using `final` or `var` on formal parameters in any other declaration
+(such as top-level functions, methods, closures, and in-body constructors)
+produces a compile-time error (`extraneous_modifier`).
+
+<?code-excerpt "language/lib/primary_constructors/primary_constructors.dart (declaring-parameters-error)" replace="/PointFinal/Point/g; /void printValue\(int x\)/void printValue(final int x)/g"?>
+```dart
+// Valid: Primary constructor declaring parameter.
+class Point(final int x, final int y);
+
+// Compile-time error (extraneous_modifier):
+void printValue(final int x) => print(x);
+```
+
+To fix this error, remove the modifier or run [`dart fix`][].
+To enforce immutable parameters as a style choice,
+use the [`parameter_assignments`][] lint rule instead.
+:::
 
 <a id="primary-initializer-scope" aria-hidden="true"></a>
 
@@ -388,7 +388,7 @@ when using primary constructors:
     Note that the lints `avoid_final_parameters` and
     `var_with_no_type_annotation` only work with
     a [language version][] of 3.12 or lower.
-    To enforce immutable parameters as a style choice in Dart 3.13 and later,
+    To enforce immutable parameters as a style choice,
     use the [`parameter_assignments`][] lint rule.
 *   **The `factory` method edge case**:
     If you have a method named `factory` with no return type


### PR DESCRIPTION
Add a prominent warning callout and code excerpt under 'Field declarations in parameters' explaining that \`final\` and \`var\` are reserved exclusively for declaring parameters in Dart 3.13+.
Show a valid vs. invalid comparison highlighting the \`extraneous_modifier\` error on ordinary function parameters, and provide migration guidance pointing to \`dart fix\` and the \`parameter_assignments\` lint rule.

Fixes #7475