### PR TITLE
Split OOP tutorial chapter and improve progressive disclosure

### DIFF
--- a/src/content/learn/tutorial/advanced-oop.md
+++ b/src/content/learn/tutorial/advanced-oop.md
@@ -30,7 +30,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
--   Have completed Chapter 6 and have a
+-   Have completed Chapter 7 and have a
     working Dart development environment with the `dartpedia` project.
 -   Are familiar with basic programming concepts like
     variables, functions, and control flow.

--- a/src/content/learn/tutorial/cli-polish.md
+++ b/src/content/learn/tutorial/cli-polish.md
@@ -29,7 +29,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
-- Have completed Chapter 7 and have a
+- Have completed Chapter 8 and have a
   working Dart development environment with the `dartpedia` project.
 - Are familiar with basic programming concepts like
   variables, functions, and control flow.

--- a/src/content/learn/tutorial/data-and-json.md
+++ b/src/content/learn/tutorial/data-and-json.md
@@ -34,7 +34,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
-- Have completed Chapter 8 and have a
+- Have completed Chapter 9 and have a
   working Dart development environment with the `dartpedia` project.
 - Understand basic Dart syntax, including [classes][] and data types.
 

--- a/src/content/learn/tutorial/error-handling.md
+++ b/src/content/learn/tutorial/error-handling.md
@@ -27,7 +27,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
-- Have completed Chapter 5 and have a
+- Have completed Chapter 6 and have a
   working Dart development environment with the `dartpedia` project.
 - Understand basic programming concepts like functions and classes.
 

--- a/src/content/learn/tutorial/fetch-data.md
+++ b/src/content/learn/tutorial/fetch-data.md
@@ -29,7 +29,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
--   Have completed Chapter 10 and have a
+-   Have completed Chapter 11 and have a
     working Dart development environment with the `dartpedia` project.
 -   Understand basic networking concepts (like APIs and HTTP requests).
 -   Understand basic data serialization formats such as JSON.

--- a/src/content/learn/tutorial/inheritance.md
+++ b/src/content/learn/tutorial/inheritance.md
@@ -40,14 +40,14 @@ Before starting this chapter:
 ## Abstract classes and inheritance
 
 In Dart, an **abstract class** is a class that cannot be instantiated
-directly (callers cannot run `CliElement()`).
+directly (calling `CliElement()` causes a compile-time error).
 Instead, it serves as a blueprint or contract that other classes extend.
 
 In a CLI, options (`--verbose`) and commands (`help`) share common
 features like a name and help description,
 but a generic "CLI element" does not make sense on its own.
 Declaring `CliElement` and `Command` as **abstract** ensures that code
-only instantiates specific, concrete objects like `Option` and `HelpCommand`.
+only instantiates specific classes like `Option` and `HelpCommand`.
 
 ```
        ┌──────────────┐
@@ -62,7 +62,7 @@ only instantiates specific, concrete objects like `Option` and `HelpCommand`.
                       │
                       ▼
                ┌─────────────┐
-               │ HelpCommand │ (concrete: can be instantiated and run)
+               │ HelpCommand │ (can be instantiated and run)
                └─────────────┘
 ```
 
@@ -116,7 +116,7 @@ Defining an abstract base class establishes a single contract for both.
     The `abstract` keyword marks `CliElement` as a base class that cannot
     be instantiated directly (`CliElement()`).
     Getters without bodies (`String get name;`) define required properties
-    that every concrete subclass must implement.
+    that every subclass must implement.
     The `defaultValue` getter uses type `Object?` so it can return either a
     `bool` (for flags) or a `String` (for options that accept values).
 
@@ -162,8 +162,9 @@ Defining an abstract base class establishes a single contract for both.
 
     The `extends` keyword establishes an inheritance relationship where `Option`
     becomes a subtype of `CliElement`.
-    The `@override` annotations tell the compiler that these properties supply
-    concrete implementations for the abstract getters declared in `CliElement`.
+    In Dart, every field has an implicit getter.
+    Declaring `@override final String name;` satisfies the abstract getter
+    `String get name;` declared in `CliElement`.
     The `abbr` and `type` fields remain specific to `Option`.
 
 ### Task 2: Define the Command abstract class
@@ -177,7 +178,7 @@ they also extend `CliElement`.
     ```dart title="command_runner/lib/src/arguments.dart"
     import 'dart:async';
     import 'dart:collection';
-    import '../command_runner.dart';
+    import 'command_runner_base.dart';
     ```
 
 1.  Start by defining the core `Command` abstract class with its properties and runner reference:
@@ -290,6 +291,23 @@ they also extend `CliElement`.
     - **`usage` getter**:
       Formats the command's name and description for CLI help output.
 
+1.  Update the `ArgResults` class at the bottom of
+    `command_runner/lib/src/arguments.dart` to reference `Command`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    class ArgResults {
+      Command? command;
+      String? commandArg;
+      Map<Option, Object?> options = {};
+
+      // ... existing flag, hasOption, and getOption methods ...
+    }
+    ```
+
+    In Chapter 5, `ArgResults.command` was a `String?` before `Command` existed.
+    Now that `Command` exists, changing its type to `Command?` allows the
+    command runner to store and execute the resolved `Command` object directly.
+
 ### Task 3: Update the CommandRunner class
 
 In Chapter 4, you created a placeholder `CommandRunner` in
@@ -365,7 +383,7 @@ Now, replace that placeholder with the real command coordinator.
 
 ### Task 4: Create a HelpCommand
 
-Create a concrete `HelpCommand` that extends `Command` and prints usage information.
+Create a `HelpCommand` that extends `Command` and prints usage information.
 
 1.  Create `command_runner/lib/src/help_command.dart`.
 
@@ -458,6 +476,12 @@ Test the `CommandRunner` and `HelpCommand`.
     This confirms that `CommandRunner` dispatches to `HelpCommand`
     and prints the expected usage output.
 
+    :::note
+    Always supply a command argument (such as `help`) when running this step.
+    Chapter 7 introduces error handling to manage empty or
+    invalid input gracefully.
+    :::
+
 ## Review
 
 <SummaryCard>
@@ -474,7 +498,7 @@ items:
     icon: account_tree
     details: >-
       Used `extends` to create `Option`, `Command`, and `HelpCommand` subtypes,
-      using `@override` to provide concrete implementations.
+      using `@override` to provide required implementations.
   - title: Protected internal state with encapsulation
     icon: lock
     details: >-

--- a/src/content/learn/tutorial/inheritance.md
+++ b/src/content/learn/tutorial/inheritance.md
@@ -37,29 +37,53 @@ Before starting this chapter:
   such as defining classes, constructors, fields, and getters.
 - Understand packages and libraries in Dart.
 
-## Tasks
+## Abstract classes and inheritance
 
-In Chapter 5, you created the `Option` and `ArgResults` classes.
-Now, you'll establish a shared hierarchy between commands and options,
-and expand the placeholder `CommandRunner` from Chapter 4 into
-a full-featured command parser.
+In Dart, an **abstract class** is a class that cannot be instantiated
+directly (callers cannot run `CliElement()`).
+Instead, it serves as a blueprint or contract that other classes extend.
+
+In a CLI, options (`--verbose`) and commands (`help`) share common
+features like a name and help description,
+but a generic "CLI element" does not make sense on its own.
+Declaring `CliElement` and `Command` as **abstract** ensures that code
+only instantiates specific, concrete objects like `Option` and `HelpCommand`.
 
 ```
        ┌──────────────┐
-       │  CliElement  │ (abstract)
+       │  CliElement  │ (abstract: blueprint for all CLI elements)
        └──────┬───────┘
               │
       ┌───────┴───────┐
       ▼               ▼
 ┌───────────┐   ┌───────────┐
-│  Option   │   │  Command  │ (abstract)
+│  Option   │   │  Command  │ (abstract: blueprint for commands)
 └───────────┘   └─────┬─────┘
                       │
                       ▼
                ┌─────────────┐
-               │ HelpCommand │
+               │ HelpCommand │ (concrete: can be instantiated and run)
                └─────────────┘
 ```
+
+### Share behavior with inheritance
+
+**Inheritance** allows a class to adopt properties and behavior from a parent class.
+Because both options (`Option`) and commands (`Command`) share a `name`,
+`help` text, and a formatted `usage` message,
+inheriting from a common `CliElement` parent eliminates duplicate code
+across multiple classes.
+
+Inheritance also enables **polymorphism**—the ability for the command runner
+to treat any command or option uniformly through the shared `CliElement` interface.
+
+## Tasks
+
+In Chapter 5, the `Option` and `ArgResults` classes established
+basic data structures for CLI options and parsed output.
+This chapter establishes a shared hierarchy between commands and options,
+and expands the placeholder `CommandRunner` from Chapter 4 into
+a full-featured command parser.
 
 The classes and logic in the following tasks
 create the foundation for parsing and executing CLI commands.
@@ -89,17 +113,12 @@ Defining an abstract base class establishes a single contract for both.
     }
     ```
 
-    Highlights from the preceding code:
-
-    - **`abstract class`**:
-      Declares a class that cannot be instantiated directly with `CliElement()`.
-      It serves as a shared contract for subclasses.
-    - **Abstract getters (`String get name;`)**:
-      Getters without a body define required properties that
-      every concrete subclass must implement.
-    - **`defaultValue` of type `Object?`**:
-      Allows the default value to hold either a `bool` (for flags)
-      or a `String` (for options taking a value).
+    The `abstract` keyword marks `CliElement` as a base class that cannot
+    be instantiated directly (`CliElement()`).
+    Getters without bodies (`String get name;`) define required properties
+    that every concrete subclass must implement.
+    The `defaultValue` getter uses type `Object?` so it can return either a
+    `bool` (for flags) or a `String` (for options that accept values).
 
 1.  Update the `Option` class to extend `CliElement`:
 
@@ -141,17 +160,11 @@ Defining an abstract base class establishes a single contract for both.
     }
     ```
 
-    Highlights from the preceding code:
-
-    - **`extends` keyword**:
-      Establishes an inheritance relationship where `Option` becomes a subtype
-      of `CliElement`.
-    - **`@override` annotation**:
-      Informs the compiler that this member provides a concrete implementation
-      for a member declared in the `CliElement` base class.
-    - **`abbr` and `type`**:
-      Subclass-specific properties that are unique to `Option`
-      and not part of the generic `CliElement` base.
+    The `extends` keyword establishes an inheritance relationship where `Option`
+    becomes a subtype of `CliElement`.
+    The `@override` annotations tell the compiler that these properties supply
+    concrete implementations for the abstract getters declared in `CliElement`.
+    The `abbr` and `type` fields remain specific to `Option`.
 
 ### Task 2: Define the Command abstract class
 
@@ -167,7 +180,7 @@ they also extend `CliElement`.
     import '../command_runner.dart';
     ```
 
-1.  Add the `Command` abstract class below `Option`:
+1.  Start by defining the core `Command` abstract class with its properties and runner reference:
 
     ```dart title="command_runner/lib/src/arguments.dart"
     abstract class Command extends CliElement {
@@ -188,6 +201,23 @@ they also extend `CliElement`.
 
       @override
       String? valueHelp;
+    }
+    ```
+
+    - **`abstract class Command extends CliElement`**:
+      Establishes `Command` as an abstract subtype of `CliElement`,
+      providing a template for all specific commands to follow.
+    - **`late CommandRunner runner;`**:
+      A command needs a reference to the `CommandRunner` executing it,
+      so it can access global runner state.
+      The `late` keyword promises Dart that this non-nullable variable will be
+      assigned before use (when added to the runner via `command.runner = this;`).
+
+1.  Next, add encapsulated option storage and helper methods to `Command`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    abstract class Command extends CliElement {
+      // ... existing properties ...
 
       final List<Option> _options = [];
 
@@ -225,6 +255,24 @@ they also extend `CliElement`.
           ),
         );
       }
+    }
+    ```
+
+    - **Encapsulation with `_options`**:
+      Prefixing `_options` with an underscore (`_`) makes it library-private,
+      preventing code outside `arguments.dart` from modifying the list directly.
+    - **`UnmodifiableSetView`**:
+      Exposes a read-only view of the command's options,
+      ensuring callers cannot mutate internal state directly.
+    - **`addFlag` and `addOption`**:
+      Provide controlled methods to create and register valid `Option` instances
+      into the command.
+
+1.  Finally, add the abstract `run` method and `usage` getter to complete `Command`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    abstract class Command extends CliElement {
+      // ... existing properties and helper methods ...
 
       FutureOr<Object?> run(ArgResults args);
 
@@ -235,26 +283,12 @@ they also extend `CliElement`.
     }
     ```
 
-    Highlights from the preceding code:
-
-    - **`late CommandRunner runner;`**:
-      A command needs a reference to the `CommandRunner` executing it,
-      so it can access global options and runner state.
-      The `late` keyword promises Dart that this variable will be assigned
-      before use (when registered with `runner.addCommand(this)`).
-    - **Encapsulation with `_options`**:
-      Prefixing `_options` with an underscore (`_`) makes it library-private,
-      preventing code outside `arguments.dart` from modifying the list directly.
-    - **`UnmodifiableSetView`**:
-      Exposes a read-only view of the command's options,
-      ensuring callers cannot mutate internal state directly.
-    - **`addFlag` and `addOption`**:
-      Provide controlled methods to create and register valid `Option` instances
-      into the command.
     - **`FutureOr<Object?> run(...)`**:
-      Defines an abstract method that subclasses must implement.
-      `FutureOr` allows the command to run either synchronously or
-      asynchronously (using `async/await` from Chapter 3).
+      Defines the abstract method where a command's execution logic lives.
+      `FutureOr` allows the method to return either a raw synchronous value
+      or a `Future` for asynchronous operations (connecting back to Chapter 3).
+    - **`usage` getter**:
+      Formats the command's name and description for CLI help output.
 
 ### Task 3: Update the CommandRunner class
 
@@ -376,14 +410,10 @@ Create a concrete `HelpCommand` that extends `Command` and prints usage informat
     }
     ```
 
-    Highlights from the preceding code:
-
-    - **Constructor initialization**:
-      Calls inherited helper methods `addFlag` and `addOption` to configure
-      the command's supported options.
-    - **Accessing `runner`**:
-      Reads `runner.usage` and iterates over `runner.commands` to assemble
-      the complete CLI help message dynamically.
+    The `HelpCommand` constructor calls inherited helper methods `addFlag` and
+    `addOption` to configure its supported options.
+    Its `run` method reads `runner.usage` and iterates over `runner.commands`
+    to assemble and return the complete CLI usage message dynamically.
 
 ### Task 5: Update cli.dart to use CommandRunner
 

--- a/src/content/learn/tutorial/inheritance.md
+++ b/src/content/learn/tutorial/inheritance.md
@@ -1,0 +1,472 @@
+---
+title: Structure apps with inheritance and abstract classes
+shortTitle: Inheritance and abstraction
+description: >-
+  Learn about inheritance, abstract classes, method overrides, and
+  encapsulation in Dart. Build an extensible framework for CLI apps.
+layout: learn
+---
+
+This chapter builds on the classes created in the previous lesson by
+exploring inheritance and abstract classes in Dart.
+Learn how to share behavior between classes using
+[inheritance][], define contracts using
+[abstract classes][], and
+protect internal state with [encapsulation][].
+
+<SummaryCard>
+title: What you'll accomplish
+items:
+  - title: Design and understand abstract classes
+    icon: schema
+  - title: Extend parent classes and override methods
+    icon: account_tree
+  - title: Protect internal state with encapsulation
+    icon: lock
+  - title: Build an extensible command runner framework
+    icon: terminal
+</SummaryCard>
+
+## Prerequisites
+
+Before starting this chapter:
+
+- Complete Chapter 5 and have a
+  working Dart development environment with the `dartpedia` project.
+- Understand basic object-oriented concepts in Dart,
+  such as defining classes, constructors, fields, and getters.
+- Understand packages and libraries in Dart.
+
+## Tasks
+
+In Chapter 5, you created the `Option` and `ArgResults` classes.
+Now, you'll establish a shared hierarchy between commands and options,
+and expand the placeholder `CommandRunner` from Chapter 4 into
+a full-featured command parser.
+
+```
+       ┌──────────────┐
+       │  CliElement  │ (abstract)
+       └──────┬───────┘
+              │
+      ┌───────┴───────┐
+      ▼               ▼
+┌───────────┐   ┌───────────┐
+│  Option   │   │  Command  │ (abstract)
+└───────────┘   └─────┬─────┘
+                      │
+                      ▼
+               ┌─────────────┐
+               │ HelpCommand │
+               └─────────────┘
+```
+
+The classes and logic in the following tasks
+create the foundation for parsing and executing CLI commands.
+
+### Task 1: Define the CliElement abstract class and update Option
+
+Both options and commands share core attributes such as a `name`,
+`help` text, and a formatted `usage` string.
+Defining an abstract base class establishes a single contract for both.
+
+1.  Open `command_runner/lib/src/arguments.dart`.
+
+1.  Define an `abstract class` called `CliElement` below the `OptionType` enum:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    abstract class CliElement {
+      String get name;
+      String? get help;
+
+      // In the case of flags, the default value is a bool.
+      // In other options and commands, the default value is a String.
+      // NB: flags are just Option objects that don't take arguments
+      Object? get defaultValue;
+      String? get valueHelp;
+
+      String get usage;
+    }
+    ```
+
+    Highlights from the preceding code:
+
+    - **`abstract class`**:
+      Declares a class that cannot be instantiated directly with `CliElement()`.
+      It serves as a shared contract for subclasses.
+    - **Abstract getters (`String get name;`)**:
+      Getters without a body define required properties that
+      every concrete subclass must implement.
+    - **`defaultValue` of type `Object?`**:
+      Allows the default value to hold either a `bool` (for flags)
+      or a `String` (for options taking a value).
+
+1.  Update the `Option` class to extend `CliElement`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    class Option extends CliElement {
+      Option(
+        this.name, {
+        required this.type,
+        this.help,
+        this.abbr,
+        this.defaultValue,
+        this.valueHelp,
+      });
+
+      @override
+      final String name;
+
+      final OptionType type;
+
+      @override
+      final String? help;
+
+      final String? abbr;
+
+      @override
+      final Object? defaultValue;
+
+      @override
+      final String? valueHelp;
+
+      @override
+      String get usage {
+        if (abbr != null) {
+          return '-$abbr,--$name: $help';
+        }
+
+        return '--$name: $help';
+      }
+    }
+    ```
+
+    Highlights from the preceding code:
+
+    - **`extends` keyword**:
+      Establishes an inheritance relationship where `Option` becomes a subtype
+      of `CliElement`.
+    - **`@override` annotation**:
+      Informs the compiler that this member provides a concrete implementation
+      for a member declared in the `CliElement` base class.
+    - **`abbr` and `type`**:
+      Subclass-specific properties that are unique to `Option`
+      and not part of the generic `CliElement` base.
+
+### Task 2: Define the Command abstract class
+
+Commands represent actions that users can perform, such as `help` or `search`.
+Because commands share properties with `Option` (like `name` and `usage`),
+they also extend `CliElement`.
+
+1.  Add required imports to the top of `command_runner/lib/src/arguments.dart`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    import 'dart:async';
+    import 'dart:collection';
+    import '../command_runner.dart';
+    ```
+
+1.  Add the `Command` abstract class below `Option`:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    abstract class Command extends CliElement {
+      @override
+      String get name;
+
+      String get description;
+
+      bool get requiresArgument => false;
+
+      late CommandRunner runner;
+
+      @override
+      String? help;
+
+      @override
+      String? defaultValue;
+
+      @override
+      String? valueHelp;
+
+      final List<Option> _options = [];
+
+      UnmodifiableSetView<Option> get options =>
+          UnmodifiableSetView(_options.toSet());
+
+      void addFlag(String name, {String? help, String? abbr, String? valueHelp}) {
+        _options.add(
+          Option(
+            name,
+            help: help,
+            abbr: abbr,
+            defaultValue: false,
+            valueHelp: valueHelp,
+            type: OptionType.flag,
+          ),
+        );
+      }
+
+      void addOption(
+        String name, {
+        String? help,
+        String? abbr,
+        String? defaultValue,
+        String? valueHelp,
+      }) {
+        _options.add(
+          Option(
+            name,
+            help: help,
+            abbr: abbr,
+            defaultValue: defaultValue,
+            valueHelp: valueHelp,
+            type: OptionType.option,
+          ),
+        );
+      }
+
+      FutureOr<Object?> run(ArgResults args);
+
+      @override
+      String get usage {
+        return '$name:  $description';
+      }
+    }
+    ```
+
+    Highlights from the preceding code:
+
+    - **`late CommandRunner runner;`**:
+      A command needs a reference to the `CommandRunner` executing it,
+      so it can access global options and runner state.
+      The `late` keyword promises Dart that this variable will be assigned
+      before use (when registered with `runner.addCommand(this)`).
+    - **Encapsulation with `_options`**:
+      Prefixing `_options` with an underscore (`_`) makes it library-private,
+      preventing code outside `arguments.dart` from modifying the list directly.
+    - **`UnmodifiableSetView`**:
+      Exposes a read-only view of the command's options,
+      ensuring callers cannot mutate internal state directly.
+    - **`addFlag` and `addOption`**:
+      Provide controlled methods to create and register valid `Option` instances
+      into the command.
+    - **`FutureOr<Object?> run(...)`**:
+      Defines an abstract method that subclasses must implement.
+      `FutureOr` allows the command to run either synchronously or
+      asynchronously (using `async/await` from Chapter 3).
+
+### Task 3: Update the CommandRunner class
+
+In Chapter 4, you created a placeholder `CommandRunner` in
+`command_runner/lib/src/command_runner_base.dart` that simply printed arguments.
+Now, replace that placeholder with the real command coordinator.
+
+1.  Open `command_runner/lib/src/command_runner_base.dart`.
+
+1.  Replace the file contents with the following code:
+
+    ```dart title="command_runner/lib/src/command_runner_base.dart"
+    import 'dart:collection';
+    import 'dart:io';
+    import 'arguments.dart';
+
+    class CommandRunner {
+      final Map<String, Command> _commands = <String, Command>{};
+
+      UnmodifiableSetView<Command> get commands =>
+          UnmodifiableSetView<Command>(<Command>{..._commands.values});
+
+      Future<void> run(List<String> input) async {
+        final ArgResults results = parse(input);
+        if (results.command != null) {
+          Object? output = await results.command!.run(results);
+          print(output.toString());
+        }
+      }
+
+      void addCommand(Command command) {
+        _commands[command.name] = command;
+        command.runner = this;
+      }
+
+      ArgResults parse(List<String> input) {
+        var results = ArgResults();
+        results.command = _commands[input.first];
+        return results;
+      }
+
+      String get usage {
+        final exeFile = Platform.script.path.split('/').last;
+        return 'Usage: dart bin/$exeFile <command> [commandArg?] [...options?]';
+      }
+    }
+    ```
+
+    Highlights from the preceding code:
+
+    - **Spread operator (`..._commands.values`)**:
+      Unpacks the values of the private `_commands` map into a new set,
+      preventing callers from modifying the underlying map.
+    - **`command.runner = this;`**:
+      Assigns the runner instance to the command when registered,
+      fulfilling the promise made by the `late` keyword in `Command`.
+    - **Null assertion operator (`!`)**:
+      In `results.command!.run(results)`, the `!` asserts that `command`
+      is guaranteed non-null because of the `if (results.command != null)` check.
+
+1.  Open `command_runner/lib/command_runner.dart` and update the exports:
+
+    ```dart title="command_runner/lib/command_runner.dart"
+    /// Support for command-line parsing and execution.
+    library;
+
+    export 'src/arguments.dart';
+    export 'src/command_runner_base.dart';
+    export 'src/help_command.dart';
+    ```
+
+    These export statements make `arguments.dart`, `command_runner_base.dart`,
+    and `help_command.dart` part of the public API of the `command_runner` package.
+
+### Task 4: Create a HelpCommand
+
+Create a concrete `HelpCommand` that extends `Command` and prints usage information.
+
+1.  Create `command_runner/lib/src/help_command.dart`.
+
+1.  Add the following code:
+
+    ```dart title="command_runner/lib/src/help_command.dart"
+    import 'dart:async';
+    import 'arguments.dart';
+
+    class HelpCommand extends Command {
+      HelpCommand() {
+        addFlag(
+          'verbose',
+          abbr: 'v',
+          help: 'When true, prints each command and its options.',
+        );
+        addOption(
+          'command',
+          abbr: 'c',
+          help: 'Prints verbose usage for the specified command.',
+        );
+      }
+
+      @override
+      String get name => 'help';
+
+      @override
+      String get description => 'Prints usage information to the command line.';
+
+      @override
+      String? get help => 'Prints this usage information';
+
+      @override
+      FutureOr<Object?> run(ArgResults args) async {
+        var usage = runner.usage;
+        for (var command in runner.commands) {
+          usage += '\n ${command.usage}';
+        }
+
+        return usage;
+      }
+    }
+    ```
+
+    Highlights from the preceding code:
+
+    - **Constructor initialization**:
+      Calls inherited helper methods `addFlag` and `addOption` to configure
+      the command's supported options.
+    - **Accessing `runner`**:
+      Reads `runner.usage` and iterates over `runner.commands` to assemble
+      the complete CLI help message dynamically.
+
+### Task 5: Update cli.dart to use CommandRunner
+
+Connect `CommandRunner` and `HelpCommand` in the executable entry point.
+
+1.  Open `cli/bin/cli.dart`.
+
+1.  Replace the file contents with the following code:
+
+    ```dart title="cli/bin/cli.dart"
+    import 'package:command_runner/command_runner.dart';
+
+    const version = '0.0.1';
+
+    void main(List<String> arguments) {
+      var commandRunner = CommandRunner()..addCommand(HelpCommand());
+      commandRunner.run(arguments);
+    }
+    ```
+
+    The cascade notation `..addCommand(...)` calls `addCommand` on the
+    newly constructed `CommandRunner` and returns that runner instance,
+    enabling concise method chaining before passing `arguments` to `run()`.
+
+### Task 6: Run the application
+
+Test the `CommandRunner` and `HelpCommand`.
+
+1.  From the `cli` directory, run:
+
+    ```bash
+    dart run bin/cli.dart help
+    ```
+
+    The console outputs:
+
+    ```bash
+    Usage: dart bin/cli.dart <command> [commandArg?] [...options?]
+     help:  Prints usage information to the command line.
+    ```
+
+    This confirms that `CommandRunner` dispatches to `HelpCommand`
+    and prints the expected usage output.
+
+## Review
+
+<SummaryCard>
+title: What you accomplished
+subtitle: A summary of the concepts and code introduced in this lesson.
+completed: true
+items:
+  - title: Designed and understood abstract classes
+    icon: schema
+    details: >-
+      Created the abstract `CliElement` and `Command` classes as base contracts
+      that cannot be instantiated directly.
+  - title: Extended parent classes and overrode methods
+    icon: account_tree
+    details: >-
+      Used `extends` to create `Option`, `Command`, and `HelpCommand` subtypes,
+      using `@override` to provide concrete implementations.
+  - title: Protected internal state with encapsulation
+    icon: lock
+    details: >-
+      Stored options in private lists (`_options`, `_commands`) and exposed
+      them via `UnmodifiableSetView` to prevent unintended mutations.
+  - title: Built an extensible command runner framework
+    icon: terminal
+    details: >-
+      Applied object-oriented principles to implement a polymorphic
+      CLI framework capable of dispatching commands dynamically.
+</SummaryCard>
+
+## Quiz
+
+<Quiz title="Check your understanding" id="inheritance" />
+
+## Next lesson
+
+The next chapter covers handling errors and exceptions in Dart.
+Create a custom exception class, and
+add error handling to `CommandRunner` to make the application more robust.
+
+[inheritance]: /language/extend
+[abstract classes]: /language/class-modifiers#abstract
+[encapsulation]: /resources/glossary#encapsulation

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -157,20 +157,16 @@ creating a new file for the logger and setting up the necessary imports.
     }
     ```
 
-    This code does the following:
+    The `initFileLogger` function returns a configured `Logger` instance
+    that appends timestamped records to a file in the `logs/` directory:
 
-    -   It enables hierarchical logging using
-        `hierarchicalLoggingEnabled = true`.
-    -   It creates a `Logger` instance with the given name.
-    -   It gets the project directory from the `Platform.script.path`.
-    -   It creates a `logs` directory if it doesn't exist.
-    -   It creates a log file with the current date and the logger name.
-    -   It sets the logger level to `Level.ALL`,
-        meaning it will log all messages.
-        This is useful for development and debugging, but
-        you'll likely want to use a more restrictive level like
-        `Level.INFO` or `Level.WARNING` in production.
-    -   It listens for log records and writes them to the log file.
+    - **`logger.level = Level.ALL`**:
+      Captures all messages regardless of severity during development.
+      Production apps typically use higher thresholds like
+      `Level.INFO` or `Level.WARNING`.
+    - **`logger.onRecord.listen(...)`**:
+      Subscribes to the stream of log events, formatting each entry with
+      its timestamp, logger name, and severity level before writing to disk.
 
 ### Task 3: Create the SearchCommand command
 
@@ -495,11 +491,9 @@ create the complete CLI application.
     }
     ```
 
-    This code does the following:
-
-    -   Initializes a `Logger` instance using `initFileLogger('errors')`.
-    -   Passes the logger instance to `SearchCommand` and `GetArticleCommand`.
-    -   Registers all commands with `CommandRunner`.
+    This setup initializes an `errors` file logger, passes it to
+    `SearchCommand` and `GetArticleCommand`, and registers all commands
+    with `CommandRunner`.
 
 ### Task 6: Run the application and check the logs
 

--- a/src/content/learn/tutorial/logging.md
+++ b/src/content/learn/tutorial/logging.md
@@ -26,7 +26,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
-- Have completed Chapter 11 and have a
+- Have completed Chapter 12 and have a
   working Dart development environment with the `dartpedia` project.
 - Understand the basics of debugging and why it's
   important to track errors and events in your application.

--- a/src/content/learn/tutorial/object-oriented.md
+++ b/src/content/learn/tutorial/object-oriented.md
@@ -1,144 +1,100 @@
 ---
-title: Define relationships with classes
-shortTitle: Object-oriented Dart
+title: Define classes and objects
+shortTitle: Classes and objects
 description: >-
   Learn about object-oriented programming in Dart, including
-  abstract classes, inheritance, overrides, and enums.
-  Build a framework for well-architected CLI apps.
+  classes, constructors, getters, and enums.
+  Build data models for command-line arguments.
 layout: learn
 ---
 
-In this chapter, you'll explore the
-power of object-oriented programming (OOP) in Dart.
-You'll learn how to create [classes](/language/classes) and
-define relationships between them, including
-[inheritance](/language/extend) and
-[abstract classes](/language/class-modifiers#abstract).
-You'll also build a foundation for creating well-structured CLI applications.
+This chapter covers the fundamentals of
+object-oriented programming (OOP) in Dart.
+Explore how to create [classes][],
+define constructors and fields,
+compute properties with [getters][], and
+use [enums][] to represent fixed sets of values.
 
 <SummaryCard>
 title: What you'll accomplish
 items:
-  - title: Design and understand abstract classes
-    icon: schema
-  - title: Extend parent classes and override methods
-    icon: account_tree
+  - title: Define classes to model data and behavior
+    icon: view_in_ar
+  - title: Create constructors with initializing formals and named parameters
+    icon: build
+  - title: Use getters to compute properties dynamically
+    icon: functions
   - title: Use enums to represent fixed sets of values
     icon: format_list_bulleted
-  - title: Continue building out your CLI framework
-    icon: terminal
 </SummaryCard>
 
 ## Prerequisites
 
-Before you begin this chapter, ensure you:
+Before starting this chapter:
 
-- Have completed Chapter 4 and have a
+- Complete Chapter 4 and have a
   working Dart development environment with the `dartpedia` project.
-- Are familiar with basic programming concepts like
-  variables, functions, and control flow.
-- Understand the concepts of packages and libraries in Dart.
+- Understand basic programming concepts,
+  such as variables, functions, and control flow.
+- Understand packages and libraries in Dart.
 
 ## Tasks
 
 A command-line interface (CLI) is defined by the
-commands, options, and arguments a user can type into their terminal.
+commands, options, and arguments typed into a terminal.
 
-By the end of this lesson, you will have
-built a framework that can understand a command like this:
+This lesson and the next build a framework
+capable of parsing a command such as:
 
 ```bash
 $ dartpedia help --verbose --command=search
 ```
 
-Here is a breakdown of each part:
+Each part serves a distinct purpose:
 
 - `dartpedia`:
-  This is the **executable**, the name of your application.
+  The **executable**, or the name of the application.
 - `help`:
-  This is a **command**, an action you want the application to perform.
+  A **command**, representing an action to perform.
 - `--verbose`:
-  This is a **flag** (a type of option that doesn't take a value),
-  which modifies the command's behavior.
+  A **flag** (a boolean option without a value),
+  modifying the command's behavior.
 - `--command=search`:
-  This is an **option** that takes a value.
-  Here, the `option` is named `command`, and its value is `search`.
+  An **option** that accepts a value (`search`).
 
-The classes and logic you build in the following tasks
-create the foundation for parsing and executing commands just like this one.
+This chapter builds the data models representing options and parsed results.
 
-### Task 1: Define the CLI element hierarchy
+### Task 1: Define the OptionType enum
 
-First, you'll define a `CliElement` class,
-an `Option` class, and a `Command` class,
-establishing an inheritance relationship.
+Command-line options fall into two distinct categories:
+flags (which evaluate to boolean `true` or `false`) and
+regular options (which accept a string value).
+Using an enum ensures that code only allows these two valid categories.
 
-1.  Create the file `command_runner/lib/src/arguments.dart`.
-    This file will
-    contain the definitions for your `CliElement`, `Option`, `Command`, and
-    `ArgResults` classes.
+1.  Create `command_runner/lib/src/arguments.dart`.
 
-1.  Define an `enum` called `OptionType`.
+1.  Define the `OptionType` enum:
 
     ```dart title="command_runner/lib/src/arguments.dart"
     enum OptionType { flag, option }
     ```
 
-    This [`enum`](/language/enums) represents the type of option,
-    which can be either a **`flag`**
-    (a boolean option) or a regular **`option`** (an option that takes a value).
-    Enums are useful for representing a fixed set of possible values.
+    This enumeration defines two members: `flag` and `option`.
+    Enums provide compile-time type safety,
+    ensuring code accepts only valid option types.
 
-1.  Define an `abstract class` called `CliElement`.
+### Task 2: Define the Option class
 
-    Start by defining the basic structure of your `CliElement` class.
-    You'll declare it as [`abstract`](/language/class-modifiers#abstract),
-    which means it serves as a base class that
-    other classes can extend, but it can't be [instantiated](/resources/glossary#instantiate) on its own.
+Classes in Dart define blueprints for objects,
+combining state (fields) and behavior (methods and getters).
+The `Option` class models command-line options such as
+`--verbose` or `--command=search`.
 
-    Below the `enum` you just added, paste in the following code:
-
-    ```dart title="command_runner/lib/src/arguments.dart"
-    // Paste this new class below the enum you added
-    abstract class CliElement {
-      String get name;
-      String? get help;
-
-      // In the case of flags, the default value is a bool.
-      // In other options and commands, the default value is a String.
-      // NB: flags are just Option objects that don't take arguments
-      Object? get defaultValue;
-      String? get valueHelp;
-
-      String get usage;
-    }
-    ```
-
-    - **`name`** is a `String` that uniquely identifies the argument.
-    - **`help`** is an optional `String` that provides a description.
-    - **`defaultValue`** is of type `Object?` because it
-      can be a `bool` (for flags) or a `String`.
-    - **`valueHelp`** is an optional `String` to
-      give a hint about the expected value.
-    - The **`usage`** [getter](/resources/glossary#getter) will provide a
-      string showing how
-      to use the argument.
-
-    With the `CliElement` class fully defined,
-    you have a common interface for all types of command-line arguments.
-    Next, you'll build upon this by defining `Option`,
-    a specific type of CLI element that extends `CliElement`.
-
-1.  Define a class called `Option` that `extends` `CliElement`.
-
-    The `Option` class will represent command-line options like
-    `--verbose` or `--output=file.txt`.
-    It will inherit from your `CliElement` class.
-
-    Add the following `Option` class to the bottom of your file:
+1.  Add the `Option` class to `command_runner/lib/src/arguments.dart`
+    below the enum:
 
     ```dart title="command_runner/lib/src/arguments.dart"
-    class Option extends CliElement {
+    class Option {
       Option(
         this.name, {
         required this.type,
@@ -148,23 +104,13 @@ establishing an inheritance relationship.
         this.valueHelp,
       });
 
-      @override
       final String name;
-
       final OptionType type;
-
-      @override
       final String? help;
-
       final String? abbr;
-
-      @override
       final Object? defaultValue;
-
-      @override
       final String? valueHelp;
 
-      @override
       String get usage {
         if (abbr != null) {
           return '-$abbr,--$name: $help';
@@ -175,248 +121,46 @@ establishing an inheritance relationship.
     }
     ```
 
-    The [**`extends`**](/language/extend) keyword establishes the inheritance relationship.
-    The class uses the [`@override`](/language/extend#overriding-members) annotation
-    on its properties and getters to indicate it is replacing the
-    placeholder members defined in `CliElement`.
+    Highlights from the preceding code:
 
-    It also adds `type` (using the `OptionType` enum) and an
-    optional `abbr` for a short-form of the option.
-    The `usage` getter is implemented to provide clear instructions to the user.
+    - **Generative constructor (`Option(...)`)**:
+      Instantiates new `Option` objects.
+    - **Initializing formals (`this.name`, `this.type`)**:
+      Directly assigns incoming arguments to instance fields
+      before the constructor body executes, avoiding repetitive assignment code.
+    - **Named parameters (`{required this.type, ...}`)**:
+      Curly braces `{}` enclose named parameters.
+      Callers pass arguments by name in any order
+      (for example, `Option('verbose', type: OptionType.flag)`).
+    - **`required` keyword**:
+      Enforces that callers must supply the `type` parameter,
+      while other parameters remain optional.
+    - **Nullable types (`String?`, `Object?`)**:
+      The question mark `?` indicates that a field can hold a value or `null`.
+      Optional attributes like `abbr` default to `null` when omitted.
+    - **`final` fields**:
+      Guarantees that field values cannot change after initialization,
+      ensuring that option definitions remain immutable.
+    - **`usage` getter**:
+      Computes the help string on demand.
+      If an abbreviation exists, it formats the output as `-$abbr,--$name: $help`.
+      Otherwise, it formats it as `--$name: $help`.
 
-    With `Option` complete, you have a specialized type of CLI element. Next,
-    you'll define the `Command` class, another type of CLI element that will
-    represent the main actions a user can perform in your CLI application.
+### Task 3: Define the ArgResults class
 
-1.  Define an [`abstract class`](/language/class-modifiers#abstract) called `Command` that also `extends` `CliElement`.
+The `ArgResults` class stores the output of parsing command-line input.
+It maps each `Option` to its user-supplied value.
 
-    The `Command` class will represent an executable action.
-    Since it provides a template for other commands to follow,
-    you'll declare it as **`abstract`**.
-
-    ```dart title="command_runner/lib/src/arguments.dart"
-    // Add this class below the Option class
-    abstract class Command extends CliElement {
-      // Properties and methods will go here
-    }
-    ```
-
-    The **`abstract`** keyword means that
-    `Command` can't be instantiated directly.
-    It serves as a base class for other classes.
-
-    Now, add the core properties.
-    A command needs a `name` and `description`.
-    It also needs a reference back to the `CommandRunner` that executes it.
+1.  Add `ArgResults` to the bottom of `command_runner/lib/src/arguments.dart`:
 
     ```dart title="command_runner/lib/src/arguments.dart"
-    abstract class Command extends CliElement {
-      @override
-      String get name;
-
-      String get description;
-
-      bool get requiresArgument => false;
-
-      late CommandRunner runner;
-
-      @override
-      String? help;
-
-      @override
-      String? defaultValue;
-
-      @override
-      String? valueHelp;
-    }
-    ```
-
-    The `runner` property is of type `CommandRunner`,
-    which you will define later in `command_runner_base.dart`.
-
-    Notice the [**`late`**](/language/variables#late-variables) keyword.
-    It tells Dart that you promise to initialize this variable
-    before it's ever accessed, allowing you to declare
-    a non-nullable variable without assigning it immediately.
-    This is helpful when a variable's initialization
-    depends on other objects (like a command being added to a runner).
-
-    To make Dart aware of this class, you must import its defining file.
-    Add the following import to the
-    top of `command_runner/lib/src/arguments.dart`:
-
-    ```dart
-    import '../command_runner.dart';
-    ```
-
-    Next, you'll give commands their own set of options.
-    To prevent other parts of your code from unexpectedly modifying
-    these options, you'll store them in a [private](/resources/glossary#library-private) list (`_options`).
-    In Dart, prefixing a variable or field name with an underscore (`_`)
-    makes it library-private.
-
-    Instead of allowing direct access, you expose the options through a
-    read-only unmodifiable view ([`UnmodifiableSetView`][unmodifiable-set-view]).
-    This approach is a core part
-    of encapsulation: the practice of restricting direct access to a class's
-    internal state to prevent unintended interference.
-
-    The `UnmodifiableSetView` class is part of Dart's core collection library.
-    To use it, you must import that library.
-
-    Update the imports at the top of your file to include `dart:collection`:
-
-    ```dart
-    import 'dart:collection'; // New import
-    import '../command_runner.dart';
-    ```
-
-    Now, add the `options` list and getter to your `Command` class:
-
-    ```dart
-    abstract class Command extends CliElement {
-      // ... existing properties ...
-
-      @override
-      String? valueHelp;
-
-
-      // Add the following lines to the bottom of your Command class:
-
-      final List<Option> _options = [];
-
-      UnmodifiableSetView<Option> get options =>
-          UnmodifiableSetView(_options.toSet());
-    }
-    ```
-
-    Because `_options` is private, external code can't add options directly.
-    To allow commands to define their options, you'll provide two internal
-    helper methods: `addFlag` and `addOption`. These methods will instantiate
-    the appropriate `Option` objects and add them to the private list.
-
-    ```dart
-    abstract class Command extends CliElement {
-      // ... existing properties and getters ...
-
-      UnmodifiableSetView<Option> get options =>
-          UnmodifiableSetView(_options.toSet());
-
-
-      // Add the following lines to the bottom of your Command class:
-
-      // A flag is an [Option] that's treated as a boolean.
-      void addFlag(String name, {String? help, String? abbr, String? valueHelp}) {
-        _options.add(
-          Option(
-            name,
-            help: help,
-            abbr: abbr,
-            defaultValue: false,
-            valueHelp: valueHelp,
-            type: OptionType.flag,
-          ),
-        );
-      }
-
-      // An option is an [Option] that takes a value.
-      void addOption(
-        String name, {
-        String? help,
-        String? abbr,
-        String? defaultValue,
-        String? valueHelp,
-      }) {
-        _options.add(
-          Option(
-            name,
-            help: help,
-            abbr: abbr,
-            defaultValue: defaultValue,
-            valueHelp: valueHelp,
-            type: OptionType.option,
-          ),
-        );
-      }
-    }
-    ```
-
-    Finally, every command must have logic to execute when called.
-    You'll define an abstract `run` method that concrete commands must implement.
-
-    Because a command might be either synchronous or asynchronous, its `run`
-    method returns the [`FutureOr`][future-or] type from `dart:async`, allowing it to
-    return either a raw value or a `Future`. This is your final required import.
-
-    Update the imports at the top of your file to include `dart:async`:
-
-    ```dart
-    import 'dart:async'; // New import
-    import 'dart:collection';
-    import '../command_runner.dart';
-    ```
-
-    Now you can add the abstract `run` method and
-    provide the `usage` implementation to complete the `Command` class.
-
-    ```dart
-    abstract class Command extends CliElement {
-      // ... existing properties, getters, and methods ...
-
-      void addOption(
-        String name, {
-        String? help,
-        String? abbr,
-        String? defaultValue,
-        String? valueHelp,
-      }) {
-        _options.add(
-          Option(
-            name,
-            help: help,
-            abbr: abbr,
-            defaultValue: defaultValue,
-            valueHelp: valueHelp,
-            type: OptionType.option,
-          ),
-        );
-      }
-
-
-      // Add the following lines to the bottom of your Command class:
-      FutureOr<Object?> run(ArgResults args);
-
-      @override
-      String get usage {
-        return '$name:  $description';
-      }
-    }
-    ```
-
-    - **`run(ArgResults args)`**:
-      This abstract method is where a command's logic resides.
-      Concrete subclasses *must* implement it.
-    - **`usage`**:
-      This getter provides a simple usage string,
-      combining the command's `name` and `description`.
-
-    The `Command` class now provides a
-    robust foundation for all commands in your CLI app.
-    With the class hierarchy in place, you're ready to
-    define `ArgResults` to hold the parsed input.
-
-1.  Define a class called `ArgResults`.
-
-    ```dart title="command_runner/lib/src/arguments.dart"
-    // Add this class to the end of the file
     class ArgResults {
-      Command? command;
+      String? command;
       String? commandArg;
       Map<Option, Object?> options = {};
 
-      // Returns true if the flag exists.
+      // Returns true if the flag exists and is true.
       bool flag(String name) {
-        // Only check flags, because we're sure that flags are booleans.
         for (var option in options.keys.where(
           (option) => option.type == OptionType.flag,
         )) {
@@ -441,253 +185,108 @@ establishing an inheritance relationship.
     }
     ```
 
-    This class represents the results of parsing command-line arguments.
-    It holds the detected command, any argument to that command, and
-    a map of the specified options.
+    Highlights from the preceding code:
 
-    - The `flag()` method: Iterates over the keys of the `options` map,
-      filtering for those where `type` is `OptionType.flag`. It uses explicit type 
-      casting (`as bool`) because we know flags are boolean values.
-    - Record types: The `getOption` method returns a record type
-      `(option: ..., input: ...)`, which lets you group multiple values together 
-      without creating a full class.
+    - **`options` map (`Map<Option, Object?>`)**:
+      Associates each `Option` instance with its parsed user input.
+    - **`where()` method in `flag()`**:
+      Filters map keys to inspect only boolean flags (`option.type == OptionType.flag`),
+      ignoring options that take string arguments.
+    - **Type cast (`as bool`)**:
+      Tells the type checker to treat the value as a `bool` because
+      flags always store boolean values.
+    - **Record return type (`({Option option, Object? input})`)**:
+      Returns a lightweight, named record grouping both the `Option`
+      and its value without declaring a separate class.
 
-    Now you have defined the basic structure for handling
-    commands, arguments, and options in your command-line application.
+### Task 4: Export arguments from the package
 
-### Task 2: Update the CommandRunner class
+Export `arguments.dart` from the package entry point to
+allow other packages to import `Option` and `ArgResults`.
 
-Next, update the `CommandRunner` class to use the new `CliElement` hierarchy.
+1.  Open `command_runner/lib/command_runner.dart`.
 
-1.  Open the `command_runner/lib/src/command_runner_base.dart` file.
-
-1.  Replace the existing `CommandRunner` class with the following:
-
-    ```dart title="command_runner/lib/src/command_runner_base.dart"
-    import 'dart:collection';
-    import 'dart:io';
-    import 'arguments.dart';
-
-    class CommandRunner {
-      final Map<String, Command> _commands = <String, Command>{};
-
-      UnmodifiableSetView<Command> get commands =>
-          UnmodifiableSetView<Command>(<Command>{..._commands.values});
-
-      Future<void> run(List<String> input) async {
-        final ArgResults results = parse(input);
-        if (results.command != null) {
-          Object? output = await results.command!.run(results);
-          print(output.toString());
-        }
-      }
-
-      void addCommand(Command command) {
-        // TODO: handle error (Commands can't have names that conflict)
-        _commands[command.name] = command;
-        command.runner = this;
-      }
-
-      ArgResults parse(List<String> input) {
-        var results = ArgResults();
-        results.command = _commands[input.first];
-        return results;
-      }
-
-      // Returns usage for the executable only.
-      // Should be overridden if you aren't using [HelpCommand]
-      // or another means of printing usage.
-
-      String get usage {
-        final exeFile = Platform.script.path.split('/').last;
-        return 'Usage: dart bin/$exeFile <command> [commandArg?] [...options?]';
-      }
-    }
-    ```
-
-    This updated class incorporates your new object-oriented structure.
-    It uses the spread operator (`...`) in the `commands` getter to
-    unpack the values of the `_commands` map into a new set.
-    This ensures the return value is a copy,
-    preventing external code from modifying your data.
-
-    In the `run()` method, `results.command!.run(...)` uses the
-    not-null assertion operator (`!`) to tell the Dart analyzer that you are
-    sure `results.command` is not null.
-    It's safe here because you just checked if it wasn't null
-    in the preceding `if` statement.
-
-    Here are the key implementation details:
-
-    - **`_commands` map:** A private map linking command names to their
-      concrete `Command` object instances. Its values are exposed via an
-      `UnmodifiableSetView`.
-    - **`addCommand()`:** Registers a command and assigns `this` runner to the 
-      command's `runner` property. This fulfills the `late` initialization 
-      promise made earlier in the `Command` class.
-    - **`parse()` and `run()`:** Evaluates the user's input, identifies the 
-      corresponding `Command` from the map, and uses `await` to call the 
-      command's `run()` method.
-
-1.  Open `command_runner/lib/command_runner.dart`, and
-    add the following exports:
+1.  Add the export statement:
 
     ```dart title="command_runner/lib/command_runner.dart"
-    /// Support for doing something awesome.
-    ///
-    /// More dartdocs go here.
+    /// Support for command-line parsing and execution.
     library;
 
     export 'src/arguments.dart';
-    export 'src/command_runner_base.dart';
-    export 'src/help_command.dart';
-
-    // TODO: Export any libraries intended for clients of this package.
     ```
 
-    This makes the `arguments.dart`, `command_runner_base.dart`, and
-    `help_command.dart` files available to other packages that
-    depend on `command_runner`.
+    This `export` statement makes declarations in `arguments.dart` accessible
+    to any package that imports `package:command_runner/command_runner.dart`.
 
-### Task 3: Create a HelpCommand
+### Task 5: Test the classes in cli.dart
 
-Create a `HelpCommand` that extends the `Command` class and
-prints usage information.
+Verify that `Option` instantiates and computes its `usage` string correctly.
 
-1.  Create the file `command_runner/lib/src/help_command.dart`.
+1.  Open `cli/bin/cli.dart`.
 
-1.  Add the following code to `command_runner/lib/src/help_command.dart`:
-
-    ```dart title="command_runner/lib/src/help_command.dart"
-    import 'dart:async';
-
-    import 'arguments.dart';
-
-    // Prints program and argument usage.
-    //
-    // When given a command as an argument, it prints the usage of
-    // that command only, including its options and other details.
-    // When the flag 'verbose' is set, it prints options and details for all commands.
-    //
-    // This command isn't automatically added to CommandRunner instances.
-    // Packages users should add it themselves with [CommandRunner.addCommand],
-    // or create their own command that prints usage.
-
-    class HelpCommand extends Command {
-      HelpCommand() {
-        addFlag(
-          'verbose',
-          abbr: 'v',
-          help: 'When true, this command will print each command and its options.',
-        );
-        addOption(
-          'command',
-          abbr: 'c',
-          help:
-              "When a command is passed as an argument, prints only that command's verbose usage.",
-        );
-      }
-      @override
-      String get name => 'help';
-
-      @override
-      String get description => 'Prints usage information to the command line.';
-
-      @override
-      String? get help => 'Prints this usage information';
-
-      @override
-      FutureOr<Object?> run(ArgResults args) async {
-        var usage = runner.usage;
-        for (var command in runner.commands) {
-          usage += '\n ${command.usage}';
-        }
-
-        return usage;
-      }
-    }
-    ```
-
-    The `HelpCommand` class demonstrates the benefits of inheritance.
-    It uses its parent's methods to set up its options,
-    overrides the abstract `run` method,
-    and accesses the `runner` state to generate the usage message.
-
-### Task 4: Update cli.dart to use the new CommandRunner
-
-Modify `cli/bin/cli.dart` to use the new `CommandRunner` and `HelpCommand`.
-
-1.  Open the `cli/bin/cli.dart` file.
-
-1.  Replace the existing code with the following:
+1.  Replace the file contents with the following test code:
 
     ```dart title="cli/bin/cli.dart"
     import 'package:command_runner/command_runner.dart';
 
-    const version = '0.0.1';
+    void main() {
+      final verboseOption = Option(
+        'verbose',
+        type: OptionType.flag,
+        abbr: 'v',
+        help: 'Display extra logging information.',
+      );
 
-    void main(List<String> arguments) {
-      var commandRunner = CommandRunner()..addCommand(HelpCommand());
-      commandRunner.run(arguments);
+      print('Defined option: ${verboseOption.name}');
+      print('Usage: ${verboseOption.usage}');
     }
     ```
 
-    This code creates a `CommandRunner` instance,
-    adds the `HelpCommand` to it using a
-    [method cascade](/language/operators#cascade-notation) (`..addCommand`)
-    which lets you call a method on an object directly after creating it, and
-    then runs the command runner with the command-line arguments.
+    This code calls the `Option` constructor to create an instance,
+    and then prints its `name` field and computed `usage` getter.
 
-### Task 5: Run the application
-
-Test the new `CommandRunner` and `HelpCommand`.
-
-1.  Open your terminal and navigate to the `cli` directory.
-
-1.  Run the command `dart run bin/cli.dart help`.
-
-    You should see the usage information printed to the console:
+1.  Run the application from the `cli` directory:
 
     ```bash
-    Usage: dart bin/cli.dart <command> [commandArg?] [...options?]
-     help:  Prints usage information to the command line.
+    dart run bin/cli.dart
     ```
 
-    This confirms that the `CommandRunner` and `HelpCommand` are
-    working correctly.
+    The console outputs:
+
+    ```bash
+    Defined option: verbose
+    Usage: -v,--verbose: Display extra logging information.
+    ```
+
+    This confirms that the `Option` class and getter function as expected.
 
 ## Review
 
 <SummaryCard>
 title: What you accomplished
-subtitle: Here's a summary of what you built and learned in this lesson.
+subtitle: A summary of the concepts and code introduced in this lesson.
 completed: true
 items:
-  - title: Designed and understood abstract classes
-    icon: schema
+  - title: Defined classes to model data and behavior
+    icon: view_in_ar
     details: >-
-      You created an abstract `CliElement` class as a base class that
-      can't be instantiated directly.
-      Abstract classes define a contract that subclasses must fulfill,
-      ensuring consistency across your class hierarchy.
-  - title: Extended parent classes and overrode methods
-    icon: account_tree
+      Created the `Option` and `ArgResults` classes to structure command-line
+      arguments and parsed output.
+  - title: Created constructors with initializing formals and named parameters
+    icon: build
     details: >-
-      You used `extends` to create `Option` and `Command` subclasses of
-      the abstract `CliElement` class.
-      Within those subclasses, you used `@override` to
-      provide concrete implementations of abstract members.
+      Used `this.fieldName` syntax for automatic field initialization and
+      defined optional and required named parameters with `{}` and `required`.
+  - title: Used getters to compute properties dynamically
+    icon: functions
+    details: >-
+      Implemented the `usage` getter to format option help text on demand
+      without storing duplicate string state.
   - title: Used enums to represent fixed sets of values
     icon: format_list_bulleted
     details: >-
-      You defined an `OptionType` enum to represent a fixed set of values.
-      In Dart, enums are type-safe and help prevent invalid values from
-      being used where only specific options are valid.
-  - title: Continued building out your CLI framework
-    icon: terminal
-    details: >-
-      You applied object-oriented programming principles to implement a
-      robust and extensible framework for parsing command-line arguments.
+      Defined the `OptionType` enum to represent valid option types
+      (`flag` and `option`), ensuring compile-time safety.
 </SummaryCard>
 
 ## Quiz
@@ -696,11 +295,11 @@ items:
 
 ## Next lesson
 
-In the next lesson, you'll learn how to
-handle errors and exceptions in your Dart code.
-You'll create a custom exception class and
-add error handling to your `CommandRunner` to
-make your application more robust.
+The next chapter covers sharing behavior between classes
+using inheritance and abstract classes.
+Define an abstract `CliElement` base class, and
+build out the `Command` and `CommandRunner` architecture.
 
-[unmodifiable-set-view]: {{site.dart-api}}/dart-collection/UnmodifiableSetView-class.html
-[future-or]: {{site.dart-api}}/dart-async/FutureOr-class.html
+[classes]: /language/classes
+[getters]: /resources/glossary#getter
+[enums]: /language/enums

--- a/src/content/learn/tutorial/object-oriented.md
+++ b/src/content/learn/tutorial/object-oriented.md
@@ -40,9 +40,6 @@ Before starting this chapter:
 
 ## Classes and objects in Dart
 
-A **class** is a blueprint that defines the structure and behavior of a concept in code.
-An **object** (or **instance**) is a concrete copy created from that blueprint.
-
 Classes bundle two main components together:
 
 - **State (fields)**:
@@ -113,10 +110,10 @@ The `Option` class models command-line options such as
 
     ```dart title="command_runner/lib/src/arguments.dart"
     class Option {
+      Option(this.name, {required this.type});
+
       final String name;
       final OptionType type;
-
-      Option(this.name, {required this.type});
     }
     ```
 
@@ -222,6 +219,9 @@ It maps each `Option` to its user-supplied value.
       Returns a lightweight, named record grouping both the `Option`
       and its value without declaring a separate class.
 
+    The `ArgResults` class serves as the data contract for parsed output.
+    Chapter 6 connects this class to the full `CommandRunner`.
+
 ### Task 4: Export arguments from the package
 
 Export `arguments.dart` from the package entry point to
@@ -229,13 +229,14 @@ allow other packages to import `Option` and `ArgResults`.
 
 1.  Open `command_runner/lib/command_runner.dart`.
 
-1.  Add the export statement:
+1.  Export `arguments.dart` alongside `command_runner_base.dart`:
 
     ```dart title="command_runner/lib/command_runner.dart"
     /// Support for command-line parsing and execution.
     library;
 
     export 'src/arguments.dart';
+    export 'src/command_runner_base.dart';
     ```
 
     This `export` statement makes declarations in `arguments.dart` accessible

--- a/src/content/learn/tutorial/object-oriented.md
+++ b/src/content/learn/tutorial/object-oriented.md
@@ -38,6 +38,24 @@ Before starting this chapter:
   such as variables, functions, and control flow.
 - Understand packages and libraries in Dart.
 
+## Classes and objects in Dart
+
+A **class** is a blueprint that defines the structure and behavior of a concept in code.
+An **object** (or **instance**) is a concrete copy created from that blueprint.
+
+Classes bundle two main components together:
+
+- **State (fields)**:
+  The data each object holds,
+  such as an option's `name` or `help` text.
+- **Behavior (methods and getters)**:
+  The actions an object can perform or properties it computes,
+  such as formatting a `usage` string.
+
+Instead of tracking loose strings or maps across an application,
+modeling command-line arguments as classes ensures compile-time type safety,
+editor autocomplete, and a consistent data structure.
+
 ## Tasks
 
 A command-line interface (CLI) is defined by the
@@ -90,8 +108,31 @@ combining state (fields) and behavior (methods and getters).
 The `Option` class models command-line options such as
 `--verbose` or `--command=search`.
 
-1.  Add the `Option` class to `command_runner/lib/src/arguments.dart`
-    below the enum:
+1.  Start by defining a minimal `Option` class with essential fields and a constructor.
+    Add the following code to `command_runner/lib/src/arguments.dart` below the enum:
+
+    ```dart title="command_runner/lib/src/arguments.dart"
+    class Option {
+      final String name;
+      final OptionType type;
+
+      Option(this.name, {required this.type});
+    }
+    ```
+
+    - **Fields (`final String name;`, `final OptionType type;`)**:
+      Variables that store the object's data.
+      Declaring them as `final` ensures they cannot change after creation.
+    - **Constructor (`Option(...)`)**:
+      Instantiates new `Option` objects.
+      The `this.name` syntax is an *initializing formal*—a Dart shortcut
+      that assigns the argument directly to the instance field before the body runs.
+    - **Named parameters (`{required this.type}`)**:
+      Parameters inside curly braces `{}` are passed by name
+      (for example, `Option('verbose', type: OptionType.flag)`).
+      The `required` keyword makes the parameter mandatory.
+
+1.  Now, expand the `Option` class with optional metadata fields and a `usage` getter:
 
     ```dart title="command_runner/lib/src/arguments.dart"
     class Option {
@@ -121,30 +162,12 @@ The `Option` class models command-line options such as
     }
     ```
 
-    Highlights from the preceding code:
-
-    - **Generative constructor (`Option(...)`)**:
-      Instantiates new `Option` objects.
-    - **Initializing formals (`this.name`, `this.type`)**:
-      Directly assigns incoming arguments to instance fields
-      before the constructor body executes, avoiding repetitive assignment code.
-    - **Named parameters (`{required this.type, ...}`)**:
-      Curly braces `{}` enclose named parameters.
-      Callers pass arguments by name in any order
-      (for example, `Option('verbose', type: OptionType.flag)`).
-    - **`required` keyword**:
-      Enforces that callers must supply the `type` parameter,
-      while other parameters remain optional.
     - **Nullable types (`String?`, `Object?`)**:
-      The question mark `?` indicates that a field can hold a value or `null`.
-      Optional attributes like `abbr` default to `null` when omitted.
-    - **`final` fields**:
-      Guarantees that field values cannot change after initialization,
-      ensuring that option definitions remain immutable.
-    - **`usage` getter**:
-      Computes the help string on demand.
-      If an abbreviation exists, it formats the output as `-$abbr,--$name: $help`.
-      Otherwise, it formats it as `--$name: $help`.
+      The question mark `?` indicates that a field is optional and can hold `null`.
+      When callers omit `help` or `abbr`, they default to `null`.
+    - **Getter (`get usage`)**:
+      A getter computes a value on demand when accessed,
+      formatting the help string based on whether an abbreviation exists.
 
 ### Task 3: Define the ArgResults class
 

--- a/src/content/learn/tutorial/packages-libs.md
+++ b/src/content/learn/tutorial/packages-libs.md
@@ -341,8 +341,6 @@ items:
 
 ## Next lesson
 
-In the next chapter, you'll dive into
-object-oriented programming (OOP) concepts in Dart.
-You'll learn how to create classes, define inheritance relationships,
-and build a more robust command-line argument parsing framework using
-OOP principles within your new `command_runner` package.
+The next chapter covers object-oriented programming (OOP) concepts in Dart.
+Create classes, constructors, and getters, and
+use enums to model command-line arguments within the `command_runner` package.

--- a/src/content/learn/tutorial/testing.md
+++ b/src/content/learn/tutorial/testing.md
@@ -28,7 +28,7 @@ items:
 
 Before you begin this chapter, ensure you:
 
--   Have completed Chapter 9 and have a
+-   Have completed Chapter 10 and have a
     working Dart development environment with the `dartpedia` project.
 -   Are familiar with basic programming concepts like
     variables, functions, and control flow.

--- a/src/data/quiz/inheritance.yml
+++ b/src/data/quiz/inheritance.yml
@@ -1,0 +1,86 @@
+- question: >-
+    In the `Option` class,
+    what is the purpose of the `@override` annotation?
+  options:
+    - text: >-
+        To provide a specific implementation for a method or property
+        defined in a parent class.
+      correct: true
+      explanation: >-
+        `@override` indicates that you're providing
+        a concrete implementation for an abstract member
+        or replacing an inherited implementation.
+    - text: >-
+        To create a new method that doesn't exist in the parent class.
+      correct: false
+      explanation: >-
+        `@override` doesn't create new methods.
+        New methods are created simply by defining them in the class.
+    - text: >-
+        To indicate that a method is optional.
+      correct: false
+      explanation: >-
+        `@override` doesn't affect whether methods are optional.
+        Optional parameters use different syntax entirely.
+    - text: >-
+        To make a property private.
+      correct: false
+      explanation: >-
+        Privacy is indicated by a leading underscore (`_`), not by annotations.
+        `@override` serves a different purpose related to inheritance.
+- question: >-
+    What is the difference between an `abstract` class
+    and a regular class in Dart?
+  options:
+    - text: >-
+        An `abstract` class can't be instantiated directly.
+      correct: true
+      explanation: >-
+        Abstract classes serve as blueprints that other classes extend.
+        You can't create instances of an abstract class directly.
+    - text: >-
+        An `abstract` class can't have any methods.
+      correct: false
+      explanation: >-
+        Abstract classes can have both abstract methods (without implementation)
+        and concrete methods (with implementation).
+    - text: >-
+        An `abstract` class can only have private methods.
+      correct: false
+      explanation: >-
+        Abstract classes can have methods with any visibility level.
+        The `abstract` keyword doesn't restrict visibility.
+    - text: >-
+        There is no difference between an `abstract` class and a regular class.
+      correct: false
+      explanation: >-
+        There is a significant difference.
+        Try writing `var x = MyAbstractClass();` and see what happens.
+- question: >-
+    Why does the `Command` class expose `options` through an
+    `UnmodifiableSetView` instead of allowing direct access to `_options`?
+  options:
+    - text: >-
+        To prevent external code from modifying the command's internal list of options directly.
+      correct: true
+      explanation: >-
+        Encapsulating the list and exposing an unmodifiable view prevents external
+        callers from adding, removing, or reordering options without using the
+        command's helper methods.
+    - text: >-
+        Because Dart doesn't allow classes to contain mutable lists.
+      correct: false
+      explanation: >-
+        Dart classes can contain mutable lists. The unmodifiable view is an intentional
+        design choice for encapsulation.
+    - text: >-
+        To make the options accessible from outside the library.
+      correct: false
+      explanation: >-
+        Public getters already make data accessible; the unmodifiable wrapper specifically
+        protects the collection from being mutated externally.
+    - text: >-
+        To automatically sort the options alphabetically.
+      correct: false
+      explanation: >-
+        `UnmodifiableSetView` does not sort collections; it only prevents mutations.

--- a/src/data/quiz/object-oriented.yml
+++ b/src/data/quiz/object-oriented.yml
@@ -1,61 +1,57 @@
 - question: >-
-    In the `Option` class,
-    what is the purpose of the `@override` annotation?
+    In the constructor `Option(this.name, {required this.type})`,
+    what is the purpose of the `this.name` syntax?
   options:
     - text: >-
-        To provide a specific implementation for a method or property
-        defined in a parent class.
+        It automatically assigns the constructor argument directly to the instance field `name`.
       correct: true
       explanation: >-
-        `@override` indicates that you're providing
-        a concrete implementation for an abstract member
-        or replacing an inherited implementation.
+        In Dart, `this.fieldName` in a constructor's parameter list is an
+        "initializing formal" that assigns the argument value directly to the field
+        before the constructor body runs.
     - text: >-
-        To create a new method that doesn't exist in the parent class.
+        It creates a new global variable named `name`.
       correct: false
       explanation: >-
-        `@override` doesn't create new methods.
-        New methods are created simply by defining them in the class.
+        `this.name` refers specifically to the instance field of the class,
+        not a global variable.
     - text: >-
-        To indicate that a method is optional.
+        It makes the `name` property private to the library.
       correct: false
       explanation: >-
-        `@override` doesn't affect whether methods are optional.
-        Optional parameters use different syntax entirely.
+        Privacy in Dart is designated by a leading underscore (`_name`),
+        not by `this`.
     - text: >-
-        To make a property private.
+        It marks the parameter as optional.
       correct: false
       explanation: >-
-        Privacy is indicated by a leading underscore (`_`), not by annotations.
-        `@override` serves a different purpose related to inheritance.
+        Optional parameters are enclosed in square brackets `[]` or curly braces `{}`.
+        Positional `this.name` is required.
 - question: >-
-    What is the difference between an `abstract` class
-    and a regular class in Dart?
+    What is the primary benefit of using a getter like `String get usage`
+    instead of storing a `String usage` field?
   options:
     - text: >-
-        An `abstract` class can't be instantiated directly.
+        It dynamically computes the value whenever accessed, ensuring it reflects current state without redundant storage.
       correct: true
       explanation: >-
-        Abstract classes serve as blueprints that other classes extend.
-        You can't create instances of an abstract class directly.
+        Getters behave like properties from the caller's perspective, but execute code
+        on demand to calculate their value.
     - text: >-
-        An `abstract` class can't have any methods.
+        Getters can only be accessed from within the same file.
       correct: false
       explanation: >-
-        Abstract classes can have both abstract methods (without implementation)
-        and concrete methods (with implementation).
+        Getters have the same visibility rules as normal fields and methods.
     - text: >-
-        An `abstract` class can only have private methods.
+        Getters run faster than reading a stored field.
       correct: false
       explanation: >-
-        Abstract classes can have methods with any visibility level.
-        The `abstract` keyword doesn't restrict visibility.
+        Reading a stored field is typically faster than executing logic in a getter.
     - text: >-
-        There is no difference between an `abstract` class and a regular class.
+        Getters allow the property to be modified from outside the class.
       correct: false
       explanation: >-
-        There is a significant difference.
-        Try writing `var x = MyAbstractClass();` and see what happens.
+        A getter provides read-only access unless a corresponding setter (`set usage(...)`) is also defined.
 - question: >-
     When should you use an `enum` instead of a class or a set of constants?
   options:

--- a/src/data/sidenav/getStarted.yml
+++ b/src/data/sidenav/getStarted.yml
@@ -28,8 +28,10 @@
   permalink: /learn/tutorial/async
 - title: Organize code with packages and libraries
   permalink: /learn/tutorial/packages-libs
-- title: Define relationships with classes
+- title: Define classes and objects
   permalink: /learn/tutorial/object-oriented
+- title: Structure apps with inheritance
+  permalink: /learn/tutorial/inheritance
 - title: Handle errors gracefully
   permalink: /learn/tutorial/error-handling
 - title: Extend your app with enums and extensions

--- a/src/data/tutorial.yml
+++ b/src/data/tutorial.yml
@@ -11,8 +11,10 @@ units:
         url: /learn/tutorial/async
       - title: Organize code with packages and libraries
         url: /learn/tutorial/packages-libs
-      - title: Define relationships with classes
+      - title: Define classes and objects
         url: /learn/tutorial/object-oriented
+      - title: Structure apps with inheritance
+        url: /learn/tutorial/inheritance
       - title: Handle errors gracefully
         url: /learn/tutorial/error-handling
       - title: Extend your app with enums and extensions


### PR DESCRIPTION
## Summary

Resolves cognitive overload and uneven pacing in the tutorial's OOP content by splitting the monolithic OOP chapter into two progressive lessons and deconstructing complex classes into incremental steps.

### Changes
- **Split OOP into two chapters:** Chapter 5 (*Classes and objects*) focuses on core classes, constructors, getters, and enums; Chapter 6 (*Inheritance and abstract classes*) introduces abstract classes, `extends`, `@override`, and command execution.
- **Improved progressive disclosure:** Deconstructs `Option` and `Command` step-by-step; explains Dart features like implicit getters satisfying abstract getters, `late`, `UnmodifiableSetView`, and records.
- **Maintained continuity:** Synchronized navigation (`tutorial.yml`, `getStarted.yml`), separated quizzes, and renumbered downstream chapter prerequisites (Chapters 7–13).
- **Verified code flow:** Tested end-to-end in a clean project with `dart analyze` (0 issues) and `dart run`.

Fixes #7333 
Fixes #7418
