### PR TITLE
Update server docs for Cloud Functions for Firebase and Admin SDK

### DIFF
--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -62,10 +62,10 @@ To get started, see the
 When running server-side Dart on Google Cloud, consider your architectural
 needs:
 
-* **Choose Cloud Functions for Firebase** if you're building a Flutter
-  backend that requires serverless event handling, lightweight HTTP or callable
-  APIs, or tight integration with Firebase Authentication and Cloud Firestore
-  without managing containers.
+* **Choose Cloud Functions for Firebase** if you're building backends for
+  Flutter apps that require serverless event handling, lightweight HTTP or
+  callable APIs, or tight integration with Firebase Authentication and Cloud
+  Firestore without managing containers.
 * **Choose Cloud Run** if you need custom Docker containers, long-running
   processes, WebSocket connections (such as with Serverpod), or custom
   networking configurations.

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -63,8 +63,8 @@ needs:
 
 * **Choose Cloud Functions for Firebase** if you're building a Flutter
   backend that requires serverless event handling, lightweight HTTP or callable
-  APIs, or tight integration with Firebase Auth and Firestore without managing
-  containers.
+  APIs, or tight integration with Firebase Authentication and Cloud Firestore
+  without managing containers.
 * **Choose Cloud Run** if you need custom Docker containers, long-running
   processes, WebSocket connections (such as with Serverpod), or custom
   networking configurations.

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -26,9 +26,8 @@ To run Dart in the Cloud, we recommend using serverless computing solutions.
 ### Cloud Run
 
 You can use Cloud Run's flexible container support,
-combined with Dart's Docker images, to run server-side Dart code.
 Creating scalable, high performance APIs and event-driven apps
-are good use cases for Cloud Run's serverless platform,
+are good use cases for the Cloud Run serverless platform,
 which frees developers from managing infrastructure.
 
 Examples of Dart servers implemented to run on Cloud Run are

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -57,6 +57,19 @@ To get started, see the
 [firebase-docs]: https://firebase.google.com/docs/functions/start-dart
 [firebase-repo]: https://github.com/firebase/firebase-functions-dart
 
+### Choosing between Cloud Run and Cloud Functions for Firebase
+
+When running server-side Dart on Google Cloud, consider your architectural
+needs:
+
+* **Choose Cloud Functions for Firebase** if you're building a Flutter
+  backend that requires serverless event handling, lightweight HTTP or callable
+  APIs, or tight integration with Firebase Auth and Firestore without managing
+  containers.
+* **Choose Cloud Run** if you need custom Docker containers, long-running
+  processes, WebSocket connections (such as with Serverpod), or custom
+  networking configurations.
+
 ## Other solutions
 
 Depending on your needs, you might also want to consider running Dart on the

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -27,7 +27,7 @@ To run Dart in the Cloud, we recommend using serverless computing solutions.
 
 You can use Cloud Run's flexible container support,
 combined with Dart's Docker images, to run server-side Dart code.
-Creating scalable, high performance APIs and event-driven apps
+Scalable, high-performance APIs and event-driven apps
 are good use cases for the Cloud Run serverless platform,
 which frees developers from managing infrastructure.
 

--- a/src/content/server/google-cloud.md
+++ b/src/content/server/google-cloud.md
@@ -26,6 +26,7 @@ To run Dart in the Cloud, we recommend using serverless computing solutions.
 ### Cloud Run
 
 You can use Cloud Run's flexible container support,
+combined with Dart's Docker images, to run server-side Dart code.
 Creating scalable, high performance APIs and event-driven apps
 are good use cases for the Cloud Run serverless platform,
 which frees developers from managing infrastructure.

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -33,10 +33,10 @@ requirements:
 
 | Architecture / framework | Best suited for | Key advantages | Data and persistence |
 | :--- | :--- | :--- | :--- |
-| **[Cloud Functions for Firebase](https://firebase.google.com/docs/functions/start-dart)** | Serverless HTTP and callable APIs, Flutter backends | Shared code with Flutter, zero server management, fast AOT cold starts | Cloud Firestore and Cloud Storage via [`firebase_admin_sdk`]({{site.pub-pkg}}/firebase_admin_sdk) |
+| **[Cloud Functions for Firebase][firebase-docs]** | Serverless HTTP and callable APIs, Flutter backends | Shared code with Flutter, zero server management, fast AOT cold starts | Cloud Firestore and Cloud Storage via [`firebase_admin_sdk`][] |
 | **[Serverpod](https://serverpod.dev)** | Full-stack applications requiring relational databases | Code generation, built-in authentication, database migrations | PostgreSQL, Redis |
 | **[Dart Frog](https://dart-frog.dev/)** | Fast REST APIs, modular microservices | Minimalistic routing, dependency injection, built on Shelf | Database agnostic |
-| **[Shelf]({{site.pub-pkg}}/shelf)** | Custom web servers, composable middleware | Lightweight primitive, modular architecture | Database agnostic |
+| **[Shelf][`shelf`]** | Custom web servers, composable middleware | Lightweight primitive, modular architecture | Database agnostic |
 
 {:.table .table-striped}
 

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -33,8 +33,8 @@ requirements:
 
 | Architecture / framework | Best suited for | Key advantages | Data and persistence |
 | :--- | :--- | :--- | :--- |
-| **[Cloud Functions for Firebase][firebase-docs]** | Serverless HTTP and callable APIs, Flutter backends | Shared code with Flutter, zero server management, fast AOT cold starts | Cloud Firestore and Cloud Storage via [`firebase_admin_sdk`][] |
-| **[Serverpod](https://serverpod.dev)** | Full-stack applications requiring relational databases | Code generation, built-in authentication, database migrations | PostgreSQL, Redis |
+| **[Cloud Functions for Firebase][firebase-docs]** | Serverless HTTP and callable APIs, backends for Flutter apps | Shared code with Flutter, zero server management, fast AOT cold starts | Cloud Firestore and Cloud Storage via [`firebase_admin_sdk`][] |
+| **[Serverpod](https://serverpod.dev)** | Full-stack applications, backends for Flutter apps | Built-in authentication, file storage, server functions, and code generation | PostgreSQL and Redis databases (built-in ORM and migrations) |
 | **[Dart Frog](https://dart-frog.dev/)** | Fast REST APIs, modular microservices | Minimalistic routing, dependency injection, built on Shelf | Database agnostic |
 | **[Shelf][`shelf`]** | Custom web servers, composable middleware | Lightweight primitive, modular architecture | Database agnostic |
 

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -26,7 +26,7 @@ that can help you develop command-line and server apps.
 : [Install the Dart SDK](/get-dart) to get the core Dart
   libraries and [tools](/tools).
 
-## Server architectures and frameworks {#frameworks}
+## Server architectures and frameworks {:#frameworks}
 
 Dart supports multiple backend architectures depending on your application
 requirements:

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -49,7 +49,7 @@ For additional options, see [#server packages on pub.dev][server-pkgs].
 
 Write Cloud Functions for Firebase using Dart to enable full-stack development,
 reuse code between your client and backend, and respond to Firebase triggers.
-Dart Cloud Functions compile Ahead-of-Time (AOT) to native binaries that deploy
+Dart Cloud Functions compile ahead-of-time (AOT) to native binaries that deploy
 directly to Google Cloud infrastructure, delivering fast cold-start performance
 with minimal memory overhead.
 

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -26,29 +26,33 @@ that can help you develop command-line and server apps.
 : [Install the Dart SDK](/get-dart) to get the core Dart
   libraries and [tools](/tools).
 
-## Frameworks
+## Server architectures and frameworks {#frameworks}
 
-Server-side frameworks written in Dart include:
+Dart supports multiple backend architectures depending on your application
+requirements:
 
-[Serverpod](https://serverpod.dev)
-: A scalable app server that supports code generation,
-  authentication, real-time communication, databases, and caching.
+| Architecture / framework | Best suited for | Key advantages | Data and persistence |
+| :--- | :--- | :--- | :--- |
+| **[Cloud Functions for Firebase](https://firebase.google.com/docs/functions/start-dart)** | Serverless HTTP and callable APIs, Flutter backends | Shared code with Flutter, zero server management, fast AOT cold starts | Cloud Firestore and Cloud Storage via [`firebase_admin_sdk`]({{site.pub-pkg}}/firebase_admin_sdk) |
+| **[Serverpod](https://serverpod.dev)** | Full-stack applications requiring relational databases | Code generation, built-in authentication, database migrations | PostgreSQL, Redis |
+| **[Dart Frog](https://dart-frog.dev/)** | Fast REST APIs, modular microservices | Minimalistic routing, dependency injection, built on Shelf | Database agnostic |
+| **[Shelf]({{site.pub-pkg}}/shelf)** | Custom web servers, composable middleware | Lightweight primitive, modular architecture | Database agnostic |
 
-[Dart Frog](https://dart-frog.dev/)
-: A fast, minimalistic backend framework for Dart.
+{:.table .table-striped}
 
-More tools
-: The [Tools](/tools) page links to generally useful tools,
-  such as Dart plugins for your favorite IDE or editor.
-
+For more tools and IDE plugins, see the [Tools](/tools) page.
 For additional options, see [#server packages on pub.dev][server-pkgs].
 
 [server-pkgs]: {{site.pub-pkg}}?q=topic%3Aserver
 
-## Cloud Functions for Firebase
+## Building serverless backends with Cloud Functions for Firebase
 
 Write Cloud Functions for Firebase using Dart to enable full-stack development,
 reuse code between your client and backend, and respond to Firebase triggers.
+Dart Cloud Functions compile Ahead-of-Time (AOT) to native binaries that deploy
+directly to Google Cloud infrastructure, delivering fast cold-start performance
+with minimal memory overhead.
+
 To get started, see the
 [Cloud Functions for Firebase documentation][firebase-docs].
 
@@ -65,6 +69,24 @@ To get started, see the
 [firebase-docs]: https://firebase.google.com/docs/functions/start-dart
 [firebase-repo]: https://github.com/firebase/firebase-functions-dart
 
+### Sharing code between Flutter apps and Dart backends
+
+When you use Dart for both your Flutter client and Firebase backend, you can
+organize your workspace into a monorepo or multi-package structure with a
+shared package:
+
+```text
+my_project/
+├── packages/
+│   ├── app/           # Flutter frontend application
+│   ├── functions/     # Cloud Functions for Firebase in Dart
+│   └── shared/        # Shared models, DTOs, and validation logic
+```
+
+By placing data classes, JSON serialization logic, and validation rules in
+`package:shared`, any change to your data models propagates across both client
+and server, keeping your frontend and backend synchronized.
+
 ## Samples
 
 [A simple Dart HTTP server][simple-sample]
@@ -73,15 +95,12 @@ To get started, see the
   * Is deployable on Cloud Run.
 
 [A Dart HTTP server that uses Cloud Firestore][cloud-sample]
-: * Uses the Cloud Firestore features in the [`googleapis`][] package.
-  * Also uses the [`googleapis_auth`][], [`shelf`][], and
-    [`shelf_router`][] packages.
+: * Uses Cloud Firestore with the [`firebase_admin_sdk`][] package.
   * Is deployable on Cloud Run.
 
 [simple-sample]: {{site.repo.dart.samples}}/tree/main/server/simple
 [cloud-sample]: {{site.repo.dart.samples}}/tree/main/server/google_apis
-[`googleapis`]: {{site.pub-pkg}}/googleapis
-[`googleapis_auth`]: {{site.pub-pkg}}/googleapis_auth
+[`firebase_admin_sdk`]: {{site.pub-pkg}}/firebase_admin_sdk
 [`shelf`]: {{site.pub-pkg}}/shelf
 [`shelf_router`]: {{site.pub-pkg}}/shelf_router
 [`shelf_static`]: {{site.pub-pkg}}/shelf_static

--- a/src/content/server/index.md
+++ b/src/content/server/index.md
@@ -61,7 +61,7 @@ To get started, see the
 
 [Firebase Admin SDK package]({{site.pub-pkg}}/firebase_admin_sdk)
 : Access Firebase services securely from backend servers or Cloud Functions.
-  Use it to manage data, send notifications, or verify auth tokens.
+  Use it to manage data, send notifications, or verify authentication tokens.
 
 [Firebase Functions for Dart repository][firebase-repo]
 : GitHub repository with quickstart guides, examples, and source code.

--- a/src/content/server/libraries.md
+++ b/src/content/server/libraries.md
@@ -61,7 +61,7 @@ and [general-purpose packages][] such as `logging`:
 | [grpc]({{site.pub-pkg}}/grpc)           | Implements [gRPC][], a high performance, open source, general RPC framework that puts mobile and HTTP/2 first.        |
 | [shelf]({{site.pub-pkg}}/shelf)         | Provides a model for web server middleware that encourages composition and easy reuse.                                |
 | [dart_frog]({{site.pub-pkg}}/dart_frog)                   | A fast, minimalistic backend framework for Dart built on top of Shelf.                                                |
-| [firebase_admin_sdk]({{site.pub-pkg}}/firebase_admin_sdk) | Accesses Firebase services like Firestore and Auth securely on the server.                                            |
+| [firebase_admin_sdk]({{site.pub-pkg}}/firebase_admin_sdk) | Accesses Firebase services like Cloud Firestore and Firebase Authentication securely on the server.                  |
 | [firebase_functions]({{site.pub-pkg}}/firebase_functions) | Writes serverless backend functions and APIs for Cloud Functions for Firebase.                                        |
 | [serverpod]({{site.pub-pkg}}/serverpod)                   | A scalable app server that supports code generation, authentication, real-time communication, databases, and caching. |
 

--- a/src/content/server/libraries.md
+++ b/src/content/server/libraries.md
@@ -60,8 +60,10 @@ and [general-purpose packages][] such as `logging`:
 | [crypto]({{site.pub-pkg}}/crypto)       | Implements cryptographic hashing functions for algorithms such as SHA-1, SHA-256, MD5, and HMAC.                      |
 | [grpc]({{site.pub-pkg}}/grpc)           | Implements [gRPC][], a high performance, open source, general RPC framework that puts mobile and HTTP/2 first.        |
 | [shelf]({{site.pub-pkg}}/shelf)         | Provides a model for web server middleware that encourages composition and easy reuse.                                |
-| [dart_frog]({{site.pub-pkg}}/dart_frog) | A fast, minimalistic backend framework for Dart built on top of Shelf.                                                |
-| [serverpod]({{site.pub-pkg}}/serverpod) | A scalable app server that supports code generation, authentication, real-time communication, databases, and caching. |
+| [dart_frog]({{site.pub-pkg}}/dart_frog)                   | A fast, minimalistic backend framework for Dart built on top of Shelf.                                                |
+| [firebase_admin_sdk]({{site.pub-pkg}}/firebase_admin_sdk) | Accesses Firebase services like Firestore and Auth securely on the server.                                            |
+| [firebase_functions]({{site.pub-pkg}}/firebase_functions) | Writes serverless backend functions and APIs for Cloud Functions for Firebase.                                        |
+| [serverpod]({{site.pub-pkg}}/serverpod)                   | A scalable app server that supports code generation, authentication, real-time communication, databases, and caching. |
 
 {:.table .table-striped .nowrap}
 

--- a/src/content/server/libraries.md
+++ b/src/content/server/libraries.md
@@ -57,13 +57,13 @@ and [general-purpose packages][] such as `logging`:
 
 | **Package**                             | **Description**                                                                                                       |
 |-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| [crypto]({{site.pub-pkg}}/crypto)       | Implements cryptographic hashing functions for algorithms such as SHA-1, SHA-256, MD5, and HMAC.                      |
-| [grpc]({{site.pub-pkg}}/grpc)           | Implements [gRPC][], a high performance, open source, general RPC framework that puts mobile and HTTP/2 first.        |
-| [shelf]({{site.pub-pkg}}/shelf)         | Provides a model for web server middleware that encourages composition and easy reuse.                                |
+| [crypto]({{site.pub-pkg}}/crypto)                         | Implements cryptographic hashing functions for algorithms such as SHA-1, SHA-256, MD5, and HMAC.                      |
 | [dart_frog]({{site.pub-pkg}}/dart_frog)                   | A fast, minimalistic backend framework for Dart built on top of Shelf.                                                |
 | [firebase_admin_sdk]({{site.pub-pkg}}/firebase_admin_sdk) | Accesses Firebase services like Cloud Firestore and Firebase Authentication securely on the server.                  |
 | [firebase_functions]({{site.pub-pkg}}/firebase_functions) | Writes serverless backend functions and APIs for Cloud Functions for Firebase.                                        |
+| [grpc]({{site.pub-pkg}}/grpc)                             | Implements [gRPC][], a high performance, open source, general RPC framework that puts mobile and HTTP/2 first.        |
 | [serverpod]({{site.pub-pkg}}/serverpod)                   | A scalable app server that supports code generation, authentication, real-time communication, databases, and caching. |
+| [shelf]({{site.pub-pkg}}/shelf)                           | Provides a model for web server middleware that encourages composition and easy reuse.                                |
 
 {:.table .table-striped .nowrap}
 


### PR DESCRIPTION
This PR updates the server documentation (`server/index.md`, `server/libraries.md`, and `server/google-cloud.md`) to highlight full-stack Dart capabilities with Cloud Functions for Firebase and the Firebase Admin SDK for Dart.

### Summary of changes

* **`src/content/server/index.md`:**
  * Adds an architectural comparison matrix contrasting Cloud Functions for Firebase, Serverpod, Dart Frog, and Shelf.
  * Adds clause-style (T3) headings (`## Building serverless backends with Cloud Functions for Firebase`) and details fast AOT cold starts on Google Cloud infrastructure.
  * Documents the Shared Package Pattern (`packages/shared`) for sharing data models, validation logic, and serialization between Flutter apps and Dart backends.
  * Updates the Cloud Firestore sample entry to reference `package:firebase_admin_sdk` rather than the legacy `googleapis` package.

* **`src/content/server/libraries.md`:**
  * Adds `firebase_functions` and `firebase_admin_sdk` to the Server packages catalog in alphabetical order.

* **`src/content/server/google-cloud.md`:**
  * Adds decision guidance comparing Cloud Run (custom containers, WebSockets, Serverpod) with Cloud Functions for Firebase (serverless HTTP/callable functions).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.