### PR TITLE
Add event listener and stream helper migration examples to package:web doc

### DIFF
--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -220,15 +220,14 @@ element.insertAdjacentHTML('beforeend', html.toJS); // Add
 var checkbox = CheckboxInputElement(); // Remove
 var checkbox = HTMLInputElement()..type='checkbox'; // Add
 
+element.text = 'Hello'; // Remove
+element.textContent = 'Hello'; // Add
+
 element.querySelectorAll('a').classes.add('link'); // Remove
 for (final a in JSImmutableListWrapper(element.querySelectorAll('a'))) {
   a.classList.add('a');
 } // Add
 ```
-
-{% comment %}
-TODO: add more examples
-{% endcomment -%}
 
 ### Type tests
 
@@ -263,15 +262,36 @@ calling the member.
 Learn how to use interop conversion methods from the [Conversions][]
 section of the JS types page.
 
+For example, when passing callbacks to `addEventListener`,
+convert the Dart function into a `JSFunction` using `.toJS`:
+
 ```dart
 window.addEventListener('click', callback); // Remove
 window.addEventListener('click', callback.toJS); // Add
+
+// Callbacks with parameters also use .toJS:
+button.addEventListener('click', ((Event event) {
+  final mouseEvent = event as MouseEvent;
+  print('Clicked at (${mouseEvent.clientX}, ${mouseEvent.clientY})');
+}).toJS);
 ```
 
-{% comment %}
-TODO: Think of a better example. People will likely use the stream helpers
-instead of `addEventListener`.
-{% endcomment -%}
+If you prefer subscribing to DOM events using Dart `Stream`s
+rather than `addEventListener`, you can use the stream helper extensions
+from `package:web`:
+
+```dart
+// Using the stream helper extension (same API shape as dart:html):
+button.onClick.listen((event) {
+  // event is already typed as MouseEvent without needing a cast:
+  print('Clicked at (${event.clientX}, ${event.clientY})');
+});
+
+// Or using EventStreamProviders directly:
+EventStreamProviders.clickEvent.forTarget(button).listen((event) {
+  print('Clicked at (${event.clientX}, ${event.clientY})');
+});
+```
 
 Generally, you can spot which methods need a conversion because they'll be
 flagged with some variation of the exception:

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -16,7 +16,7 @@ import 'package:web/web.dart';
 
 void main() {
   final div = document.querySelector('div')!;
-  div.text = 'Text set at ${DateTime.now()}';
+  div.textContent = 'Text set at ${DateTime.now()}';
 }
 ```
 
@@ -270,9 +270,8 @@ window.addEventListener('click', callback); // Remove
 window.addEventListener('click', callback.toJS); // Add
 
 // Callbacks with parameters also use .toJS:
-button.addEventListener('click', ((Event event) {
-  final mouseEvent = event as MouseEvent;
-  print('Clicked at (${mouseEvent.clientX}, ${mouseEvent.clientY})');
+button.addEventListener('click', ((MouseEvent event) {
+  print('Clicked at (${event.clientX}, ${event.clientY})');
 }).toJS);
 ```
 

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -269,11 +269,33 @@ convert the Dart function into a `JSFunction` using `.toJS`:
 window.addEventListener('click', callback); // Remove
 window.addEventListener('click', callback.toJS); // Add
 
-// Callbacks with parameters also use .toJS:
 button.addEventListener('click', ((MouseEvent event) {
   print('Clicked at (${event.clientX}, ${event.clientY})');
 }).toJS);
 ```
+:::note
+Each call to `.toJS` creates a *new* `JSFunction` object, even if the
+underlying Dart function is identical. If you need to remove a listener
+later with `removeEventListener`, store the converted `JSFunction` in a
+variable and reuse that same reference in both calls, rather than calling
+`.toJS` again:
+
+```dart
+// Remove
+final handler = (web.MouseEvent event) {
+  print('Clicked at (${event.clientX}, ${event.clientY})');
+};
+button.addEventListener('click', handler.toJS);
+button.removeEventListener('click', handler.toJS); // Won't work! Different JSFunction
+
+// Add
+final handler = ((web.MouseEvent event) {
+  print('Clicked at (${event.clientX}, ${event.clientY})');
+}).toJS;
+button.addEventListener('click', handler);
+button.removeEventListener('click', handler); // Will Work: same reference
+```
+:::
 
 If you prefer subscribing to DOM events using Dart `Stream`s
 rather than `addEventListener`, you can use the stream helper extensions

--- a/src/content/interop/js-interop/package-web.md
+++ b/src/content/interop/js-interop/package-web.md
@@ -268,32 +268,20 @@ convert the Dart function into a `JSFunction` using `.toJS`:
 ```dart
 window.addEventListener('click', callback); // Remove
 window.addEventListener('click', callback.toJS); // Add
-
-button.addEventListener('click', ((MouseEvent event) {
-  print('Clicked at (${event.clientX}, ${event.clientY})');
-}).toJS);
+// where callback's first parameter accepts Event.
 ```
+
 :::note
-Each call to `.toJS` creates a *new* `JSFunction` object, even if the
-underlying Dart function is identical. If you need to remove a listener
-later with `removeEventListener`, store the converted `JSFunction` in a
-variable and reuse that same reference in both calls, rather than calling
-`.toJS` again:
+Calling `.toJS` creates a new `JSFunction` each time.
+To later remove the listener with `removeEventListener`,
+store the converted `JSFunction` in a variable and pass
+that same instance to both methods:
 
 ```dart
-// Remove
-final handler = (web.MouseEvent event) {
-  print('Clicked at (${event.clientX}, ${event.clientY})');
-};
-button.addEventListener('click', handler.toJS);
-button.removeEventListener('click', handler.toJS); // Won't work! Different JSFunction
-
-// Add
-final handler = ((web.MouseEvent event) {
-  print('Clicked at (${event.clientX}, ${event.clientY})');
-}).toJS;
-button.addEventListener('click', handler);
-button.removeEventListener('click', handler); // Will Work: same reference
+final jsCallback = callback.toJS;
+window.addEventListener('click', jsCallback);
+// ...
+window.removeEventListener('click', jsCallback);
 ```
 :::
 


### PR DESCRIPTION

This PR updates the `package:web` migration doc file by addressing open TODO placeholders and adding   
 practical DOM manipulation and event handling examples:                                                       
                                                                                                              
#### Link on the website : [package:web](https://dart.dev/interop/js-interop/package-web)
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

---
