### PR TITLE
Align tutorial objectives, content, and quizzes for data and error ha…

### DIFF
--- a/src/content/learn/tutorial/data-and-json.md
+++ b/src/content/learn/tutorial/data-and-json.md
@@ -8,16 +8,16 @@ description: >-
 layout: learn
 ---
 
-In this chapter, you learn how to work with
+In this chapter, learn how to work with
 [JSON (JavaScript Object Notation)][] data in Dart.
-You create data models to represent Wikipedia API responses,
+Create data models to represent Wikipedia API responses,
 use `dart:convert` to decode JSON text into Dart collections, and
 use pattern matching to extract and validate data.
 
 <SummaryCard>
 title: What you'll accomplish
 items:
-  - title: Understand JSON handling in Dart
+  - title: Learn about JSON handling in Dart
     icon: convert_to_text
   - title: Set up a multi-package workspace
     icon: workspaces
@@ -60,7 +60,7 @@ involves two steps:
 
     const String jsonString = '{"title": "Dart", "pageid": 12345}';
 
-    // jsonDecode parses the string into a Map<String, dynamic>
+    // jsonDecode parses the string, cast to a Map<String, Object?>
     final Map<String, Object?> jsonMap =
         jsonDecode(jsonString) as Map<String, Object?>;
     ```
@@ -554,7 +554,7 @@ article titles, descriptions (which are ignored), and URLs:
       discards the descriptions array, which your application does not need.
 
 You now have typed data models to represent Wikipedia API responses.
-In upcoming chapters, you use `package:test` to test
+In upcoming chapters, use `package:test` to test
 how data is deserialized and use `package:http` to fetch
 live JSON data from the API.
 
@@ -565,7 +565,7 @@ title: What you accomplished
 subtitle: Here's a summary of what you built and learned in this lesson.
 completed: true
 items:
-  - title: Understood JSON handling in Dart
+  - title: Learned about JSON handling in Dart
     icon: convert_to_text
     details: >-
       You explored how `dart:convert` and `jsonDecode()`

--- a/src/content/learn/tutorial/data-and-json.md
+++ b/src/content/learn/tutorial/data-and-json.md
@@ -335,20 +335,24 @@ Create a Dart class to represent this summary.
     }
     ```
 
-    This code defines a `Summary` class with properties that
-    correspond to the fields in the JSON response from the Wikipedia API.
-    The `fromJson` factory constructor uses [pattern matching][] to
-    validate the JSON structure, extract the data, and
-    create a new `Summary` instance.
-    Because the `description` field is optional in Wikipedia's API,
-    the `switch` expression has two cases: one that extracts `description`
-    when present, and one that matches when it is omitted.
-    The `toString` method provides a convenient way to
-    print the contents of the `Summary` object.
+    This code defines a `Summary` class to represent the fields returned
+    by the Wikipedia summary endpoint:
 
-    > [!NOTE]
-    > Your editor might flag `import 'title_set.dart'` and `TitlesSet`
-    > as unresolved references until you create `TitlesSet` in Task 4.
+    * **`fromJson` pattern matching:** While you can access map keys
+      individually with manual casting (such as `json['pageid'] as int`),
+      the `fromJson` factory constructor uses [pattern matching][] to
+      validate the structure, confirm types, and extract values in a single
+      declarative expression.
+    * **`switch` expression:** Provides two cases to handle Wikipedia's
+      optional `description` field: one that extracts it when present,
+      and a fallback case that matches when it is omitted.
+    * **`toString`:** Provides a readable string representation of
+      the `Summary` object for debugging.
+
+    :::note
+    Your editor might flag `import 'title_set.dart'` and `TitlesSet`
+    as unresolved references until you create `TitlesSet` in Task 4.
+    :::
 
 [pattern matching]: /language/patterns
 
@@ -407,14 +411,13 @@ Create that class next.
     }
     ```
 
-    This code defines a `TitlesSet` class with properties that correspond to
-    the title information in the JSON response from the Wikipedia API.
-    Unlike `Summary`, which handles optional fields with a `switch` expression,
-    `TitlesSet` validates a single structure using an `if case` statement.
-    If the JSON map matches the pattern, the constructor creates the
-    `TitlesSet` instance; otherwise, it throws a `FormatException`.
-    The `toString` method provides a convenient way to
-    print the contents of the `TitlesSet` object.
+    This code defines a `TitlesSet` class to hold the title variants
+    returned by the Wikipedia API.
+    Unlike `Summary`, which uses a `switch` expression for optional fields,
+    `TitlesSet` has a fixed structure and validates all three fields at once
+    using an `if case` statement.
+    If the JSON map does not match the pattern, it throws a
+    `FormatException`.
 
 ### Task 5: Create the Article class
 
@@ -460,17 +463,20 @@ Create a Dart class to represent an article.
     }
     ```
 
-    This code defines an `Article` class with properties for
-    the title and extract of an article.
-    Because this method converts a JSON map into a `List<Article>` rather
-    than a single `Article` instance, it is defined as a `static` method
-    named `listFromJson`.
-    The `for` loop uses Dart's object pattern destructuring
-    (`final MapEntry(:value)`) to directly extract the `value` of each
-    entry without manual property access.
-    The `toJson` method converts the `Article` object back into a JSON map.
-    The `toString` method provides a convenient way to
-    print the contents of the `Article` object.
+    This code defines an `Article` class to represent an article's
+    title and extract:
+
+    * **`listFromJson`:** Unlike previous models that create a single instance,
+      the Wikipedia search endpoint returns multiple articles in a map.
+      Dart constructors only return a single instance, so `Article` uses
+      a `static` method named `listFromJson` to return a `List<Article>`.
+    * **Object pattern destructuring:** The `for` loop uses
+      `final MapEntry(:value)` to extract each entry's value directly
+      without manual property access.
+    * **`toJson`:** Converts an `Article` instance back into a JSON map.
+      In Dart convention, `toJson()` returns a `Map<String, Object?>`
+      that you can pass to `jsonEncode()` from `dart:convert`
+      when serializing an object to a JSON string.
 
 ### Task 6: Create the SearchResults class
 
@@ -535,14 +541,17 @@ article titles, descriptions (which are ignored), and URLs:
     }
     ```
 
-    This code defines a `SearchResults` class with a
-    list of `SearchResult` objects and a search term.
-    Because the search API returns a JSON array rather than an object,
-    `fromJson` accepts a `List<Object?>`.
-    The `if case` statement uses a list pattern `[...]` to match the array
-    positionally, using the wildcard `_` to discard the unused descriptions.
-    The `toString` method provides a convenient way to
-    print the contents of the `SearchResults` object.
+    This code defines two classes: `SearchResult` to hold an individual
+    article's title and URL, and `SearchResults` to hold the list of
+    results along with the search query:
+
+    * **`fromJson` with `List<Object?>`:** The constructor accepts
+      a `List<Object?>` rather than a `Map<String, Object?>` to match
+      the top-level JSON array returned by Wikipedia's search API.
+    * **List pattern matching:** The `if case` statement uses a list pattern
+      `[...]` to match the array positionally and extract each section.
+    * **Wildcard pattern (`_`):** The `Iterable _` pattern matches and
+      discards the descriptions array, which your application does not need.
 
 You now have typed data models to represent Wikipedia API responses.
 In upcoming chapters, you use `package:test` to test

--- a/src/content/learn/tutorial/data-and-json.md
+++ b/src/content/learn/tutorial/data-and-json.md
@@ -8,26 +8,23 @@ description: >-
 layout: learn
 ---
 
-In this chapter, you'll learn how to work with
+In this chapter, you learn how to work with
 [JSON (JavaScript Object Notation)][] data in Dart.
-JSON is a common format for data exchange on the web, and
-you'll often encounter it when working with APIs.
-You'll learn how to convert JSON data into Dart objects,
-making it easier to work with in your application.
-You'll use the [`dart:convert` library][],
-the `jsonDecode` function, and pattern matching.
+You create data models to represent Wikipedia API responses,
+use `dart:convert` to decode JSON text into Dart collections, and
+use pattern matching to extract and validate data.
 
 <SummaryCard>
 title: What you'll accomplish
 items:
-  - title: Create data model classes for JSON data
-    icon: data_object
-  - title: Use dart:convert to work with JSON data
+  - title: Understand JSON handling in Dart
     icon: convert_to_text
-  - title: Use pattern matching to extract data from JSON objects
-    icon: bento
   - title: Set up a multi-package workspace
     icon: workspaces
+  - title: Create data model classes for JSON data
+    icon: data_object
+  - title: Use pattern matching in fromJson constructors
+    icon: bento
 </SummaryCard>
 
 [JSON (JavaScript Object Notation)]:  https://en.wikipedia.org/wiki/JSON
@@ -43,11 +40,64 @@ Before you begin this chapter, ensure you:
 
 [classes]: /language/classes
 
+## How Dart handles JSON
+
+JSON is a text-based format for
+representing structured data such as objects, arrays, numbers, and strings.
+When you interact with web APIs, responses arrive as JSON strings.
+
+In Dart, converting a JSON string into a strongly-typed data model
+involves two steps:
+
+1.  **Decode the JSON string into Dart collections.**
+    The [`dart:convert` library][] provides the `jsonDecode()` function,
+    which parses a raw JSON string into a standard Dart collection:
+    - A JSON object (`{...}`) becomes a `Map<String, dynamic>`.
+    - A JSON array (`[...]`) becomes a `List<dynamic>`.
+
+    ```dart
+    import 'dart:convert';
+
+    const String jsonString = '{"title": "Dart", "pageid": 12345}';
+
+    // jsonDecode parses the string into a Map<String, dynamic>
+    final Map<String, Object?> jsonMap =
+        jsonDecode(jsonString) as Map<String, Object?>;
+    ```
+
+1.  **Convert the decoded collections into custom model objects.**
+    While you can read values directly from a `Map` (like `jsonMap['title']`),
+    using raw maps throughout your application lacks type safety,
+    invites typos, and provides no IDE autocompletion.
+
+    To solve this, Dart applications define data model classes with
+    `factory` constructors, conventionally named `fromJson`, that
+    instantiate typed objects from decoded maps:
+
+    ```dart
+    class ArticleSummary {
+      final String title;
+      final int pageid;
+
+      ArticleSummary({required this.title, required this.pageid});
+
+      factory ArticleSummary.fromJson(Map<String, Object?> json) {
+        return ArticleSummary(
+          title: json['title'] as String,
+          pageid: json['pageid'] as int,
+        );
+      }
+    }
+    ```
+
+Dart also supports [pattern matching][] in `fromJson` constructors,
+allowing you to validate the shape of the JSON map and
+extract values in a single, concise step.
+
 ## Tasks
 
-In this chapter, you'll create Dart classes to
-represent the JSON data returned by the Wikipedia API.
-This will allow you to easily access and use the data in your application.
+The following tasks set up a multi-package workspace and
+create the data model classes for Wikipedia API responses.
 
 ### Task 1: Create the Wikipedia package
 
@@ -130,10 +180,45 @@ it's a good time to configure your project to use a Dart workspace.
         # ... (existing content) ...
         ```
 
+1.  **Resolve workspace dependencies.**
+
+    Run `dart pub get` in your project root to
+    resolve dependencies across all packages in the workspace:
+
+    ```bash
+    dart pub get
+    ```
+
 ### Task 3: Create the Summary class
 
 The Wikipedia API returns a JSON object containing a summary of an article.
-Let's create a Dart class to represent this summary.
+A typical response from the page summary endpoint looks like this:
+
+```json
+{
+  "titles": {
+    "canonical": "Dart_(programming_language)",
+    "normalized": "Dart (programming language)",
+    "display": "Dart (programming language)"
+  },
+  "pageid": 37194605,
+  "extract": "Dart is a client-optimized language for fast apps...",
+  "extract_html": "<p><b>Dart</b> is a client-optimized language...</p>",
+  "lang": "en",
+  "dir": "ltr",
+  "content_urls": {
+    "desktop": {
+      "page": "https://en.wikipedia.org/wiki/Dart_(programming_language)"
+    },
+    "mobile": {
+      "page": "https://en.m.wikipedia.org/wiki/Dart_(programming_language)"
+    }
+  },
+  "description": "Programming language"
+}
+```
+
+Create a Dart class to represent this summary.
 
 1.  Create the directory `wikipedia/lib/src/model`.
 
@@ -185,8 +270,8 @@ Let's create a Dart class to represent this summary.
       /// Wikidata description for the page
       String? description;
 
-      /// Returns a new [Summary] instance
-      static Summary fromJson(Map<String, Object?> json) {
+      /// Creates a [Summary] instance from a JSON map.
+      factory Summary.fromJson(Map<String, Object?> json) {
         return switch (json) {
           {
             'titles': final Map<String, Object?> titles,
@@ -252,19 +337,25 @@ Let's create a Dart class to represent this summary.
 
     This code defines a `Summary` class with properties that
     correspond to the fields in the JSON response from the Wikipedia API.
-    The `fromJson` method uses [pattern matching][] to
-    extract the data from the JSON object and create a new `Summary` instance.
+    The `fromJson` factory constructor uses [pattern matching][] to
+    validate the JSON structure, extract the data, and
+    create a new `Summary` instance.
+    Because the `description` field is optional in Wikipedia's API,
+    the `switch` expression has two cases: one that extracts `description`
+    when present, and one that matches when it is omitted.
     The `toString` method provides a convenient way to
     print the contents of the `Summary` object.
-    Note that the `TitlesSet` class is used in the `Summary` class,
-    so you'll need to create that next.
+
+    > [!NOTE]
+    > Your editor might flag `import 'title_set.dart'` and `TitlesSet`
+    > as unresolved references until you create `TitlesSet` in Task 4.
 
 [pattern matching]: /language/patterns
 
 ### Task 4: Create the TitleSet class
 
 The `Summary` class uses a `TitlesSet` class to represent the title information.
-Let's create that class now.
+Create that class next.
 
 1.  Create the file `wikipedia/lib/src/model/title_set.dart`.
 
@@ -290,8 +381,8 @@ Let's create that class now.
       /// the title as it should be displayed to the user
       String display;
 
-      /// Returns a new [TitlesSet] instance and imports its values from a JSON map
-      static TitlesSet fromJson(Map<String, Object?> json) {
+      /// Creates a [TitlesSet] instance from a JSON map.
+      factory TitlesSet.fromJson(Map<String, Object?> json) {
         if (json case {
           'canonical': final String canonical,
           'normalized': final String normalized,
@@ -318,15 +409,17 @@ Let's create that class now.
 
     This code defines a `TitlesSet` class with properties that correspond to
     the title information in the JSON response from the Wikipedia API.
-    The `fromJson` method uses pattern matching to
-    extract the data from the JSON object and create a new `TitlesSet` instance.
+    Unlike `Summary`, which handles optional fields with a `switch` expression,
+    `TitlesSet` validates a single structure using an `if case` statement.
+    If the JSON map matches the pattern, the constructor creates the
+    `TitlesSet` instance; otherwise, it throws a `FormatException`.
     The `toString` method provides a convenient way to
     print the contents of the `TitlesSet` object.
 
 ### Task 5: Create the Article class
 
 The Wikipedia API also returns a list of articles in a search result.
-Let's create a Dart class to represent an article.
+Create a Dart class to represent an article.
 
 1.  Create the file `wikipedia/lib/src/model/article.dart`.
 
@@ -369,17 +462,33 @@ Let's create a Dart class to represent an article.
 
     This code defines an `Article` class with properties for
     the title and extract of an article.
-    The `listFromJson` method uses pattern matching to
-    extract the data from the JSON object and
-    create a list of `Article` instances.
-    The `toJson` method converts the `Article` object back into a JSON object.
+    Because this method converts a JSON map into a `List<Article>` rather
+    than a single `Article` instance, it is defined as a `static` method
+    named `listFromJson`.
+    The `for` loop uses Dart's object pattern destructuring
+    (`final MapEntry(:value)`) to directly extract the `value` of each
+    entry without manual property access.
+    The `toJson` method converts the `Article` object back into a JSON map.
     The `toString` method provides a convenient way to
     print the contents of the `Article` object.
 
 ### Task 6: Create the SearchResults class
 
-Finally, let's create a class to represent the
-search results from the Wikipedia API.
+Finally, create a class to represent search results from the Wikipedia API.
+The Wikipedia search endpoint returns an array containing the search term,
+article titles, descriptions (which are ignored), and URLs:
+
+```json
+[
+  "dart",
+  ["Dart (programming language)", "Dart"],
+  ["", ""],
+  [
+    "https://en.wikipedia.org/wiki/Dart_(programming_language)",
+    "https://en.wikipedia.org/wiki/Dart"
+  ]
+]
+```
 
 1.  Create the file `wikipedia/lib/src/model/search_results.dart`.
 1.  Add the following code to `wikipedia/lib/src/model/search_results.dart`:
@@ -396,7 +505,8 @@ search results from the Wikipedia API.
       final List<SearchResult> results;
       final String? searchTerm;
 
-      static SearchResults fromJson(List<Object?> json) {
+      /// Creates a [SearchResults] instance from a JSON list.
+      factory SearchResults.fromJson(List<Object?> json) {
         final List<SearchResult> results = <SearchResult>[];
         if (json case [
           String searchTerm,
@@ -427,15 +537,17 @@ search results from the Wikipedia API.
 
     This code defines a `SearchResults` class with a
     list of `SearchResult` objects and a search term.
-    The `fromJson` method uses pattern matching to extract the data from
-    the JSON object and create a new `SearchResults` instance.
+    Because the search API returns a JSON array rather than an object,
+    `fromJson` accepts a `List<Object?>`.
+    The `if case` statement uses a list pattern `[...]` to match the array
+    positionally, using the wildcard `_` to discard the unused descriptions.
     The `toString` method provides a convenient way to
     print the contents of the `SearchResults` object.
 
-At this point, you've created data models to represent JSON structures.
-There's nothing to test at this point.
-You'll add that application logic in the upcoming sections,
-which will enable you to test how data is deserialized from the Wikipedia API.
+You now have typed data models to represent Wikipedia API responses.
+In upcoming chapters, you use `package:test` to test
+how data is deserialized and use `package:http` to fetch
+live JSON data from the API.
 
 ## Review
 
@@ -444,26 +556,13 @@ title: What you accomplished
 subtitle: Here's a summary of what you built and learned in this lesson.
 completed: true
 items:
-  - title: Created data model classes for JSON
-    icon: data_object
-    details: >-
-      You built `Summary`, `TitlesSet`, `Article`, and `SearchResults` classes
-      to represent Wikipedia API responses.
-      These typed models provide compile-time safety and
-      IDE support when working with API data.
-  - title: Used dart:convert to work with JSON data
+  - title: Understood JSON handling in Dart
     icon: convert_to_text
     details: >-
-      You imported the `dart:convert` library and used `jsonDecode()` to
-      parse JSON strings into Dart objects, including `Map` and `List`,
-      that you can then work with programmatically.
-  - title: Used pattern matching to extract data from JSON objects
-    icon: bento
-    details: >-
-      You implemented `fromJson` factory methods using Dart's pattern matching
-      with `switch` expressions and `if case` statement.
-      This structure allowed you to validate the JSON structure and
-      extract values from the JSON objects in single, readable expressions.
+      You explored how `dart:convert` and `jsonDecode()`
+      parse JSON strings into Dart collections (`Map` and `List`), and
+      why typed models with `fromJson` factory constructors are preferred
+      over raw maps.
   - title: Set up a pub workspace
     icon: workspaces
     details: >-
@@ -472,6 +571,20 @@ items:
       To do so, you created a root `pubspec.yaml` file with
       a `workspace:` section listing your packages, then
       added `resolution: workspace` to each sub-package.
+  - title: Created data model classes for JSON
+    icon: data_object
+    details: >-
+      You built `Summary`, `TitlesSet`, `Article`, and `SearchResults` classes
+      to represent Wikipedia API responses.
+      These typed models provide compile-time safety and
+      IDE support when working with API data.
+  - title: Used pattern matching in fromJson factory constructors
+    icon: bento
+    details: >-
+      You implemented `fromJson` factory constructors using Dart's pattern
+      matching with `switch` expressions and `if case` statements.
+      This structure validates the JSON shape and
+      extracts values in concise, readable expressions.
 </SummaryCard>
 
 ## Quiz
@@ -480,7 +593,7 @@ items:
 
 ## Next lesson
 
-In the next lesson, you'll learn how to
+In the next lesson, learn how to
 test your Dart code using the `package:test` library.
-You'll write tests to ensure that your
-JSON deserialization logic is working correctly.
+Write tests to verify that your
+JSON deserialization logic works correctly.

--- a/src/content/learn/tutorial/error-handling.md
+++ b/src/content/learn/tutorial/error-handling.md
@@ -7,9 +7,9 @@ description: >-
 layout: learn
 ---
 
-In this chapter, you'll learn how to
-make your application more robust by handling errors gracefully.
-You'll explore exceptions, `try/catch` blocks, and how to
+In this chapter, you make your application more robust
+by handling errors gracefully.
+You explore exceptions, `try/catch` blocks, and how to
 create custom exceptions to manage errors in a structured way.
 
 <SummaryCard>
@@ -33,36 +33,48 @@ Before you begin this chapter, ensure you:
 
 ## Errors versus exceptions
 
-Before you start writing code to handle failures,
-you need to understand the two main types of failures in Dart:
+Dart distinguishes between two main types of failures:
 **errors** and **exceptions**.
 
-- **Exceptions** represent conditions that you might expect to happen
-  and that your program can recover from.
-  Examples include invalid user input,
-  a missing file, or a network timeout.
-  Your code can catch and handle exceptions to keep running.
-- **Errors** represent failure conditions that indicate bugs in the code.
-  Examples include calling a method on a `null` object,
-  passing an invalid index to a list, or
-  failing to initialize a late variable before use.
-  You don't catch errors.
-  Instead, you let them crash the application,
-  which helps you find and fix the underlying bug.
+| Concept | `Exception` | `Error` |
+| :--- | :--- | :--- |
+| **What it indicates** | An expected runtime failure that code can recover from. | A programming bug or flaw in the code. |
+| **Common examples** | `FormatException`, `HttpException`, `SocketException`. | `RangeError`, `TypeError`, `StateError`. |
+| **Typical causes** | Invalid user input, network failure, missing file. | Off-by-one index, calling a method on `null`. |
+| **How to handle** | Catch and handle gracefully (for example, with `try/catch`). | Do not catch; fix the bug in your code. |
 
-In Dart, any non-null object can be thrown as an exception.
-However, by convention, exceptions implement `Exception`,
-while errors extend or implement `Error`.
-When you design an API, throw subtypes of `Exception` for
-conditions that callers can catch and handle.
+### Exceptions
+
+Exceptions represent conditions that you can anticipate and recover from.
+For example, when a user enters an unrecognized command-line argument,
+your application shouldn't crash with a raw stack trace.
+Instead, your code catches the exception,
+displays a friendly error message, and
+prompts the user with proper usage instructions.
+
+In Dart, custom exceptions typically implement the `Exception` class or
+extend an existing exception type like `FormatException`.
+
+### Errors
+
+Errors represent programmatic bugs in your logic that
+should be fixed during development rather than handled at runtime.
+For example, accessing an element beyond the bounds of a list throws a
+`RangeError`.
+Attempting to catch and suppress a `RangeError` hides the bug and
+can leave your application in an unpredictable state.
+Instead, let errors propagate so you can inspect the stack trace and
+fix the underlying mistake.
+
+In Dart, classes that represent bugs extend or implement `Error`.
 
 ## Tasks
 
-In this chapter, you will improve the robustness of
-your `command_runner` package by implementing error handling.
-You'll create a custom exception class
-and add error handling to the `CommandRunner` to
-gracefully manage errors that might occur during command execution.
+The following tasks apply these principles to the `command_runner` package.
+You define a custom exception class for invalid user arguments,
+use `try/catch` blocks to intercept failures, and
+configure `CommandRunner` to handle exceptions gracefully
+while letting unexpected errors propagate.
 
 ### Task 1: Create a custom ArgumentException
 
@@ -70,7 +82,7 @@ First, define a custom exception class called `ArgumentException` to
 represent errors related to command-line arguments.
 
 1.  Create the file `command_runner/lib/src/exceptions.dart`.
-    This file will contain the definition for your `ArgumentException` class.
+    This file contains the definition for your `ArgumentException` class.
 
 1.  Define a class called `ArgumentException` that `extends` `FormatException`.
 
@@ -101,7 +113,10 @@ represent errors related to command-line arguments.
     ```
 
     This class extends `FormatException`, which
-    is a built-in Dart exception class.
+    is a built-in Dart class that implements `Exception`.
+    Because invalid command-line arguments are an expected condition
+    that callers can anticipate and handle gracefully,
+    `ArgumentException` is designed as an exception rather than an `Error`.
     It includes additional properties to store the
     command and argument name associated with the error.
     This provides more context when handling the exception.
@@ -112,7 +127,7 @@ represent errors related to command-line arguments.
       The name of the argument that caused the exception.
 
 
-## Task 2: Implement error handling in CommandRunner
+### Task 2: Implement error handling in CommandRunner
 
 Next, update the `CommandRunner` class to
 handle potential errors gracefully.
@@ -139,7 +154,7 @@ throwing your new `ArgumentException` when the user provides bad input.
 
     Modify the CommandRunner to
     accept an optional `onError` function in its constructor.
-    This will allow the user of your package to
+    This allows users of your package to
     define their own error-handling logic.
 
     ```dart
@@ -166,8 +181,8 @@ throwing your new `ArgumentException` when the user provides bad input.
 1.  Update the run method to use `try`/`catch`.
 
     Wrap the logic inside the run method in a `try`/`catch` block.
-    If an exception occurs, this block will "catch" it and either
-    pass it to the `onError` callback or rethrow it if no callback was provided.
+    If an exception occurs, this block catches it and either
+    passes it to the `onError` callback or rethrows it if no callback is provided.
     `rethrow` preserves the original error and stack trace.
 
     ```dart
@@ -192,8 +207,8 @@ throwing your new `ArgumentException` when the user provides bad input.
 1.  Add validation to the `parse` method.
 
     Finally, replace the existing `parse` method in `command_runner_base.dart`
-    with the following updated version. This new version is much more robust.
-    It's filled with checks that will throw your custom `ArgumentException`
+    with the following updated version.
+    It includes checks that throw your custom `ArgumentException`
     whenever it detects invalid user input.
 
     ```dart
@@ -436,7 +451,7 @@ items:
 
 ## Next lesson
 
-In the next lesson, you'll learn about
+In the next lesson, learn about
 advanced object-oriented features in Dart,
 including enhanced enums and extensions.
-You'll improve the output formatting and add color to your CLI application.
+Improve the output formatting and add color to your CLI application.

--- a/src/content/learn/tutorial/error-handling.md
+++ b/src/content/learn/tutorial/error-handling.md
@@ -57,7 +57,7 @@ extend an existing exception type like `FormatException`.
 
 ### Errors
 
-Errors represent programmatic bugs in your logic that
+Errors represent bugs in your logic that
 should be fixed during development rather than handled at runtime.
 For example, accessing an element beyond the bounds of a list throws a
 `RangeError`.
@@ -114,8 +114,8 @@ represent errors related to command-line arguments.
 
     This class extends `FormatException`, which
     is a built-in Dart class that implements `Exception`.
-    Because invalid command-line arguments are an expected condition
-    that callers can anticipate and handle gracefully,
+    Invalid command-line arguments are an expected condition
+    that callers can anticipate and handle gracefully, so
     `ArgumentException` is designed as an exception rather than an `Error`.
     It includes additional properties to store the
     command and argument name associated with the error.
@@ -203,6 +203,13 @@ throwing your new `ArgumentException` when the user provides bad input.
       }
     }
     ```
+
+    Notice the use of `on Exception catch (exception)`.
+    In Dart, a bare `catch (e)` intercepts all thrown objects,
+    including `Error` instances.
+    Specifying `on Exception` ensures that your code catches only
+    recoverable exceptions,
+    allowing bugs to propagate uncaught so you can fix them.
 
 1.  Add validation to the `parse` method.
 
@@ -363,17 +370,10 @@ Modify `cli/bin/cli.dart` to use the new error handling in `CommandRunner`.
     }
     ```
 
-    This code passes in an `onError` callback function to
-    the `CommandRunner` constructor.
-    If an error occurs during the execution of a command,
-    the `onError` callback function is called with the error object.
-    The callback checks whether the error is an `Error` or an `Exception`.
-    Because an `Error` indicates a bug in the code,
-    the callback rethrows it.
-    This lets the application crash so you can fix the bug.
-    For an `Exception`, which represents a recoverable failure,
-    the callback handles it gracefully by
-    printing it to the console instead of rethrowing it.
+    This code passes an `onError` callback to `CommandRunner`.
+    The callback rethrows any `Error` so the application crashes,
+    while printing any `Exception` to the console so the user sees
+    the error message.
 
 ### Task 4: Update command_runner library exports
 
@@ -396,8 +396,10 @@ Make `ArgumentException` available to the `command_runner` library.
     // TODO: Export any libraries intended for clients of this package.
     ```
 
-    This ensures that the `ArgumentException` is
-    available to consumers of the `command_runner` package.
+    In Dart packages, files inside `lib/src/` are private implementation details.
+    Exporting `src/exceptions.dart` from `lib/command_runner.dart` exposes
+    `ArgumentException` as part of the package's public API so callers
+    (like `cli.dart`) can import and use it.
 
 ### Task 5: Test the new error handling
 

--- a/src/content/learn/tutorial/error-handling.md
+++ b/src/content/learn/tutorial/error-handling.md
@@ -7,9 +7,9 @@ description: >-
 layout: learn
 ---
 
-In this chapter, you make your application more robust
+In this chapter, make your application more robust
 by handling errors gracefully.
-You explore exceptions, `try/catch` blocks, and how to
+Explore exceptions, `try/catch` blocks, and how to
 create custom exceptions to manage errors in a structured way.
 
 <SummaryCard>

--- a/src/data/quiz/error-handling.yml
+++ b/src/data/quiz/error-handling.yml
@@ -92,3 +92,32 @@
       explanation: >-
         Exceptions are never silently ignored in Dart.
         If a catch block doesn't match, the exception doesn't just disappear.
+- question: >-
+    In Dart, what is the primary difference between an `Error` and an `Exception`?
+  options:
+    - text: >-
+        An `Error` indicates a programming bug that shouldn't be caught,
+        while an `Exception` represents an expected condition that code can recover from.
+      correct: true
+      explanation: >-
+        Subtypes of `Error` (such as `RangeError` or `TypeError`) indicate bugs
+        in code that you should fix. Subtypes of `Exception`
+        (such as `FormatException` or `HttpException`) represent conditions
+        that your code can anticipate and handle gracefully.
+    - text: >-
+        `Error` is thrown by the Dart runtime, while `Exception` can only be thrown by user code.
+      correct: false
+      explanation: >-
+        Both the Dart runtime and user code can throw exceptions and errors.
+    - text: >-
+        `Exception` requires a `try/catch` block, but `Error` is ignored if uncaught.
+      correct: false
+      explanation: >-
+        Uncaught errors and uncaught exceptions both terminate execution.
+        Neither is silently ignored.
+    - text: >-
+        `Error` and `Exception` are identical in Dart and can be used interchangeably.
+      correct: false
+      explanation: >-
+        Dart distinguishes between them by design:
+        errors indicate bugs, while exceptions represent recoverable failures.


### PR DESCRIPTION
Align tutorial objectives, content, and quizzes for data and error handling

### Summary of Changes

#### 1. Data and JSON (`data-and-json.md`)
- Added a dedicated "How Dart handles JSON" section introducing `dart:convert` and `jsonDecode()`.
- Converted `Summary.fromJson`, `TitlesSet.fromJson`, and `SearchResults.fromJson` to `factory` constructors to align with standard Dart idioms and the chapter quiz.
- Added sample JSON responses and explained pattern matching (`switch`, `if case`, and list patterns).
- Added `dart pub get` step to workspace configuration.
- Aligned top and review `<SummaryCard>` items to match 1:1.

#### 2. Error Handling (`error-handling.md` & `error-handling.yml`)
- Added an explicit "Errors versus exceptions" section with a comparison table distinguishing `Error` (bugs) from `Exception` (recoverable conditions).
- Added an active-voice transition from the concepts into the tasks.
- Fixed heading level for Task 2 (`## Task 2` -> `### Task 2`).
- Added Quiz Question 4 testing the difference between `Error` and `Exception`.

Fixes #7133
Fixes #7212
Fixes #7219
Fixes #7238
Fixes #7277
Fixes #7447

