### PR TITLE
Fix inline feedback analytics event name

### DIFF
--- a/site/lib/src/analytics/analytics.dart
+++ b/site/lib/src/analytics/analytics.dart
@@ -16,6 +16,6 @@ abstract class Analytics {
   void sendEvent(String eventName, Map<String, Object?> parameters);
 
   void sendFeedback(bool helpful) {
-    sendEvent('feedback', {'feedback_type': helpful ? 'up' : 'down'});
+    sendEvent('inline_feedback', {'feedback_type': helpful ? 'up' : 'down'});
   }
 }


### PR DESCRIPTION
Updates `Analytics.sendFeedback` to dispatch `inline_feedback` instead of `feedback`.

Google Tag Manager (`GTM-5VSZM5J`) uses a custom event trigger configured to match `event == 'inline_feedback'` to fire the GA4 Event tag. Because the Jaspr migration dispatched `event: 'feedback'`, the GTM trigger was not matched, preventing thumbs-up and thumbs-down feedback events from reaching Google Analytics.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.