### PR TITLE
Clarify for in loop explanation

### DIFF
--- a/examples/misc/test/language_tour/functions_test.dart
+++ b/examples/misc/test/language_tour/functions_test.dart
@@ -98,8 +98,11 @@ ORANGES: 7
       const list = ['apples', 'bananas', 'oranges'];
       // #docregion anon-func
       var uppercaseList = list.map((item) => item.toUpperCase()).toList();
-      uppercaseList.forEach((item) => print('$item: ${item.length}'));
       // #enddocregion anon-func
+
+      for (var item in uppercaseList) {
+        print('$item: ${item.length}');
+      }
     }
 
     expect(testAnonymousFunction, prints(indexedFruit));

--- a/src/content/language/functions.md
+++ b/src/content/language/functions.md
@@ -330,13 +330,12 @@ The following code block contains the function's body:
 }
 ```
 
-The following example defines an anonymous function
-with an untyped parameter, `item`.
-The anonymous function passes it to the `map` function.
+The following example passes an anonymous function
+with an untyped parameter, `item`,
+to the `map` function.
 The `map` function, invoked for each item in the list,
 converts each string to uppercase.
-Then, the anonymous function passed to `forEach`,
-prints each converted string with its length.
+Then, a `for-in` loop prints each converted string with its length.
 
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anonymous-function)"?>
 ```dart
@@ -378,7 +377,6 @@ to verify that it is functionally equivalent.
 <?code-excerpt "misc/test/language_tour/functions_test.dart (anon-func)"?>
 ```dart
 var uppercaseList = list.map((item) => item.toUpperCase()).toList();
-uppercaseList.forEach((item) => print('$item: ${item.length}'));
 ```
 
 ## Lexical scope


### PR DESCRIPTION
Updates the anonymous functions section on `/language/functions` to match the example code:
- Updates the prose to describe passing the anonymous function to `map()` and using a `for-in` loop to print each item, removing the outdated reference to `forEach`. Follows up on #7351.
- Trims the `anon-func` excerpt in `functions_test.dart` to just the arrow function definition, ensuring it matches the instruction ("Paste the following line...") while keeping the example compliant with Effective Dart's `avoid_function_literals_in_foreach_calls`.
